### PR TITLE
R3: real runsc/gVisor sandbox launch — provision + trust-verify + gated real-launch test (IRO-4)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -70,6 +70,10 @@ func main() {
 		"directory under which per-session OCI bundles (config.json + rootfs) are written")
 	sandboxImage := flag.String("sandbox-image", "ironclaw-sandbox:latest",
 		"container image reference recorded in each sandbox's OCI spec")
+	sandboxProvisioner := flag.String("sandbox-provisioner", "none",
+		"how each sandbox rootfs is populated for the runsc/gVisor runtime: \"containerd\" (pull + unpack --sandbox-image via ctr, trust-verified against --sandbox-image-digest) or \"none\" (operator pre-stages the rootfs under --bundle-root/<session>/rootfs)")
+	sandboxImageDigest := flag.String("sandbox-image-digest", "",
+		"pinned sha256:<hex> digest the --sandbox-image must resolve to; the rootfs provisioner refuses any other content (REQUIRED when --sandbox-provisioner=containerd — fail closed)")
 	sweepInterval := flag.Duration("sweep-interval", 60*time.Second,
 		"how often the maintenance sweep runs (stale-sandbox detection + due-message wake)")
 	deliveryInterval := flag.Duration("delivery-interval", 2*time.Second,
@@ -443,10 +447,35 @@ func main() {
 		logger.Warn("isolation runtime is Docker (runc, NOT gVisor) — development only",
 			"network", network, "binds", strings.Join(binds, " "))
 	} else {
-		isolator = isolation.NewRunsc(
+		// gVisor/runsc production path. Build the rootfs provisioner so the normal
+		// install-and-run flow can actually populate a per-session rootfs; without a
+		// provisioner Launch fails closed (ErrRootfsMissing) unless the operator
+		// pre-stages it. When the containerd provisioner is selected, a pinned-digest
+		// trust policy is MANDATORY — a provisioner that pulls content unverified
+		// would let a repointed tag or substituted image reach a sandbox.
+		runscOpts := []isolation.Option{
 			isolation.WithRuntimeBinary(*runtimeBin),
 			isolation.WithBundleRoot(*bundleRoot),
-		)
+		}
+		switch strings.TrimSpace(*sandboxProvisioner) {
+		case "", "none":
+			logger.Info("sandbox rootfs provisioner is none — operator must pre-stage rootfs (Launch fails closed if absent)",
+				"bundle_root", *bundleRoot)
+		case "containerd":
+			if strings.TrimSpace(*sandboxImageDigest) == "" {
+				logger.Error("--sandbox-provisioner=containerd requires --sandbox-image-digest (a pinned sha256 the image must match); refusing to provision unverified images")
+				os.Exit(1)
+			}
+			policy := isolation.NewPinnedDigestPolicy(map[string]string{*sandboxImage: *sandboxImageDigest})
+			provisioner := isolation.NewContainerdProvisioner(isolation.WithTrustPolicy(policy))
+			runscOpts = append(runscOpts, isolation.WithProvisioner(provisioner))
+			logger.Info("sandbox rootfs provisioner is containerd (trust-policy-verified)",
+				"image", *sandboxImage, "pinned_digest", *sandboxImageDigest)
+		default:
+			logger.Error("unknown --sandbox-provisioner", "value", *sandboxProvisioner, "want", "none|containerd")
+			os.Exit(1)
+		}
+		isolator = isolation.NewRunsc(runscOpts...)
 	}
 
 	// Per-session lifecycle: the SessionManager composes the encrypted queue

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -58,10 +58,29 @@ parallelism there.)
 
 Full sandbox isolation uses gVisor (`runsc`) / Kata and is **Linux-only**.
 
-- macOS has no `runsc`. The real-isolator end-to-end variant
-  `TestFullLifecycleRunscGated` (`test/e2e/lifecycle_test.go`) detects this via
-  `exec.LookPath("runsc")` and **`t.Skip`s** — it is environment-gated, not
-  stubbed out, and no trust boundary is weakened to make it pass.
+- macOS has no `runsc`. Two environment-gated tests cover the real path and
+  `t.Skip` cleanly where gVisor is absent — neither weakens a trust boundary to
+  pass:
+  - `TestRunscRealLaunch` (`internal/host/isolation`) does an **actual `runsc
+    run`** of a hardened bundle: it stages a tiny static probe as `/sandbox` in a
+    from-scratch rootfs, launches it through the production `RunscIsolator.Launch`
+    path, and asserts from inside the live sandbox that the inbound queue is
+    read-only, the outbound queue is writable, and `network=none` holds (no
+    non-loopback interfaces). Opt in on a gVisor host with
+    `IRONCLAW_RUNSC_INTEGRATION=1 go test -run TestRunscRealLaunch ./internal/host/isolation`
+    (point at an alternate runtime with `IRONCLAW_RUNSC_BIN`).
+  - `TestFullLifecycleRunscGated` (`test/e2e/lifecycle_test.go`) detects `runsc`
+    via `exec.LookPath` and checks the real isolator constructs and the hardened
+    spec builds for the runsc path.
+
+  On the normal install-and-run flow, pass `--sandbox-provisioner=containerd`
+  with a pinned `--sandbox-image-digest sha256:<hex>` so the control plane pulls
+  and unpacks `--sandbox-image` host-side (via `ctr`) and refuses any image whose
+  resolved digest does not match the pin. `containerd` without a digest pin is a
+  fatal misconfiguration (fail closed). `--sandbox-provisioner=none` (the
+  default) requires the operator to pre-stage each session's rootfs under
+  `--bundle-root/<session>/rootfs`; `Launch` fails closed (`ErrRootfsMissing`)
+  rather than launch an empty rootfs.
 - The isolation unit tests (`internal/host/isolation`, `internal/host/mcp`)
   verify OCI-spec construction and the hardened spec (`network=none`, RO mounts,
   seccomp, model-proxy socket) without needing a live `runsc`, so they run and

--- a/internal/host/isolation/runsc_integration_test.go
+++ b/internal/host/isolation/runsc_integration_test.go
@@ -1,0 +1,190 @@
+// Real-launch integration test for the runsc/gVisor isolator.
+//
+// This is the env-gated test the R3 acceptance calls for: it exercises an
+// ACTUAL `runsc run` of a hardened bundle and asserts the trust boundary from
+// inside a live sandbox — least-privilege queue mounts (inbound read-only,
+// outbound read-write) and network=none. It is deliberately NOT part of the
+// normal `go test` run because most CI hosts (and all macOS dev machines) lack
+// gVisor; it only executes when explicitly opted in:
+//
+//	IRONCLAW_RUNSC_INTEGRATION=1 go test -run TestRunscRealLaunch ./internal/host/isolation
+//
+// Optionally point at a specific runtime binary with IRONCLAW_RUNSC_BIN
+// (defaults to "runsc" on PATH). The test builds a tiny static probe binary at
+// /sandbox in a from-scratch rootfs, launches it through the production
+// RunscIsolator.Launch path, and reads back what the sandbox observed via the
+// read-write outbound mount.
+
+package isolation
+
+import (
+	"context"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// probeSource is the in-sandbox program staged as /sandbox. It records what the
+// sandbox can see about its own boundary and writes the verdict to the
+// read-write outbound mount (the host reads it back after the container exits):
+//   - inbound_ro: opening the inbound queue for WRITE must fail (it is bound ro).
+//   - nonloop_ifaces: count of non-loopback interfaces with addresses; under
+//     network=none this must be zero.
+//
+// It is pure stdlib and built static (CGO_ENABLED=0) so it runs in a rootfs that
+// contains nothing but this one binary.
+const probeSource = `package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+func main() {
+	inboundRO := false
+	if f, err := os.OpenFile("/queue/inbound.db", os.O_WRONLY, 0); err != nil {
+		inboundRO = true // good: cannot open the read-only inbound mount for write
+	} else {
+		f.Close()
+	}
+
+	nonLoop := 0
+	if ifaces, err := net.Interfaces(); err == nil {
+		for _, ifi := range ifaces {
+			if ifi.Flags&net.FlagLoopback != 0 {
+				continue
+			}
+			if addrs, _ := ifi.Addrs(); len(addrs) > 0 {
+				nonLoop++
+			}
+		}
+	}
+
+	out := fmt.Sprintf("PROBE inbound_ro=%v nonloop_ifaces=%d\n", inboundRO, nonLoop)
+	if err := os.WriteFile("/queue/outbound.db", []byte(out), 0o600); err != nil {
+		os.Exit(3) // could not write the read-write outbound mount
+	}
+}
+`
+
+func TestRunscRealLaunch(t *testing.T) {
+	if os.Getenv("IRONCLAW_RUNSC_INTEGRATION") != "1" {
+		t.Skip("set IRONCLAW_RUNSC_INTEGRATION=1 to run the real runsc/gVisor launch test")
+	}
+
+	runtimeBin := os.Getenv("IRONCLAW_RUNSC_BIN")
+	if runtimeBin == "" {
+		runtimeBin = DefaultRuntimeBinary
+	}
+	if _, err := exec.LookPath(runtimeBin); err != nil {
+		t.Skipf("runtime %q not found on PATH — install gVisor or set IRONCLAW_RUNSC_BIN: %v", runtimeBin, err)
+	}
+
+	root := t.TempDir()
+	bundleRoot := filepath.Join(root, "bundles")
+
+	// Host-side mount sources. The inbound/outbound queue files stand in for the
+	// real encrypted SQLite queues; the probe only needs them to exist so the
+	// bind mounts resolve, then checks the read-only vs read-write distinction.
+	hostDir := filepath.Join(root, "host")
+	if err := os.MkdirAll(hostDir, 0o700); err != nil {
+		t.Fatalf("mkdir host dir: %v", err)
+	}
+	inboundPath := filepath.Join(hostDir, "inbound.db")
+	outboundPath := filepath.Join(hostDir, "outbound.db")
+	if err := os.WriteFile(inboundPath, []byte("inbound"), 0o600); err != nil {
+		t.Fatalf("seed inbound: %v", err)
+	}
+	if err := os.WriteFile(outboundPath, nil, 0o600); err != nil {
+		t.Fatalf("seed outbound: %v", err)
+	}
+
+	// A real unix socket for the model-proxy bind mount. The probe does not
+	// connect to it; it only needs to exist so the OCI bind resolves.
+	sockPath := filepath.Join(hostDir, "modelproxy.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen model-proxy socket: %v", err)
+	}
+	defer ln.Close()
+
+	const sessionID = "ses_runsc_integration"
+
+	// Pre-stage the rootfs: build the static probe as /sandbox and create the
+	// bind-mount target dirs the OCI spec expects. We use the no-provisioner
+	// path so the test stays self-contained (no containerd dependency); the
+	// provisioner seam is covered by the provisioner unit tests.
+	rootfs := filepath.Join(bundleRoot, sessionID, "rootfs")
+	for _, d := range []string{rootfs, filepath.Join(rootfs, "queue"), filepath.Join(rootfs, "workspace"), filepath.Join(rootfs, "run", "ironclaw")} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir rootfs dir %s: %v", d, err)
+		}
+	}
+	buildProbe(t, filepath.Join(rootfs, "sandbox"))
+
+	iso := NewRunsc(WithRuntimeBinary(runtimeBin), WithBundleRoot(bundleRoot))
+	spec := HardenedSpec(sessionID, "ironclaw-sandbox:integration", inboundPath, outboundPath, sockPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	handle, err := iso.Launch(ctx, spec)
+	if err != nil {
+		t.Fatalf("Launch under %q: %v", runtimeBin, err)
+	}
+	t.Cleanup(func() { _ = handle.Stop(context.Background()) })
+
+	// Wait for the init process (the probe) to exit. `runsc run` reaps the
+	// container when init exits, so Alive flips to false.
+	deadline := time.Now().Add(45 * time.Second)
+	for handle.Alive(ctx) {
+		if time.Now().After(deadline) {
+			t.Fatalf("sandbox did not exit within deadline")
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	data, err := os.ReadFile(outboundPath)
+	if err != nil {
+		t.Fatalf("read outbound mount back: %v", err)
+	}
+	got := strings.TrimSpace(string(data))
+	if got == "" {
+		t.Fatalf("probe wrote nothing to the read-write outbound mount — sandbox did not run or could not write outbound")
+	}
+	t.Logf("sandbox probe verdict: %q", got)
+
+	if !strings.Contains(got, "inbound_ro=true") {
+		t.Errorf("inbound queue was NOT read-only inside the sandbox: %q", got)
+	}
+	if !strings.Contains(got, "nonloop_ifaces=0") {
+		t.Errorf("sandbox saw non-loopback network interfaces (network=none violated): %q", got)
+	}
+}
+
+// buildProbe compiles probeSource into a static linux binary at outPath.
+func buildProbe(t *testing.T, outPath string) {
+	t.Helper()
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "main.go")
+	if err := os.WriteFile(srcFile, []byte(probeSource), 0o600); err != nil {
+		t.Fatalf("write probe source: %v", err)
+	}
+	cmd := exec.Command("go", "build", "-o", outPath, srcFile)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=linux")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build probe: %v\n%s", err, out)
+	}
+	if err := os.Chmod(outPath, 0o755); err != nil {
+		t.Fatalf("chmod probe: %v", err)
+	}
+	// Sanity: the probe must be a real file the runtime can exec.
+	if fi, err := os.Stat(outPath); err != nil || fi.Size() == 0 {
+		t.Fatalf("probe binary missing or empty at %s (err=%v)", outPath, err)
+	}
+}

--- a/test/e2e/lifecycle_test.go
+++ b/test/e2e/lifecycle_test.go
@@ -208,9 +208,11 @@ func TestFullLifecycle(t *testing.T) {
 }
 
 // TestFullLifecycleRunscGated exercises the real isolation spec path when runsc
-// is installed; it is skipped in environments without runsc (e.g. CI). A full
-// real launch additionally needs a provisioned rootfs image, which a hermetic
-// test does not build — the end-to-end message flow is covered by the
+// is installed; it is skipped in environments without runsc (e.g. CI). It checks
+// that the real isolator constructs and the hardened spec builds for the runsc
+// path. An ACTUAL `runsc run` of a hardened bundle (which additionally needs a
+// rootfs) is covered by TestRunscRealLaunch in internal/host/isolation, gated by
+// IRONCLAW_RUNSC_INTEGRATION=1; the end-to-end message flow is covered by the
 // fake-Isolator test above.
 func TestFullLifecycleRunscGated(t *testing.T) {
 	if _, err := exec.LookPath("runsc"); err != nil {


### PR DESCRIPTION
## R3 — Real runsc/gVisor sandbox launch (IRO-4)

Security-approved by the CEO (board approval `fb94a8b6`). Isolated onto R1's foundation (`forge/iro-2-setup`) so this PR is a **pure R3 diff** — it is not entangled with the sibling R4/R5 work that accumulated on the shared dev branch.

### What this closes
R1 already shipped the isolator, OCI hardening, and a `ContainerdProvisioner`/`TrustPolicy`. Two gaps remained:

1. **Production wiring** — `cmd/controlplane` built `NewRunsc` with no provisioner and no trust policy, so the normal install-and-run flow could not provision a trust-verified image. Adds `--sandbox-provisioner` (`none`|`containerd`) and `--sandbox-image-digest`. `containerd` attaches `ContainerdProvisioner` + `PinnedDigestPolicy` and is **fail-closed** (no pinned digest → process exits non-zero). `none` keeps the pre-staged-rootfs path (`ErrRootfsMissing` on empty rootfs).
2. **Real-launch integration test** — `TestRunscRealLaunch` stages a static probe as `/sandbox` in a from-scratch rootfs, launches it through `RunscIsolator.Launch`, and asserts from inside the live sandbox: inbound **read-only**, outbound **read-write**, `network=none` (no non-loopback interfaces). Env-gated by `IRONCLAW_RUNSC_INTEGRATION=1`; skips where gVisor is absent.

Docs (`docs/SETUP.md`) and the `TestFullLifecycleRunscGated` comment updated.

### Verification
- `CGO_ENABLED=1 go build ./...` — green
- `CGO_ENABLED=1 go test ./internal/host/isolation ./test/e2e ./cmd/controlplane` — 78 pass
- `gofmt` clean; `GOOS=linux go vet ./internal/host/isolation` clean
- `TestRunscRealLaunch` skips cleanly when not opted in
- Reviewer, on a gVisor host: `IRONCLAW_RUNSC_INTEGRATION=1 go test -run TestRunscRealLaunch ./internal/host/isolation`

### Files
- `cmd/controlplane/main.go`
- `internal/host/isolation/runsc_integration_test.go` (new)
- `test/e2e/lifecycle_test.go` (comment)
- `docs/SETUP.md`

Acceptance gate "hand to CEO for security review before merge" is satisfied (approved).