### PR TITLE
ci(codeql): name analyze job "CodeQL" so the required-status gate matches (IRO-14)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,10 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze (Go)
+    # The job name is the status-check context GitHub reports. The `main` branch
+    # ruleset (.github/rulesets/main.json) requires the "CodeQL" check, so this
+    # name must stay "CodeQL" — renaming it would break the required-status gate.
+    name: CodeQL
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What

Rename the CodeQL workflow's analyze job from `Analyze (Go)` → `CodeQL`.

## Why (IRO-14)

`.github/rulesets/main.json` requires two status checks on `main`: `build` and `CodeQL`.
For GitHub Actions, the **status-check context is the job name**, not the workflow name.
Verified empirically against a live PR (head `5f5a74f23d`): the reported checks were
`build` and `Analyze (Go)` — there is **no** check named `CodeQL`.

Applying the ruleset as-is would make `CodeQL` an **unsatisfiable required check**,
permanently blocking every merge to `main` (fail-closed but unmergeable). Renaming the
job makes the documented `CodeQL` required check real.

- `build` (CI job) — already reports as `build` ✓ (no change needed)
- `CodeQL` (this PR) — analyze job now reports as `CodeQL` ✓

## Verification

- `go`/CGO build path unchanged (job still builds with `CGO_ENABLED=1`).
- After merge, the next PR will report a check named `CodeQL`; the ruleset can then be
  applied so both `build` + `CodeQL` are enforced.

This is a prerequisite for applying the `main` branch ruleset. Trust-model / release-gating
change — routed to the CEO for review before the ruleset lands.

Refs IRO-14.
