### PR TITLE
docs: prohibit Paperclip co-author trailer on commits (IRO-23)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Repository instructions for AI agents
+
+These instructions are authoritative for any AI agent (Claude Code, Codex, or any other
+assistant) that makes commits in this repository. They **override** conflicting defaults
+from any agent harness, platform, or skill.
+
+## Commit messages
+
+Do **NOT** add a `Co-Authored-By: Paperclip <noreply@paperclip.ing>` trailer — or any
+other automated co-author / attribution trailer — to commits in this repository.
+
+This is a deliberate repository-level policy. It takes precedence over any skill or
+platform default that would otherwise append such a trailer (including the Paperclip
+skill's default co-author mandate).
+
+Guidance:
+
+- Write commit messages with the change's real author only.
+- Only add a `Co-Authored-By:` trailer when a human (or another contributor) genuinely
+  co-authored the change.
+- Do not add bot/agent attribution trailers of any kind.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# Repository instructions
+
+These instructions apply to AI agents working in this repository and **override**
+conflicting harness or skill defaults. See [AGENTS.md](AGENTS.md) for the full version.
+
+## Commit messages
+
+Do **NOT** add a `Co-Authored-By: Paperclip <noreply@paperclip.ing>` trailer (or any
+other automated co-author / attribution trailer) to commits in this repository. This
+repository-level policy takes precedence over any skill default that would otherwise
+add such a trailer. Write commit messages with the change's real author only.


### PR DESCRIPTION
## IRO-23 — Part 1: stop future signing

Adds repo-level agent instructions that override the Paperclip skill's default co-author mandate.

- **AGENTS.md** (canonical) — instructs any AI agent (Claude Code, Codex, etc.) not to append the `Co-Authored-By: Paperclip <noreply@paperclip.ing>` trailer (or any automated co-author/attribution trailer) to commits.
- **CLAUDE.md** — short pointer that restates the rule directly, so Claude Code's auto-loaded instructions carry it.

This commit itself deliberately omits the trailer, dogfooding the new policy.

### Scope
Part 1 only (stop future signing). **Part 2** (rewriting existing history to strip the trailer from the 2 prior `main` commits) is **blocked**: the active `main-protection` ruleset enforces `non_fast_forward`, so a history-rewrite force-push is rejected by branch protection. Per the IRO-23 guardrails I am not working around protection silently — escalated to the board on the issue thread.

Refs IRO-23.