### PR TITLE
docs(site): MkDocs Material docs site + GitHub Pages publish (IRO-28)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,75 @@
+# Build the MkDocs (Material) documentation site and publish it to GitHub Pages.
+#
+# - On pull requests: build only (with --strict), as a CI gate. No deploy.
+# - On push to main: build + deploy to GitHub Pages.
+#
+# Least-privilege: the default token is read-only; only the deploy job is granted
+# the pages/id-token scopes the GitHub Pages OIDC deployment needs.
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "api/openapi.yaml"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "api/openapi.yaml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never run two Pages deploys at once; let a newer push supersede an in-flight one.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # hooks.py derives the version from `git rev-list --count HEAD`.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs toolchain (pinned)
+        run: pip install -r docs/requirements.txt
+
+      - name: Build site (strict)
+        run: mkdocs build --strict --site-dir _site
+
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    # Publish only the main branch; PRs validate the build above but never deploy.
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ Thumbs.db
 # Local agent / session state — never commit
 .claude/
 .remember/
+
+# Docs site build artifacts (MkDocs)
+/site/
+_site/
+docs/reference/openapi.yaml
+__pycache__/

--- a/docs/building.md
+++ b/docs/building.md
@@ -69,8 +69,8 @@ ironctl change reject  <id> --by slack:admin
 ironctl --addr http://<tailnet-ip>:8787 change pending
 ```
 
-See [../api/control-plane.md](../api/control-plane.md) for the HTTP API and
-[../deploy/README.md](../deploy/README.md) for the gVisor + Tailscale deployment.
+See the [API reference](reference/api.md) for the HTTP API and
+[../deploy/README.md](https://github.com/IronSecCo/ironclaw/blob/main/deploy/README.md) for the gVisor + Tailscale deployment.
 
 ## What stays gated
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,7 +1,7 @@
 # Channel adapters & their credentials
 
 IronClaw delivers an agent's replies through **channel adapters** in
-[`internal/host/channels/`](../internal/host/channels). Each adapter implements a
+[`internal/host/channels/`](https://github.com/IronSecCo/ironclaw/tree/main/internal/host/channels). Each adapter implements a
 tiny interface (`Name()` + `Deliver()`) and talks to one platform. This page is the
 single reference for **what each adapter needs to be configured**.
 
@@ -38,7 +38,7 @@ Two things to know up front:
 ## Configuring an auto-registered adapter
 
 Set the variable in the control-plane's environment (or in `.env` when running with
-[Docker Compose](site/self-hosting/docker)), then start the daemon:
+[Docker Compose](https://github.com/IronSecCo/ironclaw/blob/main/docker-compose.yml)), then start the daemon:
 
 ```sh
 export DISCORD_BOT_TOKEN=...      # registers the Discord adapter on boot
@@ -46,8 +46,8 @@ export DISCORD_BOT_TOKEN=...      # registers the Discord adapter on boot
 ```
 
 Then wire it to an agent group with the registry — see
-[`examples/`](../examples) for runnable templates and the
-[CLI reference](site/reference/cli) for `ironctl registry`.
+[`examples/`](https://github.com/IronSecCo/ironclaw/tree/main/examples) for runnable templates and the
+[CLI reference](https://github.com/IronSecCo/ironclaw/blob/main/README.md) for `ironctl registry`.
 
 ## Adding a new adapter
 

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,0 +1,61 @@
+"""MkDocs build hooks for the IronClaw docs site.
+
+Two jobs, both reproducible and run identically in local builds and in CI:
+
+1. Copy the canonical OpenAPI spec (``api/openapi.yaml``, the single source of
+   truth) into ``docs/reference/openapi.yaml`` so the API reference page renders
+   a same-origin, vendored copy — no committed duplicate, no runtime fetch from
+   an external host.
+2. Stamp the site with the release version derived the same way the release
+   pipeline derives it (``v0.1.<commit-count>``), so every published site is
+   tied to the source commit it was built from. CI passes the version via
+   ``IRONCLAW_DOCS_VERSION``; locally we fall back to ``git rev-list --count``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+# repo_root/docs/hooks.py -> repo_root
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BASE_VERSION = "0.1"
+
+
+def _derive_version() -> str:
+    env = os.environ.get("IRONCLAW_DOCS_VERSION")
+    if env:
+        return env if env.startswith("v") else f"v{env}"
+    try:
+        count = subprocess.check_output(
+            ["git", "rev-list", "--count", "HEAD"],
+            cwd=REPO_ROOT,
+            stderr=subprocess.DEVNULL,
+        ).decode().strip()
+        return f"v{BASE_VERSION}.{count}"
+    except Exception:
+        return f"v{BASE_VERSION}.dev"
+
+
+def on_config(config, **kwargs):
+    version = _derive_version()
+    # Surfaced in the footer copyright and available to templates via extra.version.
+    config.setdefault("extra", {})
+    config["extra"]["version"] = version
+    base = config.get("copyright") or ""
+    sep = " · " if base else ""
+    config["copyright"] = f"{base}{sep}Docs built from {version}"
+    return config
+
+
+def on_pre_build(config, **kwargs):
+    src = REPO_ROOT / "api" / "openapi.yaml"
+    dst = REPO_ROOT / "docs" / "reference" / "openapi.yaml"
+    if not src.exists():
+        raise FileNotFoundError(
+            f"OpenAPI spec not found at {src}; the API reference page cannot render."
+        )
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,61 @@
+---
+title: IronClaw
+description: Security-first, self-hosted AI agents — isolation you can prove, not just claim.
+---
+
+# IronClaw
+
+**Security-hardened, self-hosted AI agents — isolation you can prove, not just claim.**
+
+IronClaw runs autonomous agents the way a security team would want them run: every
+agent lives in a per-session **sandbox**, every capability change passes through a
+deterministic **human-approval gateway**, and every action lands in an append-only
+**audit log**. There is no path that bypasses the gateway.
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch: **[Quickstart](quickstart.md)**
+
+    From a clean clone to submitting, approving, and auditing your first agent
+    action — in about five minutes, on your machine.
+
+-   :material-shield-lock: **[Security & trust](security.md)**
+
+    The trust story: the threat model, the sealed-runtime invariants, and how a
+    user verifies what they install.
+
+-   :material-sitemap: **[Architecture](architecture.md)**
+
+    The control-plane / sandbox split, the frozen contract between them, and the
+    encrypted queues they speak over.
+
+-   :material-api: **[API reference](reference/api.md)**
+
+    The control-plane HTTP API (OpenAPI 3.1) consumed by `ironctl` and the web
+    console.
+
+</div>
+
+## What makes IronClaw different
+
+- **Assume the agent is hostile.** The [threat model](threat-model.md) treats the
+  agent inside the sandbox as potentially compromised — by prompt injection, a
+  poisoned tool result, or a hostile model output — and designs the blast radius
+  around that assumption.
+- **Every mutation is gated.** Persona, enabled tools, packages, wiring,
+  permissions, and mounts are *held* at the gateway until a human approves them.
+  See the [Quickstart](quickstart.md) for a hands-on demonstration.
+- **Verifiable supply chain.** Every release is checksummed, keyless-signed
+  (cosign), and carries build-provenance attestations. See the
+  [Release runbook](release-runbook.md) for how to verify a download.
+
+## Where to go next
+
+| If you want to… | Read |
+| --- | --- |
+| Run IronClaw locally | [Quickstart](quickstart.md) |
+| Understand the design | [IronClaw, Explained](ironclaw-explained.md) → [Architecture](architecture.md) |
+| Evaluate the security posture | [Security & trust](security.md) → [Threat model](threat-model.md) |
+| Wire an agent to Slack / Discord / … | [Channel adapters](channels.md) |
+| Extend an agent with curated capabilities | [Skills](skills.md) |
+| Drive the control-plane API | [API reference](reference/api.md) |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -110,7 +110,7 @@ sandboxes.
 ## Next steps
 
 - **Run it for real:** install the prebuilt binaries and a systemd/launchd service — see the
-  [Deployment](../README.md#deployment) section of the README and [`deploy/install.sh`](../deploy/install.sh).
+  [Deployment](https://github.com/IronSecCo/ironclaw/blob/main/README.md#deployment) section of the README and [`deploy/install.sh`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/install.sh).
   Production sandboxing needs **containerd + gVisor (`runsc`)**.
 - **Wire a channel:** connect an agent group to Slack / Discord / Telegram via the registry
   (`ironctl registry ...`).

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,28 @@
+# API reference
+
+The control-plane exposes a small HTTP API consumed by `ironctl` and the web
+console. It is the machine-readable contract for `ironclaw-controlplane`, kept in
+lockstep with `internal/host/api` and the frozen wire types in
+`internal/contract`.
+
+!!! info "No public port"
+    The API binds **only** to the private mesh (Tailscale) interface — it has no
+    public port. Network reachability is the primary access control; the optional
+    bearer token is defense-in-depth on top of it. See
+    [Security & trust](../security.md).
+
+The route family is `/v1`. The three surfaces are:
+
+- **Gateway** (`/v1/changes`, `/v1/audit`) — submit capability changes, list what
+  is pending, record human approve/reject decisions, and read the append-only
+  audit log.
+- **Registry** — administer agent groups, personas, tools, and wiring.
+- **Health / version** — liveness and the running build version.
+
+The full specification is below, rendered from the canonical
+[`api/openapi.yaml`](https://github.com/IronSecCo/ironclaw/blob/main/api/openapi.yaml)
+(OpenAPI 3.1). The spec is the source of truth; this page renders it.
+
+<!-- The OpenAPI spec is copied into the build by docs/hooks.py (single source of
+     truth: api/openapi.yaml) and rendered below. -->
+!!swagger openapi.yaml!!

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -13,7 +13,7 @@ separately and the runbook is updated when it merges.
 > release. Every published set is checksummed, the checksum file is signed keylessly
 > with cosign, and every archive carries a build-provenance attestation tied to the
 > source commit and workflow. Never weaken or skip signing, checksums, or attestation
-> to make a build go green — yank a bad release instead (see [Yanking a release](#yanking-a-release)).
+> to make a build go green — yank a bad release instead (see [Yanking a release](#6-yanking-a-release)).
 
 ---
 
@@ -43,7 +43,7 @@ version ──> build (5-target matrix) ──> release ──> [smoke]
   is published only if every matrix target built** — no partial release sets.
 - All post-publish steps (SBOM, cosign signature, attestation) run **after** the binaries
   and checksums are uploaded, so a Sigstore/tooling hiccup cannot block the artifacts from
-  shipping. See [Partial-failure semantics](#5-partial-failure-semantics) — this is the one
+  shipping. See [Partial-failure semantics](#5-partial-failure-semantics-operator-decision) — this is the one
   case that needs an operator decision.
 
 ---
@@ -136,7 +136,7 @@ Attached to the GitHub Release for tag `<tag>` (version `<ver>` = tag without th
 - `ironclaw_<ver>.spdx.json` + `ironclaw_<ver>.cdx.json` — SBOMs (syft, SPDX + CycloneDX).
 - Build-provenance attestations for each archive (queryable via `gh attestation verify`).
 
-### 3.5 Post-release verification gate (smoke — in flight, [IRO-15](/IRO/issues/IRO-15))
+### 3.5 Post-release verification gate (smoke — in flight, IRO-15)
 
 A `smoke` job installs the freshly-cut release through the real, checksum-verifying
 `scripts/install.sh` (the normal user path, **not** `--dev`) on `linux/amd64`, `linux/arm64`,
@@ -144,7 +144,7 @@ A `smoke` job installs the freshly-cut release through the real, checksum-verify
 `ironctl version` reports the exact tag. It is **fail-closed**: a failure turns the whole
 Release run red, which also blocks the Image workflow (it chains on Release `success`). A red
 smoke run on an already-published release is the signal to **yank** (the assets are out by
-that point). This gate lands with [IRO-15](/IRO/issues/IRO-15).
+that point). This gate lands with IRO-15.
 
 ---
 
@@ -273,7 +273,7 @@ banners so the one-liner install path is advertised again.
 `main` is intended to be protected by enforced required checks. The spec lives at
 `.github/rulesets/main.json` (`build` + `CodeQL` required, linear history, signed commits,
 no force-push/deletion). Applying that file as an *active* GitHub ruleset is tracked
-separately ([IRO-14](/IRO/issues/IRO-14)); ratcheting protection **up** (more enforced checks)
+separately (IRO-14); ratcheting protection **up** (more enforced checks)
 is the default direction. Never relax or disable a required check to unblock a merge — fix the
 check on its own ticket instead.
 
@@ -311,6 +311,6 @@ gh attestation verify ironclaw_<ver>_<os>_<arch>.tar.gz --repo IronSecCo/ironcla
 
 ---
 
-*Related tickets:* pipeline handoff [IRO-12](/IRO/issues/IRO-12); this runbook
-[IRO-16](/IRO/issues/IRO-16); arm64 image [IRO-13](/IRO/issues/IRO-13); ruleset enforcement
-[IRO-14](/IRO/issues/IRO-14); release smoke test [IRO-15](/IRO/issues/IRO-15).
+*Related tickets:* pipeline handoff IRO-12; this runbook
+IRO-16; arm64 image IRO-13; ruleset enforcement
+IRO-14; release smoke test IRO-15.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+# Pinned toolchain for the IronClaw docs site (MkDocs Material).
+# Reproducibility: the published site must be re-derivable from a known commit,
+# so these are exact pins. Bump deliberately, not implicitly.
+mkdocs==1.6.1
+mkdocs-material==9.5.39
+mkdocs-render-swagger-plugin==0.1.2

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,71 @@
+# Security & trust
+
+IronClaw's value is not "AI agents" — it is **AI agents you can run without
+trusting them**. This page is the map of that trust story: what IronClaw defends
+against, the invariants that make the defense hold, and how *you* verify what you
+install.
+
+## Start here
+
+<div class="grid cards" markdown>
+
+-   :material-shield-bug: **[Threat model](threat-model.md)**
+
+    The assumption that drives every design decision: the agent inside the
+    sandbox is *potentially compromised*. What that means for the blast radius,
+    and — in §8 — what counts as a vulnerability.
+
+-   :material-lock-check: **[Verify a release](release-runbook.md#4-how-to-verify-a-release-user-facing)**
+
+    Every release is checksummed, keyless-signed with cosign, and carries
+    build-provenance attestations. Here is how to check all three before you
+    trust a download.
+
+</div>
+
+## The invariants
+
+IronClaw's hardening rests on a small set of invariants that hold regardless of
+what the agent does:
+
+- **Sealed runtime.** The sandbox has no interpreter, no in-sandbox package
+  install, and no rootfs mutation. An agent can only invoke capabilities the
+  binary already compiled in. This is why [skills](skills.md) and
+  [MCP servers](mcp.md) grant capabilities through configuration, never code.
+- **Deterministic approval gateway.** Every mutation — persona, enabled tools,
+  packages, wiring, permissions, mounts, `create_agent` — is *held* at the
+  gateway until a human approves it. There is no bypass path. The
+  [Quickstart](quickstart.md) makes this choke point concrete in two commands.
+- **No public surface.** The control-plane API binds only to the private mesh
+  (Tailscale) interface; network reachability is the primary control, and the
+  bearer token is defense-in-depth on top of it. See the
+  [API reference](reference/api.md).
+- **Network-isolated sandboxes.** Sandboxes run `network=none` by default;
+  outbound access is granted host-by-host through the egress broker, only as
+  part of an approved change.
+- **Append-only audit.** Every approve/reject decision and every gated action is
+  recorded. See [Architecture](architecture.md).
+
+## The supply chain is part of the promise
+
+A release a user cannot verify is not a secured release. IronClaw's published
+artifacts are:
+
+- **Reproducible** — re-derivable from a known commit, with no nondeterministic
+  inputs leaking into the build.
+- **Checksummed** — every archive is listed in `SHA256SUMS`; the installers
+  (`install.sh` / `install.ps1`) verify checksums *before* executing anything.
+- **Signed** — a keyless [cosign](https://github.com/sigstore/cosign) signature
+  over `SHA256SUMS` is the trust anchor.
+- **Attested** — build-provenance attestations tie every artifact back to its
+  source commit and the workflow that built it.
+
+The [Release runbook](release-runbook.md) is the operational reference for cutting,
+verifying, and yanking a release.
+
+## Reporting a vulnerability
+
+Disclosure policy lives in
+[SECURITY.md](https://github.com/IronSecCo/ironclaw/blob/main/SECURITY.md). The
+scope — what counts as a vulnerability — is defined in §8 of the
+[threat model](threat-model.md), which the disclosure policy points back to.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,80 @@
+# Skills
+
+A **skill** is a declarative, host-curated **capability bundle** — a persona
+fragment, an enabled subset of the *compiled* sandbox tools, a set of approved
+egress hosts, and read-only reference assets. A skill is **never executable code
+that runs in the sandbox**.
+
+This is the central design choice: installing a skill cannot introduce new code.
+It can only *compose capabilities the binary already implements*, and only through
+the gateway's human-approval flow. That preserves IronClaw's sealed-runtime
+pillar — no interpreter, no in-sandbox install, no rootfs mutation.
+
+> Source: [`internal/host/skills/`](https://github.com/IronSecCo/ironclaw/tree/main/internal/host/skills)
+> (`manifest.go` is the schema + loader, `install.go` maps an install to a
+> gateway `ChangeRequest`).
+
+## The manifest
+
+A skill is described by a `skill.yaml` manifest. The only schema version v1
+accepts is `ironclaw.dev/skill/v1`. The loader parses and validates it into a
+typed `Manifest`, **failing closed** on anything malformed or out of policy.
+
+```yaml
+apiVersion: ironclaw.dev/skill/v1
+name: web-research
+version: 1.2.0
+description: Curated web-research capability for an agent group.
+grants:
+  persona: |
+    You can research topics on the public web and cite your sources.
+  tools:
+    - web_search          # must be a tool the binary already compiles in
+    - http_get
+  egress:
+    - duckduckgo.com
+    - api.search.brave.com
+  assets:
+    - reference/search-operators.md   # read-only, mounted noexec
+signature: <provenance attestation over (manifest + asset tree)>
+```
+
+Every ingredient under `grants` maps to an existing gateway-governed mechanism:
+
+| Manifest field | What it grants | Enforced by |
+| --- | --- | --- |
+| `persona` | A persona fragment added to the agent group | Gateway change-approval |
+| `tools` | An enabled subset of the **already-compiled** sandbox tools | Tool allow-list |
+| `egress` | Approved outbound hosts | Egress broker (sandbox stays `network=none` by default) |
+| `assets` | Read-only reference files mounted at `/skills/<name>` | Mount is `nosuid,nodev,noexec` |
+
+There is deliberately **no** `command`, `script`, or `rootfs` field. An approved
+install can only ever touch configuration.
+
+## Signatures are recorded, not trusted
+
+The `signature` field is a provenance attestation over the manifest plus its asset
+tree. The loader **records** it but does not trust it — it is verified separately
+against a host-configured trust root. A malformed or unsigned manifest does not
+silently become trusted.
+
+## Installing a skill is a set of approvals
+
+Installing a skill is not a privileged side-channel. `install.go` turns a skill
+into a gateway `ChangeRequest` whose `After` payload (`SkillInstall`) is the exact,
+human-readable bundle the approver sees: which persona text, which tools, which
+egress hosts, and which read-only asset mount the skill wants — **and nothing
+else**.
+
+So a skill install flows through the same human-approval gateway as every other
+capability change (see the [Quickstart](quickstart.md) for the gateway in action),
+and lands in the same [audit log](architecture.md). One skill → one mount at
+`/skills/<name>`, enforced `noexec`.
+
+## Why this shape
+
+The reference design IronClaw was built to harden wired extensions with a *blind*
+approval surface — "approve this bundle" and it brings whatever it likes. IronClaw
+closes that gap the same way it closes it for [MCP servers](mcp.md): a human
+approves a **named** capability set, every grant is explicit and gated, and no part
+of a skill ever executes inside the sandbox.

--- a/docs/stylesheets/brand.css
+++ b/docs/stylesheets/brand.css
@@ -1,0 +1,19 @@
+/* IronClaw brand palette for MkDocs Material.
+   Primary orange #ff7a2e (matches the logo and the former Mintlify config). */
+:root {
+  --md-primary-fg-color:        #ff7a2e;
+  --md-primary-fg-color--light: #ff9a5c;
+  --md-primary-fg-color--dark:  #e85f12;
+  --md-accent-fg-color:         #ff7a2e;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color:        #ff7a2e;
+  --md-primary-fg-color--light: #ff9a5c;
+  --md-primary-fg-color--dark:  #e85f12;
+  --md-accent-fg-color:         #ff9a5c;
+  --md-typeset-a-color:         #ff9a5c;
+}
+
+/* Keep the header readable on the orange primary. */
+.md-header { color: #11161f; }

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,7 +1,7 @@
 # Threat model
 
-> Versioned with the code. Linked from the [README](../README.md) and
-> [SECURITY.md](../SECURITY.md). The scope in §8 ("what counts as a
+> Versioned with the code. Linked from the [README](https://github.com/IronSecCo/ironclaw/blob/main/README.md) and
+> [SECURITY.md](https://github.com/IronSecCo/ironclaw/blob/main/SECURITY.md). The scope in §8 ("what counts as a
 > vulnerability") is the reference the disclosure policy points back to.
 
 IronClaw assumes the agent inside the sandbox is **potentially compromised** — by
@@ -201,7 +201,7 @@ per-request audit, and bounded by keeping the sandbox itself network-less.
 
 ## 8. What counts as a vulnerability
 
-For disclosure (see [SECURITY.md](../SECURITY.md)), a finding **is** a vulnerability
+For disclosure (see [SECURITY.md](https://github.com/IronSecCo/ironclaw/blob/main/SECURITY.md)), a finding **is** a vulnerability
 if it lets the untrusted agent or an external sender cross a boundary above —
 concretely, if it allows any of:
 

--- a/docs/writing-a-channel-adapter.md
+++ b/docs/writing-a-channel-adapter.md
@@ -2,7 +2,7 @@
 
 A **channel adapter** delivers an agent's outbound messages to one platform (Slack,
 Discord, a webhook, …). They live in
-[`internal/host/channels/`](../internal/host/channels) and are deliberately small and
+[`internal/host/channels/`](https://github.com/IronSecCo/ironclaw/tree/main/internal/host/channels) and are deliberately small and
 uniform. This guide is the house pattern; the existing adapters
 (`slack.go`, `discord.go`, `whatsapp.go`, `matrix.go` are the cleanest templates) are
 your reference implementations.
@@ -100,7 +100,7 @@ func (a *FooAdapter) Name() string { return a.AdapterName }
 ## Registering it
 
 Adapters are activated in `registerChannelAdapters` in
-[`cmd/controlplane/main.go`](../cmd/controlplane/main.go). For a single-token adapter,
+[`cmd/controlplane/main.go`](https://github.com/IronSecCo/ironclaw/blob/main/cmd/controlplane/main.go). For a single-token adapter,
 add it to the env-gated `specs` slice:
 
 ```go

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,101 @@
+site_name: IronClaw
+site_description: Security-first, self-hosted AI agents — isolation you can prove, not just claim.
+site_url: https://ironsecco.github.io/ironclaw/
+repo_url: https://github.com/IronSecCo/ironclaw
+repo_name: IronSecCo/ironclaw
+edit_uri: edit/main/docs/
+copyright: "© IronSec Co. — AGPL-3.0 / commercial dual-licensed"
+
+docs_dir: docs
+
+# The Mintlify scaffold (docs/site/**, docs/docs.json) is a separate hosted-docs
+# experiment; it is not part of this MkDocs build.
+exclude_docs: |
+  site/
+  docs.json
+  reference/openapi.yaml
+
+# docs/hooks.py copies api/openapi.yaml into the build and stamps the version.
+hooks:
+  - docs/hooks.py
+
+theme:
+  name: material
+  language: en
+  logo: assets/logo.svg
+  favicon: assets/logo.svg
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - navigation.footer
+    - content.code.copy
+    - content.action.edit
+    - search.suggest
+    - search.highlight
+    - toc.follow
+
+extra_css:
+  - stylesheets/brand.css
+
+plugins:
+  - search
+  - render_swagger:
+      allow_arbitrary_locations: true
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - footnotes
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+nav:
+  - Home: index.md
+  - Get Started:
+      - Quickstart: quickstart.md
+      - Building from source: building.md
+  - Concepts:
+      - IronClaw, Explained: ironclaw-explained.md
+      - Architecture: architecture.md
+      - The frozen contract: contract.md
+      - MCP servers: mcp.md
+  - Channels:
+      - Channel adapters: channels.md
+      - Writing a channel adapter: writing-a-channel-adapter.md
+  - Skills: skills.md
+  - Security & Trust:
+      - Overview: security.md
+      - Threat model: threat-model.md
+  - Reference:
+      - API (OpenAPI): reference/api.md
+      - Release runbook: release-runbook.md
+      - Roadmap: roadmap.md


### PR DESCRIPTION
## What

Ships a real, static documentation site (**MkDocs Material**) sourced from the existing `docs/*.md`, published to **GitHub Pages via Actions** on push to `main`. Implements WS-B / IRO-28.

## Why MkDocs (not the existing Mintlify scaffold)

`docs/docs.json` + `docs/site/*.mdx` is a Mintlify scaffold — a hosted SaaS that deploys through Mintlify's dashboard, **not** GitHub Pages via Actions. The acceptance criteria require a static site that *builds in CI and publishes on push to main*. MkDocs consumes the existing Markdown natively (no MDX rewrite, no Node toolchain) and is trivial to publish + version. The Mintlify scaffold is left in place but excluded from this build.

## Information architecture (B3)

Home · Quickstart · Building · Concepts (Explained, Architecture, Contract, MCP) · Channels · **Skills** (new) · **Security & trust** (new — links the threat model + release verification prominently) · Reference (API/OpenAPI, Release runbook, Roadmap).

## Supply-chain notes

- **Reproducibility**: pinned MkDocs toolchain (`docs/requirements.txt`); `docs/hooks.py` stamps the site with the release-derived version `v0.1.<commit-count>` (same scheme as `release.yml`) and copies the canonical `api/openapi.yaml` into the build (single source of truth; no committed duplicate; same-origin Swagger UI).
- **Least-privilege CI**: default token is read-only; only the `deploy` job gets `pages: write` + `id-token: write` (OIDC). PRs build-only with `--strict`; deploy is `main`-only.
- Known follow-up: the Swagger UI *chrome* loads from `unpkg.com@5` (render-swagger plugin default) — fine for a docs site, but worth pinning/vendoring later.

## Verification

`mkdocs build --strict` exits 0 with **zero** link warnings. OpenAPI page renders the spec same-origin. Rewrote cross-repo / Mintlify-scaffold links to absolute GitHub/on-site targets and de-linked internal tracker refs so the public site has no dead/internal links.

Per repo policy (CLAUDE.md/AGENTS.md, IRO-23), commits carry **no** Paperclip co-author trailer.