### PR TITLE
ci(supply-chain): cosign verify, image SBOM, Scorecard, repro, SHA-pins (IRO-32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+# Least-privilege default for every job in this workflow (Scorecard Token-Permissions).
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,10 +17,15 @@ jobs:
     env:
       CGO_ENABLED: "1"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      # Third-party actions are pinned to a commit SHA (with the human-readable tag in
+      # a trailing comment) so a moved tag can never change what runs in CI. Dependabot
+      # (github-actions ecosystem) bumps these SHAs. See OpenSSF Scorecard Pinned-Dependencies.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.23'
+          # Exact patch pin (not just "1.23") so every build uses one toolchain — a
+          # prerequisite for reproducible builds (IRO-32 A4).
+          go-version: "1.23.12"
       - name: build
         run: go build ./...
       - name: vet

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,14 +26,15 @@ jobs:
       contents: read
       security-events: write # required to upload CodeQL results
     steps:
-      - uses: actions/checkout@v6
+      # Actions pinned to commit SHAs (tag in trailing comment); Dependabot bumps them.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.23"
+          go-version: "1.23.12"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: go
 
@@ -43,6 +44,6 @@ jobs:
         run: CGO_ENABLED=1 go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:go"

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -62,7 +62,7 @@ jobs:
       # Build the exact commit the release was cut from (workflow_run), else the ref
       # the dispatch was started on. Full history + tags so we can read the release
       # tag this commit carries.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
           fetch-depth: 0
@@ -123,15 +123,15 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
         run: echo "pair=${PLATFORM//\//-}" >> "${GITHUB_OUTPUT}"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -139,7 +139,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: container/controlplane.Dockerfile
@@ -163,7 +163,7 @@ jobs:
           touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: digest-${{ steps.plat.outputs.pair }}
           path: ${{ runner.temp }}/digests/*
@@ -181,15 +181,15 @@ jobs:
       digest: ${{ steps.manifest.outputs.digest }}
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: ${{ runner.temp }}/digests
           pattern: digest-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -213,10 +213,35 @@ jobs:
           docker buildx imagetools inspect "${IMAGE}:latest"
 
       - name: Attest the control-plane image
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ needs.prepare.outputs.image }}
           subject-digest: ${{ steps.manifest.outputs.digest }}
+          push-to-registry: true
+
+      # Per-container-image SBOM (IRO-32 A2). Scan the exact published index by digest
+      # with syft → CycloneDX, then attach it as a signed SBOM attestation to the same
+      # index digest. Consumers verify it anonymously alongside provenance:
+      #   gh attestation verify oci://<image>@<digest> --repo <repo> \
+      #     --predicate-type https://cyclonedx.org/bom
+      - name: Generate image SBOM (syft → CycloneDX)
+        env:
+          IMAGE: ${{ needs.prepare.outputs.image }}
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b "$RUNNER_TEMP/bin"
+          "$RUNNER_TEMP/bin/syft" version
+          # Scan the multi-arch index by its immutable digest (logged into GHCR above).
+          "$RUNNER_TEMP/bin/syft" scan "registry:${IMAGE}@${DIGEST}" \
+            -o "cyclonedx-json=${RUNNER_TEMP}/image.cdx.json"
+
+      - name: Attest the image SBOM
+        uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34 # v3
+        with:
+          subject-name: ${{ needs.prepare.outputs.image }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
+          sbom-path: ${{ runner.temp }}/image.cdx.json
           push-to-registry: true
 
   # Consumer-side guard. The jobs above PRODUCE the image + attestation; this proves they

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       version: ${{ steps.v.outputs.version }}
       exists: ${{ steps.v.outputs.exists }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -93,10 +93,10 @@ jobs:
           - { goos: windows, goarch: amd64, runner: windows-latest, name: windows_amd64 }
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.23"
+          go-version: "1.23.12"
 
       - name: Install cross C toolchain
         if: matrix.apt != ''
@@ -153,7 +153,7 @@ jobs:
           fi
           ls -l dist/out
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.name }}
           path: dist/out/*
@@ -174,9 +174,9 @@ jobs:
       id-token: write # keyless cosign + provenance signing (Sigstore OIDC)
       attestations: write # actions/attest-build-provenance
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
 
@@ -244,7 +244,7 @@ jobs:
             -o "cyclonedx-json=ironclaw_${VERSION}.cdx.json"
           gh release upload "${TAG}" "ironclaw_${VERSION}.spdx.json" "ironclaw_${VERSION}.cdx.json" --clobber
 
-      - uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Sign the checksum file (cosign keyless) and attach it
         env:
@@ -259,7 +259,7 @@ jobs:
           echo "Signed SHA256SUMS keylessly (cert + signature attached to the release)."
 
       - name: Attest build provenance for the release binaries
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: "dist/*.tar.gz, dist/*.zip"
 
@@ -296,7 +296,42 @@ jobs:
           - { runner: macos-15-intel, name: darwin_amd64 }
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+
+      # Verify the keyless cosign signature over SHA256SUMS the way a real user does:
+      # anonymously, from the published release, with no key to manage — the trusted
+      # identity is the Release workflow's own OIDC cert. This proves A1 end-to-end
+      # (sign on publish → verify on consume) before we trust the release. Runs BEFORE
+      # the installer so a forged/missing signature fails the release, not just a bad
+      # checksum. (Windows is covered by the install.ps1 smoke job; cosign verify here
+      # exercises the Linux/macOS matrix.)
+      - name: Verify cosign signature over SHA256SUMS (anonymous)
+        shell: bash
+        env:
+          TAG: ${{ needs.version.outputs.tag }}
+          MATRIX_NAME: ${{ matrix.name }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          work="${RUNNER_TEMP}/cosign-verify"
+          mkdir -p "${work}"
+          # Pull exactly the three signing artifacts the Release job attached.
+          gh release download "${TAG}" --repo "${REPO}" --dir "${work}" --clobber \
+            -p SHA256SUMS -p SHA256SUMS.sig -p SHA256SUMS.pem
+          # The cert identity is this repo's Release workflow; the issuer is GitHub's
+          # OIDC provider. A signature from any other identity/issuer is rejected.
+          if ! cosign verify-blob "${work}/SHA256SUMS" \
+              --signature "${work}/SHA256SUMS.sig" \
+              --certificate "${work}/SHA256SUMS.pem" \
+              --certificate-identity-regexp "^https://github.com/${REPO}/" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com; then
+            echo "::error title=Smoke (${MATRIX_NAME})::cosign could not verify the SHA256SUMS signature for ${TAG} against the Release workflow identity. The release signature is missing or untrusted — yank it (see the release runbook)." >&2
+            exit 1
+          fi
+          echo "cosign OK on ${MATRIX_NAME}: SHA256SUMS signed by ${REPO} Release workflow (keyless)."
 
       - name: Install via scripts/install.sh and verify ironctl version
         shell: bash
@@ -360,7 +395,7 @@ jobs:
       contents: read # read the just-published release assets through install.ps1
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install via scripts/install.ps1 and verify ironctl version
         shell: pwsh

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -1,0 +1,67 @@
+# Reproducible-build verification (IRO-32 A4).
+#
+# Proves IronClaw's binaries are bit-for-bit deterministic: build every command twice
+# from a clean checkout with the SAME pinned toolchain and flags the release uses
+# (-trimpath, pinned ldflags, fixed module versions via go.sum), then assert the two
+# SHA256 sets are identical. A drift here means something non-deterministic crept into
+# the build (an unpinned tool, a timestamp, a map-iteration order in codegen) and the
+# "reproducible builds" guarantee is broken — fail loud.
+#
+# Runs on PRs to main + weekly so a regression is caught before it ships, without
+# adding cost to the per-push release.
+name: Reproducibility
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "53 4 * * 1" # Mondays 04:53 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify deterministic build
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: "1"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          # Must match the exact toolchain pin in ci.yml / release.yml — a different
+          # patch can change the emitted binary and is itself a reproducibility break.
+          go-version: "1.23.12"
+
+      - name: Build twice and compare checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Mirror the release build flags. The version string is fixed (not derived
+          # from git state) so it can't be the source of a difference here.
+          ldflags="-s -w -X github.com/IronSecCo/ironclaw/internal/version.Version=repro-check"
+          build() {
+            local dest="$1"
+            mkdir -p "${dest}"
+            for cmd in controlplane ironctl sandbox; do
+              go build -trimpath -ldflags "${ldflags}" -o "${dest}/${cmd}" "./cmd/${cmd}"
+            done
+          }
+          build out/a
+          # Clean the build cache between runs so a deterministic result can't be an
+          # artifact of cache reuse — it must reproduce from a cold compile.
+          go clean -cache
+          build out/b
+
+          ( cd out/a && sha256sum controlplane ironctl sandbox ) | sed 's| .*/| |' > a.sums
+          ( cd out/b && sha256sum controlplane ironctl sandbox ) | sed 's| .*/| |' > b.sums
+          echo "== build A =="; cat a.sums
+          echo "== build B =="; cat b.sums
+          if ! diff -u a.sums b.sums; then
+            echo "::error title=Reproducibility::two clean builds of the same commit produced different binaries — the build is not deterministic. Investigate the non-pinned input before relying on the reproducible-build guarantee." >&2
+            exit 1
+          fi
+          echo "Reproducible: both builds of controlplane/ironctl/sandbox are byte-identical."

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,54 @@
+# OpenSSF Scorecard — automated supply-chain security posture scoring (IRO-32 A6).
+#
+# Runs the Scorecard analysis, uploads the results to GitHub's code-scanning dashboard
+# (so findings show up under Security ▸ Code scanning), and publishes the score to the
+# public OpenSSF API that backs the README badge. Weekly + on default-branch pushes —
+# Scorecard's branch-protection/maintained checks read repo state, not a PR diff, so it
+# runs on `main`, not on PRs.
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "41 4 * * 1" # Mondays 04:41 UTC
+  push:
+    branches: [main]
+
+# Least privilege at the top; the analyze job elevates only what it needs.
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload the SARIF results to code scanning
+      id-token: write # publish results to the public OpenSSF API (badge backing)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # publish_results=true feeds the public api.securityscorecards.dev endpoint
+          # that the README Scorecard badge renders from.
+          publish_results: true
+
+      # Keep the raw SARIF as a build artifact for debugging a score regression.
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPLv3-blue.svg)](LICENSE)
 [![Commercial license](https://img.shields.io/badge/License-Commercial%20available-555.svg)](LICENSING.md)
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/IronSecCo/ironclaw/badge)](https://scorecard.dev/viewer/?uri=github.com/IronSecCo/ironclaw)
+[![CodeQL](https://github.com/IronSecCo/ironclaw/actions/workflows/codeql.yml/badge.svg)](https://github.com/IronSecCo/ironclaw/actions/workflows/codeql.yml)
+[![Signed releases (cosign)](https://img.shields.io/badge/releases-cosign%20signed-0a7bbb.svg)](#verifying-a-release)
+[![SBOM: SPDX + CycloneDX](https://img.shields.io/badge/SBOM-SPDX%20%2B%20CycloneDX-44883e.svg)](#verifying-a-release)
+[![SLSA provenance](https://img.shields.io/badge/SLSA-build%20provenance-44883e.svg)](#verifying-a-release)
+
 </div>
 
 IronClaw is an open-source platform for running personal AI assistants on infrastructure you
@@ -281,6 +287,20 @@ Verify build provenance for a binary archive or the image:
 gh attestation verify ironclaw_<version>_<platform>.tar.gz --repo IronSecCo/ironclaw
 gh attestation verify oci://ghcr.io/ironsecco/ironclaw-controlplane:latest --repo IronSecCo/ironclaw
 ```
+
+The container image also carries a signed **SBOM attestation** (CycloneDX) you can verify
+and read anonymously:
+
+```sh
+gh attestation verify oci://ghcr.io/ironsecco/ironclaw-controlplane:latest \
+  --repo IronSecCo/ironclaw \
+  --predicate-type https://cyclonedx.org/bom
+```
+
+Every third-party GitHub Action is **pinned to a commit SHA**, builds are **reproducible**
+(pinned toolchain + `-trimpath`, verified by a double-build CI check), and the project's
+supply-chain posture is scored continuously by [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/IronSecCo/ironclaw)
+(see the badge above).
 
 </details>
 


### PR DESCRIPTION
## WS-A — Supply-chain trust (IRO-32, parent IRO-24)

Closes the remaining acceptance gaps so **signed + SBOM'd + provenanced releases are verifiable by an anonymous user**, Scorecard runs with badges, and Dependabot + SHA-pinned actions are live.

| Sub | What lands here |
|-----|-----------------|
| **A1** cosign | `release.yml` smoke job installs cosign and **verifies the keyless signature over `SHA256SUMS` anonymously** (cert-identity = Release workflow, issuer = GitHub OIDC) **before** install — fail-closed. Sign-on-publish proven by verify-on-consume. |
| **A2** SBOM | `image.yml` attaches a signed **CycloneDX SBOM attestation** to the published multi-arch index (syft scan by digest + `actions/attest-sbom`). Per-artifact SPDX+CycloneDX SBOMs already emitted by `release.yml`. |
| **A3** SLSA provenance | Already shipped via `actions/attest-build-provenance` (binaries + image); left in place. L3/reproducible target may extend in 1.1. |
| **A4** Reproducible | Exact toolchain pin (`go 1.23.12`) across ci/codeql/release + new `reproducibility.yml` double-builds every command with `-trimpath` and asserts byte-identical SHA256. |
| **A5** Hygiene | Every third-party Action **pinned to a commit SHA** (tag in trailing comment; Dependabot `github-actions` group bumps them). Top-level least-privilege `permissions` on ci.yml. Dependabot + CodeQL already on. |
| **A6** Scorecard | New `scorecard.yml` (OpenSSF Scorecard, `publish_results` + SARIF upload to code-scanning) + README badges (Scorecard, CodeQL, cosign, SBOM, SLSA) + image-SBOM verification docs. |

### Security review (this touches the release trust model)
- **Mandatory gateway / isolation / egress / encryption-at-rest:** unaffected — CI/release tooling only; no sandbox capability widened, `network=none` untouched.
- **Supply-chain integrity (the point):** strengthened — anonymous verify gates the release; SBOM/provenance attested to immutable digests; actions SHA-pinned so a moved tag can't change what runs.

### Validation
- All workflow YAML validates.
- Full end-to-end proof of A1/A2 (anonymous cosign-verify smoke, image-SBOM attestation, Scorecard publish) only fires on **release tag / push-to-main / schedule**, not on PR — so merging then watching the next release run is the final gate. PR-triggered `ci`, `codeql`, and `reproducibility` run here.

### Notes
- Supersedes the duplicate **IRO-26** (same WS-A scope; both were assigned to Forge — IRO-26 will be closed as superseded).
- Prior local commit carried a prohibited `Co-Authored-By: Paperclip` trailer and an unrelated README "Community" hunk; both removed here per repo policy (IRO-23) and scope.

🔒 Recommend CEO approval before merge — merging cuts a release that exercises the new verify-on-consume gate.