### PR TITLE
ci(release): attest build provenance for raw binaries, not just archives (IRO-46)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,10 @@ jobs:
           # Windows x86_64 — native mingw-w64 gcc (preinstalled on the runner).
           - { goos: windows, goarch: amd64, runner: windows-latest, name: windows_amd64 }
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read # checkout
+      id-token: write # OIDC token for keyless provenance signing (Sigstore)
+      attestations: write # actions/attest-build-provenance over the raw binaries
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -135,6 +139,19 @@ jobs:
             go build -trimpath -ldflags "${ldflags}" -o "dist/pkg/${out}${ext}" "./cmd/${cmd}"
           done
           cp LICENSE README.md dist/pkg/
+
+      # Attest build provenance for the RAW binaries (ironctl, ironclaw-controlplane,
+      # ironclaw-sandbox), not just the archive. The archive attestation in the release
+      # job is keyed on the .tar.gz/.zip digest; a user who extracts the tarball and runs
+      # `gh attestation verify ./ironctl` is checking the *binary* digest, which has no
+      # attestation unless we publish one here — that was the IRO-46 404. Attesting per
+      # build leg is where the binaries exist (the release job only ever sees archives).
+      # The `dist/pkg/iron*` glob matches the three binaries (and their .exe variants on
+      # Windows) while excluding the copied-in LICENSE / README.md.
+      - name: Attest build provenance for the binaries
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: "dist/pkg/iron*"
 
       - name: Package archive
         shell: bash

--- a/README.md
+++ b/README.md
@@ -279,10 +279,11 @@ cosign verify-blob SHA256SUMS \
 sha256sum -c SHA256SUMS        # then confirm your archive matches
 ```
 
-Verify build provenance for a binary archive or the image:
+Verify build provenance for an archive, an extracted binary, or the image:
 
 ```sh
 gh attestation verify ironclaw_<version>_<platform>.tar.gz --repo IronSecCo/ironclaw
+gh attestation verify ./ironctl --repo IronSecCo/ironclaw   # a binary extracted from the archive
 gh attestation verify oci://ghcr.io/ironsecco/ironclaw-controlplane:latest --repo IronSecCo/ironclaw
 ```
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -134,7 +134,10 @@ Attached to the GitHub Release for tag `<tag>` (version `<ver>` = tag without th
 - `SHA256SUMS` — checksums of every archive (**the trust anchor**).
 - `SHA256SUMS.sig` + `SHA256SUMS.pem` — the keyless cosign signature and its certificate.
 - `ironclaw_<ver>.spdx.json` + `ironclaw_<ver>.cdx.json` — SBOMs (syft, SPDX + CycloneDX).
-- Build-provenance attestations for each archive (queryable via `gh attestation verify`).
+- Build-provenance attestations for each archive **and for each raw binary**
+  (`ironctl`, `ironclaw-controlplane`, `ironclaw-sandbox` on every platform), so
+  `gh attestation verify` works whether you point it at the downloaded `.tar.gz`/`.zip`
+  or at a binary extracted from it.
 
 ### 3.5 Post-release verification gate (smoke — in flight, IRO-15)
 
@@ -178,8 +181,11 @@ sha256sum -c SHA256SUMS        # macOS: shasum -a 256 -c SHA256SUMS
 **Step 3 — verify build provenance (ties the artifact to the source commit + workflow):**
 
 ```sh
+# the downloaded archive:
 gh attestation verify ironclaw_<ver>_<os>_<arch>.tar.gz --repo IronSecCo/ironclaw
-# and for the container image:
+# a binary extracted from it (e.g. after `tar xzf`):
+gh attestation verify ./ironctl --repo IronSecCo/ironclaw
+# and the container image:
 gh attestation verify oci://ghcr.io/ironsecco/ironclaw-controlplane:<tag> --repo IronSecCo/ironclaw
 ```
 
@@ -307,6 +313,7 @@ cosign verify-blob SHA256SUMS --signature SHA256SUMS.sig --certificate SHA256SUM
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 sha256sum -c SHA256SUMS
 gh attestation verify ironclaw_<ver>_<os>_<arch>.tar.gz --repo IronSecCo/ironclaw
+gh attestation verify ./ironctl --repo IronSecCo/ironclaw   # extracted binary
 ```
 
 ---

--- a/docs/security.md
+++ b/docs/security.md
@@ -58,7 +58,9 @@ artifacts are:
 - **Signed** — a keyless [cosign](https://github.com/sigstore/cosign) signature
   over `SHA256SUMS` is the trust anchor.
 - **Attested** — build-provenance attestations tie every artifact back to its
-  source commit and the workflow that built it.
+  source commit and the workflow that built it. Both the release archives and the
+  individual binaries inside them carry provenance, so `gh attestation verify`
+  works against either.
 
 The [Release runbook](release-runbook.md) is the operational reference for cutting,
 verifying, and yanking a release.


### PR DESCRIPTION
## What

Closes the IRO-46 gap: `gh attestation verify ./ironctl` returned **HTTP 404** for binaries extracted from a release archive.

### Root cause
The release job attests only the `.tar.gz`/`.zip` archive digests (and IRO-22 attested the image). A user who runs `tar xzf … && gh attestation verify ./ironctl` is checking the **binary** digest, which had no attestation published — hence the 404. The WS-G G10 acceptance step is literally `gh attestation verify ./ironctl`.

### Fix (issue option 1)
Attest the raw binaries in each `build` matrix leg, where the binaries exist (the `release` job only ever downloads archives):
- Adds `id-token: write` + `attestations: write` to the `build` job.
- New `actions/attest-build-provenance` step over `dist/pkg/iron*` — matches `ironctl`, `ironclaw-controlplane`, `ironclaw-sandbox` (and `.exe` on Windows); excludes the copied-in `LICENSE`/`README.md`.
- Existing **archive** and **image** attestations are unchanged.

Docs updated (release runbook, `security.md`, `README.md`) to show `gh attestation verify` against an extracted binary alongside the archive and image forms.

## Verification
- `gh attestation verify ./<archive>.tar.gz` already passes on the latest release (exit 0); `gh attestation verify ./ironctl` 404s today — reproduced against v0.1.20.
- After this lands, the next release will publish provenance for the binary digests, so both commands pass. (Provenance is published at release time; full end-to-end proof comes with the next cut tag.)
- `release.yml` validated as well-formed YAML.

## Security lenses
- **Supply-chain / provenance**: strengthens it — more artifacts attested, none weakened. No trust boundary, isolation, egress, or secret-handling surface touched.

Per repo policy (IRO-23 / CLAUDE.md) this commit intentionally carries **no** Paperclip co-author trailer.