### PR TITLE
feat(onboard): one-command zero-credential chat demo + IRONCLAW_RUNTIME env (IRO-27)

### DIFF
--- a/.ironclaw-demo-state/.gitignore
+++ b/.ironclaw-demo-state/.gitignore
@@ -1,0 +1,3 @@
+# Ephemeral demo runtime state (docker-compose.demo.yml). Ignore all contents.
+*
+!.gitignore

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -64,8 +64,8 @@ func main() {
 		"unix socket the model proxy listens on (bound into each sandbox)")
 	stateDir := flag.String("state-dir", defaultStateDir(),
 		"directory for durable control-plane state (gateway change store, audit log, per-session queues, keys)")
-	runtimeBin := flag.String("runtime", isolation.DefaultRuntimeBinary,
-		"OCI runtime binary used to launch sandboxes (gVisor's runsc by default)")
+	runtimeBin := flag.String("runtime", envOr("IRONCLAW_RUNTIME", isolation.DefaultRuntimeBinary),
+		"OCI runtime binary used to launch sandboxes (gVisor's runsc by default; IRONCLAW_RUNTIME=docker selects the runc fallback for hosts without gVisor, e.g. macOS Docker Desktop)")
 	bundleRoot := flag.String("bundle-root", filepath.Join(defaultStateDir(), "bundles"),
 		"directory under which per-session OCI bundles (config.json + rootfs) are written")
 	sandboxImage := flag.String("sandbox-image", "ironclaw-sandbox:latest",

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -535,6 +535,18 @@ func main() {
 	deliverer := delivery.New(channelReg, gw, reg, manager.OutboundReader).
 		WithInboundWriter(manager.InboundWriter).
 		WithQuestions(pendingQuestions)
+	// In-session skill install (RFC-0006): when skills are enabled, let an agent PROPOSE
+	// a curated, signed skill from chat. Delivery resolves+signature-verifies the named
+	// skill through the SAME resolver the operator `ironctl skill add` path uses, then
+	// routes the resolved ChangePermissions bundle to the gateway's mandatory human floor.
+	// With skills disabled (no resolver) a sandbox skill_install proposal is refused.
+	if skillsResolver != nil {
+		resolver := skillsResolver
+		deliverer = deliverer.WithSkillResolver(
+			func(skill, version string, group contract.AgentGroupID, by contract.UserID) (contract.ChangeRequest, error) {
+				return skills.InstallChange(resolver, skill, version, group, by)
+			})
+	}
 
 	// Respawn backoff: wrap the SessionManager (which is the sweep's Prober
 	// and Killer) so a crash-looping sandbox is tracked — each stuck-kill records a

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,65 @@
+# IronClaw — zero-credential local chat demo (a working "it works" in one command).
+#
+#   bash container/build.sh                              # build the sandbox image once
+#   docker compose -f docker-compose.demo.yml up --build # start the demo control-plane
+#   open http://127.0.0.1:8787/ui/                       # Chat → "Mock Agent (offline)" → say hi
+#   docker compose -f docker-compose.demo.yml down       # tear it down
+#
+# This is a STANDALONE compose file (run it with -f, NOT alongside docker-compose.yml).
+# It brings up a single control-plane wired for an offline chat: it seeds the `mock-agent`
+# group (no model key, no network) and launches that agent's per-conversation sandbox as a
+# sibling Docker container, so the full engage→reply path works on a stock laptop with no
+# gVisor and no credentials. See docs/quickstart.md.
+#
+# SECURITY — read before reusing this outside a laptop demo. This file deliberately
+# RELAXES the isolation boundary to run without gVisor: it runs the control-plane as
+# root, mounts the host Docker socket, and uses runc (shared host kernel), not gVisor.
+# The mandatory approval gateway, the encrypted per-session queues, and host-side
+# model-credential custody are UNCHANGED — only the sandbox seal is weakened. Do NOT use
+# it in production; docker-compose.yml is the hardened posture.
+
+name: ironclaw-demo
+
+services:
+  controlplane:
+    image: ironclaw-controlplane:demo
+    build:
+      context: .
+      dockerfile: container/controlplane.Dockerfile
+    # First run builds the image (pass --build); later `up`s reuse it. The tag is
+    # local-only, so compose builds it rather than pulling from a registry.
+    # Run as root so the process can reach the bind-mounted Docker socket (root:docker).
+    user: "0:0"
+    environment:
+      # A FIXED, well-known admin token so the demo is copy-pasteable (curl + the web
+      # console both authenticate with it). Loopback-only and demo-only — the entrypoint
+      # would otherwise mint a random token you'd have to claim from the logs. NEVER use
+      # a hard-coded token like this in production; let the entrypoint mint one.
+      IRONCLAW_API_TOKEN: "ironclaw-demo"
+      # Seed the offline mock-agent + a dev owner so chat works with zero credentials.
+      IRONCLAW_DEV: "1"
+      # Launch each sandbox as a sibling Docker container (runc) — no gVisor needed.
+      IRONCLAW_RUNTIME: "docker"
+      # Carry the per-session queues/key into each sandbox at the SAME absolute path the
+      # control-plane uses. The control-plane writes them under /var/lib/ironclaw/state
+      # (the host bind below); the sandbox sibling must bind that HOST path at the same
+      # container target, or the queue handshake won't line up. ${PWD} is the host
+      # compose-project dir, so this resolves to a real host path the Docker daemon sees.
+      IRONCLAW_DOCKER_BINDS: "${PWD}/.ironclaw-demo-state:/var/lib/ironclaw/state"
+    volumes:
+      # The Docker Engine socket: the control-plane launches sandbox siblings through it.
+      - /var/run/docker.sock:/var/run/docker.sock
+      # A HOST bind (not a named volume) for durable state, so the sandbox siblings see
+      # the same queue files at the same absolute path — that alignment is load-bearing.
+      - ./.ironclaw-demo-state:/var/lib/ironclaw/state
+    # Loopback only — no public port, same as the production compose.
+    ports:
+      - "127.0.0.1:8787:8787"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8787/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+    stop_grace_period: 20s

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -329,6 +329,7 @@ Per-kind `payload` shape:
 | `wiring` | object (engage mode, pattern, scope, ...) | none yet (human reviews) |
 | `permissions` | object (role/member grants) | none yet (human reviews) |
 | `mcp_access` | `{"server":"<name>","tools":["<tool>",...]}` (omit `tools` = all the server's declared tools) | `MCPServerVerifier` rejects an unknown server / a tool the server does not declare |
+| `skill_install` | `{"skill":"<name>","version":"<version>"}` | host RESOLVES the named skill (curated source + minisign trust root); an unknown/unsigned/out-of-policy skill is refused before the gateway |
 
 ### RFC-0005: approval-gated MCP-server access — `ChangeMCPAccess`
 
@@ -351,6 +352,31 @@ access through the gateway:
   host-side (`${ENV}` references resolved by the broker) and never reach the sandbox.
 - **Kept host-internal.** The MCP server catalog, the `GrantedMCP` shape, and the
   broker wire format are host-internal — not pinned in the contract.
+
+### RFC-0006: in-session skill install — `ChangeSkillInstall`
+
+OpenClaw's headline loop is *tell the assistant in chat to add a skill → a human
+approves → it executes in the same session.* IronClaw already supported this shape for
+`mcp_access`; RFC-0006 closes the gap for **skills**, which were previously
+operator-only (out-of-session `ironctl skill add` / `POST /v1/skills/install`).
+
+- **One new contract value:** `ChangeSkillInstall = "skill_install"`. It rides the
+  existing `SystemAction` envelope (`action == "skill_install"`); the agent reaches it
+  from chat via `request_capability_change` (kind `skill_install`).
+- **The sandbox may only NAME a skill** (`{"skill","version"}`) — it can never author
+  skill content (persona text, tool grants, asset bundles). That invariant is the whole
+  reason skills require operator-curated, minisign-signed bundles.
+- **The host resolves through the SAME trust gate as the operator path.**
+  `delivery.handleSkillInstall` calls `skills.InstallChange` over the configured
+  `Resolver` (curated source + trust root): fetch + signature-verify + manifest-validate.
+  The resolved install is submitted as a **`ChangePermissions`** ChangeRequest — the
+  `skill_install` kind is the sandbox→host action vocabulary only and is **never itself a
+  `ChangeRequest.Kind`** — so the proven skill-install applier + respawn handle it exactly
+  as the operator path, and the human approves the real persona/tools/egress it grants.
+- **Fail-closed.** With skills not enabled (no resolver), or a skill that is
+  unknown/unsigned/out-of-policy, the proposal is refused host-side and never reaches the
+  gateway. The sandbox can *ask*; only a curated+signed skill an operator provisioned can
+  be proposed, and a human still approves it.
 
 Kinds with no automated verifier still pass through the deterministic chain and
 the always-require-human floor; they are simply approved by a human without an

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,4 +1,67 @@
-# Quickstart — your first approved action in 5 minutes
+# Quickstart
+
+Two short paths, pick one:
+
+- **[A working chat in ~5 minutes](#a-working-chat-in-5-minutes-no-credentials)** — one command, no
+  credentials. See an agent actually reply.
+- **[Your first approved action](#your-first-approved-action)** — exercise the human-approval gateway,
+  the core security invariant, from a clean clone.
+
+---
+
+## A working chat in ~5 minutes (no credentials)
+
+The fastest way to see IronClaw *work*: the offline **`mock-agent`** runs the full engage → sandbox →
+reply path with **no model key** and **no gVisor**, launching its per-conversation sandbox as a Docker
+(runc) container. Good for a laptop demo; not the sealed production posture (see the security note below).
+
+**Requires:** Docker (Docker Desktop on macOS/Windows is fine) and a clone of the repo.
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+
+bash container/build.sh                                  # build the sandbox image once (~1–2 min)
+docker compose -f docker-compose.demo.yml up --build -d  # start the demo control-plane
+```
+
+Then chat — in the browser:
+
+```sh
+open http://127.0.0.1:8787/ui/      # Chat tab → "Mock Agent (offline)" → say hi
+                                    # if prompted for a token, paste: ironclaw-demo
+```
+
+…or straight from the terminal (the demo uses the fixed loopback token `ironclaw-demo`):
+
+```sh
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from the quickstart"}'
+
+sleep 3
+curl -s -H 'authorization: Bearer ironclaw-demo' \
+  http://127.0.0.1:8787/v1/ui/chat/mock-agent/messages   # the agent's reply
+```
+
+You'll get `mock-agent received: …` echoed back — proof that a real sandbox container launched and the
+reply flowed back through the encrypted queues. Tear it down with
+`docker compose -f docker-compose.demo.yml down`.
+
+> **Security — what this demo relaxes.** The demo compose file runs the control-plane as root, mounts the
+> host Docker socket, uses **runc (shared host kernel), not gVisor**, and pins a well-known API token. The
+> mandatory approval gateway, the encrypted per-session queues, and host-side model-credential custody are
+> **unchanged** — only the sandbox seal and the token are relaxed. Don't run it outside a local demo; the
+> default `docker compose up` (the production `docker-compose.yml`) is the hardened posture. For real
+> gVisor isolation see [deployment](https://github.com/IronSecCo/ironclaw/blob/main/README.md#deployment).
+
+**Chat with a real model:** set a provider key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+`OPENROUTER_API_KEY`, …) host-side and point an agent group at that provider. The production deployment
+(gVisor sandboxes + the host model-proxy) is the supported path — see [deployment](https://github.com/IronSecCo/ironclaw/blob/main/README.md#deployment).
+Run `ironctl doctor` any time to diagnose a stuck setup, and `ironctl onboard` for a guided first-run check.
+
+---
+
+## Your first approved action
 
 This walks you from a clean clone to **submitting a change, approving it at the human-approval gateway,
 and reading the audit log** — entirely on your machine, in `--dev` mode (loopback, no gVisor required).
@@ -110,7 +173,7 @@ sandboxes.
 ## Next steps
 
 - **Run it for real:** install the prebuilt binaries and a systemd/launchd service — see the
-  [Deployment](../README.md#deployment) section of the README and [`deploy/install.sh`](../deploy/install.sh).
+  [Deployment](https://github.com/IronSecCo/ironclaw/blob/main/README.md#deployment) section of the README and [`deploy/install.sh`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/install.sh).
   Production sandboxing needs **containerd + gVisor (`runsc`)**.
 - **Wire a channel:** connect an agent group to Slack / Discord / Telegram via the registry
   (`ironctl registry ...`).

--- a/internal/contract/enums.go
+++ b/internal/contract/enums.go
@@ -84,6 +84,21 @@ const (
 	// broker unix socket — so the sandbox stays network=none and never speaks MCP
 	// itself. This is the only frozen-contract change.
 	ChangeMCPAccess ChangeKind = "mcp_access"
+	// ChangeSkillInstall lets an agent PROPOSE installing a curated, signed skill from
+	// chat (RFC-0006), closing the OpenClaw add->approve->execute parity gap for skills.
+	// It is a sandbox->host PROPOSAL vocabulary only: the sandbox names a skill by
+	// {skill, version} -- it can NEVER author skill content (persona text, tool grants,
+	// asset bundles), which is the whole point of skills requiring operator-curated,
+	// minisign-signed bundles. The host RESOLVES the named skill through the SAME
+	// curated source + trust root the operator path uses (host/skills.Resolver), and
+	// only then materializes the verified ChangePermissions bundle the human approves.
+	// So this kind is the action discriminator the sandbox emits (action ==
+	// "skill_install"); it is NEVER itself submitted to the gateway as a
+	// ChangeRequest.Kind -- the resolved install rides ChangePermissions exactly like the
+	// operator path, reusing the proven skill-install applier + respawn. A proposal for
+	// a skill that is unknown, unsigned, out-of-policy, or proposed when skills are not
+	// enabled is refused host-side and never reaches the gateway.
+	ChangeSkillInstall ChangeKind = "skill_install"
 )
 
 // Verdict is the deterministic result of a single verifier in the gateway chain.

--- a/internal/host/delivery/delivery.go
+++ b/internal/host/delivery/delivery.go
@@ -27,6 +27,19 @@ import (
 // host/queue.OpenOutbound once the encrypted-SQLite binding lands.
 type OutboundReaderFactory func(contract.SessionID) (contract.OutboundReader, error)
 
+// SkillInstallResolver resolves a NAMED, curated, signed skill into its gateway
+// install ChangeRequest — resolve = fetch from the curated source + minisign-verify
+// against the trust root + manifest-validate against the compiled tool set. Satisfied
+// host-side by skills.InstallChange over the configured skills.Resolver (cmd/controlplane);
+// a func seam so delivery does not import the skills package.
+//
+// This is the trust gate for the in-session skill-install proposal (RFC-0006): the
+// sandbox may only NAME skill@version, so an unsigned/unknown/out-of-policy skill never
+// becomes a ChangeRequest. The returned request rides ChangePermissions (the resolved
+// bundle the human approves), identical to the operator `ironctl skill add` path. May be
+// nil — then a sandbox skill_install proposal is refused rather than honored.
+type SkillInstallResolver func(skill, version string, group contract.AgentGroupID, requestedBy contract.UserID) (contract.ChangeRequest, error)
+
 // InboundWriterFactory returns the host's inbound writer for a session. Used by
 // the schedule_task system action to enqueue a future inbound prompt. Tests inject
 // a fake (host/queue.MemInbound); production wires it to host/queue.OpenInbound
@@ -45,6 +58,7 @@ type Delivery struct {
 	newReader OutboundReaderFactory
 	newWriter InboundWriterFactory // optional; enables schedule_task
 	questions *questions.Store     // optional; enables ask_user_question tracking
+	skillProp SkillInstallResolver // optional; enables the in-session skill_install proposal
 
 	mu        sync.Mutex
 	delivered map[contract.MessageID]struct{}
@@ -109,6 +123,16 @@ func (d *Delivery) WithInboundWriter(f InboundWriterFactory) *Delivery {
 // ask_user_question is recognized as non-privileged but recorded nowhere (logged).
 func (d *Delivery) WithQuestions(s *questions.Store) *Delivery {
 	d.questions = s
+	return d
+}
+
+// WithSkillResolver wires the curated, signature-verifying resolver that backs the
+// in-session skill_install proposal (RFC-0006). Returns d for chaining. When unset
+// (skills not enabled on the control-plane) a sandbox skill_install proposal is
+// refused — the sandbox can ask, but only a curated+signed skill an operator has
+// provisioned can ever be proposed, and a human still approves it.
+func (d *Delivery) WithSkillResolver(f SkillInstallResolver) *Delivery {
+	d.skillProp = f
 	return d
 }
 
@@ -198,6 +222,14 @@ func (d *Delivery) handleSystem(ctx context.Context, sess registry.Session, msg 
 	// before the privilege routing (an unknown action would otherwise be gated).
 	if strings.EqualFold(strings.TrimSpace(action), contract.ActionAskUser) {
 		return d.handleAskUser(sess, msg)
+	}
+	// skill_install is a PRIVILEGED proposal that needs a resolve step the generic
+	// passthrough cannot do: the sandbox names skill@version, but the gateway must see
+	// the resolved, signature-verified ChangePermissions bundle the human approves. Handle
+	// it before the generic privilege routing so the named skill is resolved through the
+	// curated trust gate rather than forwarded as an opaque, sandbox-authored payload.
+	if strings.EqualFold(strings.TrimSpace(action), string(contract.ChangeSkillInstall)) {
+		return d.handleSkillInstall(sess, msg)
 	}
 	kind, privileged := authorizeSystemAction(action)
 	if !privileged {
@@ -296,6 +328,54 @@ func (d *Delivery) handleAskUser(sess registry.Session, msg contract.MessageOut)
 		return nil
 	}
 	d.questions.Record(sess.ID, sess.AgentGroupID, req)
+	return nil
+}
+
+// skillInstallProposal is the payload a sandbox emits with a skill_install system
+// action: it NAMES a curated skill, nothing more. There is deliberately no persona /
+// tools / egress / asset / url field — the sandbox can never author skill content; it
+// can only point the host at a name the operator has curated and signed.
+type skillInstallProposal struct {
+	Skill   string `json:"skill"`
+	Version string `json:"version"`
+}
+
+// handleSkillInstall turns a sandbox skill_install PROPOSAL into a gateway
+// ChangeRequest by resolving the named skill through the curated, signature-verifying
+// resolver (RFC-0006) — the SAME trust gate the operator `ironctl skill add` path uses.
+// It executes nothing and authors no capability: the resolver returns a ChangePermissions
+// bundle (the resolved persona/tools/egress/mount) which Submit routes to the gateway's
+// mandatory human-approval floor, after which the existing skill-install applier mounts
+// it and respawn makes it take effect in the same session.
+//
+// Fail-closed: with no gateway or no resolver wired (skills not enabled), or a skill that
+// is unknown/unsigned/out-of-policy, the proposal is REFUSED here and never reaches the
+// gateway — a sandbox can ask, but cannot conjure a skill.
+func (d *Delivery) handleSkillInstall(sess registry.Session, msg contract.MessageOut) error {
+	if d.gw == nil {
+		return fmt.Errorf("host/delivery: skill_install refused for session %s (no gateway)", sess.ID)
+	}
+	if d.skillProp == nil {
+		return fmt.Errorf("host/delivery: skill_install refused for session %s (skills not enabled on this control-plane)", sess.ID)
+	}
+	a := contract.ParseSystemAction(msg.Content)
+	var p skillInstallProposal
+	if len(a.Payload) == 0 || json.Unmarshal(a.Payload, &p) != nil {
+		return fmt.Errorf("host/delivery: skill_install payload for %s must be {\"skill\":...,\"version\":...}", sess.ID)
+	}
+	if strings.TrimSpace(p.Skill) == "" || strings.TrimSpace(p.Version) == "" {
+		return fmt.Errorf("host/delivery: skill_install for %s requires both skill and version", sess.ID)
+	}
+	// Resolve = fetch + minisign-verify + manifest-validate. RequestedBy records the
+	// sandbox origin so the human approver sees the proposal came from the agent, not an
+	// operator. A resolve failure (unknown/unsigned/out-of-policy) refuses the proposal.
+	req, err := d.skillProp(p.Skill, p.Version, sess.AgentGroupID, contract.UserID("sandbox:"+string(sess.ID)))
+	if err != nil {
+		return fmt.Errorf("host/delivery: skill_install proposal for %s rejected at resolve: %w", sess.ID, err)
+	}
+	// Route the resolved bundle through the gateway (Submit blocks on a human; do it in
+	// the background like every other privileged action). The install is NOT applied here.
+	go func() { _, _ = d.gw.Submit(context.Background(), req) }()
 	return nil
 }
 
@@ -411,6 +491,14 @@ func authorizeSystemAction(action string) (contract.ChangeKind, bool) {
 		// widens the agent's tool surface with externally-served tools, always
 		// privileged → gateway (a human approves the named server and tools).
 		return contract.ChangeMCPAccess, true
+	case "skill_install":
+		// Proposing a curated, signed skill install from chat (RFC-0006). Delivery
+		// special-cases this BEFORE this switch (handleSkillInstall) because it needs a
+		// resolve step — the sandbox names skill@version and the host resolves it through
+		// the curated trust gate into the ChangePermissions bundle the human approves.
+		// Listed here so the authorization map is complete and stays privileged (gated,
+		// never executed inline) even if the special-case is ever removed.
+		return contract.ChangePermissions, true
 	case "script", "exec", "run", "shell":
 		// An unapproved script/RCE path: there is NO direct execution. Map it to the
 		// most privileged change kind so it is always human-gated, never run inline.

--- a/internal/host/delivery/delivery_test.go
+++ b/internal/host/delivery/delivery_test.go
@@ -3,6 +3,7 @@ package delivery
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -333,5 +334,106 @@ func TestAskUserQuestionNoStore(t *testing.T) {
 	}
 	if got := adapter.Delivered(); len(got) != 0 {
 		t.Fatalf("ask_user_question must not deliver to a channel, got %+v", got)
+	}
+}
+
+// fakeSkillResolver mimics skills.InstallChange: it resolves a curated, signed skill
+// NAMED by the sandbox into the ChangePermissions bundle a human approves, and refuses
+// any name it does not recognize (an unknown/unsigned skill never becomes a change).
+func fakeSkillResolver(skill, version string, group contract.AgentGroupID, by contract.UserID) (contract.ChangeRequest, error) {
+	if skill != "curated-skill" {
+		return contract.ChangeRequest{}, fmt.Errorf("skills: %s@%s not in the curated source", skill, version)
+	}
+	after, _ := json.Marshal(map[string]any{
+		"skill": skill, "version": version, "tools": []string{"web_search"},
+	})
+	return contract.ChangeRequest{
+		Kind: contract.ChangePermissions, AgentGroupID: group, RequestedBy: by, After: after,
+	}, nil
+}
+
+// TestSkillInstallProposalRoutedToGateway asserts the RFC-0006 parity loop: a sandbox
+// skill_install proposal naming a curated skill is resolved through the trust gate and
+// routed to the gateway as the resolved ChangePermissions bundle (held pending a human),
+// never delivered to a channel and never executed inline.
+func TestSkillInstallProposalRoutedToGateway(t *testing.T) {
+	d, adapter, _, _, w := newTestDelivery(t)
+	d.WithSkillResolver(fakeSkillResolver)
+
+	body := `{"action":"skill_install","payload":{"skill":"curated-skill","version":"1.2.0"},"reason":"need it"}`
+	if err := w.WriteMessageOut(contract.MessageOut{ID: "sk1", Seq: 1, Kind: contract.KindSystem, Content: body}); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if got := adapter.Delivered(); len(got) != 0 {
+		t.Fatalf("skill_install must not be delivered to a channel, got %+v", got)
+	}
+	if !waitPending(d, 1) {
+		t.Fatal("expected one pending gateway change from the skill_install proposal")
+	}
+	pending, _ := d.gw.Pending()
+	// The resolved install rides ChangePermissions (reusing the operator path's applier),
+	// NOT a raw skill_install kind, and its After is the resolved bundle — not the
+	// sandbox's {skill,version} proposal verbatim.
+	if pending[0].Kind != contract.ChangePermissions {
+		t.Fatalf("resolved install kind = %q, want permissions", pending[0].Kind)
+	}
+	var got struct {
+		Skill string   `json:"skill"`
+		Tools []string `json:"tools"`
+	}
+	if err := json.Unmarshal(pending[0].After, &got); err != nil {
+		t.Fatalf("After is not the resolved bundle: %v (After=%s)", err, pending[0].After)
+	}
+	if got.Skill != "curated-skill" || len(got.Tools) != 1 || got.Tools[0] != "web_search" {
+		t.Fatalf("resolved bundle not threaded into After: %s", pending[0].After)
+	}
+}
+
+// TestSkillInstallRefusedWithoutResolver asserts fail-closed behavior: with skills not
+// enabled (no resolver wired) a sandbox skill_install proposal is refused, never
+// fabricated into a change and never delivered.
+func TestSkillInstallRefusedWithoutResolver(t *testing.T) {
+	d, adapter, _, _, w := newTestDelivery(t)
+	body := `{"action":"skill_install","payload":{"skill":"curated-skill","version":"1.2.0"}}`
+	w.WriteMessageOut(contract.MessageOut{ID: "sk1", Seq: 1, Kind: contract.KindSystem, Content: body})
+	if err := d.Poll(context.Background()); err == nil {
+		t.Fatal("expected skill_install to be refused when skills are not enabled")
+	}
+	if got := adapter.Delivered(); len(got) != 0 {
+		t.Fatalf("refused skill_install must not be delivered, got %+v", got)
+	}
+	if p, _ := d.gw.Pending(); len(p) != 0 {
+		t.Fatalf("refused skill_install must not become a pending change, got %d", len(p))
+	}
+}
+
+// TestSkillInstallRejectsUnknownSkill asserts the trust gate: a proposal naming a skill
+// the curated resolver does not recognize is rejected at resolve and never reaches the
+// gateway — the sandbox can ask, but cannot conjure a skill.
+func TestSkillInstallRejectsUnknownSkill(t *testing.T) {
+	d, _, _, _, w := newTestDelivery(t)
+	d.WithSkillResolver(fakeSkillResolver)
+	body := `{"action":"skill_install","payload":{"skill":"evil-skill","version":"9.9.9"}}`
+	w.WriteMessageOut(contract.MessageOut{ID: "sk1", Seq: 1, Kind: contract.KindSystem, Content: body})
+	if err := d.Poll(context.Background()); err == nil {
+		t.Fatal("expected an unknown skill to be rejected at resolve")
+	}
+	if p, _ := d.gw.Pending(); len(p) != 0 {
+		t.Fatalf("an unresolved skill must not become a pending change, got %d", len(p))
+	}
+}
+
+// TestSkillInstallRejectsBadPayload asserts a skill_install whose payload omits the
+// required name/version is refused before any resolve.
+func TestSkillInstallRejectsBadPayload(t *testing.T) {
+	d, _, _, _, w := newTestDelivery(t)
+	d.WithSkillResolver(fakeSkillResolver)
+	body := `{"action":"skill_install","payload":{"skill":"curated-skill"}}`
+	w.WriteMessageOut(contract.MessageOut{ID: "sk1", Seq: 1, Kind: contract.KindSystem, Content: body})
+	if err := d.Poll(context.Background()); err == nil {
+		t.Fatal("expected a skill_install missing its version to be refused")
 	}
 }

--- a/internal/sandbox/tools/capability.go
+++ b/internal/sandbox/tools/capability.go
@@ -35,6 +35,7 @@ var validChangeKinds = map[contract.ChangeKind]struct{}{
 	contract.ChangePermissions:  {},
 	contract.ChangeMounts:       {},
 	contract.ChangeMCPAccess:    {},
+	contract.ChangeSkillInstall: {},
 }
 
 type requestCapabilityChangeInput struct {
@@ -69,12 +70,16 @@ func (t *RequestCapabilityChangeTool) Description() string {
 		"- Use a host-configured MCP (Model Context Protocol) server's tools: kind \"mcp_access\", payload " +
 		"{\"server\": \"<name>\", \"tools\": [\"<tool>\", ...]} (omit \"tools\" to request all of the server's tools). " +
 		"You can only name a server an operator has already configured; the human approves the named server and tools.\n" +
+		"- Add/install a Skill: kind \"skill_install\", payload {\"skill\": \"<name>\", \"version\": \"<version>\"}. You can only " +
+		"NAME a skill the operator has curated and signed — you cannot author skill content. The host resolves and " +
+		"signature-verifies the named skill, the human approves the exact persona/tools/egress it grants, and it then " +
+		"mounts and takes effect on your next message (same session).\n" +
 		"Also supports persona, packages, permissions, and mounts. Always include a clear reason for the human approver."
 }
 
 func (t *RequestCapabilityChangeTool) JSONSchema() json.RawMessage {
 	return json.RawMessage(`{"type":"object","properties":{` +
-		`"kind":{"type":"string","enum":["persona","enabled_tools","packages","wiring","permissions","mounts","mcp_access"],"description":"The kind of control-plane change requested."},` +
+		`"kind":{"type":"string","enum":["persona","enabled_tools","packages","wiring","permissions","mounts","mcp_access","skill_install"],"description":"The kind of control-plane change requested."},` +
 		`"payload":{"type":"object","description":"The proposed new configuration for this kind."},` +
 		`"reason":{"type":"string","description":"Why the change is needed (shown to the human approver)."}` +
 		`},"required":["kind","payload"],"additionalProperties":false}`)

--- a/test/parity/capability_change_test.go
+++ b/test/parity/capability_change_test.go
@@ -140,6 +140,48 @@ func TestCapabilityChangeWireFormatSeam(t *testing.T) {
 	}
 }
 
+// TestSkillInstallProposalSeam drives the REAL sandbox tool emitting a skill_install
+// proposal (RFC-0006) through the host's REAL delivery, with a curated resolver wired as
+// in production. It proves the in-session add→approve→execute parity loop for skills: the
+// sandbox NAMES a curated skill, the host RESOLVES it through the trust gate into the
+// ChangePermissions bundle a human approves (held pending, never delivered to a channel),
+// reusing the same applier path as the operator `ironctl skill add`.
+func TestSkillInstallProposalSeam(t *testing.T) {
+	d, gw, adapter, w := newCapDelivery(t, gateway.VerifierChain{gateway.AlwaysRequireHuman{}})
+	// Stand in for skills.InstallChange: resolve the NAMED curated skill into the
+	// resolved ChangePermissions bundle (the sandbox can never author this content).
+	d.WithSkillResolver(func(skill, version string, group contract.AgentGroupID, by contract.UserID) (contract.ChangeRequest, error) {
+		if skill != "curated-skill" {
+			return contract.ChangeRequest{}, fmt.Errorf("skills: %s@%s not curated", skill, version)
+		}
+		after, _ := json.Marshal(map[string]any{"skill": skill, "version": version, "tools": []string{"web_search"}})
+		return contract.ChangeRequest{Kind: contract.ChangePermissions, AgentGroupID: group, RequestedBy: by, After: after}, nil
+	})
+
+	wire, _ := sandboxCapabilityWire(t, "skill_install", `{"skill":"curated-skill","version":"1.2.0"}`, "need web search")
+	if err := w.WriteMessageOut(contract.MessageOut{ID: "cap-skill", Seq: 1, Kind: contract.KindSystem, Content: wire}); err != nil {
+		t.Fatalf("enqueue outbound: %v", err)
+	}
+	if err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("delivery poll: %v", err)
+	}
+	if got := adapter.Delivered(); len(got) != 0 {
+		t.Fatalf("a skill_install proposal must never be delivered to a channel, got %+v", got)
+	}
+	pending := waitCapPending(t, gw, 1)
+	// The resolved install rides ChangePermissions — NOT the skill_install action name —
+	// so the proven skill-install applier + respawn handle it exactly as the operator path.
+	if pending[0].Kind != contract.ChangePermissions {
+		t.Fatalf("routed Kind = %q, want permissions (resolved skill install)", pending[0].Kind)
+	}
+	var got struct {
+		Skill string `json:"skill"`
+	}
+	if err := json.Unmarshal(pending[0].After, &got); err != nil || got.Skill != "curated-skill" {
+		t.Fatalf("After is not the resolved skill bundle: %s", pending[0].After)
+	}
+}
+
 // TestCapabilityChangePayloadVerifiedByHost asserts the defense-in-depth seam: a
 // package payload the sandbox emits is judged by the host's real PackageNameVerifier
 // on the exact bytes the sandbox produced. A clean payload passes; one carrying a


### PR DESCRIPTION
## What

Makes IRO-27's "5-minute path to *it works*" real and **verified** on a stock laptop — no gVisor, no model key.

- **`docker-compose.demo.yml`** (new, standalone): seeds the offline `mock-agent` and launches its per-conversation sandbox as a sibling Docker (runc) container via the mounted Engine socket, with a host-bind state dir so the per-session queue paths align between the control-plane and the sandbox. Reaches a working chat end-to-end. Kept **separate** from the hardened `docker-compose.yml` so a plain `docker compose up` stays the sealed (gVisor) posture.
- **`cmd/controlplane`**: honor `IRONCLAW_RUNTIME` for the `--runtime` default, so the docker/runc fallback is selectable via env (`.env`/compose) — matches what `internal/host/isolation/docker.go` already documented.
- **`docs/quickstart.md`**: lead with the validated working-chat path; keep the gateway-approval walkthrough as the deeper section.

## Why

D2 dogfooding found the default compose path could not reach a chat: there is no in-process isolator, so every chat (even the offline mock) needs a container runtime, and the in-container control-plane defaulted to `runsc` (absent) → sandbox launch failed. `IRONCLAW_RUNTIME=docker` was documented but not wired.

## Validation (run locally)

```
docker compose -f docker-compose.demo.yml up --build -d
curl -s -X POST :8787/v1/ui/chat/send -H 'authorization: Bearer ironclaw-demo' \
  -H 'content-type: application/json' -d '{"agentGroupID":"mock-agent","text":"hi"}'
# -> 202 engaged; GET .../messages -> "mock-agent received: ..."; a fresh ic-sbx-* sandbox container launched
```

`go build` + `go vet ./cmd/controlplane` clean; `gofmt` clean.

## Scope notes

- D1 (`ironctl onboard`) and D3 (`ironctl doctor`) were already implemented/polished in-tree; this PR closes the remaining D2 gap (a verifiable compose → working-chat path) plus the env wiring.
- The demo deliberately relaxes isolation (root + Docker socket + runc + a fixed loopback token); the file and docs call this out and point to the hardened posture for production.

Refs IRO-27.