### PR TITLE
fix(console,cli): first-run UX — real auth state, token feedback, quiet CLI (IRO-47)

### DIFF
--- a/cmd/ironctl/doctor.go
+++ b/cmd/ironctl/doctor.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -152,6 +153,16 @@ func checkRuntime(bin string) checkResult {
 	r := checkResult{Name: "sandbox runtime (" + bin + ")"}
 	path, err := exec.LookPath(bin)
 	if err != nil {
+		// gVisor's runsc is Linux-only. On macOS/Windows the production sandbox
+		// runs on the Linux control-plane host, so a missing runtime here is a
+		// dev-environment note (WARN), not a hard FAIL that breaks `doctor`'s
+		// exit code on a platform where it was never expected.
+		if runtime.GOOS != "linux" {
+			r.Status = checkWarn
+			r.Detail = bin + " not found (gVisor is Linux-only; not expected on " + runtime.GOOS + ")"
+			r.Fix = "the production sandbox runs on the Linux control-plane host — install gVisor there; this check is informational on " + runtime.GOOS
+			return r
+		}
 		r.Status = checkFail
 		r.Detail = bin + " not found on PATH"
 		r.Fix = "install gVisor (https://gvisor.dev/docs/user_guide/install/) so sandboxes can launch, or pass --runtime <bin>"

--- a/cmd/ironctl/doctor_test.go
+++ b/cmd/ironctl/doctor_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -42,10 +43,18 @@ func TestCheckRuntime(t *testing.T) {
 	if r := checkRuntime("go"); r.Status != checkOK {
 		t.Errorf("checkRuntime(go) = %s (%s), want OK", r.Status, r.Detail)
 	}
-	if r := checkRuntime("definitely-not-a-real-binary-xyz123"); r.Status != checkFail {
-		t.Errorf("checkRuntime(missing) = %s, want FAIL", r.Status)
+	// A missing runtime is a hard FAIL on Linux (where gVisor is required) but a
+	// soft WARN on macOS/Windows, where the production sandbox runs on the Linux
+	// host and `runsc` is not expected — so `doctor` should not exit non-zero
+	// just for being run on a dev laptop.
+	wantMissing := checkFail
+	if runtime.GOOS != "linux" {
+		wantMissing = checkWarn
+	}
+	if r := checkRuntime("definitely-not-a-real-binary-xyz123"); r.Status != wantMissing {
+		t.Errorf("checkRuntime(missing) on %s = %s, want %s", runtime.GOOS, r.Status, wantMissing)
 	} else if r.Fix == "" {
-		t.Error("expected an install fix when the runtime is missing")
+		t.Error("expected an actionable fix when the runtime is missing")
 	}
 }
 

--- a/cmd/ironctl/main.go
+++ b/cmd/ironctl/main.go
@@ -31,6 +31,11 @@ const defaultAddr = "http://127.0.0.1:8787"
 // IRONCLAW_API_TOKEN env var and can be overridden with the global --token flag.
 var token string
 
+// verbose, set by the global -v/--verbose flag, restores the raw "HTTP <code>"
+// status line on successful responses. By default success is quiet: callers see
+// the response body (or nothing) without protocol noise.
+var verbose bool
+
 func main() {
 	if err := run(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, "ironctl:", err)
@@ -45,17 +50,30 @@ func run(args []string) error {
 		return nil
 	}
 
-	// Global --addr / --token can appear (in any order) before the subcommand.
+	// Global --addr / --token / -v can appear (in any order) before the subcommand.
 	addr := defaultAddr
 	token = os.Getenv("IRONCLAW_API_TOKEN")
-	for len(args) >= 2 && (args[0] == "--addr" || args[0] == "--token") {
+parse:
+	for len(args) >= 1 {
 		switch args[0] {
 		case "--addr":
+			if len(args) < 2 {
+				return fmt.Errorf("--addr needs a value")
+			}
 			addr = args[1]
+			args = args[2:]
 		case "--token":
+			if len(args) < 2 {
+				return fmt.Errorf("--token needs a value")
+			}
 			token = args[1]
+			args = args[2:]
+		case "-v", "--verbose":
+			verbose = true
+			args = args[1:]
+		default:
+			break parse
 		}
-		args = args[2:]
 	}
 	if len(args) < 1 {
 		usage()
@@ -235,15 +253,30 @@ func addAuth(req *http.Request) {
 }
 
 func printBody(resp *http.Response) error {
-	out, _ := io.ReadAll(resp.Body)
-	fmt.Printf("HTTP %d\n", resp.StatusCode)
-	if len(out) > 0 {
-		fmt.Println(string(bytes.TrimSpace(out)))
-	}
+	out := bytes.TrimSpace(mustReadAll(resp.Body))
 	if resp.StatusCode >= 400 {
+		// Failures always surface the status (on stderr) so they're diagnosable,
+		// regardless of -v. The body usually carries the server's reason.
+		fmt.Fprintf(os.Stderr, "HTTP %d %s\n", resp.StatusCode, http.StatusText(resp.StatusCode))
+		if len(out) > 0 {
+			fmt.Fprintln(os.Stderr, string(out))
+		}
 		return fmt.Errorf("request failed with status %d", resp.StatusCode)
 	}
+	// Success is quiet by default: no raw "HTTP 200/202" line. The response body
+	// (a JSON list/object) is the useful output; -v restores the status line.
+	if verbose {
+		fmt.Printf("HTTP %d %s\n", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+	if len(out) > 0 {
+		fmt.Println(string(out))
+	}
 	return nil
+}
+
+func mustReadAll(r io.Reader) []byte {
+	b, _ := io.ReadAll(r)
+	return b
 }
 
 func usage() {
@@ -272,5 +305,6 @@ func usage() {
   ironctl [--addr URL] [--token T] mcp remove <name>
 
   --addr  defaults to `+defaultAddr+`
-  --token defaults to $IRONCLAW_API_TOKEN`)
+  --token defaults to $IRONCLAW_API_TOKEN
+  -v      verbose: also print the HTTP status line on success`)
 }

--- a/cmd/ironctl/print_test.go
+++ b/cmd/ironctl/print_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdouterr runs fn with os.Stdout and os.Stderr redirected to pipes and
+// returns whatever each stream received.
+func captureStdouterr(t *testing.T, fn func()) (stdout, stderr string) {
+	t.Helper()
+	origOut, origErr := os.Stdout, os.Stderr
+	outR, outW, _ := os.Pipe()
+	errR, errW, _ := os.Pipe()
+	os.Stdout, os.Stderr = outW, errW
+	defer func() { os.Stdout, os.Stderr = origOut, origErr }()
+
+	fn()
+
+	outW.Close()
+	errW.Close()
+	ob, _ := io.ReadAll(outR)
+	eb, _ := io.ReadAll(errR)
+	return string(ob), string(eb)
+}
+
+func resp(status int, body string) *http.Response {
+	return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(body))}
+}
+
+func TestPrintBodySuccessIsQuiet(t *testing.T) {
+	verbose = false
+	t.Cleanup(func() { verbose = false })
+
+	// 202 with a JSON body: the body prints, but no raw "HTTP 202" line leaks.
+	out, errOut := captureStdouterr(t, func() {
+		if err := printBody(resp(http.StatusAccepted, `{"id":"chg_1"}`)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if strings.Contains(out, "HTTP") {
+		t.Errorf("success output leaked an HTTP status line: %q", out)
+	}
+	if !strings.Contains(out, `{"id":"chg_1"}`) {
+		t.Errorf("expected body in stdout, got %q", out)
+	}
+	if errOut != "" {
+		t.Errorf("expected empty stderr on success, got %q", errOut)
+	}
+}
+
+func TestPrintBodyVerboseShowsStatus(t *testing.T) {
+	verbose = true
+	t.Cleanup(func() { verbose = false })
+
+	out, _ := captureStdouterr(t, func() {
+		_ = printBody(resp(http.StatusOK, "[]"))
+	})
+	if !strings.Contains(out, "HTTP 200") {
+		t.Errorf("verbose mode should print the status line, got %q", out)
+	}
+}
+
+func TestPrintBodyErrorGoesToStderr(t *testing.T) {
+	verbose = false
+	t.Cleanup(func() { verbose = false })
+
+	var retErr error
+	out, errOut := captureStdouterr(t, func() {
+		retErr = printBody(resp(http.StatusServiceUnavailable, "model host unreachable"))
+	})
+	if retErr == nil {
+		t.Fatal("expected an error for a 503 response")
+	}
+	if out != "" {
+		t.Errorf("error responses must not write to stdout, got %q", out)
+	}
+	if !strings.Contains(errOut, "HTTP 503") || !strings.Contains(errOut, "model host unreachable") {
+		t.Errorf("expected status + reason on stderr, got %q", errOut)
+	}
+}

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -30,6 +30,18 @@ function setStatus(msg, kind) {
   if (conn) conn.className = "conn" + (kind ? " " + kind : "");
 }
 
+// authProbe hits a bearer-gated read endpoint and reports the raw status so the
+// caller can tell "connected" (200) apart from "needs a token" (401) and
+// "daemon unreachable" (network error). This is what backs the real connection
+// indicator — never an unauthenticated /healthz ping.
+async function authProbe() {
+  const token = sessionStorage.getItem(TOKEN_KEY);
+  const headers = { Accept: "application/json" };
+  if (token) headers.Authorization = "Bearer " + token;
+  const res = await fetch("/v1/ui/agents", { headers });
+  return { status: res.status, hasToken: !!token };
+}
+
 let toastTimer = null;
 function toast(msg, kind) {
   const t = document.getElementById("toast");
@@ -127,30 +139,106 @@ function activePanel() {
   return p ? p.id : "dashboard";
 }
 
-// boot probes liveness, sets the connection status, and loads the visible panel.
-// It does NOT touch the stored token, so it is safe to run on every page load.
+// lastAuthState is the most recent result of boot(): "authed" | "open" |
+// "unauth" | "offline" | "error". connect() reads it to decide whether to show
+// an inline token error.
+let lastAuthState = "idle";
+
+// boot resolves the *real* connection state from an authenticated probe, sets the
+// indicator accordingly, reveals/hides the first-run prompt, and loads the visible
+// panel. It does NOT touch the stored token, so it is safe to run on every load.
 async function boot(announce) {
+  let live = true;
   try {
-    await api("/healthz");
-    setStatus("connected", "ok");
-    if (announce) toast("Connected", "ok");
+    const h = await fetch("/healthz");
+    live = h.ok;
+  } catch (_) {
+    live = false;
+  }
+  if (!live) {
+    lastAuthState = "offline";
+    setStatus("offline — daemon unreachable", "error");
+    if (announce) toast("Can't reach the control plane", "error");
+    applyAuthState();
+    return lastAuthState;
+  }
+
+  try {
+    const p = await authProbe();
+    if (p.status === 200) {
+      lastAuthState = p.hasToken ? "authed" : "open";
+      setStatus(p.hasToken ? "connected" : "connected · open API", "ok");
+      if (announce) toast("Connected", "ok");
+    } else if (p.status === 401) {
+      lastAuthState = "unauth";
+      setStatus(p.hasToken ? "token rejected (401)" : "not connected — token required", "warn");
+      if (announce) toast(p.hasToken ? "Token rejected (401)" : "Add an API token to connect", "error");
+    } else {
+      lastAuthState = "error";
+      setStatus("error · HTTP " + p.status, "error");
+      if (announce) toast("Unexpected response (HTTP " + p.status + ")", "error");
+    }
   } catch (e) {
+    lastAuthState = "offline";
     setStatus(String(e.message || e), "error");
     if (announce) toast(String(e.message || e), "error");
   }
+
+  applyAuthState();
   refreshPanel(activePanel());
   if (typeof Dashboard !== "undefined") Dashboard.load();
   refreshAgents();
   refreshMgGroups();
+  return lastAuthState;
 }
 
-// connect stores the token from the input, then boots.
-function connect() {
-  const token = document.getElementById("token").value.trim();
+// applyAuthState shows the first-run connect prompt and opens the sidebar token
+// control only when a token is actually needed (gated API, no/invalid token).
+function applyAuthState() {
+  const needsToken = lastAuthState === "unauth";
+  const fr = document.getElementById("firstrun");
+  if (fr) fr.hidden = !needsToken;
+  if (needsToken) {
+    const det = document.querySelector(".conn-token");
+    if (det) det.open = true;
+  } else {
+    clearTokenError();
+  }
+}
+
+function setTokenError(msg) {
+  for (const id of ["token-err", "token-fr-err"]) {
+    const e = document.getElementById(id);
+    if (e) { e.textContent = msg; e.hidden = !msg; }
+  }
+}
+function clearTokenError() { setTokenError(""); }
+
+// connect stores the token from whichever input the user used, boots, and on a
+// gated/rejected result shows an inline error instead of silently "succeeding".
+async function connect(srcId) {
+  const inp = document.getElementById(srcId || "token");
+  const token = inp ? inp.value.trim() : "";
   if (token) sessionStorage.setItem(TOKEN_KEY, token);
   else sessionStorage.removeItem(TOKEN_KEY);
+  clearTokenError();
   setStatus("connecting…");
-  return boot(true);
+  const state = await boot(true);
+  if (state === "unauth") {
+    setTokenError(token
+      ? "Token rejected — check it matches the daemon's IRONCLAW_API_TOKEN."
+      : "Enter a bearer token — this API requires authentication.");
+  } else if (state === "offline") {
+    setTokenError("Can't reach the control plane — is the daemon running?");
+  } else {
+    // Connected: keep both token inputs in sync so the value is visible wherever
+    // the operator looks next.
+    for (const id of ["token", "token-fr"]) {
+      const el2 = document.getElementById(id);
+      if (el2 && el2 !== inp) el2.value = token;
+    }
+  }
+  return state;
 }
 
 function refreshPanel(name) {
@@ -206,8 +294,14 @@ function updateApprovalsBadge(n) {
 }
 
 function init() {
-  document.getElementById("connect").addEventListener("click", connect);
-  document.getElementById("token").addEventListener("keydown", (e) => { if (e.key === "Enter") connect(); });
+  document.getElementById("connect").addEventListener("click", () => connect("token"));
+  document.getElementById("token").addEventListener("keydown", (e) => { if (e.key === "Enter") connect("token"); });
+  // First-run connect prompt (dashboard body; also the only token entry on mobile,
+  // where the sidebar footer is hidden).
+  const cfr = document.getElementById("connect-fr");
+  if (cfr) cfr.addEventListener("click", () => connect("token-fr"));
+  const tfr = document.getElementById("token-fr");
+  if (tfr) tfr.addEventListener("keydown", (e) => { if (e.key === "Enter") connect("token-fr"); });
   const ra = document.getElementById("refresh-approvals");
   if (ra) ra.addEventListener("click", loadApprovals);
   const rau = document.getElementById("refresh-audit");
@@ -226,7 +320,12 @@ function init() {
   // load the visible panel immediately (works on an open loopback; a gated
   // deployment shows a 401 prompting the user to add a token in the sidebar).
   const stored = sessionStorage.getItem(TOKEN_KEY);
-  if (stored) document.getElementById("token").value = stored;
+  if (stored) {
+    for (const id of ["token", "token-fr"]) {
+      const el2 = document.getElementById(id);
+      if (el2) el2.value = stored;
+    }
+  }
   boot(false);
 }
 

--- a/web/static/dashboard.js
+++ b/web/static/dashboard.js
@@ -26,7 +26,7 @@ const Dashboard = (() => {
     const host = $("dash-approvals");
     if (!host) return;
     host.innerHTML = "";
-    if (!approvals) { host.append(el("p", { class: "muted", text: "Not connected — add your API token in the sidebar." })); return; }
+    if (!approvals) { host.append(el("p", { class: "muted", text: "Not connected — add your API token to load approvals." })); return; }
     if (!approvals.length) { host.append(emptyState("All clear", "No changes are waiting for a decision.")); return; }
 
     for (const a of approvals.slice(0, 5)) {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -78,6 +78,7 @@
                    autocomplete="off" spellcheck="false" />
             <button id="connect" class="btn-primary btn-sm" type="button">Connect</button>
           </div>
+          <p class="error token-err" id="token-err" role="alert" hidden></p>
         </details>
       </div>
     </aside>
@@ -91,6 +92,30 @@
             <h1>Dashboard</h1>
             <p class="sub">Your self-hosted, security-isolated agents — at a glance.</p>
           </div>
+
+          <!-- First-run connect prompt: shown only when the API is gated and no
+               valid token is set. Also the primary token entry on mobile, where
+               the sidebar footer is hidden. -->
+          <div id="firstrun" class="firstrun" hidden>
+            <div class="firstrun-ico" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 18v3h3l8.5-8.5"/><circle cx="16.5" cy="7.5" r="4.5"/><path d="m13.5 10.5 7 7"/></svg>
+            </div>
+            <div class="firstrun-body">
+              <h2>Connect to your control plane</h2>
+              <p class="muted">The daemon is reachable, but its API is gated. Paste a bearer token to load
+                your agents, approvals, and sessions. The token stays in this browser tab only
+                (<code>sessionStorage</code>) and is sent as <code>Authorization: Bearer</code>.</p>
+              <div class="token-row">
+                <input id="token-fr" type="password" placeholder="bearer token (IRONCLAW_API_TOKEN)"
+                       autocomplete="off" spellcheck="false" />
+                <button id="connect-fr" class="btn-primary" type="button">Connect</button>
+              </div>
+              <p class="error token-err" id="token-fr-err" role="alert" hidden></p>
+              <p class="hint">This is the <code>IRONCLAW_API_TOKEN</code> the daemon was started with.
+                On an open loopback you can leave it blank.</p>
+            </div>
+          </div>
+
           <div class="stat-grid">
             <div class="stat accent">
               <div class="ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="7" width="16" height="12" rx="3"/><path d="M9 7V4h6v3M9 13h.01M15 13h.01"/></svg></div>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -133,7 +133,9 @@ code {
 .conn { display: flex; align-items: center; gap: 8px; padding: 4px 8px; }
 .conn .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--faint); box-shadow: 0 0 0 3px rgba(255,255,255,0.03); }
 .conn.ok .dot { background: var(--ok); box-shadow: 0 0 10px var(--ok); }
+.conn.warn .dot { background: var(--warn); box-shadow: 0 0 10px var(--warn); }
 .conn.error .dot { background: var(--danger); box-shadow: 0 0 10px var(--danger); }
+.conn.ok .conn-label { color: var(--text-2); }
 .conn-label { font-size: 12px; color: var(--muted); }
 .conn-token { margin-top: 6px; border: none; padding: 0; background: transparent; }
 .conn-token > summary { list-style: none; cursor: pointer; font-size: 12px; color: var(--faint); padding: 4px 8px; }
@@ -141,6 +143,28 @@ code {
 .conn-token > summary::-webkit-details-marker { display: none; }
 .conn-token .token-row { display: flex; gap: 6px; margin-top: 6px; padding: 0 4px; }
 .conn-token input { flex: 1; min-width: 0; }
+/* inline token feedback (empty / rejected) */
+.token-err { font-size: 11.5px; margin: 6px 4px 0; }
+.token-err[hidden] { display: none; }
+
+/* ---- First-run connect prompt ----------------------------------------- */
+.firstrun {
+  display: flex; gap: 16px; align-items: flex-start;
+  background: linear-gradient(180deg, var(--surface), var(--bg-2));
+  border: 1px solid var(--accent-line); border-radius: var(--radius);
+  padding: 20px; margin: 0 0 22px; box-shadow: var(--shadow-sm);
+}
+.firstrun[hidden] { display: none; }
+.firstrun-ico {
+  flex: 0 0 42px; width: 42px; height: 42px; border-radius: 11px; display: grid; place-items: center;
+  background: var(--accent-soft); color: var(--accent-2);
+}
+.firstrun-ico svg { width: 21px; height: 21px; }
+.firstrun-body { flex: 1; min-width: 0; }
+.firstrun-body h2 { font-size: 16px; margin: 2px 0 6px; }
+.firstrun-body p { margin: 0 0 4px; font-size: 13px; }
+.firstrun .token-row { display: flex; gap: 8px; margin: 12px 0 0; max-width: 460px; }
+.firstrun .token-row input { flex: 1; min-width: 0; }
 
 /* ---- Content ----------------------------------------------------------- */
 .content { flex: 1; min-width: 0; }


### PR DESCRIPTION
## WS-H — console + CLI first-run UX friction (IRO-47)

UX gaps surfaced during WS-G verification. None blocked function; all hurt the first-run experience. Each fix was rendered and verified at a real viewport against a **gated** control plane (`IRONCLAW_API_TOKEN` set).

### Web console
| # | Issue | Fix |
|---|-------|-----|
| 1 | False "connected" (green dot from an unauthenticated `/healthz` ping while every data view 401s) | Indicator now reflects an **authenticated** probe (`/v1/ui/agents`). Honest states: **connected** (green), **token required / token rejected** (amber), **offline** (red). |
| 2 | Token not persisted | Already in `sessionStorage`; verified it survives a full reload. Both token inputs prefill from it. |
| 3 | No feedback on empty/invalid token | Inline error under both token inputs — "Enter a bearer token…" (empty + gated) / "Token rejected — check it matches the daemon's IRONCLAW_API_TOKEN." (401). |
| 4 | Weak empty-state / token hard to find | Prominent **first-run connect card** on the dashboard, shown only when gated + unauthenticated. It is also the **only** token-entry path on mobile (the sidebar footer is `display:none` < 760px — previously authentication was impossible on a phone). |

### CLI (`ironctl`)
| # | Issue | Fix |
|---|-------|-----|
| 5 | Raw `HTTP 202`/`HTTP 200` lines leak on success | `printBody` is quiet on success (body is the output). New global `-v`/`--verbose` restores the status line. Failures print `HTTP <code> <text>` + reason to **stderr** and still exit non-zero. |
| 6 | `doctor` exits non-zero on macOS (`runsc` Linux-only) | Missing `runsc` is a **WARN** (not FAIL) on non-Linux hosts → `doctor` exits 0 on macOS; still a hard FAIL on Linux where gVisor is required. |

### Verification
- Console: rendered at **1440×900** (desktop) and **390×844** (mobile) — gated-no-token → first-run card + amber dot; bad token → inline "rejected"; correct token → green "connected", stats populate (3 agents / 1 approval); reload stays connected.
- CLI: `change pending/audit/submit` print clean output, `-v` restores `HTTP 200 OK`, bad token → `HTTP 401 Unauthorized` on stderr + exit 1; `doctor` exits 0 on macOS.
- `go test ./cmd/ironctl/ ./web/` → 42 passing (incl. new `print_test.go` and a GOOS-aware `doctor_test.go`).

Closes IRO-47.