### PR TITLE
test(channels): add table-driven test for subjectFromContent

### DIFF
--- a/internal/host/channels/email_test.go
+++ b/internal/host/channels/email_test.go
@@ -159,3 +159,25 @@ func TestEmailAdapterRedactsPassword(t *testing.T) {
 		t.Fatalf("expected the password to be redacted, got %v", err)
 	}
 }
+
+func TestSubjectFromContent(t *testing.T) {
+	longInput := strings.Repeat("a", 150)
+	longExpected := strings.Repeat("a", 120) + "…"
+
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{"short content", "this is a single line", "this is a single line"},
+		{"content longer than cap", longInput, longExpected},
+		{"empty content", "", "(no subject)"},
+		{"content with newline", "This is the first line.\nThis is the second line", "This is the first line."},
+	}
+	for _, tt := range tests {
+		result := subjectFromContent(tt.content)
+		if result != tt.expected {
+			t.Errorf("subjectFromContent(%q) = %q, want %q", tt.content, result, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thanks for contributing to IronClaw! Keep changes small, focused, and reversible,
and link the issue this addresses.
-->

## What & why

This PR introduces a table-driven test for the `subjectFromContent` function in the email channel adapter to ensure its behavior is fully covered across various content scenarios.

Closes #111

## Changes

- Added `TestSubjectFromContent` (table-driven) in `internal/host/channels/email_test.go`.
- Covered 4 specific scenarios: short content, content exceeding the 120-character cap (validating truncation), content with newlines, and empty content fallback.

## Checklist

- [x] **Tests pass:** `CGO_ENABLED=1 go test ./...` is green (CGO is required — SQLCipher binding).
- [x] **Formatted & vetted:** `gofmt -l .` is empty and `go vet ./...` passes.
- [x] **Frozen contract:** `internal/contract/**` is **untouched** — or this carries an approved joint RFC (`docs/contract.md`) with code-owner sign-off.
- [x] **Threat model:** no change to the sandbox seal / `network=none` / approval-gateway posture — or it is called out and reviewed.
- [x] **Docs updated:** README / `docs/**` reflect any user-facing or behavioral change.
- [x] **No secrets:** no tokens, keys, or credentials in code, tests, fixtures, or logs.

## Validation

```bash
CGO_ENABLED=1 go test ./internal/host/channels/...
```

All 4 table-driven test cases passed successfully. No production code was modified (test-only PR).
