### PR TITLE
feat(skills): in-session chat path to propose a Skill install (RFC-0006, IRO-48)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -535,6 +535,18 @@ func main() {
 	deliverer := delivery.New(channelReg, gw, reg, manager.OutboundReader).
 		WithInboundWriter(manager.InboundWriter).
 		WithQuestions(pendingQuestions)
+	// In-session skill install (RFC-0006): when skills are enabled, let an agent PROPOSE
+	// a curated, signed skill from chat. Delivery resolves+signature-verifies the named
+	// skill through the SAME resolver the operator `ironctl skill add` path uses, then
+	// routes the resolved ChangePermissions bundle to the gateway's mandatory human floor.
+	// With skills disabled (no resolver) a sandbox skill_install proposal is refused.
+	if skillsResolver != nil {
+		resolver := skillsResolver
+		deliverer = deliverer.WithSkillResolver(
+			func(skill, version string, group contract.AgentGroupID, by contract.UserID) (contract.ChangeRequest, error) {
+				return skills.InstallChange(resolver, skill, version, group, by)
+			})
+	}
 
 	// Respawn backoff: wrap the SessionManager (which is the sweep's Prober
 	// and Killer) so a crash-looping sandbox is tracked — each stuck-kill records a

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -329,6 +329,7 @@ Per-kind `payload` shape:
 | `wiring` | object (engage mode, pattern, scope, ...) | none yet (human reviews) |
 | `permissions` | object (role/member grants) | none yet (human reviews) |
 | `mcp_access` | `{"server":"<name>","tools":["<tool>",...]}` (omit `tools` = all the server's declared tools) | `MCPServerVerifier` rejects an unknown server / a tool the server does not declare |
+| `skill_install` | `{"skill":"<name>","version":"<version>"}` | host RESOLVES the named skill (curated source + minisign trust root); an unknown/unsigned/out-of-policy skill is refused before the gateway |
 
 ### RFC-0005: approval-gated MCP-server access — `ChangeMCPAccess`
 
@@ -351,6 +352,31 @@ access through the gateway:
   host-side (`${ENV}` references resolved by the broker) and never reach the sandbox.
 - **Kept host-internal.** The MCP server catalog, the `GrantedMCP` shape, and the
   broker wire format are host-internal — not pinned in the contract.
+
+### RFC-0006: in-session skill install — `ChangeSkillInstall`
+
+OpenClaw's headline loop is *tell the assistant in chat to add a skill → a human
+approves → it executes in the same session.* IronClaw already supported this shape for
+`mcp_access`; RFC-0006 closes the gap for **skills**, which were previously
+operator-only (out-of-session `ironctl skill add` / `POST /v1/skills/install`).
+
+- **One new contract value:** `ChangeSkillInstall = "skill_install"`. It rides the
+  existing `SystemAction` envelope (`action == "skill_install"`); the agent reaches it
+  from chat via `request_capability_change` (kind `skill_install`).
+- **The sandbox may only NAME a skill** (`{"skill","version"}`) — it can never author
+  skill content (persona text, tool grants, asset bundles). That invariant is the whole
+  reason skills require operator-curated, minisign-signed bundles.
+- **The host resolves through the SAME trust gate as the operator path.**
+  `delivery.handleSkillInstall` calls `skills.InstallChange` over the configured
+  `Resolver` (curated source + trust root): fetch + signature-verify + manifest-validate.
+  The resolved install is submitted as a **`ChangePermissions`** ChangeRequest — the
+  `skill_install` kind is the sandbox→host action vocabulary only and is **never itself a
+  `ChangeRequest.Kind`** — so the proven skill-install applier + respawn handle it exactly
+  as the operator path, and the human approves the real persona/tools/egress it grants.
+- **Fail-closed.** With skills not enabled (no resolver), or a skill that is
+  unknown/unsigned/out-of-policy, the proposal is refused host-side and never reaches the
+  gateway. The sandbox can *ask*; only a curated+signed skill an operator provisioned can
+  be proposed, and a human still approves it.
 
 Kinds with no automated verifier still pass through the deterministic chain and
 the always-require-human floor; they are simply approved by a human without an

--- a/internal/contract/enums.go
+++ b/internal/contract/enums.go
@@ -84,6 +84,21 @@ const (
 	// broker unix socket — so the sandbox stays network=none and never speaks MCP
 	// itself. This is the only frozen-contract change.
 	ChangeMCPAccess ChangeKind = "mcp_access"
+	// ChangeSkillInstall lets an agent PROPOSE installing a curated, signed skill from
+	// chat (RFC-0006), closing the OpenClaw add->approve->execute parity gap for skills.
+	// It is a sandbox->host PROPOSAL vocabulary only: the sandbox names a skill by
+	// {skill, version} -- it can NEVER author skill content (persona text, tool grants,
+	// asset bundles), which is the whole point of skills requiring operator-curated,
+	// minisign-signed bundles. The host RESOLVES the named skill through the SAME
+	// curated source + trust root the operator path uses (host/skills.Resolver), and
+	// only then materializes the verified ChangePermissions bundle the human approves.
+	// So this kind is the action discriminator the sandbox emits (action ==
+	// "skill_install"); it is NEVER itself submitted to the gateway as a
+	// ChangeRequest.Kind -- the resolved install rides ChangePermissions exactly like the
+	// operator path, reusing the proven skill-install applier + respawn. A proposal for
+	// a skill that is unknown, unsigned, out-of-policy, or proposed when skills are not
+	// enabled is refused host-side and never reaches the gateway.
+	ChangeSkillInstall ChangeKind = "skill_install"
 )
 
 // Verdict is the deterministic result of a single verifier in the gateway chain.

--- a/internal/host/delivery/delivery.go
+++ b/internal/host/delivery/delivery.go
@@ -27,6 +27,19 @@ import (
 // host/queue.OpenOutbound once the encrypted-SQLite binding lands.
 type OutboundReaderFactory func(contract.SessionID) (contract.OutboundReader, error)
 
+// SkillInstallResolver resolves a NAMED, curated, signed skill into its gateway
+// install ChangeRequest — resolve = fetch from the curated source + minisign-verify
+// against the trust root + manifest-validate against the compiled tool set. Satisfied
+// host-side by skills.InstallChange over the configured skills.Resolver (cmd/controlplane);
+// a func seam so delivery does not import the skills package.
+//
+// This is the trust gate for the in-session skill-install proposal (RFC-0006): the
+// sandbox may only NAME skill@version, so an unsigned/unknown/out-of-policy skill never
+// becomes a ChangeRequest. The returned request rides ChangePermissions (the resolved
+// bundle the human approves), identical to the operator `ironctl skill add` path. May be
+// nil — then a sandbox skill_install proposal is refused rather than honored.
+type SkillInstallResolver func(skill, version string, group contract.AgentGroupID, requestedBy contract.UserID) (contract.ChangeRequest, error)
+
 // InboundWriterFactory returns the host's inbound writer for a session. Used by
 // the schedule_task system action to enqueue a future inbound prompt. Tests inject
 // a fake (host/queue.MemInbound); production wires it to host/queue.OpenInbound
@@ -45,6 +58,7 @@ type Delivery struct {
 	newReader OutboundReaderFactory
 	newWriter InboundWriterFactory // optional; enables schedule_task
 	questions *questions.Store     // optional; enables ask_user_question tracking
+	skillProp SkillInstallResolver // optional; enables the in-session skill_install proposal
 
 	mu        sync.Mutex
 	delivered map[contract.MessageID]struct{}
@@ -109,6 +123,16 @@ func (d *Delivery) WithInboundWriter(f InboundWriterFactory) *Delivery {
 // ask_user_question is recognized as non-privileged but recorded nowhere (logged).
 func (d *Delivery) WithQuestions(s *questions.Store) *Delivery {
 	d.questions = s
+	return d
+}
+
+// WithSkillResolver wires the curated, signature-verifying resolver that backs the
+// in-session skill_install proposal (RFC-0006). Returns d for chaining. When unset
+// (skills not enabled on the control-plane) a sandbox skill_install proposal is
+// refused — the sandbox can ask, but only a curated+signed skill an operator has
+// provisioned can ever be proposed, and a human still approves it.
+func (d *Delivery) WithSkillResolver(f SkillInstallResolver) *Delivery {
+	d.skillProp = f
 	return d
 }
 
@@ -198,6 +222,14 @@ func (d *Delivery) handleSystem(ctx context.Context, sess registry.Session, msg 
 	// before the privilege routing (an unknown action would otherwise be gated).
 	if strings.EqualFold(strings.TrimSpace(action), contract.ActionAskUser) {
 		return d.handleAskUser(sess, msg)
+	}
+	// skill_install is a PRIVILEGED proposal that needs a resolve step the generic
+	// passthrough cannot do: the sandbox names skill@version, but the gateway must see
+	// the resolved, signature-verified ChangePermissions bundle the human approves. Handle
+	// it before the generic privilege routing so the named skill is resolved through the
+	// curated trust gate rather than forwarded as an opaque, sandbox-authored payload.
+	if strings.EqualFold(strings.TrimSpace(action), string(contract.ChangeSkillInstall)) {
+		return d.handleSkillInstall(sess, msg)
 	}
 	kind, privileged := authorizeSystemAction(action)
 	if !privileged {
@@ -296,6 +328,54 @@ func (d *Delivery) handleAskUser(sess registry.Session, msg contract.MessageOut)
 		return nil
 	}
 	d.questions.Record(sess.ID, sess.AgentGroupID, req)
+	return nil
+}
+
+// skillInstallProposal is the payload a sandbox emits with a skill_install system
+// action: it NAMES a curated skill, nothing more. There is deliberately no persona /
+// tools / egress / asset / url field — the sandbox can never author skill content; it
+// can only point the host at a name the operator has curated and signed.
+type skillInstallProposal struct {
+	Skill   string `json:"skill"`
+	Version string `json:"version"`
+}
+
+// handleSkillInstall turns a sandbox skill_install PROPOSAL into a gateway
+// ChangeRequest by resolving the named skill through the curated, signature-verifying
+// resolver (RFC-0006) — the SAME trust gate the operator `ironctl skill add` path uses.
+// It executes nothing and authors no capability: the resolver returns a ChangePermissions
+// bundle (the resolved persona/tools/egress/mount) which Submit routes to the gateway's
+// mandatory human-approval floor, after which the existing skill-install applier mounts
+// it and respawn makes it take effect in the same session.
+//
+// Fail-closed: with no gateway or no resolver wired (skills not enabled), or a skill that
+// is unknown/unsigned/out-of-policy, the proposal is REFUSED here and never reaches the
+// gateway — a sandbox can ask, but cannot conjure a skill.
+func (d *Delivery) handleSkillInstall(sess registry.Session, msg contract.MessageOut) error {
+	if d.gw == nil {
+		return fmt.Errorf("host/delivery: skill_install refused for session %s (no gateway)", sess.ID)
+	}
+	if d.skillProp == nil {
+		return fmt.Errorf("host/delivery: skill_install refused for session %s (skills not enabled on this control-plane)", sess.ID)
+	}
+	a := contract.ParseSystemAction(msg.Content)
+	var p skillInstallProposal
+	if len(a.Payload) == 0 || json.Unmarshal(a.Payload, &p) != nil {
+		return fmt.Errorf("host/delivery: skill_install payload for %s must be {\"skill\":...,\"version\":...}", sess.ID)
+	}
+	if strings.TrimSpace(p.Skill) == "" || strings.TrimSpace(p.Version) == "" {
+		return fmt.Errorf("host/delivery: skill_install for %s requires both skill and version", sess.ID)
+	}
+	// Resolve = fetch + minisign-verify + manifest-validate. RequestedBy records the
+	// sandbox origin so the human approver sees the proposal came from the agent, not an
+	// operator. A resolve failure (unknown/unsigned/out-of-policy) refuses the proposal.
+	req, err := d.skillProp(p.Skill, p.Version, sess.AgentGroupID, contract.UserID("sandbox:"+string(sess.ID)))
+	if err != nil {
+		return fmt.Errorf("host/delivery: skill_install proposal for %s rejected at resolve: %w", sess.ID, err)
+	}
+	// Route the resolved bundle through the gateway (Submit blocks on a human; do it in
+	// the background like every other privileged action). The install is NOT applied here.
+	go func() { _, _ = d.gw.Submit(context.Background(), req) }()
 	return nil
 }
 
@@ -411,6 +491,14 @@ func authorizeSystemAction(action string) (contract.ChangeKind, bool) {
 		// widens the agent's tool surface with externally-served tools, always
 		// privileged → gateway (a human approves the named server and tools).
 		return contract.ChangeMCPAccess, true
+	case "skill_install":
+		// Proposing a curated, signed skill install from chat (RFC-0006). Delivery
+		// special-cases this BEFORE this switch (handleSkillInstall) because it needs a
+		// resolve step — the sandbox names skill@version and the host resolves it through
+		// the curated trust gate into the ChangePermissions bundle the human approves.
+		// Listed here so the authorization map is complete and stays privileged (gated,
+		// never executed inline) even if the special-case is ever removed.
+		return contract.ChangePermissions, true
 	case "script", "exec", "run", "shell":
 		// An unapproved script/RCE path: there is NO direct execution. Map it to the
 		// most privileged change kind so it is always human-gated, never run inline.

--- a/internal/host/delivery/delivery_test.go
+++ b/internal/host/delivery/delivery_test.go
@@ -3,6 +3,7 @@ package delivery
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -333,5 +334,106 @@ func TestAskUserQuestionNoStore(t *testing.T) {
 	}
 	if got := adapter.Delivered(); len(got) != 0 {
 		t.Fatalf("ask_user_question must not deliver to a channel, got %+v", got)
+	}
+}
+
+// fakeSkillResolver mimics skills.InstallChange: it resolves a curated, signed skill
+// NAMED by the sandbox into the ChangePermissions bundle a human approves, and refuses
+// any name it does not recognize (an unknown/unsigned skill never becomes a change).
+func fakeSkillResolver(skill, version string, group contract.AgentGroupID, by contract.UserID) (contract.ChangeRequest, error) {
+	if skill != "curated-skill" {
+		return contract.ChangeRequest{}, fmt.Errorf("skills: %s@%s not in the curated source", skill, version)
+	}
+	after, _ := json.Marshal(map[string]any{
+		"skill": skill, "version": version, "tools": []string{"web_search"},
+	})
+	return contract.ChangeRequest{
+		Kind: contract.ChangePermissions, AgentGroupID: group, RequestedBy: by, After: after,
+	}, nil
+}
+
+// TestSkillInstallProposalRoutedToGateway asserts the RFC-0006 parity loop: a sandbox
+// skill_install proposal naming a curated skill is resolved through the trust gate and
+// routed to the gateway as the resolved ChangePermissions bundle (held pending a human),
+// never delivered to a channel and never executed inline.
+func TestSkillInstallProposalRoutedToGateway(t *testing.T) {
+	d, adapter, _, _, w := newTestDelivery(t)
+	d.WithSkillResolver(fakeSkillResolver)
+
+	body := `{"action":"skill_install","payload":{"skill":"curated-skill","version":"1.2.0"},"reason":"need it"}`
+	if err := w.WriteMessageOut(contract.MessageOut{ID: "sk1", Seq: 1, Kind: contract.KindSystem, Content: body}); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if got := adapter.Delivered(); len(got) != 0 {
+		t.Fatalf("skill_install must not be delivered to a channel, got %+v", got)
+	}
+	if !waitPending(d, 1) {
+		t.Fatal("expected one pending gateway change from the skill_install proposal")
+	}
+	pending, _ := d.gw.Pending()
+	// The resolved install rides ChangePermissions (reusing the operator path's applier),
+	// NOT a raw skill_install kind, and its After is the resolved bundle — not the
+	// sandbox's {skill,version} proposal verbatim.
+	if pending[0].Kind != contract.ChangePermissions {
+		t.Fatalf("resolved install kind = %q, want permissions", pending[0].Kind)
+	}
+	var got struct {
+		Skill string   `json:"skill"`
+		Tools []string `json:"tools"`
+	}
+	if err := json.Unmarshal(pending[0].After, &got); err != nil {
+		t.Fatalf("After is not the resolved bundle: %v (After=%s)", err, pending[0].After)
+	}
+	if got.Skill != "curated-skill" || len(got.Tools) != 1 || got.Tools[0] != "web_search" {
+		t.Fatalf("resolved bundle not threaded into After: %s", pending[0].After)
+	}
+}
+
+// TestSkillInstallRefusedWithoutResolver asserts fail-closed behavior: with skills not
+// enabled (no resolver wired) a sandbox skill_install proposal is refused, never
+// fabricated into a change and never delivered.
+func TestSkillInstallRefusedWithoutResolver(t *testing.T) {
+	d, adapter, _, _, w := newTestDelivery(t)
+	body := `{"action":"skill_install","payload":{"skill":"curated-skill","version":"1.2.0"}}`
+	w.WriteMessageOut(contract.MessageOut{ID: "sk1", Seq: 1, Kind: contract.KindSystem, Content: body})
+	if err := d.Poll(context.Background()); err == nil {
+		t.Fatal("expected skill_install to be refused when skills are not enabled")
+	}
+	if got := adapter.Delivered(); len(got) != 0 {
+		t.Fatalf("refused skill_install must not be delivered, got %+v", got)
+	}
+	if p, _ := d.gw.Pending(); len(p) != 0 {
+		t.Fatalf("refused skill_install must not become a pending change, got %d", len(p))
+	}
+}
+
+// TestSkillInstallRejectsUnknownSkill asserts the trust gate: a proposal naming a skill
+// the curated resolver does not recognize is rejected at resolve and never reaches the
+// gateway — the sandbox can ask, but cannot conjure a skill.
+func TestSkillInstallRejectsUnknownSkill(t *testing.T) {
+	d, _, _, _, w := newTestDelivery(t)
+	d.WithSkillResolver(fakeSkillResolver)
+	body := `{"action":"skill_install","payload":{"skill":"evil-skill","version":"9.9.9"}}`
+	w.WriteMessageOut(contract.MessageOut{ID: "sk1", Seq: 1, Kind: contract.KindSystem, Content: body})
+	if err := d.Poll(context.Background()); err == nil {
+		t.Fatal("expected an unknown skill to be rejected at resolve")
+	}
+	if p, _ := d.gw.Pending(); len(p) != 0 {
+		t.Fatalf("an unresolved skill must not become a pending change, got %d", len(p))
+	}
+}
+
+// TestSkillInstallRejectsBadPayload asserts a skill_install whose payload omits the
+// required name/version is refused before any resolve.
+func TestSkillInstallRejectsBadPayload(t *testing.T) {
+	d, _, _, _, w := newTestDelivery(t)
+	d.WithSkillResolver(fakeSkillResolver)
+	body := `{"action":"skill_install","payload":{"skill":"curated-skill"}}`
+	w.WriteMessageOut(contract.MessageOut{ID: "sk1", Seq: 1, Kind: contract.KindSystem, Content: body})
+	if err := d.Poll(context.Background()); err == nil {
+		t.Fatal("expected a skill_install missing its version to be refused")
 	}
 }

--- a/internal/sandbox/tools/capability.go
+++ b/internal/sandbox/tools/capability.go
@@ -35,6 +35,7 @@ var validChangeKinds = map[contract.ChangeKind]struct{}{
 	contract.ChangePermissions:  {},
 	contract.ChangeMounts:       {},
 	contract.ChangeMCPAccess:    {},
+	contract.ChangeSkillInstall: {},
 }
 
 type requestCapabilityChangeInput struct {
@@ -69,12 +70,16 @@ func (t *RequestCapabilityChangeTool) Description() string {
 		"- Use a host-configured MCP (Model Context Protocol) server's tools: kind \"mcp_access\", payload " +
 		"{\"server\": \"<name>\", \"tools\": [\"<tool>\", ...]} (omit \"tools\" to request all of the server's tools). " +
 		"You can only name a server an operator has already configured; the human approves the named server and tools.\n" +
+		"- Add/install a Skill: kind \"skill_install\", payload {\"skill\": \"<name>\", \"version\": \"<version>\"}. You can only " +
+		"NAME a skill the operator has curated and signed — you cannot author skill content. The host resolves and " +
+		"signature-verifies the named skill, the human approves the exact persona/tools/egress it grants, and it then " +
+		"mounts and takes effect on your next message (same session).\n" +
 		"Also supports persona, packages, permissions, and mounts. Always include a clear reason for the human approver."
 }
 
 func (t *RequestCapabilityChangeTool) JSONSchema() json.RawMessage {
 	return json.RawMessage(`{"type":"object","properties":{` +
-		`"kind":{"type":"string","enum":["persona","enabled_tools","packages","wiring","permissions","mounts","mcp_access"],"description":"The kind of control-plane change requested."},` +
+		`"kind":{"type":"string","enum":["persona","enabled_tools","packages","wiring","permissions","mounts","mcp_access","skill_install"],"description":"The kind of control-plane change requested."},` +
 		`"payload":{"type":"object","description":"The proposed new configuration for this kind."},` +
 		`"reason":{"type":"string","description":"Why the change is needed (shown to the human approver)."}` +
 		`},"required":["kind","payload"],"additionalProperties":false}`)

--- a/test/parity/capability_change_test.go
+++ b/test/parity/capability_change_test.go
@@ -140,6 +140,48 @@ func TestCapabilityChangeWireFormatSeam(t *testing.T) {
 	}
 }
 
+// TestSkillInstallProposalSeam drives the REAL sandbox tool emitting a skill_install
+// proposal (RFC-0006) through the host's REAL delivery, with a curated resolver wired as
+// in production. It proves the in-session add→approve→execute parity loop for skills: the
+// sandbox NAMES a curated skill, the host RESOLVES it through the trust gate into the
+// ChangePermissions bundle a human approves (held pending, never delivered to a channel),
+// reusing the same applier path as the operator `ironctl skill add`.
+func TestSkillInstallProposalSeam(t *testing.T) {
+	d, gw, adapter, w := newCapDelivery(t, gateway.VerifierChain{gateway.AlwaysRequireHuman{}})
+	// Stand in for skills.InstallChange: resolve the NAMED curated skill into the
+	// resolved ChangePermissions bundle (the sandbox can never author this content).
+	d.WithSkillResolver(func(skill, version string, group contract.AgentGroupID, by contract.UserID) (contract.ChangeRequest, error) {
+		if skill != "curated-skill" {
+			return contract.ChangeRequest{}, fmt.Errorf("skills: %s@%s not curated", skill, version)
+		}
+		after, _ := json.Marshal(map[string]any{"skill": skill, "version": version, "tools": []string{"web_search"}})
+		return contract.ChangeRequest{Kind: contract.ChangePermissions, AgentGroupID: group, RequestedBy: by, After: after}, nil
+	})
+
+	wire, _ := sandboxCapabilityWire(t, "skill_install", `{"skill":"curated-skill","version":"1.2.0"}`, "need web search")
+	if err := w.WriteMessageOut(contract.MessageOut{ID: "cap-skill", Seq: 1, Kind: contract.KindSystem, Content: wire}); err != nil {
+		t.Fatalf("enqueue outbound: %v", err)
+	}
+	if err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("delivery poll: %v", err)
+	}
+	if got := adapter.Delivered(); len(got) != 0 {
+		t.Fatalf("a skill_install proposal must never be delivered to a channel, got %+v", got)
+	}
+	pending := waitCapPending(t, gw, 1)
+	// The resolved install rides ChangePermissions — NOT the skill_install action name —
+	// so the proven skill-install applier + respawn handle it exactly as the operator path.
+	if pending[0].Kind != contract.ChangePermissions {
+		t.Fatalf("routed Kind = %q, want permissions (resolved skill install)", pending[0].Kind)
+	}
+	var got struct {
+		Skill string `json:"skill"`
+	}
+	if err := json.Unmarshal(pending[0].After, &got); err != nil || got.Skill != "curated-skill" {
+		t.Fatalf("After is not the resolved skill bundle: %s", pending[0].After)
+	}
+}
+
 // TestCapabilityChangePayloadVerifiedByHost asserts the defense-in-depth seam: a
 // package payload the sandbox emits is judged by the host's real PackageNameVerifier
 // on the exact bytes the sandbox produced. A clean payload passes; one carrying a


### PR DESCRIPTION
## IRO-48 — Parity gap: in-session chat path to ADD/INSTALL a Skill

Closes the openclaw `add → approve → execute` parity gap for **skills** (WS-G11 step 2), found by QA verifying IRO-31. IronClaw already had this shape for `mcp_access` (RFC-0005); skills were operator/admin-only and out-of-session (`ironctl skill add` / `POST /v1/skills/install`), so step 2 ("add a new Skill via chat") could not be done in one session.

### What changed
- **Contract** (`internal/contract/enums.go`): new `ChangeSkillInstall = "skill_install"`. It is a **sandbox → host PROPOSAL vocabulary only** — the sandbox NAMES `skill@version` and can *never* author skill content. The resolved install rides `ChangePermissions` (identical to the operator path), reusing the proven skill-install applier + respawn. Documented as **RFC-0006** in `docs/contract.md`.
- **Sandbox tool** (`internal/sandbox/tools/capability.go`): `request_capability_change` accepts kind `skill_install` with payload `{"skill":"<name>","version":"<version>"}`.
- **Host delivery** (`internal/host/delivery/delivery.go`): `handleSkillInstall` resolves the named skill through the **same** curated, signature-verifying resolver (`skills.InstallChange`) the operator path uses, then routes the resolved `ChangePermissions` bundle through the gateway's **mandatory human-approval floor**. Fail-closed: no gateway / no resolver / unknown / unsigned / out-of-policy ⇒ refused before reaching the gateway.
- **Wiring** (`cmd/controlplane/main.go`): `WithSkillResolver` wired when skills are enabled.
- **Respawn**: existing applier already covers `ChangePermissions`, so an approved install takes effect **in the same session**.

### Trust model
The sandbox can *ask*, but cannot conjure a skill. Only an operator-curated, minisign-signed skill can be proposed; a human still approves the exact persona/tools/egress it grants.

### Tests
- delivery: routed-to-gateway, refused-without-resolver, unknown-skill, bad-payload.
- parity: drives the **real** sandbox tool through to the host; asserts it rides `ChangePermissions` and is never delivered to a channel.
- Clean `go build ./...` + targeted tests green on latest `main`.