### PR TITLE
docs(readme): link the published documentation site (IRO-33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ### Security-first, self-hosted AI agents — isolation you can prove, not just promise.
 
+[![Documentation](https://img.shields.io/badge/docs-ironsecco.github.io-0a7bbb.svg)](https://ironsecco.github.io/ironclaw/)
 [![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#project-status)
 [![Latest release](https://img.shields.io/github/v/release/IronSecCo/ironclaw?sort=semver)](https://github.com/IronSecCo/ironclaw/releases/latest)
 [![Go Reference](https://pkg.go.dev/badge/github.com/IronSecCo/ironclaw.svg)](https://pkg.go.dev/github.com/IronSecCo/ironclaw)
@@ -144,6 +145,10 @@ files per conversation:
 For the full design, see [`docs/architecture.md`](docs/architecture.md),
 [`docs/threat-model.md`](docs/threat-model.md), and the plain-language tour in
 [`docs/ironclaw-explained.md`](docs/ironclaw-explained.md).
+
+> 📚 **Full documentation site:** [**ironsecco.github.io/ironclaw**](https://ironsecco.github.io/ironclaw/)
+> — quickstart, architecture, threat model, channels, skills, the OpenAPI reference, and security,
+> all in one navigable place (built from `docs/` and published on every push to `main`).
 
 ## Platform support
 


### PR DESCRIPTION
## WS-B — Documentation site (IRO-33), final gap

The MkDocs Material docs site (sourced from `docs/`) builds in CI and is **published live** at https://ironsecco.github.io/ironclaw/ via the `Docs` GitHub Actions workflow (build-on-PR with `--strict`, build+deploy-to-Pages on push to `main`). The full IA is in place and navigable:

- Quickstart · Building from source
- IronClaw Explained · Architecture · Frozen contract · MCP
- Channels · Writing a channel adapter
- Skills
- Security overview · Threat model
- API (OpenAPI) · Release runbook · Roadmap

**Remaining gap closed here:** the README linked individual `docs/*.md` source files but never the *published, navigable site*. The 'Done' criterion requires the IA to be **linked from the README**. This PR adds:

1. A **Documentation** badge in the header badge block → the docs site.
2. A prominent 📚 pointer next to the design references.

Touches only `README.md` (not part of the mkdocs build), so the strict docs gate is unaffected.

Closes the last item of IRO-33.