### PR TITLE
docs: content accuracy refresh — current shipped state (IRO-79)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,7 +83,16 @@ on-disk files:
 
 The same interfaces accept the durable backends with no caller changes.
 
-## What remains gated
+## What runs today
+
+The control-plane is composed and runnable end-to-end. `cmd/controlplane` wires the
+full daemon — durable key custody, the gateway (durable change store + append-only
+audit, including the `create_agent` verifier/applier), the API with Prometheus
+`/metrics`, structured logging, the model-proxy egress with rate caps + audit +
+secret redaction, the live per-session lifecycle (a `SessionManager` over the
+encrypted-queue factory + isolator), the maintenance sweep with respawn backoff,
+the outbound delivery loop, and the channel adapters that register from their
+environment tokens.
 
 The encrypted-SQLite queue binding is live: the frozen contract exposes
 `contract.OpenInboundRW`/`OpenInboundRO` and `OpenOutboundRW`/`OpenOutboundRO`
@@ -91,20 +100,33 @@ The encrypted-SQLite queue binding is live: the frozen contract exposes
 SQLCipher binding, and the cross-mount live-poll parity checks run in
 `test/parity`. See the RFC log in [contract.md](contract.md).
 
-- **Sandbox rootfs provisioning.** `isolation` builds a hardened OCI spec,
-  provisions the bundle `rootfs/` through a pluggable provisioner (verifying the
-  image digest/signature against a trust policy before unpack), and execs the
-  runtime. A live `Launch` now needs `runsc` and a provisioned/signed image
-  present in the environment rather than the stdlib tree itself.
-- **Daemon wiring of the Wave-4 hardening.** Durable key custody, the metrics
-  `/metrics` handler, structured logging, API hardening, respawn + provider
-  backoff, and model-proxy rate caps/audit land as standalone packages; composing
-  them into `cmd/controlplane` is the remaining integration step.
+Sandbox launch is wired through a pluggable provisioner: `isolation` builds the
+hardened OCI spec, provisions the bundle `rootfs/` (verifying the image
+digest/signature against a trust policy before unpack), and execs the runtime. A
+*live* `Launch` still needs `runsc` and a provisioned/signed image present in the
+host environment — everything up to that boundary builds, tests, and runs today.
 
-## Future extensions
+## Shipped beyond the reference design
 
-Documented but design-gated (Wave 5): a Kata isolation backend behind the same
-`Isolator` interface, an egress broker for approved external APIs (beyond the
-model-proxy allowlist), a gateway auto-approval policy + RBAC over the
-mandatory-human floor, and agent-to-agent messaging with approval-gated
-`create_agent` (RFC-0004).
+These have landed and are part of the daemon (most behind an explicit opt-in flag,
+none widening the default posture):
+
+- **Kata isolation backend** behind the same `Isolator` interface, alongside
+  gVisor/`runsc`.
+- **Egress broker** for approved external hosts — deny-by-default, audited, brokered
+  over a host unix socket; the sandbox itself stays sealed `network=none`. Powers the
+  `web_search` tool. Opt-in via `--egress-socket`.
+- **Agent-to-agent messaging** with approval-gated `create_agent` (RFC-0004).
+- **Multiple model providers** — Anthropic, OpenAI, OpenRouter — selectable per
+  agent group through the host model proxy.
+- **MCP servers** — host-brokered, per-tool human-approved, audited.
+- A private, **mesh-only web console** embedded in the control-plane binary at `/ui/`.
+
+## Built but inert by default
+
+- **Gateway auto-approval policy + RBAC.** Implemented as a verifier/approver, but
+  **off by default**: the mandatory-human floor is the only active decision path
+  until an operator deliberately opts in. The remaining entrypoint task is attaching
+  the API-server hardening knobs (optional TLS, rate-limit, body limits, `/readyz`
+  readiness gate) — the `api.With*` options exist but are not yet wired in
+  `cmd/controlplane`.

--- a/docs/building.md
+++ b/docs/building.md
@@ -72,15 +72,24 @@ ironctl --addr http://<tailnet-ip>:8787 change pending
 See the [API reference](reference/api.md) for the HTTP API and
 [../deploy/README.md](https://github.com/IronSecCo/ironclaw/blob/main/deploy/README.md) for the gVisor + Tailscale deployment.
 
-## What stays gated
+## What's wired vs. what a live launch still needs
 
-The encrypted binding is wired, so `host/queue` opens real per-session databases.
-The remaining gated piece is **sandbox rootfs provisioning**: `isolation` builds
-the hardened OCI spec and execs `runsc`, but unpacking an OCI image into the bundle
-needs an external image tool, so `Launch` returns `ErrRootfsMissing` until a rootfs
-is provisioned. Until the full per-session lifecycle (session dirs + key custody +
-sandbox launch) is wired into the daemon, the control-plane runs with in-memory
-backends under `--dev`; the per-session queue factories and live `RouteInbound` /
-`Poll` / sweep wiring activate with that lifecycle. The pure logic
-(`NamespaceUserID`, `EvaluateEngage`, `DecideStuckAction`, the gateway, keys,
-model proxy, channels, queue SQL, and the API) is fully implemented and tested.
+The control-plane is composed end-to-end. `cmd/controlplane` wires the durable
+gateway + audit, key custody, the API + `/metrics`, the model proxy, the live
+per-session lifecycle (a `SessionManager` over the encrypted-queue factory +
+isolator), the maintenance sweep, the outbound delivery loop, and the channel
+adapters — so `host/queue` opens real per-session SQLCipher databases and
+`RouteInbound` / `Poll` / sweep run against them outside of `--dev`. The in-memory
+backends remain only for `--dev` and tests.
+
+The one piece that needs an external dependency at runtime is a **live sandbox
+launch**: `isolation` builds the hardened OCI spec and provisions the bundle rootfs
+through a pluggable provisioner (verifying the image digest/signature against a
+trust policy), then execs the runtime — but a real `Launch` needs `runsc` and a
+provisioned/signed image present in the host environment. You can build, vet, test,
+and run the control-plane today; only that final exec needs gVisor + an image.
+
+The remaining entrypoint task is attaching the API-server hardening knobs (optional
+TLS, rate-limit, body limits, `/readyz` readiness gate): the `api.With*` options
+exist but are not yet wired into `cmd/controlplane`. See the
+[roadmap](roadmap.md) for the full status.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,7 +20,7 @@ supply-chain trust.
 | **Waves 0–5** | Security backend (isolation, encrypted queues, gateway, registry, channels, scheduling, egress, a2a) | ✅ **complete** |
 | **Wave 6** | Public-launch readiness | 🚧 most of the way |
 | **Wave 7** | Product parity + web UI | 🚧 channels done; web UI planned |
-| **Wave 8** | Trust, supply-chain & ecosystem | 🚧 threat model + OpenAPI + examples done |
+| **Wave 8** | Trust, supply-chain & ecosystem | 🚧 docs site, signed releases + SBOM, threat model, OpenAPI & examples done |
 
 The backend is done; the remaining work is product surface, a UI, onboarding,
 and open-source/supply-chain polish — **not** the security core.
@@ -35,13 +35,15 @@ Everything needed to flip the repo public credibly.
 | `CODE_OF_CONDUCT.md` | ✅ |
 | Issue forms + PR template | ✅ |
 | Launch-grade README (hero, demo, badges) | ✅ |
-| Repo description, topics, social-preview image | ⬜ |
-| `docker-compose.yml` + `.env.example` + published image | 🚧 |
+| Repo description + topics | ✅ |
+| Social-preview image | 🚧 (asset ready; upload pending) |
+| `docker-compose.yml` + `.env.example` + published image | ✅ |
 | Guided `ironctl onboard` wizard | ✅ |
 | 5-minute quickstart tutorial | ✅ |
 | Homebrew tap + CHANGELOG + release notes | ✅ |
 | Public-repo ruleset for push-to-main | ⬜ |
-| Discussions + community channels + seeded good-first-issues | ⬜ |
+| Discussions + seeded good-first-issues | ✅ |
+| Real-time community chat (Discord / Matrix) | 🚧 |
 
 ## Wave 7 — Product parity & web UI
 
@@ -72,14 +74,15 @@ widening the network posture — ships embedded in the control-plane binary:
 | Channel adapter: Email / Gmail | ✅ |
 | Channel adapter: Matrix | ✅ |
 | Channel adapter: Google Chat | ✅ |
-| Teams / iMessage / Signal (tracking) | 🚧 |
+| Channel adapters: Microsoft Teams, Signal, iMessage | ✅ |
 | First-class persona / identity surface | ✅ |
 | Observability CLI (`ironctl status` / `doctor` / usage) | ✅ |
 | Host-side skills / extension system | ✅ |
 | Multi-provider model support | ✅ |
 
-IronClaw now speaks Slack, Discord, Telegram, Webhook, WhatsApp, Email/SMTP,
-Matrix, and Google Chat.
+IronClaw now speaks Slack, Discord, Telegram, Microsoft Teams, Signal, iMessage,
+Webhook, WhatsApp, Email/SMTP, Matrix, and Google Chat — plus the in-product web
+chat playground, for twelve delivery surfaces in all.
 
 ## Wave 8 — Trust, supply-chain & ecosystem
 
@@ -87,13 +90,13 @@ Press the security advantage — several of these are wins neither peer has clai
 
 | Item | Status |
 |------|--------|
-| Documentation site | ⬜ |
+| Documentation site | ✅ (this site) |
 | Checked-in OpenAPI spec | ✅ |
 | Threat model — STRIDE + data-flow | ✅ |
-| Signed releases + SBOM + provenance | ⬜ |
-| Supply-chain hygiene (Dependabot / CodeQL / secret scanning / pinned actions) | 🚧 |
-| OpenSSF Scorecard + Best-Practices badges | ⬜ |
-| SLSA L3 provenance + reproducible builds | ⬜ |
+| Signed releases + SBOM + provenance | ✅ |
+| Supply-chain hygiene (Dependabot / CodeQL / secret scanning / pinned actions) | ✅ |
+| OpenSSF Scorecard + Best-Practices badges | 🚧 (Scorecard workflow live) |
+| Reproducible builds | 🚧 (`ironctl` / `sandbox` reproducible; control-plane tracked) |
 | Examples gallery + templates | ✅ |
 | Public roadmap + comparison (this page) | ✅ |
 | Third-party security audit | 👤 |
@@ -122,7 +125,7 @@ will evolve — corrections welcome via an issue.
 | Container isolation | Docker / opt-in host access | gVisor + `network=none` + Kata backend | ✅ **stronger** |
 | Approval / permissions | role checks / host access | mandatory **deterministic gateway** with a human-approval floor | ✅ **stronger** |
 | Encrypted per-session queues | single-writer SQLite | SQLCipher-encrypted, read-only inbound | ✅ **stronger** |
-| Channels | broad | Slack · Discord · Telegram · Webhook · WhatsApp · Email · Matrix · Google Chat | ✅ **at parity** (was a gap; closed) |
+| Channels | broad | Slack · Discord · Telegram · Teams · Signal · iMessage · Webhook · WhatsApp · Email · Matrix · Google Chat · web chat | ✅ **at parity** (was a gap; closed) |
 | Outbound + interactive tools | yes | send / file / ask / schedule / tasks / a2a `create_agent` | ✅ at parity |
 | Scheduling & multi-agent (a2a) | yes | yes (RFC-0004, gateway-gated `create_agent`) | ✅ at parity |
 | Published threat model | partial / none | full STRIDE + data-flow + privilege matrix | ✅ **ahead** |
@@ -134,14 +137,15 @@ will evolve — corrections welcome via an issue.
 | Credential vault (arbitrary APIs) | yes | model credential + gateway-approved egress broker | 👤 partial (vault planned) |
 | Multiple LLM providers | drop-in modules | Anthropic / OpenAI / OpenRouter / Codex via host proxy | ✅ at parity |
 | In-product diagnostics | `/status` `/usage` | Prometheus metrics + audit + `ironctl status`/`doctor` | ✅ at parity |
-| **Signed releases + SBOM + reproducible builds** | neither peer | planned (Wave 8) | 🎯 **win available** |
+| **Signed releases + SBOM + provenance** | neither peer | cosign-signed releases + SBOM + build provenance, reproducible `ironctl`/`sandbox` | ✅ **shipped** (a win neither peer has claimed) |
 
 **The short version:** IronClaw is *ahead on the security spine* — provable
 isolation, a mandatory approval gateway, encrypted queues, and a published threat
 model — and has *closed most of the product-surface gap* (channels, an embedded web
 console, skills, and multi-provider support are all shipped). The supply-chain trust
-items (signing, SBOM, reproducible builds) are differentiators neither peer has
-claimed yet, and they're next.
+items — cosign-signed releases, an SBOM, and build provenance — have now shipped too;
+they're differentiators neither peer has claimed, and reproducible builds are landing
+component by component.
 
 ---
 


### PR DESCRIPTION
## Docs site — content accuracy refresh (IRO-79)

Parent: IRO-77. Audits the published docs (`docs/*.md`) for stale / pre-current-state content and reconciles them with the README, which is the canonical source of truth for the run flow.

### What was stale vs. corrected

**`architecture.md`** — the "What remains gated" + "Future extensions" sections described the daemon wiring as *"the remaining integration step"* and listed Kata / egress broker / `create_agent` / multi-provider as *"design-gated (Wave 5)"*. All of that has shipped and is composed into `cmd/controlplane` (verified against `main.go`). Replaced with:
- **What runs today** — the full composed daemon (key custody, gateway + audit + `create_agent`, API + `/metrics`, model proxy, live `SessionManager` lifecycle, sweep, delivery, channel adapters).
- **Shipped beyond the reference design** — Kata backend, egress broker, a2a/`create_agent` (RFC-0004), multi-provider, MCP, web console.
- **Built but inert by default** — gateway auto-approval + RBAC.

**`building.md`** — "What stays gated" claimed the per-session lifecycle wasn't wired and the daemon runs on in-memory backends. Corrected: the lifecycle is wired; only a *live* `runsc` launch needs gVisor + a provisioned/signed image.

**`roadmap.md`** — marked shipped items that were still ⬜/🚧: documentation site (this site), signed releases + SBOM + provenance, supply-chain hygiene (Dependabot/CodeQL/secret-scanning/pinned actions), `docker-compose.yml` + `.env.example` + published image, Discussions + good-first-issues. Reconciled channel breadth to the full **12 surfaces** that `channels.md` already documents (added Teams / Signal / iMessage / web chat).

### Audit result for the rest of the tree
- No `nivardsec` / internal-only / dead-link leftovers found (openclaw/nanoclaw mentions are intentional comparisons in roadmap/threat-model/contract).
- `index.md`, `security.md`, `skills.md`, `channels.md`, `quickstart.md`, `mkdocs.yml` already reflect OSS reality (IronSecCo repo, AGPLv3 + commercial, gateway/isolation/encrypted-queue story).

### Verification
- All internal markdown links in the edited pages resolve to existing nav pages.
- Content-only edits within existing pages; no nav/page additions. CI `docs.yml` validates the MkDocs build on push (mkdocs not installed locally).

Coordination: edits are isolated to page **content** — no `palette` / `extra_css` / theme changes, leaving the sibling UXDesigner theme work conflict-free.