### PR TITLE
docs: link the documentation site (README Community + CONTRIBUTING) (IRO-80)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,9 @@
 Thanks for your interest in IronClaw! Contributions of every kind are welcome —
 bug reports, fixes, new channel adapters, docs, and tests.
 
+New here? The [**documentation site**](https://ironsecco.github.io/ironclaw/) is the best
+starting point — architecture, threat model, quickstart, channels, and skills in one place.
+
 ## Ground rules
 
 - **Open an issue first** for anything non-trivial, so we can agree on the approach

--- a/README.md
+++ b/README.md
@@ -707,6 +707,9 @@ Questions, ideas, "is this a bug or am I holding it wrong?" — bring them to
 **[GitHub Discussions](https://github.com/IronSecCo/ironclaw/discussions)**. It's the project's
 home for Q&A, design discussion, and show-and-tell, and it's where maintainers answer first.
 
+- **New to the project or want the full picture?** Read the
+  [**documentation site**](https://ironsecco.github.io/ironclaw/) — architecture, threat model,
+  quickstart, channels, and skills, all in one navigable place.
 - **Found a bug or have a feature request?** Open an [issue](https://github.com/IronSecCo/ironclaw/issues/new/choose).
 - **Security report?** Do **not** open a public issue — follow [`SECURITY.md`](SECURITY.md).
 - **Want to contribute code?** Start with a


### PR DESCRIPTION
## Docs site discoverability (IRO-80)

The docs site is live at https://ironsecco.github.io/ironclaw/ but was under-linked. This makes it discoverable.

### Changes
- **README** — add a docs-site bullet to the **Community** section (top-of-list "New to the project?" pointer). The top-row `Documentation` badge and the in-body callout already landed in IRO-33.
- **CONTRIBUTING.md** — add a "New here? start at the docs site" pointer near the top.

### Done outside this PR
- **Repo About → Website** set via API: `gh api -X PATCH repos/IronSecCo/ironclaw -f homepage=https://ironsecco.github.io/ironclaw/` (now returns the docs URL).
- **mkdocs.yml** — confirmed `site_url`, `repo_url`, `repo_name`, `edit_uri` already correct (no change needed).

Parent: IRO-77. Branched off `main` after IRO-79 (#130) + IRO-33 (#129) merged to avoid README/mkdocs conflicts.