### PR TITLE
docs: sync README roadmap with docs-site roadmap (IRO-81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,13 @@ To report a vulnerability, please open a private security advisory rather than a
 
 ## Roadmap
 
+> **The living roadmap is on the docs site:
+> [Road to 1.0](https://ironsecco.github.io/ironclaw/roadmap/)** — the single source
+> of truth. It tracks the *product* road to 1.0 (public launch, web UI, channels, and
+> supply-chain trust) with a status-at-a-glance table and a comparison against the
+> category. The checklist below is the **engineering build-log** for the security
+> backend (Waves 0–5) and the hardening that followed.
+
 - [x] Architecture and threat model
 - [x] Compiling skeleton: frozen contract, control-plane and sandbox stubs, CI
 - [x] Control plane (routing, gateway, isolation spec, key custody, delivery, sweep) on in-memory backends
@@ -696,6 +703,7 @@ To report a vulnerability, please open a private security advisory rather than a
 - [x] Multiple model providers — Anthropic, OpenAI, OpenRouter — selectable per agent group
 - [x] MCP servers — host-brokered, with per-tool human-approved grants
 - [x] Private, mesh-only web console at `/ui/`
+- [x] Channel breadth beyond the first three — WhatsApp, Email/SMTP, Matrix, Google Chat, Microsoft Teams, Signal, iMessage, and Webhook, plus the in-product web chat playground (twelve delivery surfaces in all)
 
 **Design-gated (built, off by default):**
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -149,5 +149,8 @@ component by component.
 
 ---
 
-*For the architecture and security design, see [`architecture.md`](architecture.md)
-and [`threat-model.md`](threat-model.md).*
+*This page is the single source of truth for the roadmap. For the architecture and
+security design, see [`architecture.md`](architecture.md) and
+[`threat-model.md`](threat-model.md); for the engineering build-log of the security
+backend (Waves 0–5), see the
+[README roadmap](https://github.com/IronSecCo/ironclaw#roadmap).*


### PR DESCRIPTION
## Sync the docs-site roadmap with the repo's roadmap (IRO-81)

Parent: IRO-77 (Docs Website update). Board ask: *"make sure the roadmap is also synced with the repo's roadmap."*

The earlier content refresh ([#130](https://github.com/IronSecCo/ironclaw/pull/130), IRO-79) already brought `docs/roadmap.md` current, so there were **no remaining hard status contradictions** between the two roadmaps. What was left for the *sync* task:

- **No single source of truth / no cross-link.** README's §Roadmap is a backend build-log that never pointed at the canonical living "Road to 1.0" page, so the two would drift again.
- **One real divergence.** README understated channels ("Telegram, Slack, Discord") vs `docs/roadmap.md`'s twelve delivery surfaces.

### Changes
- **Declare `docs/roadmap.md` the single source of truth** and link README §Roadmap to it (`https://ironsecco.github.io/ironclaw/roadmap/`). README's checklist is reframed as the engineering build-log for the security backend (Waves 0–5).
- **Fix the channel understatement** — add the full channel set (WhatsApp, Email/SMTP, Matrix, Google Chat, Microsoft Teams, Signal, iMessage, Webhook + web chat = twelve surfaces) to README's "landed" list, matching the canonical roadmap.
- **Reciprocal link** from `docs/roadmap.md` back to the README build-log.

### Verification
- `mkdocs.yml` nav entry `Roadmap: roadmap.md` resolves to `docs/roadmap.md`.
- Local `mkdocs build` renders `/roadmap/` with the new single-source note and the README back-link present in the output.
- Docs-only change — no code, no trust-boundary surface touched.