### PR TITLE
ci(ruleset): require PR + 1 approving review on main (IRO-88)

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -14,6 +14,17 @@
     { "type": "required_linear_history" },
     { "type": "required_signatures" },
     {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["squash", "rebase"]
+      }
+    },
+    {
       "type": "required_status_checks",
       "parameters": {
         "strict_required_status_checks_policy": false,


### PR DESCRIPTION
## Summary
Adds a `pull_request` rule to the checked-in `main-protection` ruleset spec (`.github/rulesets/main.json`), syncing it with the **live ruleset already applied** to `IronSecCo/ironclaw`.

Closes the remaining HIGH Scorecard repo-governance alerts from IRO-88:
- **Branch-Protection** — require PR before merge, dismiss stale reviews on push (no-force-push / linear-history / signatures / required-status-checks were already enforced).
- **Code-Review** — require ≥1 approving review.

## Live ruleset state (already active, id 17917971)
`deletion`, `non_fast_forward`, `required_linear_history`, `required_signatures`, `required_status_checks` (build, CodeQL), and now `pull_request` (1 approval + dismiss stale).

## Notes / tradeoff for review
- Merge methods restricted to `squash`/`rebase` to stay consistent with `required_linear_history`.
- The **Admin role retains `bypass_mode: always`** so the autonomous trunk flow is not deadlocked (only the human owner + admins can satisfy/bypass the 1-approval rule today). Removing admin bypass would raise the Scorecard Branch-Protection tier further but blocks agent merges — flagged for CEO decision.

## Supply-chain lenses
- **Required-checks gating** — ratchets protection *up* (PR + review added); no existing check relaxed.
- Enforcement-touching → routed to CEO for review per release contract.

Refs IRO-88.