### PR TITLE
fix(skills): make path barrier data-flow-visible to CodeQL (IRO-90)

### DIFF
--- a/internal/host/skills/catalog.go
+++ b/internal/host/skills/catalog.go
@@ -74,21 +74,9 @@ func (d DirSource) List() ([]SkillRef, error) {
 // delete outside the catalog. Removing an absent bundle is an error (so the caller
 // learns it named nothing), not a silent success.
 func (d DirSource) Remove(name, version string) error {
-	if d.Root == "" {
-		return fmt.Errorf("skills: DirSource has no configured root")
-	}
-	if !validName(name) {
-		return fmt.Errorf("skills: invalid skill name %q", name)
-	}
-	target := filepath.Join(d.Root, name)
-	if version != "" {
-		if !validVersion(version) {
-			return fmt.Errorf("skills: invalid skill version %q", version)
-		}
-		target = filepath.Join(target, version)
-	}
-	if !withinRoot(d.Root, target) {
-		return fmt.Errorf("skills: resolved path escapes the catalog root")
+	target, err := resolveBundlePath(d.Root, name, version, false)
+	if err != nil {
+		return err
 	}
 	if _, err := os.Stat(target); err != nil {
 		return fmt.Errorf("skills: %s not in catalog: %w", catalogLabel(name, version), err)

--- a/internal/host/skills/source.go
+++ b/internal/host/skills/source.go
@@ -238,18 +238,9 @@ type DirSource struct {
 }
 
 func (d DirSource) Open(name, version string) ([]byte, string, error) {
-	if strings.TrimSpace(d.Root) == "" {
-		return nil, "", errors.New("skills: DirSource has no configured root")
-	}
-	if !validName(name) {
-		return nil, "", fmt.Errorf("skills: invalid skill name %q", name)
-	}
-	if !validVersion(version) {
-		return nil, "", fmt.Errorf("skills: invalid skill version %q", version)
-	}
-	base := filepath.Join(d.Root, name, version)
-	if !withinRoot(d.Root, base) {
-		return nil, "", errors.New("skills: resolved skill path escapes the source root")
+	base, err := resolveBundlePath(d.Root, name, version, true)
+	if err != nil {
+		return nil, "", err
 	}
 	manifest, err := os.ReadFile(filepath.Join(base, manifestFileName))
 	if err != nil {
@@ -262,22 +253,38 @@ func (d DirSource) Open(name, version string) ([]byte, string, error) {
 	return manifest, string(sig), nil
 }
 
-// withinRoot reports whether p resolves to a location inside root, guarding the
-// filesystem fetch against traversal even if validation upstream regresses.
-func withinRoot(root, p string) bool {
-	rootAbs, err := filepath.Abs(root)
-	if err != nil {
-		return false
+// resolveBundlePath is the single path barrier every catalog filesystem op routes
+// through. It charset-validates name (and version), derives the bundle path from a
+// cleaned root, then confirms — on the exact cleaned value it returns — that the
+// result is contained within root. validName/validVersion already forbid path
+// separators and "."/"..", so the containment check is belt-and-suspenders; its real
+// job is to make the sanitizer *data-flow-visible*: the guard sits directly on the
+// returned path, so CodeQL can follow that the value handed to os.Stat/os.ReadFile/
+// os.RemoveAll is confined to root. This closes the go/path-injection findings that
+// the previous out-of-line withinRoot helper left invisible to the analyzer.
+//
+// An empty version selects the whole <root>/<name> directory (Remove uses this to
+// un-catalog every version); requireVersion forces a concrete <name>/<version>.
+func resolveBundlePath(root, name, version string, requireVersion bool) (string, error) {
+	if strings.TrimSpace(root) == "" {
+		return "", errors.New("skills: catalog has no configured root")
 	}
-	pAbs, err := filepath.Abs(p)
-	if err != nil {
-		return false
+	if !validName(name) {
+		return "", fmt.Errorf("skills: invalid skill name %q", name)
 	}
-	rel, err := filepath.Rel(rootAbs, pAbs)
-	if err != nil {
-		return false
+	cleanRoot := filepath.Clean(root)
+	target := cleanRoot + string(filepath.Separator) + name
+	if requireVersion || version != "" {
+		if !validVersion(version) {
+			return "", fmt.Errorf("skills: invalid skill version %q", version)
+		}
+		target += string(filepath.Separator) + version
 	}
-	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+	clean := filepath.Clean(target)
+	if clean != cleanRoot && !strings.HasPrefix(clean, cleanRoot+string(filepath.Separator)) {
+		return "", errors.New("skills: resolved path escapes the catalog root")
+	}
+	return clean, nil
 }
 
 // validVersion accepts a non-empty semver-style version token (letters, digits,

--- a/internal/host/skills/source_test.go
+++ b/internal/host/skills/source_test.go
@@ -255,6 +255,49 @@ func TestDirSourceRejectsBadIdentifiers(t *testing.T) {
 	}
 }
 
+// TestResolveBundlePathContainment exercises the path barrier directly: every value
+// it returns must be confined to root, and any traversal/charset violation must be
+// refused before a filesystem path is produced. This is the sanitizer CodeQL follows
+// for the go/path-injection sinks in Open/Remove.
+func TestResolveBundlePathContainment(t *testing.T) {
+	root := t.TempDir()
+	prefix := filepath.Clean(root) + string(filepath.Separator)
+
+	// Accepted: concrete name@version and (Remove-only) whole-name selection.
+	for _, c := range []struct {
+		name, version  string
+		requireVersion bool
+	}{
+		{"triage", "1.0.0", true},
+		{"triage", "", false},
+	} {
+		got, err := resolveBundlePath(root, c.name, c.version, c.requireVersion)
+		if err != nil {
+			t.Fatalf("resolveBundlePath(%q,%q) rejected a valid bundle: %v", c.name, c.version, err)
+		}
+		if got != filepath.Clean(root) && !strings.HasPrefix(got, prefix) {
+			t.Errorf("resolved path %q escapes root %q", got, root)
+		}
+	}
+
+	// Refused: traversal tokens, bad charset, empty root, and empty version when required.
+	for _, c := range []struct {
+		root, name, version string
+		requireVersion      bool
+	}{
+		{root, "../etc", "1.0.0", true},
+		{root, "ok", "../../1", true},
+		{root, "a/b", "1.0.0", true},
+		{root, "ok", "..", false},
+		{root, "ok", "", true},
+		{"", "ok", "1.0.0", true},
+	} {
+		if _, err := resolveBundlePath(c.root, c.name, c.version, c.requireVersion); err == nil {
+			t.Errorf("resolveBundlePath(root=%q,name=%q,version=%q) accepted an unsafe input", c.root, c.name, c.version)
+		}
+	}
+}
+
 // --- Resolver (end to end) ------------------------------------------------
 
 const resolverManifest = `apiVersion: ironclaw.dev/skill/v1


### PR DESCRIPTION
## What

Resolves the 4 HIGH `go/path-injection` CodeQL alerts (#22–#25) in the skills catalog/source filesystem layer (from IRO-48 skill_install work).

| Alert | File | Sink |
|------|------|------|
| #22 | `catalog.go` | `os.Stat` |
| #23 | `catalog.go` | `os.RemoveAll` |
| #24 | `source.go` | `os.ReadFile` (manifest) |
| #25 | `source.go` | `os.ReadFile` (signature) |

## How

These were sanitizer **false positives** — `validName`/`validVersion` forbid path separators and `.`/`..`, and the out-of-line `withinRoot` helper confirmed containment. But CodeQL could not see `withinRoot` as a barrier, so the name-derived path read as unsanitized into each sink.

Per the issue's **preferred** option (visible barrier over suppression), I folded validation + containment into a single `resolveBundlePath(root, name, version, requireVersion)` barrier that returns the **only** path used downstream. The containment guard (`filepath.Clean` + root-prefix check) now sits directly on the value it returns, making the sanitizer data-flow-visible — `Open` and `Remove` receive a path CodeQL can follow as confined to root. `withinRoot` is removed.

Behaviour is unchanged: empty version still selects the whole `<name>` dir for `Remove`; version stays required for `Open`.

## Tests

- Added `TestResolveBundlePathContainment` — accepted paths stay within root; traversal/charset/empty-root inputs refused.
- Existing traversal coverage (`TestDirSourceRejectsBadIdentifiers`, `TestCatalogRemoveRejects`) still passes.
- `go build ./... && go test ./internal/host/skills/...` green (CGO_ENABLED=1), `go vet` clean.

## Security lenses

Trust-boundary / isolation: tightens the host-side path barrier; the sandbox still only *names* a skill and cannot supply a URL/path. No boundary widened. CodeQL alerts should auto-close once this merges and the scan re-runs against `main`.

Parent: IRO-82