### PR TITLE
ci: pin all CI/Docker deps to immutable digests (IRO-87)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
-# Dependabot keeps the supply chain current: Go modules and the GitHub
-# Actions used by the workflows. Weekly to keep PR volume (and Actions minutes from
-# the resulting CI runs) bounded.
+# Dependabot keeps the supply chain current: Go modules, the GitHub Actions used by
+# the workflows, and the Docker base images. Everything is pinned to immutable hashes
+# (action commit SHAs, image @sha256 digests) for provenance, so Dependabot is what
+# bumps those pins as upstream patches land. Weekly to keep PR volume (and Actions
+# minutes from the resulting CI runs) bounded.
 version: 2
 updates:
   - package-ecosystem: gomod
@@ -23,4 +25,17 @@ updates:
       prefix: ci
     groups:
       actions:
+        patterns: ["*"]
+
+  # Both container/Dockerfile and container/controlplane.Dockerfile pin their
+  # golang/debian bases to @sha256 digests; this keeps those digests fresh.
+  - package-ecosystem: docker
+    directory: "/container"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: container
+    groups:
+      docker-bases:
         patterns: ["*"]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,13 +36,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # hooks.py derives the version from `git rev-list --count HEAD`.
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: _site
 
@@ -72,4 +72,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
       # The `dist/pkg/iron*` glob matches the three binaries (and their .exe variants on
       # Windows) while excluding the copied-in LICENSE / README.md.
       - name: Attest build provenance for the binaries
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: "dist/pkg/iron*"
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -12,7 +12,7 @@
 # Build from the repository root with container/build.sh (sets the build context).
 
 # --- build stage ------------------------------------------------------------
-FROM golang:1.23-bookworm AS build
+FROM golang:1.23-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db AS build
 
 # go-sqlcipher (the encrypted-queue binding) needs CGO + libcrypto headers.
 RUN apt-get update \
@@ -29,7 +29,7 @@ ENV CGO_ENABLED=1
 RUN go build -trimpath -ldflags "-s -w" -o /out/sandbox ./cmd/sandbox
 
 # --- runtime stage ----------------------------------------------------------
-FROM debian:bookworm-slim AS runtime
+FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716 AS runtime
 
 # libssl3 satisfies the go-sqlcipher dynamic link; ca-certificates is harmless and
 # small. No other packages — the sandbox has network=none and installs nothing.

--- a/container/controlplane.Dockerfile
+++ b/container/controlplane.Dockerfile
@@ -20,7 +20,7 @@
 #   docker build -f container/controlplane.Dockerfile -t ironclaw-controlplane:latest .
 
 # --- build stage ------------------------------------------------------------
-FROM golang:1.23-bookworm AS build
+FROM golang:1.23-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db AS build
 
 # go-sqlcipher (the encrypted-queue binding) needs CGO + libcrypto headers; the
 # control-plane links it transitively through the encrypted session queues.
@@ -46,7 +46,7 @@ RUN go build -trimpath \
       -o /out/ironctl ./cmd/ironctl
 
 # --- runtime stage ----------------------------------------------------------
-FROM debian:bookworm-slim AS runtime
+FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716 AS runtime
 
 # libssl3 satisfies the go-sqlcipher dynamic link; ca-certificates lets the
 # host-proxied model egress validate TLS; curl backs the compose healthcheck


### PR DESCRIPTION
## Summary
Closes the 12 Scorecard **Pinned-Dependencies (MEDIUM)** alerts ([IRO-87](/IRO/issues/IRO-87), parent [IRO-82](/IRO/issues/IRO-82)). Pins every remaining unpinned GitHub Action to a full commit SHA and both Docker base images to `@sha256` digests.

Most actions were already SHA-pinned (IRO-32). This PR closes the gaps.

### Actions → commit SHAs (version in trailing comment)
- `docs.yml`: `checkout@v6`, `setup-python@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4`
- `release.yml`: `attest-build-provenance@v4` (per-binary attestation step, line 158)
- SHAs reuse the exact values already pinned elsewhere in-repo where applicable (checkout, attest-build-provenance).

### Docker bases → `@sha256` multi-arch index digests (tag kept for readability)
`container/Dockerfile` + `container/controlplane.Dockerfile`:
- `golang:1.23-bookworm@sha256:167053a2…`
- `debian:bookworm-slim@sha256:96e378d7…`

Both digests are the **OCI image-index (manifest list)** the tags currently resolve to — so the amd64+arm64 image build (`image.yml`) and the CGO build are unaffected.

### Maintainability
Added the `docker` ecosystem to `.github/dependabot.yml` (directory `/container`) so the new image digests stay bumped alongside `gomod` and `github-actions`.

## Supply-chain lenses
- **Pinned, auditable actions** — every `uses:` and `FROM` in the release/CI path is now an immutable hash.
- **Reproducibility** — frozen base-image digests remove a nondeterministic input.
- No change to signing, attestation logic, token scopes, or installer verification — purely tightens what is already there.

## Verification
- `actionlint` clean on edited workflows
- `dependabot.yml` parses (ecosystems: gomod, github-actions, docker)
- Both pinned digests resolve to multi-arch OCI indexes via `docker buildx imagetools inspect`

## Acceptance
0 open Pinned-Dependencies alerts expected after Scorecard re-runs; builds remain green.