### PR TITLE
fix(skills): confine catalog paths with filepath.IsLocal (CodeQL path-injection, IRO-85)

### DIFF
--- a/internal/host/skills/catalog.go
+++ b/internal/host/skills/catalog.go
@@ -80,16 +80,21 @@ func (d DirSource) Remove(name, version string) error {
 	if !validName(name) {
 		return fmt.Errorf("skills: invalid skill name %q", name)
 	}
-	target := filepath.Join(d.Root, name)
+	rel := name
 	if version != "" {
 		if !validVersion(version) {
 			return fmt.Errorf("skills: invalid skill version %q", version)
 		}
-		target = filepath.Join(target, version)
+		rel = filepath.Join(name, version)
 	}
-	if !withinRoot(d.Root, target) {
+	// Confine the user-supplied relative path with filepath.IsLocal before joining
+	// onto the root, so the path handed to os.Stat/os.RemoveAll provably cannot
+	// escape the catalog. See DirSource.Open for the rationale; IsLocal rejects
+	// absolute paths and any "../" escape and is the barrier the analyser tracks.
+	if !filepath.IsLocal(rel) {
 		return fmt.Errorf("skills: resolved path escapes the catalog root")
 	}
+	target := filepath.Join(d.Root, rel)
 	if _, err := os.Stat(target); err != nil {
 		return fmt.Errorf("skills: %s not in catalog: %w", catalogLabel(name, version), err)
 	}

--- a/internal/host/skills/catalog_test.go
+++ b/internal/host/skills/catalog_test.go
@@ -113,3 +113,45 @@ func TestCatalogRemoveRejects(t *testing.T) {
 		t.Error("valid bundle must be untouched by rejected removes")
 	}
 }
+
+// TestCatalogRemoveRejectsTraversal proves Remove cannot delete anything outside
+// the catalog root: every traversal/absolute payload is refused and a sentinel
+// directory placed next to (but outside) the root survives. This exercises the
+// filepath.IsLocal confinement barrier on the destructive os.RemoveAll path.
+func TestCatalogRemoveRejectsTraversal(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A sentinel a traversal would try to delete.
+	sentinel := filepath.Join(parent, "sentinel")
+	if err := os.MkdirAll(sentinel, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	catalogBundle(t, root, "triage", "1.0.0")
+	d := DirSource{Root: root}
+
+	traversals := [][2]string{
+		{"..", "sentinel"},
+		{"../sentinel", ""},
+		{"../..", ""},
+		{"../../../../../../tmp", ""},
+		{"/etc", ""},
+		{"ok", "/etc"},
+		{"ok", "../../sentinel"},
+		{".", ""},
+		{"ok", ".."},
+	}
+	for _, c := range traversals {
+		if err := d.Remove(c[0], c[1]); err == nil {
+			t.Errorf("Remove(%q,%q) was not rejected", c[0], c[1])
+		}
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("a traversal Remove deleted the out-of-root sentinel: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "triage", "1.0.0")); err != nil {
+		t.Error("valid bundle must survive rejected traversal removes")
+	}
+}

--- a/internal/host/skills/source.go
+++ b/internal/host/skills/source.go
@@ -247,10 +247,19 @@ func (d DirSource) Open(name, version string) ([]byte, string, error) {
 	if !validVersion(version) {
 		return nil, "", fmt.Errorf("skills: invalid skill version %q", version)
 	}
-	base := filepath.Join(d.Root, name, version)
-	if !withinRoot(d.Root, base) {
+	// Anchor the user-supplied components to a relative path and confine it with
+	// filepath.IsLocal BEFORE joining onto the root. IsLocal (Go 1.20+) is the
+	// standard library's lexical path-confinement predicate: it rejects absolute
+	// paths, the empty path, and any "../" escape. validName/validVersion already
+	// forbid separators and dot segments, so this is defence-in-depth — but it is
+	// also the barrier the static analyser recognises, so the path that reaches
+	// os.ReadFile is provably confined to the source root rather than merely
+	// charset-checked.
+	rel := filepath.Join(name, version)
+	if !filepath.IsLocal(rel) {
 		return nil, "", errors.New("skills: resolved skill path escapes the source root")
 	}
+	base := filepath.Join(d.Root, rel)
 	manifest, err := os.ReadFile(filepath.Join(base, manifestFileName))
 	if err != nil {
 		return nil, "", fmt.Errorf("skills: read manifest: %w", err)
@@ -260,24 +269,6 @@ func (d DirSource) Open(name, version string) ([]byte, string, error) {
 		return nil, "", fmt.Errorf("skills: read signature (unsigned bundles are refused): %w", err)
 	}
 	return manifest, string(sig), nil
-}
-
-// withinRoot reports whether p resolves to a location inside root, guarding the
-// filesystem fetch against traversal even if validation upstream regresses.
-func withinRoot(root, p string) bool {
-	rootAbs, err := filepath.Abs(root)
-	if err != nil {
-		return false
-	}
-	pAbs, err := filepath.Abs(p)
-	if err != nil {
-		return false
-	}
-	rel, err := filepath.Rel(rootAbs, pAbs)
-	if err != nil {
-		return false
-	}
-	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // validVersion accepts a non-empty semver-style version token (letters, digits,

--- a/internal/host/skills/source_test.go
+++ b/internal/host/skills/source_test.go
@@ -334,6 +334,87 @@ func TestResolverRefusesIdentityMismatch(t *testing.T) {
 	}
 }
 
+// TestDirSourceOpenRejectsTraversal proves that no agent-supplied name/version can
+// make Open read a file outside the source root: every "../", absolute-path, and
+// dot-segment payload is refused, and a secret placed next to (but outside) the
+// root is never read. This exercises the filepath.IsLocal confinement barrier as
+// well as the charset validators.
+func TestDirSourceOpenRejectsTraversal(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A secret bundle a traversal would try to reach, laid out so that name=".."
+	// version="secret" would resolve to it if confinement regressed.
+	if err := os.MkdirAll(filepath.Join(parent, "secret"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, "secret", manifestFileName), []byte("TOPSECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, "secret", signatureFileName), []byte("sig"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	src := DirSource{Root: root}
+	traversals := [][2]string{
+		{"..", "secret"},
+		{"../secret", "x"},
+		{"../..", "etc"},
+		{"../../../../../../etc", "passwd"},
+		{"a/../../secret", "x"},
+		{"/etc", "passwd"},     // absolute name
+		{"ok", "/etc/passwd"},  // absolute version
+		{"ok", "../../secret"}, // traversal version
+		{".", "1.0.0"},
+		{"ok", "."},
+		{"ok", ".."},
+	}
+	for _, c := range traversals {
+		manifest, _, err := src.Open(c[0], c[1])
+		if err == nil {
+			t.Errorf("Open(%q,%q) was not rejected", c[0], c[1])
+		}
+		if string(manifest) == "TOPSECRET" {
+			t.Fatalf("Open(%q,%q) escaped the root and read the secret bundle", c[0], c[1])
+		}
+	}
+}
+
+// TestDirSourceOpenSymlinkBoundary documents the symlink stance: agent-supplied
+// name/version components are single charset-restricted labels (no separators, no
+// dot segments), so an agent can never craft a value that traverses through a
+// symlink. A symlink placed *inside* the root is part of the operator's curated
+// source (operator trust boundary), not an injection vector — this test asserts
+// only the agent-facing property, that a label which would have to contain a path
+// to escape is rejected.
+func TestDirSourceOpenSymlinkBoundary(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(parent, "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A symlink whose *name* would itself have to be a traversal/separator string
+	// to be useful to an attacker; such a name is rejected by validName before any
+	// filesystem access happens.
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+	for _, c := range [][2]string{{"../outside", "1.0.0"}, {"link/..", "x"}, {"a/b", "1"}} {
+		if _, _, err := src(root).Open(c[0], c[1]); err == nil {
+			t.Errorf("Open(%q,%q) via symlink-adjacent path was not rejected", c[0], c[1])
+		}
+	}
+}
+
+func src(root string) DirSource { return DirSource{Root: root} }
+
 func TestResolverRequiresTrustRoot(t *testing.T) {
 	r := &Resolver{Source: DirSource{Root: t.TempDir()}, KnownTools: resolverTools()}
 	if _, err := r.Resolve("x", "1.0.0"); err == nil {


### PR DESCRIPTION
## Summary
Fixes the 4 HIGH `go/path-injection` CodeQL alerts in the skills host (parent IRO-82, IRO-85):
- `internal/host/skills/catalog.go:93,96` — alerts #22, #23
- `internal/host/skills/source.go:254,258` — alerts #24, #25

The user-supplied `name`/`version` were already charset-validated (`validName`/`validVersion`) and confined by the bespoke `withinRoot` helper, but **CodeQL does not recognise those as sanitizers**, so the dataflow stayed tainted into `os.ReadFile`/`os.Stat`/`os.RemoveAll`.

## Fix
Route the components through **`filepath.IsLocal`** (Go 1.20+) — the stdlib's lexical path-confinement predicate, which CodeQL **does** recognise as a path-injection barrier — applied to the relative path *before* it is joined onto the root. `IsLocal` rejects absolute paths, the empty path, and any `../` escape, so the path reaching the filesystem is provably confined. The bespoke `withinRoot` helper is removed in favour of the stdlib check (charset validators kept for clear errors + defence-in-depth).

This is the *refactor-so-the-taint-is-provably-broken* option from the acceptance criteria, not an alert dismissal.

## Tests
- `TestDirSourceOpenRejectsTraversal` — `../`, absolute-path, and dot-segment payloads all rejected; an out-of-root secret bundle is never read.
- `TestCatalogRemoveRejectsTraversal` — same payloads on the destructive path; an out-of-root sentinel survives.
- `TestDirSourceOpenSymlinkBoundary` — documents the agent-facing symlink boundary.

## Verification
- `CGO_ENABLED=1 go test ./internal/host/skills/` → 40 pass (+3 new)
- `CGO_ENABLED=1 go test ./internal/host/api/ ./internal/host/isolation/` → 128 pass
- `go vet ./internal/host/skills/` → clean

## Security lenses
- **Trust boundary integrity** — narrows, never widens, what the skills host will read/delete from agent-supplied input. No queue/sandbox capability change.
- **Mandatory gateway** — install remains a separate gateway-gated step; this only hardens catalog read/remove.

Re-run CodeQL on merge to confirm 0 open `go/path-injection` alerts. Hand to @QA for verification.