### PR TITLE
ci: least-privilege token permissions + workflow_run trust guard (IRO-91)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -29,11 +29,12 @@ on:
         required: false
         default: ""
 
+# Least-privilege default: read-only token for the workflow; each job below opts into
+# exactly the write scopes it needs (Scorecard Token-Permissions). `packages: write`
+# lives only on the jobs that push to GHCR (`build`, `merge`); `id-token`/`attestations`
+# write only on `merge`, which signs + attaches the provenance/SBOM attestations.
 permissions:
   contents: read
-  packages: write # push to GHCR under the repository owner
-  id-token: write # keyless provenance signing (Sigstore OIDC)
-  attestations: write # actions/attest-build-provenance for the image
 
 # Serialize image publishes so two builds never race the :latest tag.
 concurrency:
@@ -51,8 +52,19 @@ jobs:
   # failure.
   prepare:
     runs-on: ubuntu-latest
-    # On the workflow_run path, only build when the Release actually succeeded.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read # checkout only; resolve the GHCR ref + release tag for this commit
+    # Trust boundary for the `workflow_run` checkout below (Scorecard DangerousWorkflow):
+    #   - workflow_dispatch: a maintainer (write access) started it on `github.ref`.
+    #   - workflow_run: only when the Release run SUCCEEDED *and* it ran in the base repo
+    #     (head_repository.fork == false). Release itself triggers only on `push: [main]`
+    #     and `workflow_dispatch` — never on `pull_request` — so head_sha is always a
+    #     commit already merged to main; the fork gate is belt-and-suspenders so no
+    #     fork-originated run can ever reach this packages-writing chain.
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event.workflow_run.conclusion == 'success' &&
+           github.event.workflow_run.head_repository.fork == false) }}
     outputs:
       present: ${{ steps.meta.outputs.present }}
       image: ${{ steps.meta.outputs.image }}
@@ -107,6 +119,9 @@ jobs:
   build:
     needs: prepare
     if: ${{ needs.prepare.outputs.present == 'true' }}
+    permissions:
+      contents: read # checkout the released commit
+      packages: write # push the per-arch image to GHCR by digest
     strategy:
       fail-fast: false
       matrix:
@@ -177,6 +192,11 @@ jobs:
     needs: [prepare, build]
     if: ${{ needs.prepare.outputs.present == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # no checkout; reads digests + pushes the manifest list
+      packages: write # push the tagged manifest list to GHCR
+      id-token: write # keyless provenance/SBOM signing (Sigstore OIDC)
+      attestations: write # actions/attest-build-provenance + attest-sbom on the index
     outputs:
       digest: ${{ steps.manifest.outputs.digest }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,12 @@ concurrency:
   group: release
   cancel-in-progress: false
 
+# Least-privilege default: every job gets a read-only token unless it declares more
+# (Scorecard Token-Permissions). Only the `release` job that creates the GitHub Release
+# is granted `contents: write`, and only the jobs that sign/attest get id-token /
+# attestations write — see the per-job `permissions:` blocks below.
 permissions:
-  contents: write # create tags + releases
+  contents: read
 
 jobs:
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Harden CI workflows: DangerousWorkflow (CRITICAL) + TokenPermissions (HIGH)

Remediates the two highest-severity Scorecard findings on the release path (IRO-91, parent IRO-82). Touches only `.github/workflows/release.yml` + `.github/workflows/image.yml`. SHA-pin style preserved (no action refs changed).

### TokenPermissions (HIGH) — alerts #4, #5, #6
Least-privilege restructuring: read-only token by default, write scopes opted into per-job.

- **release.yml** top-level `contents: write` → `contents: read` (#6). Only the `release` job keeps `contents: write` (create release + upload assets); `build`/`release` keep their existing job-scoped `id-token`/`attestations: write`. `version`/`smoke`/`smoke_windows` are read-only.
- **image.yml** top-level `packages`/`id-token`/`attestations: write` removed → default `contents: read` (#5). `packages: write` now lives only on `build` (push by digest) and `merge` (push manifest list); `id-token`/`attestations: write` only on `merge` (signs + attaches provenance/SBOM). `prepare`/`verify-consumer` read-only.

The residual job-scoped writes (`release.yml` release job #4, and the `merge`/`build` grants) are the **documented best-practice target** of this very check — each is the minimal scope that job needs to do its job. With top-level now read-only, the Token-Permissions probe should pass on the next Scorecard run; any remaining job-scoped-write notes are correct-by-design (dismiss-with-rationale: required for the job's function).

### DangerousWorkflow (CRITICAL) — alerts #2, #3
`image.yml` checks out `ref: ${{ github.event.workflow_run.head_sha || github.ref }}` in a `workflow_run`-triggered, GHCR-pushing chain.

**Trust assessment:** `image.yml` chains only off the **Release** workflow (`workflow_run: ["Release"]`). Release triggers **only** on `push: branches:[main]` and `workflow_dispatch` — **never** `pull_request`/`pull_request_target`. Therefore `workflow_run.head_sha` is always a commit already merged to `main` (trusted) or a maintainer-dispatched ref. No untrusted fork-PR build can reach this push job.

**Defense in depth (this PR):** `prepare` now additionally gates the `workflow_run` path on `github.event.workflow_run.head_repository.fork == false`, so even a hypothetical future fork-originated run cannot reach the `packages: write` chain. No checked-out code is executed before this trust check (the build only runs the repo's own Dockerfile against the trusted commit).

Scorecard's DangerousWorkflow probe statically flags the `head_sha` checkout pattern and does not evaluate the runtime `if:` gate, so alerts #2/#3 will likely **persist after rescan and need dismiss-with-rationale** (the invariant above) — option 3 in the issue. Flagged for CEO confirmation (CRITICAL + trust-model-touching).

### Verification
- `actionlint` clean on both files; YAML parses; the multi-line `prepare` `if:` evaluates correctly (dispatch → allow; workflow_run base-repo success → allow; fork → skip the whole chain).
- No signing/attestation/checksum/installer-verification logic weakened — only token scopes narrowed and a trust gate added.

### Lenses
Least-privilege CI · Provenance & attestation (writes preserved on the jobs that sign) · Signing integrity (untouched) · Fail-closed (fork/non-success → chain skips).

Closes IRO-91.
