### PR TITLE
ci(supply-chain): SHA-pin docs/release actions + container base digests (IRO-92)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,13 +36,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # hooks.py derives the version from `git rev-list --count HEAD`.
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: _site
 
@@ -72,4 +72,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
       # The `dist/pkg/iron*` glob matches the three binaries (and their .exe variants on
       # Windows) while excluding the copied-in LICENSE / README.md.
       - name: Attest build provenance for the binaries
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: "dist/pkg/iron*"
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -12,7 +12,7 @@
 # Build from the repository root with container/build.sh (sets the build context).
 
 # --- build stage ------------------------------------------------------------
-FROM golang:1.23-bookworm AS build
+FROM golang:1.23-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db AS build
 
 # go-sqlcipher (the encrypted-queue binding) needs CGO + libcrypto headers.
 RUN apt-get update \
@@ -29,7 +29,7 @@ ENV CGO_ENABLED=1
 RUN go build -trimpath -ldflags "-s -w" -o /out/sandbox ./cmd/sandbox
 
 # --- runtime stage ----------------------------------------------------------
-FROM debian:bookworm-slim AS runtime
+FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716 AS runtime
 
 # libssl3 satisfies the go-sqlcipher dynamic link; ca-certificates is harmless and
 # small. No other packages — the sandbox has network=none and installs nothing.

--- a/container/controlplane.Dockerfile
+++ b/container/controlplane.Dockerfile
@@ -20,7 +20,7 @@
 #   docker build -f container/controlplane.Dockerfile -t ironclaw-controlplane:latest .
 
 # --- build stage ------------------------------------------------------------
-FROM golang:1.23-bookworm AS build
+FROM golang:1.23-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db AS build
 
 # go-sqlcipher (the encrypted-queue binding) needs CGO + libcrypto headers; the
 # control-plane links it transitively through the encrypted session queues.
@@ -46,7 +46,7 @@ RUN go build -trimpath \
       -o /out/ironctl ./cmd/ironctl
 
 # --- runtime stage ----------------------------------------------------------
-FROM debian:bookworm-slim AS runtime
+FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716 AS runtime
 
 # libssl3 satisfies the go-sqlcipher dynamic link; ca-certificates lets the
 # host-proxied model egress validate TLS; curl backs the compose healthcheck


### PR DESCRIPTION
## What

Resolve the **declarative** `PinnedDependencies` Scorecard alerts (IRO-92) that IRO-32 missed or that were added afterward — 9 of the 12 alerts:

**GitHub Actions → commit SHA (`# vX` comment kept for Dependabot/Renovate):**
- `docs.yml`: `checkout@v6`, `setup-python@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4`
- `release.yml`: `attest-build-provenance@v4` (same SHA already used elsewhere in the file)

**Container bases → digest (tag kept inline for Dependabot's docker manager):**
- `container/Dockerfile` + `container/controlplane.Dockerfile`: `golang:1.23-bookworm` and `debian:bookworm-slim`

The two digests are **OCI image indexes** covering `linux/amd64` + `linux/arm64`, matching the `image.yml` build matrix (verified with `docker buildx imagetools inspect`).

## Verification

- `actionlint` passes on `docs.yml` and `release.yml`.
- No unpinned declarative `uses:` remain in the touched workflows.
- Both base-image digests confirmed multi-arch indexes (amd64 + arm64 present).

## Out of scope (tracked separately)

3 of the 12 alerts are **download-then-run** dependencies, a different remediation class than SHA/digest pinning of `uses:`/`FROM`:
- `image.yml` + `release.yml`: the `curl … syft/main/install.sh | sh` SBOM installer (touches the trust-critical SBOM/attestation path → warrants CEO review)
- `docs.yml`: the `pip install -r docs/requirements.txt` step (needs a linux-verified hash-pinned lock to avoid breaking the docs deploy)

These are tracked in a sibling follow-up so this PR's clean, low-risk pins can land independently.

Refs IRO-92 · parent IRO-82 · sibling IRO-91