### PR TITLE
ci(codeql): add workflow_dispatch to refresh default-branch analysis (IRO-85)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,10 @@
 # Cost note: this runs on PRs to main and once weekly — deliberately NOT on every
 # push — to keep Actions minutes bounded. (The per-push release build in release.yml
 # is the heavy consumer; CodeQL is kept light.)
+#
+# workflow_dispatch lets a maintainer refresh the default-branch analysis on demand
+# (e.g. after a fix merges to main) so code-scanning alerts re-evaluate immediately
+# instead of waiting for the weekly schedule. Still bounded — manual, not per-push.
 name: CodeQL
 
 on:
@@ -10,6 +14,7 @@ on:
     branches: [main]
   schedule:
     - cron: "27 3 * * 1" # Mondays 03:27 UTC
+  workflow_dispatch:
 
 # Least privilege at the top level; the analyze job elevates only what it needs.
 permissions:


### PR DESCRIPTION
## Why

CodeQL is configured (deliberately, for Actions-minute cost) to run only on PRs to `main` and a weekly schedule — **not** on push to main. When a fix merges to main (e.g. #135 / IRO-90, which fixed the 4 `go/path-injection` alerts #22–#25), the default-branch code-scanning alerts stay `open` until the next Monday scan because main is never re-analyzed in between.

## What

Adds a `workflow_dispatch:` trigger so a maintainer can manually refresh the **default-branch** CodeQL analysis on demand and let code-scanning re-evaluate alerts immediately. No inputs, no per-push runs — cost stays bounded.

## Context

Unblocks QA verification on IRO-85: once merged, dispatching CodeQL on `main` will re-scan the already-fixed code and auto-close alerts #22–#25.