### PR TITLE
fix(skills): use filepath.IsLocal as the CodeQL-recognised path barrier (IRO-85)

### DIFF
--- a/internal/host/skills/source.go
+++ b/internal/host/skills/source.go
@@ -254,14 +254,17 @@ func (d DirSource) Open(name, version string) ([]byte, string, error) {
 }
 
 // resolveBundlePath is the single path barrier every catalog filesystem op routes
-// through. It charset-validates name (and version), derives the bundle path from a
-// cleaned root, then confirms — on the exact cleaned value it returns — that the
-// result is contained within root. validName/validVersion already forbid path
-// separators and "."/"..", so the containment check is belt-and-suspenders; its real
-// job is to make the sanitizer *data-flow-visible*: the guard sits directly on the
-// returned path, so CodeQL can follow that the value handed to os.Stat/os.ReadFile/
-// os.RemoveAll is confined to root. This closes the go/path-injection findings that
-// the previous out-of-line withinRoot helper left invisible to the analyzer.
+// through. It charset-validates name (and version), assembles the user-supplied
+// components into a relative path, and confines that relative path with
+// filepath.IsLocal *before* joining it onto the root. validName/validVersion already
+// forbid path separators and "."/"..", so the confinement is belt-and-suspenders;
+// its real job is to make the sanitizer *data-flow-visible to CodeQL*. IsLocal
+// (Go 1.20+) is the standard library's lexical path-confinement predicate — it
+// rejects absolute paths, the empty path, and any ".." escape — and, unlike a custom
+// filepath.Clean + strings.HasPrefix containment check, it is a barrier the CodeQL
+// go/path-injection query recognises. So the value handed to os.Stat/os.ReadFile/
+// os.RemoveAll is provably confined to root rather than merely charset-checked,
+// which closes alerts #22–#25 that the prior custom checks left visibly tainted.
 //
 // An empty version selects the whole <root>/<name> directory (Remove uses this to
 // un-catalog every version); requireVersion forces a concrete <name>/<version>.
@@ -272,19 +275,17 @@ func resolveBundlePath(root, name, version string, requireVersion bool) (string,
 	if !validName(name) {
 		return "", fmt.Errorf("skills: invalid skill name %q", name)
 	}
-	cleanRoot := filepath.Clean(root)
-	target := cleanRoot + string(filepath.Separator) + name
+	rel := name
 	if requireVersion || version != "" {
 		if !validVersion(version) {
 			return "", fmt.Errorf("skills: invalid skill version %q", version)
 		}
-		target += string(filepath.Separator) + version
+		rel = filepath.Join(name, version)
 	}
-	clean := filepath.Clean(target)
-	if clean != cleanRoot && !strings.HasPrefix(clean, cleanRoot+string(filepath.Separator)) {
+	if !filepath.IsLocal(rel) {
 		return "", errors.New("skills: resolved path escapes the catalog root")
 	}
-	return clean, nil
+	return filepath.Join(filepath.Clean(root), rel), nil
 }
 
 // validVersion accepts a non-empty semver-style version token (letters, digits,


### PR DESCRIPTION
## Problem

IRO-90 (#135, merged) routed every catalog filesystem op through `resolveBundlePath`, but its containment check was `filepath.Clean` + `strings.HasPrefix` — a **custom** predicate CodeQL does *not* recognise as a path-injection sanitizer (the same blind spot as the old `withinRoot`). 

**Verified:** a fresh full CodeQL analysis of `main` at `ba2bec5d` (which already contains #135) **still reports 4 open `go/path-injection` alerts** (#22–#25). The merged fix is functionally safe but does not clear the alerts.

## Fix

Swap the containment check for **`filepath.IsLocal`** (Go 1.20+), applied to the relative `<name>/<version>` path before joining onto root. `IsLocal` rejects absolute paths, the empty path, and any `..` escape — and is the barrier the CodeQL query **recognises**, so the path reaching `os.Stat`/`os.ReadFile`/`os.RemoveAll` is provably confined. `validName`/`validVersion` kept for clear errors + defence-in-depth.

## Verification

- `go build ./internal/host/skills/` → ok
- `go test ./internal/host/skills/` → **38 pass** (incl. IRO-90's traversal cases)
- `go vet ./internal/host/skills/` → clean
- Post-merge: will dispatch CodeQL on `main` (now possible via #143's `workflow_dispatch`) to confirm alerts #22–#25 close.

Closes the code-level work on IRO-85. Parent: IRO-82.