### PR TITLE
docs(tutorials): onboarding tutorial series (IRO-105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ For the full design, see [`docs/architecture.md`](docs/architecture.md),
 > 📚 **Full documentation site:** [**ironsecco.github.io/ironclaw**](https://ironsecco.github.io/ironclaw/)
 > — quickstart, architecture, threat model, channels, skills, the OpenAPI reference, and security,
 > all in one navigable place (built from `docs/` and published on every push to `main`).
+>
+> 🧭 **New here?** The [**hands-on tutorials**](https://ironsecco.github.io/ironclaw/tutorials/) take
+> you from `git clone` to a running agent: [your first sandboxed agent in 5 minutes](https://ironsecco.github.io/ironclaw/tutorials/first-agent/),
+> [connecting Slack](https://ironsecco.github.io/ironclaw/tutorials/connect-slack/), and
+> [writing a custom channel adapter](https://ironsecco.github.io/ironclaw/tutorials/custom-channel-adapter/).
 
 ## Platform support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,11 @@ deterministic **human-approval gateway**, and every action lands in an append-on
     From a clean clone to submitting, approving, and auditing your first agent
     action — in about five minutes, on your machine.
 
+-   :material-school: **[Tutorials](tutorials/index.md)**
+
+    Hands-on, copy-pasteable walkthroughs: your first sandboxed agent, connecting
+    Slack, and writing a custom channel adapter.
+
 -   :material-shield-lock: **[Security & trust](security.md)**
 
     The trust story: the threat model, the sealed-runtime invariants, and how a
@@ -59,6 +64,7 @@ deterministic **human-approval gateway**, and every action lands in an append-on
 | If you want to… | Read |
 | --- | --- |
 | Run IronClaw locally | [Quickstart](quickstart.md) |
+| Follow a hands-on walkthrough | [Tutorials](tutorials/index.md) |
 | Understand the design | [IronClaw, Explained](ironclaw-explained.md) → [Architecture](architecture.md) |
 | Evaluate the security posture | [Security & trust](security.md) → [Threat model](threat-model.md) |
 | Wire an agent to Slack / Discord / … | [Channel adapters](channels.md) |

--- a/docs/tutorials/connect-slack.md
+++ b/docs/tutorials/connect-slack.md
@@ -1,0 +1,152 @@
+---
+title: Connect IronClaw to Slack
+description: Wire an agent group to a live Slack channel — bot token, messaging group, wiring, and a reply destination.
+---
+
+# Connect IronClaw to Slack
+
+This tutorial connects an IronClaw agent to a **real Slack channel**. You'll create a Slack bot,
+hand its token to the control-plane, and use `ironctl` to wire an agent group so it engages in the
+channel and posts back into it.
+
+By the end you'll have a `triage` agent that:
+
+- engages **only when `@mentioned`**,
+- acts **only for known senders**,
+- **accumulates** the messages it stays out of so it has context when called in, and
+- can **post replies back** into the channel.
+
+This mirrors the runnable [`examples/channel-triage`](https://github.com/IronSecCo/ironclaw/tree/main/examples/channel-triage)
+template — read it alongside this page.
+
+## Prerequisites
+
+- A running IronClaw control-plane. The fastest way to one is the
+  [Quickstart](../quickstart.md#your-first-approved-action) (`--dev` mode, loopback) or a real
+  [deployment](https://github.com/IronSecCo/ironclaw/blob/main/README.md#deployment).
+- The `ironctl` binary on your `PATH` (built with `CGO_ENABLED=1 go build -o bin/ ./cmd/ironctl`).
+- [`jq`](https://jqlang.github.io/jq/) — used below to read the new messaging group's id.
+- Admin access to a Slack workspace.
+
+## 1. Create a Slack bot and get its token
+
+1. Go to the [Slack API console](https://api.slack.com/apps) → **Create New App** → *From scratch*.
+2. Open **OAuth & Permissions** → under **Scopes**, add the **`chat:write`** bot scope (so the bot
+   can post messages).
+3. **Install** the app to your workspace.
+4. Copy the **Bot User OAuth Token** — it starts with `xoxb-…`. This is the only secret you need.
+5. Invite the bot into the channel you want it in (e.g. `/invite @your-bot`), and note the channel
+   **id** (`C…`) — in Slack, open the channel, click its name → the id is at the bottom of the
+   *About* tab.
+
+## 2. Give the token to the control-plane
+
+The Slack adapter **auto-registers from an environment variable** when the daemon boots. Set
+`SLACK_BOT_TOKEN` in the control-plane's environment **before** you start it:
+
+```sh
+export SLACK_BOT_TOKEN=xoxb-your-bot-token   # held host-side; never enters a sandbox
+./bin/controlplane --dev --api-addr 127.0.0.1:8787
+```
+
+On boot the daemon logs:
+
+```
+channel adapter registered  adapter=slack
+```
+
+That line is your confirmation the adapter is live.
+
+!!! info "Where the secret lives"
+    The token is held **host-side** by the control-plane and **never enters a sandbox**. The
+    adapter also redacts its own credential from any error string, so a token can't leak into logs.
+    See [Channel adapters](../channels.md) for the full credential reference.
+
+If you run with Docker Compose instead, put `SLACK_BOT_TOKEN=xoxb-…` in your `.env` file and start
+the stack as usual.
+
+## 3. Point `ironctl` at the control-plane
+
+In a second terminal:
+
+```sh
+export IRONCLAW_API_TOKEN=<your control-plane API token>
+# --addr defaults to http://127.0.0.1:8787, so no extra flag is needed in dev
+```
+
+## 4. Wire the agent to the channel
+
+These are the five registry calls that connect an agent group to the Slack channel. Replace
+`C0123ABCD` with your channel id and `slack:U0FRONTDESK` with a real Slack user id (the bare handle
+prefixed with `slack:`).
+
+```sh
+# 1) the agent group
+ironctl registry agent-group put --id triage --name "Triage Bot" --folder triage
+
+# 2) a Slack channel messaging group, strict about unknown senders
+MG="$(ironctl registry messaging-group create \
+  --channel slack --platform C0123ABCD --group --policy strict | jq -r .ID)"
+echo "messaging-group id: $MG"
+
+# 3) register a known sender and make them a member of the agent group
+ironctl registry user   put --id slack:U0FRONTDESK --kind person --name "On-call"
+ironctl registry member add --user slack:U0FRONTDESK --agent triage
+
+# 4) the wiring: engage on @mention, known senders only, keep context, one shared session
+ironctl registry wiring create --mg "$MG" --agent triage \
+  --engage mention --scope known --ignored accumulate --session shared --priority 5
+
+# 5) allow the agent to post back into the channel
+ironctl registry destination add --agent triage --channel slack --platform C0123ABCD
+```
+
+What each piece does:
+
+| Call | Purpose |
+| --- | --- |
+| `agent-group put` | Creates the `triage` agent group. |
+| `messaging-group create --channel slack` | Binds a Slack channel as an inbound surface. `--group` marks it a channel (not a DM); `--policy strict` means messages from unregistered senders are not acted on. |
+| `user put` + `member add` | Registers a known sender and grants them access to the agent. |
+| `wiring create` | The engagement rules — `--engage mention` (only on `@mention`), `--scope known` (registered users only), `--ignored accumulate` (keep non-engaging messages as context), `--session shared` (one shared thread of context). |
+| `destination add` | Lets the agent **deliver** replies back into the channel. |
+
+## 5. Verify the wiring
+
+```sh
+ironctl registry messaging-group wirings --id "$MG"          # the wiring you just created
+ironctl registry access --user slack:U0FRONTDESK --agent triage   # confirms the sender has access
+```
+
+Then, in Slack, `@mention` the bot from the on-call user's account. The agent engages, runs in its
+sandbox, and posts the reply back into the channel.
+
+## What to notice
+
+- Because the policy is `strict` and the scope is `known`, a **stranger in the channel cannot make
+  the bot act** — a safe default for a shared workspace.
+- `--ignored accumulate` means the bot isn't blind to the conversation it stayed out of: when
+  finally mentioned, it has the recent context.
+- The bot only **posts where you allowed it** — delivery is gated by the `destination` you added,
+  not implied by the inbound wiring.
+
+## Other channels
+
+The same five-step shape works for every **auto-registered** adapter — just change the env var and
+`--channel` value:
+
+| Channel | Env var | `--channel` |
+| --- | --- | --- |
+| Slack | `SLACK_BOT_TOKEN` | `slack` |
+| Discord | `DISCORD_BOT_TOKEN` | `discord` |
+| Telegram | `TELEGRAM_BOT_TOKEN` | `telegram` |
+
+Teams, Signal, and iMessage take richer config and register explicitly — see
+[Channel adapters](../channels.md) for every adapter's credential.
+
+## Next steps
+
+- **No adapter for your platform?** [Write a custom channel adapter](custom-channel-adapter.md).
+- **See the credential reference** for every channel: [Channel adapters](../channels.md).
+- **Browse runnable templates:**
+  [`examples/`](https://github.com/IronSecCo/ironclaw/tree/main/examples).

--- a/docs/tutorials/custom-channel-adapter.md
+++ b/docs/tutorials/custom-channel-adapter.md
@@ -1,0 +1,312 @@
+---
+title: Write a custom channel adapter
+description: Build, register, and test a new channel adapter end to end — a complete, working Pushover example.
+---
+
+# Write a custom channel adapter
+
+IronClaw ships adapters for Slack, Discord, Telegram, WhatsApp, email, Matrix, and more. When your
+platform isn't in that list, you add it — and adapters are deliberately small. This tutorial builds
+a **complete, working adapter from scratch**: a [Pushover](https://pushover.net) notifier that
+delivers an agent's replies as push notifications to your phone.
+
+You'll write the adapter, register it, test it without touching the network, and wire it to an
+agent — the same shape every built-in adapter follows. For the reference version of the house
+pattern, keep [Writing a channel adapter](../writing-a-channel-adapter.md) open alongside this page.
+
+## What an adapter is
+
+A channel adapter delivers an agent's **outbound** messages to one platform. It satisfies a tiny
+interface, lives in
+[`internal/host/channels/`](https://github.com/IronSecCo/ironclaw/tree/main/internal/host/channels),
+and uses **only the standard library** — no SDKs, no new dependencies.
+
+```go
+type Adapter interface {
+	Name() string
+	Deliver(ctx context.Context, msg contract.MessageOut) (string, error)
+}
+```
+
+- **`Name()`** returns a stable adapter name (e.g. `"pushover"`).
+- **`Deliver()`** sends `msg` to the platform and returns the platform's **message id** (used for
+  threading and delivery dedup), or an error.
+
+The `contract.MessageOut` fields you'll use here:
+
+| Field | Use |
+| --- | --- |
+| `Content` | the message text to send |
+| `PlatformID` | the destination on the platform — for Pushover, the recipient **user/group key** (a `*string`) |
+| `ThreadID` | the platform's thread key, if the reply should thread (Pushover doesn't thread, so we ignore it) |
+
+## What we're building
+
+Pushover's send API is a single `POST` to `https://api.pushover.net/1/messages.json` with three
+fields: your **application token** (the credential), the recipient **user key** (the destination),
+and the **message**. On success it returns `{"status":1,"request":"<id>"}`. We map:
+
+- **credential** → the Pushover **application token**, held host-side, supplied via an env var;
+- **`msg.PlatformID`** → the recipient **user key**;
+- **`msg.Content`** → the notification text;
+- **returned message id** → Pushover's `request` id.
+
+## 1. Scaffold the adapter
+
+Create `internal/host/channels/pushover.go`. Start with the type and constructor — copy the shape
+from `slack.go` and adapt:
+
+```go
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+)
+
+// defaultPushoverBaseURL is the Pushover API host. Overridable (BaseURL) so tests
+// can point at an httptest server.
+const defaultPushoverBaseURL = "https://api.pushover.net"
+
+// PushoverAdapter delivers an agent's replies as Pushover push notifications.
+type PushoverAdapter struct {
+	AdapterName string
+	Token       string       // the Pushover application token — held host-side, never logged
+	BaseURL     string       // defaults to defaultPushoverBaseURL; overridable for tests
+	Client      *http.Client
+}
+
+// NewPushoverAdapter builds an adapter from a name and the application token.
+func NewPushoverAdapter(name, token string) *PushoverAdapter {
+	if name == "" {
+		name = "pushover"
+	}
+	return &PushoverAdapter{
+		AdapterName: name,
+		Token:       token,
+		BaseURL:     defaultPushoverBaseURL,
+		Client:      &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (a *PushoverAdapter) Name() string { return a.AdapterName }
+
+// Compile-time check that we satisfy the interface.
+var _ Adapter = (*PushoverAdapter)(nil)
+```
+
+## 2. Implement `Deliver`
+
+`Deliver` validates its inputs, builds the platform payload, POSTs with the standard library, caps
+the response read, and returns the platform's message id. Add it to the same file:
+
+```go
+func (a *PushoverAdapter) Deliver(ctx context.Context, msg contract.MessageOut) (string, error) {
+	// 1) Validate the credential and the destination.
+	if a.Token == "" {
+		return "", fmt.Errorf("host/channels: pushover application token not set")
+	}
+	if msg.PlatformID == nil || *msg.PlatformID == "" {
+		return "", fmt.Errorf("host/channels: pushover delivery requires a recipient user key (PlatformID)")
+	}
+
+	// 2) Build the platform payload. Pushover takes form fields; the token goes in
+	//    the body, never in the URL.
+	form := url.Values{}
+	form.Set("token", a.Token)
+	form.Set("user", *msg.PlatformID)
+	form.Set("message", msg.Content)
+
+	// 3) POST with the standard library, honoring context cancellation.
+	endpoint := a.BaseURL + "/1/messages.json"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("host/channels: pushover request: %s", a.redact(err.Error()))
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := a.Client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("host/channels: pushover POST failed: %s", a.redact(err.Error()))
+	}
+	defer resp.Body.Close()
+
+	// 4) Cap the response read and parse the result.
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	var out struct {
+		Status  int      `json:"status"`
+		Request string   `json:"request"`
+		Errors  []string `json:"errors"`
+	}
+	_ = json.Unmarshal(body, &out)
+
+	if resp.StatusCode != http.StatusOK || out.Status != 1 {
+		if len(out.Errors) > 0 {
+			return "", fmt.Errorf("host/channels: pushover rejected message: %s", a.redact(strings.Join(out.Errors, "; ")))
+		}
+		return "", fmt.Errorf("host/channels: pushover returned status %d", resp.StatusCode)
+	}
+
+	// 5) Return the platform message id (Pushover's request id).
+	return out.Request, nil
+}
+
+// redact strips the credential from any string we might log or return as an error.
+func (a *PushoverAdapter) redact(s string) string {
+	if a.Token == "" {
+		return s
+	}
+	return strings.ReplaceAll(s, a.Token, "<redacted>")
+}
+```
+
+Note the five rules from the [reference](../writing-a-channel-adapter.md#five-rules-that-keep-adapters-safe-and-testable)
+in action: standard library only, `BaseURL` overridable, the credential redacted from every error,
+and the real message id returned. (Pushover doesn't thread, so we skip `ThreadID` — your platform
+may not.)
+
+## 3. Register it
+
+Single-token adapters register from an environment variable. Add one line to the `specs` slice in
+`registerChannelAdapters` in
+[`cmd/controlplane/main.go`](https://github.com/IronSecCo/ironclaw/blob/main/cmd/controlplane/main.go):
+
+```go
+specs := []adapterSpec{
+	{"slack", "SLACK_BOT_TOKEN", func(n, t string) channels.Adapter { return channels.NewSlackAdapter(n, t) }},
+	{"discord", "DISCORD_BOT_TOKEN", func(n, t string) channels.Adapter { return channels.NewDiscordAdapter(n, t) }},
+	{"telegram", "TELEGRAM_BOT_TOKEN", func(n, t string) channels.Adapter { return channels.NewTelegramAdapter(n, t) }},
+	{"pushover", "PUSHOVER_APP_TOKEN", func(n, t string) channels.Adapter { return channels.NewPushoverAdapter(n, t) }}, // <-- add
+}
+```
+
+Now the daemon auto-registers the adapter on boot whenever `PUSHOVER_APP_TOKEN` is set, and logs
+`channel adapter registered  adapter=pushover`.
+
+!!! info "Richer config than a single token?"
+    If your platform needs more than one value (a URL **and** a number, a webhook, etc.), don't use
+    the `specs` slice — follow the explicit `reqExtra(...)` pattern that Teams, Signal, and iMessage
+    use in the same function.
+
+## 4. Test it — no network required
+
+Every adapter has an `httptest`-backed unit test. Create
+`internal/host/channels/pushover_test.go`:
+
+```go
+package channels
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+)
+
+func strptr(s string) *string { return &s }
+
+func TestPushoverAdapterDelivers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/1/messages.json" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_ = r.ParseForm()
+		if got := r.Form.Get("message"); got != "hello" {
+			t.Errorf("message = %q, want hello", got)
+		}
+		if got := r.Form.Get("user"); got != "uKEY" {
+			t.Errorf("user = %q, want uKEY", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":1,"request":"req-123"}`)
+	}))
+	defer srv.Close()
+
+	a := NewPushoverAdapter("pushover", "APP-TOKEN")
+	a.BaseURL = srv.URL
+
+	id, err := a.Deliver(context.Background(), contract.MessageOut{
+		ID: "m1", Content: "hello", PlatformID: strptr("uKEY"),
+	})
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if id != "req-123" {
+		t.Errorf("message id = %q, want req-123", id)
+	}
+}
+
+// A transport error must not leak the token.
+func TestPushoverAdapterRedactsToken(t *testing.T) {
+	a := NewPushoverAdapter("pushover", "SECRET-TOKEN")
+	a.BaseURL = "http://127.0.0.1:0" // unroutable → forces a transport error
+	_, err := a.Deliver(context.Background(), contract.MessageOut{Content: "x", PlatformID: strptr("uKEY")})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), "SECRET-TOKEN") {
+		t.Errorf("error leaked the token: %v", err)
+	}
+}
+```
+
+Run the suite:
+
+```sh
+CGO_ENABLED=1 go test ./internal/host/channels/...
+```
+
+Both tests exercise the adapter **without any network access** — the success path against a fake
+Pushover server, and the redaction guarantee against a forced transport error.
+
+## 5. Wire it to an agent and try it for real
+
+Build, set your real Pushover application token, and start the daemon:
+
+```sh
+CGO_ENABLED=1 go build -o bin/ ./cmd/controlplane ./cmd/ironctl
+export PUSHOVER_APP_TOKEN=your-pushover-app-token   # held host-side; never enters a sandbox
+./bin/controlplane --dev --api-addr 127.0.0.1:8787
+```
+
+Then add a delivery destination so an agent can post to your Pushover **user key** (the same
+`ironctl registry` flow as any channel — see [Connect IronClaw to Slack](connect-slack.md)):
+
+```sh
+ironctl registry destination add --agent default --channel pushover --platform uYOURUSERKEY
+```
+
+When that agent replies, the adapter delivers the message as a push notification to your device.
+
+## Recap
+
+You built a complete adapter that is **small, dependency-free, tested, and secret-safe** — the same
+shape as every adapter already in the tree:
+
+- one file implementing `Name()` + `Deliver()`,
+- the credential held host-side and **redacted from every error**,
+- a one-line registration in `registerChannelAdapters`,
+- an `httptest`-backed unit test that needs no network,
+- and a row you should add to [Channel adapters](../channels.md) documenting the new credential.
+
+## Next steps
+
+- **Reference:** [Writing a channel adapter](../writing-a-channel-adapter.md) — the house pattern in
+  brief, with the rules spelled out.
+- **The other adapters:** the cleanest templates to crib from are `slack.go`, `discord.go`,
+  `whatsapp.go`, and `matrix.go` in
+  [`internal/host/channels/`](https://github.com/IronSecCo/ironclaw/tree/main/internal/host/channels).
+- **Document your credential:** add a row to [Channel adapters](../channels.md) so operators know
+  what your adapter needs.

--- a/docs/tutorials/first-agent.md
+++ b/docs/tutorials/first-agent.md
@@ -1,0 +1,122 @@
+---
+title: Your first sandboxed agent in 5 minutes
+description: From git clone to a running, replying agent — no credentials, no model key, one command.
+---
+
+# Your first sandboxed agent in 5 minutes
+
+This tutorial takes you from `git clone` to a **running agent that actually replies** — with
+**no API key**, **no model credential**, and **one command**. It uses IronClaw's offline
+`mock-agent`, which runs the full **chat → per-session sandbox → reply** path so you can see the
+machinery work before you wire up a real model.
+
+By the end you'll have:
+
+- A control-plane running locally in Docker.
+- A real per-conversation **sandbox container** launched on demand.
+- A round-trip reply that came back through IronClaw's **encrypted per-session queues**.
+
+!!! info "What this is and isn't"
+    This is the fastest way to *see IronClaw work*. It is a **local demo posture**, not the
+    sealed production one — see [the security note](#what-the-demo-relaxes) at the end. When you're
+    ready for the hardened path (gVisor + `network=none`), follow the
+    [Quickstart's "first approved action"](../quickstart.md#your-first-approved-action).
+
+## Prerequisites
+
+- **Docker** — Docker Desktop on macOS/Windows is fine; Docker Engine on Linux.
+- **A clone of the repo** (the command below does it for you).
+
+That's it. No Go toolchain, no model key, no cloud account.
+
+## 1. Clone and build the sandbox image
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+
+bash container/build.sh    # builds the sandbox image once (~1–2 min)
+```
+
+`container/build.sh` builds the OCI image that each agent session runs inside. You only do this
+once; subsequent runs reuse the image.
+
+## 2. Start the demo control-plane
+
+```sh
+docker compose -f docker-compose.demo.yml up --build -d
+```
+
+This boots the control-plane wired to the offline `mock-agent` — no model key required. Give it a
+few seconds to come up. It serves on `http://127.0.0.1:8787`.
+
+## 3. Talk to the agent
+
+You have two ways in. **Either** is a complete round trip.
+
+### Option A — the browser console
+
+```sh
+open http://127.0.0.1:8787/ui/    # Linux: xdg-open http://127.0.0.1:8787/ui/
+```
+
+Open the **Chat** tab, pick **"Mock Agent (offline)"**, and say hi. If it asks for a token, paste
+the demo token: `ironclaw-demo`.
+
+### Option B — straight from the terminal
+
+The demo pins a fixed loopback token, `ironclaw-demo`, so you can drive it with `curl`:
+
+```sh
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from my first agent"}'
+
+sleep 3
+
+curl -s -H 'authorization: Bearer ironclaw-demo' \
+  http://127.0.0.1:8787/v1/ui/chat/mock-agent/messages   # read the agent's reply
+```
+
+You'll see `mock-agent received: …` echoed back. That reply is proof that:
+
+1. Your message engaged the agent group.
+2. A **real sandbox container** launched for the conversation.
+3. The reply flowed **back through the encrypted per-session queue** to the chat surface.
+
+## 4. Tear it down
+
+```sh
+docker compose -f docker-compose.demo.yml down
+```
+
+## What the demo relaxes
+
+The point of the demo is to remove every barrier to a first run, so it deliberately loosens the
+production seal. The demo compose file:
+
+- runs the control-plane as **root** and mounts the host **Docker socket**;
+- launches the sandbox with **runc (shared host kernel), not gVisor**;
+- pins a **well-known API token** (`ironclaw-demo`).
+
+What it **does not** relax: the mandatory **approval gateway**, the **encrypted per-session
+queues**, and **host-side model-credential custody** are all unchanged. Only the sandbox seal and
+the token are relaxed — and only for a local demo.
+
+!!! warning
+    Don't run the demo compose file outside a local machine. The default `docker compose up` (the
+    production `docker-compose.yml`) is the hardened posture: gVisor-isolated, `network=none`
+    sandboxes that reach the model only through the host proxy.
+
+## Next steps
+
+- **Exercise the security model.** The
+  [Quickstart's "first approved action"](../quickstart.md#your-first-approved-action) walks you
+  through submitting a change and approving it at the human-approval gateway — IronClaw's core
+  invariant.
+- **Plug in a real chat app.** [Connect IronClaw to Slack](connect-slack.md) wires an agent group
+  to a live Slack channel.
+- **Chat with a real model.** Set a provider key host-side (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+  `OPENROUTER_API_KEY`, …) and point an agent group at that provider — see the
+  [Quickstart](../quickstart.md#a-working-chat-in-5-minutes-no-credentials).
+- **Understand the design.** [IronClaw, Explained](../ironclaw-explained.md) ·
+  [Architecture](../architecture.md) · [Threat model](../threat-model.md).

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,33 @@
+---
+title: Tutorials
+description: Hands-on, copy-pasteable walkthroughs — from git clone to a running, useful agent.
+---
+
+# Tutorials
+
+Hands-on, copy-pasteable walkthroughs that take you from `git clone` to a running, useful agent.
+Every command is verified against the current `main`. Work through them in order, or jump to the
+one you need.
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch: **[Your first sandboxed agent in 5 minutes](first-agent.md)**
+
+    One command, no credentials, no model key. See an agent actually reply through a real
+    per-session sandbox.
+
+-   :material-slack: **[Connect IronClaw to Slack](connect-slack.md)**
+
+    Wire an agent group to a live Slack channel — bot token, messaging group, engagement rules, and
+    a reply destination.
+
+-   :material-tools: **[Write a custom channel adapter](custom-channel-adapter.md)**
+
+    Build, register, and test a new channel adapter end to end, with a complete working Pushover
+    example.
+
+</div>
+
+Looking for something else? The [Quickstart](../quickstart.md) is the shortest path to a running
+control-plane, and the [Channel adapters](../channels.md) reference lists every built-in channel and
+the credential it needs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,11 @@ nav:
   - Get Started:
       - Quickstart: quickstart.md
       - Building from source: building.md
+  - Tutorials:
+      - Overview: tutorials/index.md
+      - Your first sandboxed agent in 5 minutes: tutorials/first-agent.md
+      - Connect IronClaw to Slack: tutorials/connect-slack.md
+      - Write a custom channel adapter: tutorials/custom-channel-adapter.md
   - Concepts:
       - IronClaw, Explained: ironclaw-explained.md
       - Architecture: architecture.md


### PR DESCRIPTION
## What

Adds a hands-on **tutorial series** under `docs/tutorials/` — the #1 onboarding-conversion + SEO gap. Takes a reader from `git clone` to a running, useful agent.

Three task-focused, copy-pasteable tutorials:

1. **[Your first sandboxed agent in 5 minutes](docs/tutorials/first-agent.md)** — the zero-credential `mock-agent` demo path (`docker-compose.demo.yml`), reusing the IRO-27/IRO-38 quickstart flow.
2. **[Connect IronClaw to Slack](docs/tutorials/connect-slack.md)** — `SLACK_BOT_TOKEN` auto-register + the five `ironctl registry` calls, mirroring `examples/channel-triage`.
3. **[Write a custom channel adapter](docs/tutorials/custom-channel-adapter.md)** — turns the `writing-a-channel-adapter.md` reference into a guided, end-to-end tutorial with a complete working **Pushover** example (interface, `redact`, overridable `BaseURL`, the exact `specs`-slice registration line, and an `httptest` unit test).

Wired into the mkdocs nav (new **Tutorials** section) and cross-linked from the README and docs landing page.

## Verification

- Every command/snippet verified against `origin/main` — no aspirational steps. The Slack flow matches `cmd/ironctl/registry.go` + `examples/channel-triage/setup.sh`; the adapter example matches the `Adapter` interface, `contract.MessageOut` fields, and the `registerChannelAdapters` `specs` slice in `cmd/controlplane/main.go`.
- `mkdocs build --strict` passes — all nav entries, internal links, and anchors resolve.
- Matches the steel-blue `brand.css` theme (markdown-only; theme applies globally).

## Scope

Docs-site only. Publish-to-external (dev.to/Medium) stays out of scope, gated on IRO-40.

Closes IRO-105.