### PR TITLE
feat(ironctl): expand `doctor` preflight diagnostics (IRO-108)

### DIFF
--- a/cmd/ironctl/doctor.go
+++ b/cmd/ironctl/doctor.go
@@ -12,6 +12,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/IronSecCo/ironclaw/internal/host/onboard"
 )
 
 // checkStatus is a doctor check verdict.
@@ -23,23 +25,32 @@ const (
 	checkFail checkStatus = "FAIL"
 )
 
+// docBase is the published docs site; each check links to a relevant page so an
+// operator can go straight from a red line to the fix.
+const docBase = "https://ironsecco.github.io/ironclaw"
+
 // checkResult is one diagnostic line: what was checked, the verdict, what was
-// seen, and (when not OK) an actionable fix.
+// seen, and (when not OK) an actionable fix plus a docs link.
 type checkResult struct {
 	Name   string
 	Status checkStatus
 	Detail string
 	Fix    string
+	Doc    string
 }
 
 // cmdDoctor implements `ironctl doctor` — environment + reachability checks with
-// actionable fixes. It exits non-zero if any check FAILs so it is usable as a
-// health gate in scripts.
+// actionable fixes. It is read-only and never prints secret values (presence
+// only). It exits non-zero if any check FAILs so it is usable as a health gate in
+// scripts.
 func cmdDoctor(addr string, args []string) error {
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	socket := fs.String("model-proxy-socket", "/run/ironclaw/modelproxy.sock",
 		"model-proxy unix socket to probe")
-	runtimeBin := fs.String("runtime", "runsc", "OCI runtime binary to check (gVisor)")
+	// The runtime defaults to the same resolution the control-plane uses:
+	// $IRONCLAW_RUNTIME, else gVisor's runsc. An explicit --runtime wins.
+	runtimeBin := fs.String("runtime", envOrDefault("IRONCLAW_RUNTIME", "runsc"),
+		"OCI runtime binary to check (gVisor's runsc by default; IRONCLAW_RUNTIME selects it)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -49,6 +60,10 @@ func cmdDoctor(addr string, args []string) error {
 		checkAuth(addr),
 		checkReadiness(addr),
 		checkRuntime(*runtimeBin),
+		checkToolchain(),
+		checkModelCredential(os.Getenv),
+		checkChannels(os.Getenv),
+		checkConfig(),
 		checkModelProxy(*socket),
 	}
 	printChecks(os.Stdout, results)
@@ -65,10 +80,18 @@ func cmdDoctor(addr string, args []string) error {
 	return nil
 }
 
+// envOrDefault returns the env var if set and non-empty, else def.
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
 // checkAPI verifies the control-plane is reachable via its unauthenticated
 // liveness probe.
 func checkAPI(addr string) checkResult {
-	r := checkResult{Name: "control-plane API"}
+	r := checkResult{Name: "control-plane API", Doc: docBase + "/quickstart/"}
 	resp, err := httpGet(addr + "/healthz")
 	if err != nil {
 		r.Status = checkFail
@@ -90,7 +113,7 @@ func checkAPI(addr string) checkResult {
 
 // checkAuth probes a bearer-gated endpoint to classify the token posture.
 func checkAuth(addr string) checkResult {
-	r := checkResult{Name: "API auth / token"}
+	r := checkResult{Name: "API auth / token", Doc: docBase + "/quickstart/"}
 	resp, err := httpGet(addr + "/v1/changes/pending")
 	if err != nil {
 		r.Status = checkWarn
@@ -124,7 +147,7 @@ func checkAuth(addr string) checkResult {
 
 // checkReadiness reports the daemon's readiness probe.
 func checkReadiness(addr string) checkResult {
-	r := checkResult{Name: "readiness"}
+	r := checkResult{Name: "readiness", Doc: docBase + "/quickstart/"}
 	var rz struct {
 		Status string `json:"status"`
 		Reason string `json:"reason"`
@@ -148,9 +171,10 @@ func checkReadiness(addr string) checkResult {
 
 // checkRuntime verifies the OCI sandbox runtime (gVisor's runsc by default) is
 // installed and on PATH. Presence is the load-bearing check; a version probe is
-// best-effort.
+// best-effort. A relaxed runtime (docker/podman/runc) is reported OK but flagged,
+// because it does not provide gVisor's syscall-interception isolation boundary.
 func checkRuntime(bin string) checkResult {
-	r := checkResult{Name: "sandbox runtime (" + bin + ")"}
+	r := checkResult{Name: "sandbox runtime (" + bin + ")", Doc: docBase + "/quickstart/"}
 	path, err := exec.LookPath(bin)
 	if err != nil {
 		// gVisor's runsc is Linux-only. On macOS/Windows the production sandbox
@@ -165,14 +189,102 @@ func checkRuntime(bin string) checkResult {
 		}
 		r.Status = checkFail
 		r.Detail = bin + " not found on PATH"
-		r.Fix = "install gVisor (https://gvisor.dev/docs/user_guide/install/) so sandboxes can launch, or pass --runtime <bin>"
+		r.Fix = "install gVisor (https://gvisor.dev/docs/user_guide/install/) so sandboxes can launch, or set IRONCLAW_RUNTIME / pass --runtime <bin>"
 		return r
 	}
-	r.Status = checkOK
 	r.Detail = "found at " + path
 	if v, ok := tryVersion(bin); ok {
 		r.Detail += " (" + v + ")"
 	}
+	// runsc is the hardened default; anything else is the relaxed fallback.
+	if !strings.Contains(bin, "runsc") {
+		r.Status = checkWarn
+		r.Detail += " — relaxed runtime (no gVisor syscall isolation)"
+		r.Fix = "this is the runc fallback for hosts without gVisor; use runsc for the full isolation boundary in production"
+		return r
+	}
+	r.Status = checkOK
+	return r
+}
+
+// checkToolchain reports this binary's Go runtime version and restates the
+// control-plane's build expectation: encrypted (SQLCipher) queues require
+// CGO_ENABLED=1 and a C toolchain. ironctl itself is a pure HTTP client and needs
+// no cgo, so this is informational guidance rather than a self-test.
+func checkToolchain() checkResult {
+	return checkResult{
+		Name:   "build toolchain",
+		Status: checkOK,
+		Detail: runtime.Version() + " — control-plane build requires CGO_ENABLED=1 (encrypted SQLite)",
+		Doc:    docBase + "/building/",
+	}
+}
+
+// checkModelCredential reports whether any model-provider credential is present.
+// It is provider-agnostic and mirrors exactly what `ironctl onboard` checks (the
+// detector is shared). No credential is a WARN, not a FAIL: the zero-credential
+// `mock` provider still serves chat, so a fresh install is not broken — it just
+// can't reach a real model yet. Presence only; secret values are never read.
+func checkModelCredential(getenv func(string) string) checkResult {
+	r := checkResult{Name: "model credential", Doc: docBase + "/quickstart/"}
+	have := onboard.ModelCredentials(getenv)
+	if len(have) == 0 {
+		r.Status = checkWarn
+		r.Detail = "none set — the zero-credential `mock` provider works, but no real model is reachable"
+		r.Fix = "set one of ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, or IRONCLAW_MODEL_GATEWAY_URL on the daemon"
+		return r
+	}
+	r.Status = checkOK
+	r.Detail = strings.Join(have, ", ") + " configured (held host-side; never enters a sandbox)"
+	return r
+}
+
+// checkChannels reports which channel adapters are armed by the environment.
+// Channels are optional (the web console and API work without one), so none is a
+// WARN with guidance, not a failure. Shares the onboard detector so the two never
+// drift. Presence only; tokens are never read or printed.
+func checkChannels(getenv func(string) string) checkResult {
+	r := checkResult{Name: "channel adapters", Doc: docBase + "/channels/"}
+	armed := onboard.ArmedChannels(getenv)
+	if len(armed) == 0 {
+		r.Status = checkWarn
+		r.Detail = "no channel armed from the environment"
+		r.Fix = "set e.g. SLACK_BOT_TOKEN or TELEGRAM_BOT_TOKEN, or wire one with `ironctl registry wiring ...` (channels are optional)"
+		return r
+	}
+	r.Status = checkOK
+	r.Detail = "armed from env: " + strings.Join(armed, ", ")
+	return r
+}
+
+// checkConfig validates the onboarding config file (the 0600 env-file that holds
+// the API token). Absence is fine — onboard creates it on demand — so it is a
+// SKIP-style WARN. When present it must be readable and, on POSIX, not group/world
+// readable, since it bears a secret. The token value itself is never printed.
+func checkConfig() checkResult {
+	path := defaultOnboardConfig()
+	r := checkResult{Name: "onboard config", Doc: docBase + "/quickstart/"}
+	info, err := os.Stat(path)
+	if err != nil {
+		r.Status = checkWarn
+		r.Detail = "not present at " + path
+		r.Fix = "run `ironctl onboard` to mint an API token and write this file (0600)"
+		return r
+	}
+	if info.IsDir() {
+		r.Status = checkFail
+		r.Detail = path + " is a directory, expected a file"
+		r.Fix = "remove the directory and re-run `ironctl onboard`"
+		return r
+	}
+	if perm := info.Mode().Perm(); runtime.GOOS != "windows" && perm&0o077 != 0 {
+		r.Status = checkWarn
+		r.Detail = fmt.Sprintf("%s is %#o — readable beyond the owner (holds a secret token)", path, perm)
+		r.Fix = fmt.Sprintf("tighten it: chmod 600 %s", path)
+		return r
+	}
+	r.Status = checkOK
+	r.Detail = "present and owner-only at " + path
 	return r
 }
 
@@ -180,7 +292,7 @@ func checkRuntime(bin string) checkResult {
 // connection. The sandbox has network=none, so this socket is its only egress
 // path to the model host.
 func checkModelProxy(socket string) checkResult {
-	r := checkResult{Name: "model-proxy socket"}
+	r := checkResult{Name: "model-proxy socket", Doc: docBase + "/quickstart/"}
 	if _, err := os.Stat(socket); err != nil {
 		r.Status = checkWarn
 		r.Detail = "socket not present at " + socket
@@ -224,6 +336,9 @@ func printChecks(w io.Writer, results []checkResult) {
 		fmt.Fprintf(w, "  [%-4s] %s: %s\n", r.Status, r.Name, r.Detail)
 		if r.Status != checkOK && r.Fix != "" {
 			fmt.Fprintf(w, "         fix: %s\n", r.Fix)
+		}
+		if r.Status != checkOK && r.Doc != "" {
+			fmt.Fprintf(w, "         see: %s\n", r.Doc)
 		}
 	}
 }

--- a/cmd/ironctl/doctor_test.go
+++ b/cmd/ironctl/doctor_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"net"
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -32,16 +35,20 @@ func TestCheckReadiness(t *testing.T) {
 func TestCheckAuthUngated(t *testing.T) {
 	token = ""
 	srv, _, _ := newStatusServer(t)
-	// Ungated server + no token → WARN with a hardening fix.
+	// Ungated server + no token -> WARN with a hardening fix.
 	if r := checkAuth(srv.URL); r.Status != checkWarn || r.Fix == "" {
 		t.Errorf("checkAuth(ungated) = %s fix=%q, want WARN with fix", r.Status, r.Fix)
 	}
 }
 
 func TestCheckRuntime(t *testing.T) {
-	// `go` is guaranteed on PATH in the build/test environment.
-	if r := checkRuntime("go"); r.Status != checkOK {
-		t.Errorf("checkRuntime(go) = %s (%s), want OK", r.Status, r.Detail)
+	// `go` is guaranteed on PATH but is not runsc, so it exercises the "found but
+	// relaxed runtime" branch: present (not a FAIL) yet flagged WARN because it
+	// does not provide gVisor's syscall-interception isolation boundary.
+	if r := checkRuntime("go"); r.Status != checkWarn {
+		t.Errorf("checkRuntime(go) = %s (%s), want WARN (relaxed)", r.Status, r.Detail)
+	} else if !strings.Contains(r.Detail, "relaxed") {
+		t.Errorf("checkRuntime(go): detail %q should flag the weaker isolation", r.Detail)
 	}
 	// A missing runtime is a hard FAIL on Linux (where gVisor is required) but a
 	// soft WARN on macOS/Windows, where the production sandbox runs on the Linux
@@ -59,13 +66,13 @@ func TestCheckRuntime(t *testing.T) {
 }
 
 func TestCheckModelProxy(t *testing.T) {
-	// Missing socket → WARN.
+	// Missing socket -> WARN.
 	missing := filepath.Join(t.TempDir(), "absent.sock")
 	if r := checkModelProxy(missing); r.Status != checkWarn {
 		t.Errorf("checkModelProxy(missing) = %s, want WARN", r.Status)
 	}
 
-	// A real, listening unix socket → OK.
+	// A real, listening unix socket -> OK.
 	sock := filepath.Join(t.TempDir(), "p.sock")
 	ln, err := net.Listen("unix", sock)
 	if err != nil {
@@ -80,9 +87,131 @@ func TestCheckModelProxy(t *testing.T) {
 func TestDoctorCommandSmoke(t *testing.T) {
 	token = ""
 	srv, _, _ := newStatusServer(t)
-	// Some checks (runtime/model-proxy) will FAIL/WARN in CI, so doctor returns a
-	// non-nil error; that's expected. Assert it does not panic and runs the HTTP
+	// Some checks (runtime/model-proxy) will FAIL/WARN in CI, so doctor may return
+	// a non-nil error; that's expected. Assert it does not panic and runs the HTTP
 	// checks against a live server (no crash, returns).
 	_ = run([]string{"--addr", srv.URL, "doctor", "--runtime", "go",
 		"--model-proxy-socket", filepath.Join(t.TempDir(), "none.sock")})
+}
+
+func TestEnvOrDefault(t *testing.T) {
+	t.Setenv("IRO_TEST_DOCTOR", "")
+	if got := envOrDefault("IRO_TEST_DOCTOR", "fallback"); got != "fallback" {
+		t.Errorf("empty env: got %q, want fallback", got)
+	}
+	t.Setenv("IRO_TEST_DOCTOR", "set")
+	if got := envOrDefault("IRO_TEST_DOCTOR", "fallback"); got != "set" {
+		t.Errorf("set env: got %q, want set", got)
+	}
+}
+
+func TestCheckModelCredential(t *testing.T) {
+	// No credential -> WARN, not FAIL (the mock provider still works).
+	none := checkModelCredential(func(string) string { return "" })
+	if none.Status != checkWarn {
+		t.Errorf("no cred: status = %s, want WARN", none.Status)
+	}
+	if none.Fix == "" || none.Doc == "" {
+		t.Error("no cred: expected a fix hint and a docs link")
+	}
+
+	// A configured credential -> OK, named, and the secret VALUE is never echoed.
+	secret := "sk-super-secret-value"
+	env := map[string]string{"ANTHROPIC_API_KEY": secret}
+	ok := checkModelCredential(func(k string) string { return env[k] })
+	if ok.Status != checkOK {
+		t.Fatalf("with cred: status = %s, want OK", ok.Status)
+	}
+	if !strings.Contains(ok.Detail, "Anthropic") {
+		t.Errorf("with cred: detail %q should name the provider", ok.Detail)
+	}
+	if strings.Contains(ok.Detail+ok.Fix, secret) {
+		t.Error("secret value leaked into doctor output - presence only")
+	}
+}
+
+func TestCheckChannels(t *testing.T) {
+	none := checkChannels(func(string) string { return "" })
+	if none.Status != checkWarn {
+		t.Errorf("no channel: status = %s, want WARN", none.Status)
+	}
+
+	tok := "xoxb-secret-token"
+	env := map[string]string{"SLACK_BOT_TOKEN": tok}
+	armed := checkChannels(func(k string) string { return env[k] })
+	if armed.Status != checkOK {
+		t.Fatalf("armed: status = %s, want OK", armed.Status)
+	}
+	if !strings.Contains(armed.Detail, "slack") {
+		t.Errorf("armed: detail %q should name slack", armed.Detail)
+	}
+	if strings.Contains(armed.Detail, tok) {
+		t.Error("channel token value leaked into doctor output - presence only")
+	}
+}
+
+func TestCheckToolchain(t *testing.T) {
+	r := checkToolchain()
+	if r.Status != checkOK {
+		t.Errorf("toolchain: status = %s, want OK", r.Status)
+	}
+	if !strings.Contains(r.Detail, "CGO_ENABLED=1") {
+		t.Errorf("toolchain: detail %q should state the CGO build expectation", r.Detail)
+	}
+	if !strings.Contains(r.Detail, runtime.Version()) {
+		t.Errorf("toolchain: detail %q should report the Go version", r.Detail)
+	}
+}
+
+func TestCheckConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	// Absent -> WARN (onboard creates it on demand).
+	missing := filepath.Join(dir, "absent.env")
+	t.Setenv("IRONCLAW_CONFIG", missing)
+	if r := checkConfig(); r.Status != checkWarn {
+		t.Errorf("absent config: status = %s, want WARN", r.Status)
+	}
+
+	// Present and owner-only -> OK.
+	secure := filepath.Join(dir, "secure.env")
+	if err := os.WriteFile(secure, []byte("IRONCLAW_API_TOKEN=x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("IRONCLAW_CONFIG", secure)
+	if r := checkConfig(); r.Status != checkOK {
+		t.Errorf("0600 config: status = %s, want OK", r.Status)
+	}
+
+	// World-readable secret-bearing file -> WARN (POSIX only).
+	if runtime.GOOS != "windows" {
+		loose := filepath.Join(dir, "loose.env")
+		if err := os.WriteFile(loose, []byte("IRONCLAW_API_TOKEN=x\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("IRONCLAW_CONFIG", loose)
+		r := checkConfig()
+		if r.Status != checkWarn {
+			t.Errorf("0644 config: status = %s, want WARN", r.Status)
+		}
+		if !strings.Contains(r.Fix, "chmod 600") {
+			t.Errorf("0644 config: fix %q should suggest chmod 600", r.Fix)
+		}
+	}
+}
+
+func TestPrintChecks(t *testing.T) {
+	var buf bytes.Buffer
+	printChecks(&buf, []checkResult{
+		{Name: "ok-check", Status: checkOK, Detail: "fine", Fix: "unused", Doc: "https://example/ok"},
+		{Name: "bad-check", Status: checkFail, Detail: "broke", Fix: "do x", Doc: "https://example/fix"},
+	})
+	out := buf.String()
+	// OK lines never print fix/see; failing lines print both.
+	if strings.Contains(out, "https://example/ok") || strings.Contains(out, "unused") {
+		t.Error("OK check should not print its fix or doc link")
+	}
+	if !strings.Contains(out, "do x") || !strings.Contains(out, "https://example/fix") {
+		t.Error("failing check should print both the fix hint and the doc link")
+	}
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -181,4 +181,7 @@ sandboxes.
   [contract](contract.md).
 - **Guided first run:** `ironctl onboard` walks you through a first-run check and
   `ironctl doctor` diagnoses the common failure modes; the web console is at `/ui/`.
+- **Something not working?** Run `ironctl doctor` — a read-only preflight that
+  reports pass/warn/fail for runtime, reachability, credentials, channels and more,
+  each with a fix. See [Troubleshooting](troubleshooting.md).
 - **Where it's headed:** the [roadmap](roadmap.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,65 @@
+# Troubleshooting
+
+> _"I followed the steps, it didn't work, and I don't know why."_
+
+`ironctl doctor` exists to answer that. It runs a set of **read-only** preflight
+checks against your environment and the control-plane and prints a `pass / warn /
+fail` report — each line with a one-line remediation and a docs link. It never
+prints secret values (presence only) and exits non-zero if any check **FAILs**, so
+it doubles as a scriptable health gate.
+
+```sh
+ironctl doctor
+# or point at a non-default daemon / runtime:
+ironctl --addr http://127.0.0.1:8787 doctor --runtime runsc \
+  --model-proxy-socket /run/ironclaw/modelproxy.sock
+```
+
+Example output from a fresh, not-yet-started checkout:
+
+```
+ironctl doctor — diagnostics
+  [FAIL] control-plane API: dial tcp 127.0.0.1:8787: connect: connection refused
+         fix: is the daemon running? check --addr and that the port is reachable
+         see: https://ironsecco.github.io/ironclaw/quickstart/
+  [OK  ] build toolchain: go1.23 — control-plane build requires CGO_ENABLED=1 (encrypted SQLite)
+  [WARN] model credential: none set — the zero-credential `mock` provider works, but no real model is reachable
+         fix: set one of ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, or IRONCLAW_MODEL_GATEWAY_URL on the daemon
+         see: https://ironsecco.github.io/ironclaw/quickstart/
+  [WARN] channel adapters: no channel armed from the environment
+         ...
+```
+
+## What each check means
+
+| Check | Green | Yellow / Red |
+| --- | --- | --- |
+| **control-plane API** | `/healthz` reachable at `--addr`. | Daemon not running, wrong `--addr`, or port blocked. |
+| **API auth / token** | Bearer token accepted. | Ungated API (set `IRONCLAW_API_TOKEN` for defense-in-depth), token missing, or token rejected (`401`). |
+| **readiness** | `/readyz` reports `ready`. | Dependencies still coming up — check the daemon logs if it persists. |
+| **sandbox runtime** | gVisor's `runsc` on `PATH`. Honors `IRONCLAW_RUNTIME` / `--runtime`. | Missing runtime (FAIL on Linux; informational off-Linux), or a **relaxed** runtime (docker/runc) with no gVisor syscall isolation. |
+| **build toolchain** | Reports the Go version and restates the control-plane's build requirement. | — (informational; the daemon needs `CGO_ENABLED=1` and a C toolchain for the encrypted SQLCipher queues). |
+| **model credential** | A provider key or gateway URL is configured host-side. | None set — the zero-credential `mock` provider still serves chat, but no real model is reachable. Set `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, or `IRONCLAW_MODEL_GATEWAY_URL`. |
+| **channel adapters** | At least one adapter armed from the environment. | None armed — channels are optional; set e.g. `SLACK_BOT_TOKEN` / `TELEGRAM_BOT_TOKEN` or wire one with `ironctl registry wiring …`. |
+| **onboard config** | The `0600` token env-file is present and owner-only. | Absent (run `ironctl onboard`), a directory, or readable beyond the owner (`chmod 600`). |
+| **model-proxy socket** | The host model-proxy unix socket accepts a connection. | Socket missing (daemon not started) or present but not accepting connections (restart the control-plane). |
+
+The credential and channel checks read **exactly** the same environment variables
+the control-plane consumes on boot (the detectors are shared with `ironctl
+onboard`), so a check that says "armed" really will light up at runtime — and only
+the *presence* of a secret is ever reported, never its value.
+
+## Common fixes
+
+- **`control-plane API: connection refused`** — start the daemon (`./bin/controlplane
+  --dev` for a loopback dev run, or your service unit), then re-run `ironctl doctor`.
+- **`sandbox runtime: runsc not found` (Linux)** — install
+  [gVisor](https://gvisor.dev/docs/user_guide/install/), or set `IRONCLAW_RUNTIME=docker`
+  for the relaxed runc fallback on hosts without gVisor (not the hardened posture).
+- **`model credential: none set`** — fine for the `mock` demo; for a real model,
+  export a provider key host-side and point your agent group at that provider.
+- **`onboard config: not present`** — run `ironctl onboard` to mint a local API
+  token and write the `0600` config file.
+
+See also: [Quickstart](quickstart.md) · [Channels](channels.md) ·
+[Building from source](building.md).

--- a/internal/host/onboard/onboard.go
+++ b/internal/host/onboard/onboard.go
@@ -274,15 +274,39 @@ func (d Deps) writeConfigToken(tok string) error {
 	return nil
 }
 
-// modelCredentialStep reports OK when any supported provider credential (or the
-// credential gateway) is present, naming which — never persisted, only detected.
-func modelCredentialStep(getenv func(string) string) Step {
+// ModelCredentials returns the human labels of every supported model credential
+// (or the credential gateway) present in the environment. It is provider-agnostic
+// and never reads the secret value — only presence. An empty result means none is
+// configured, in which case the zero-credential `mock` provider still works.
+// Exported so `ironctl doctor` reports exactly what onboarding checks, with no
+// risk of the two lists drifting apart.
+func ModelCredentials(getenv func(string) string) []string {
 	var have []string
 	for _, mc := range modelCredentialEnv {
 		if getenv(mc[0]) != "" {
 			have = append(have, mc[1])
 		}
 	}
+	return have
+}
+
+// ArmedChannels returns the names of the channel adapters armed by the current
+// environment (e.g. slack when SLACK_BOT_TOKEN is set). Mirrors what the
+// control-plane auto-registers on boot; shared with `ironctl doctor`.
+func ArmedChannels(getenv func(string) string) []string {
+	var ready []string
+	for _, ce := range channelEnv {
+		if ce.ready(getenv) {
+			ready = append(ready, ce.name)
+		}
+	}
+	return ready
+}
+
+// modelCredentialStep reports OK when any supported provider credential (or the
+// credential gateway) is present, naming which — never persisted, only detected.
+func modelCredentialStep(getenv func(string) string) Step {
+	have := ModelCredentials(getenv)
 	if len(have) == 0 {
 		return Step{"model-credential", StatusAction,
 			"set a model credential in the control-plane's environment — one of ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, or IRONCLAW_MODEL_GATEWAY_URL"}
@@ -332,12 +356,7 @@ func (d Deps) imageEngine() string {
 }
 
 func (d Deps) channelStep() Step {
-	var ready []string
-	for _, ce := range channelEnv {
-		if ce.ready(d.Getenv) {
-			ready = append(ready, ce.name)
-		}
-	}
+	ready := ArmedChannels(d.Getenv)
 	if len(ready) == 0 {
 		return Step{"channel", StatusAction,
 			"no channel armed from the environment — set e.g. SLACK_BOT_TOKEN or TELEGRAM_BOT_TOKEN (see docs/channels.md), or wire one with `ironctl registry wiring ...`"}


### PR DESCRIPTION
## What

Expands `ironctl doctor` to cover the full IRO-108 scope so a stuck setup
self-diagnoses instead of failing silently — _"I followed the steps, it didn't
work, and I don't know why."_

On top of the existing API / auth / readiness / runtime / model-proxy checks,
`doctor` now reports:

- **model credential** presence — provider-agnostic, mirrors the daemon's env
  (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` /
  `IRONCLAW_MODEL_GATEWAY_URL`). WARN (not FAIL) when none is set, because the
  zero-credential `mock` provider still serves chat.
- **channel adapters** armed from env (Slack/Discord/Telegram/…). Optional, so WARN
  when none.
- **onboard config** validity — present, not a directory, owner-only `0600`.
- **build toolchain** — Go version + the control-plane's `CGO_ENABLED=1`
  (encrypted SQLite) build expectation.
- **runtime** — now honors `IRONCLAW_RUNTIME` resolution (same as the daemon) and
  WARNs when a relaxed (docker/runc) runtime is in use with no gVisor isolation.

Each check carries a **docs link** (printed as a `see:` line when not OK).

## Design

- The model-credential and channel detectors are **exported from
  `internal/host/onboard`** and shared, so `doctor` and `onboard` read the exact
  same env vars and can never drift.
- **Read-only / non-destructive throughout**; only the *presence* of a secret is
  reported, never its value (covered by a leak-check test).

## Docs

New `docs/troubleshooting.md` (per-check reference + common fixes) and a
troubleshooting pointer in the quickstart.

## Verification

- `CGO_ENABLED=1 go build ./...` ✅ · `go vet` ✅ · `gofmt` clean ✅
- `go test ./cmd/ironctl/... ./internal/host/onboard/...` — 46 + onboard tests pass,
  including new coverage for the credential/channel/config/toolchain checks, the
  relaxed-runtime branch, config perms, secret-non-leakage, and output formatting.

## Security lenses touched

- **Secret hygiene** — presence-only; secret values never read or printed (tested).
- **Isolation** — surfaces relaxed (non-gVisor) runtimes as a WARN rather than
  silently treating them as fine.

Closes IRO-108.