### PR TITLE
test: integration coverage for channel auth-env wiring + zero-cred demo (IRO-106)

### DIFF
--- a/cmd/controlplane/channels_env_test.go
+++ b/cmd/controlplane/channels_env_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/host/channels"
+	"github.com/IronSecCo/ironclaw/internal/obs"
+)
+
+// registerChannelAdapters reads bot tokens / bridge config from the environment
+// and registers exactly the adapters whose config is present, so the daemon still
+// boots with none set (e.g. in --dev). These tests pin that auth-env wiring: which
+// env var maps to which adapter, that an unset var registers nothing, and that a
+// secret token never lands in a log line. They use t.Setenv (no real network,
+// no secrets), so they are hermetic and run in the existing CI go-test job.
+
+// allChannelEnv is every environment variable registerChannelAdapters consults.
+// Tests clear all of them to "" first so the host environment cannot leak a real
+// token into a case that expects a clean slate.
+var allChannelEnv = []string{
+	"SLACK_BOT_TOKEN",
+	"DISCORD_BOT_TOKEN",
+	"TELEGRAM_BOT_TOKEN",
+	"IRONCLAW_TEAMS_WEBHOOK_URL",
+	"IRONCLAW_SIGNAL_CLI_URL",
+	"IRONCLAW_SIGNAL_NUMBER",
+	"IRONCLAW_IMESSAGE_ENABLE",
+}
+
+// clearChannelEnv blanks every channel env var for the duration of the test so
+// each case starts from a known-empty environment.
+func clearChannelEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range allChannelEnv {
+		t.Setenv(k, "")
+	}
+}
+
+func TestRegisterChannelAdapters_NoEnvRegistersNothing(t *testing.T) {
+	clearChannelEnv(t)
+
+	reg := channels.NewRegistry()
+	registerChannelAdapters(reg, obs.Discard())
+
+	if got := reg.List(); len(got) != 0 {
+		t.Fatalf("with no channel env set, registered %v, want none", got)
+	}
+}
+
+func TestRegisterChannelAdapters_TokenEnvGating(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want string // adapter name expected to register
+	}{
+		{"slack", "SLACK_BOT_TOKEN", "slack"},
+		{"discord", "DISCORD_BOT_TOKEN", "discord"},
+		{"telegram", "TELEGRAM_BOT_TOKEN", "telegram"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearChannelEnv(t)
+			t.Setenv(tc.env, "secret-"+tc.name+"-token")
+
+			reg := channels.NewRegistry()
+			registerChannelAdapters(reg, obs.Discard())
+
+			got := reg.List()
+			if len(got) != 1 || got[0] != tc.want {
+				t.Fatalf("env %s set: registered %v, want exactly [%q]", tc.env, got, tc.want)
+			}
+			if _, ok := reg.Get(tc.want); !ok {
+				t.Fatalf("adapter %q not retrievable after registration", tc.want)
+			}
+		})
+	}
+}
+
+func TestRegisterChannelAdapters_TeamsWebhookGating(t *testing.T) {
+	clearChannelEnv(t)
+	t.Setenv("IRONCLAW_TEAMS_WEBHOOK_URL", "https://example.invalid/webhook")
+
+	reg := channels.NewRegistry()
+	registerChannelAdapters(reg, obs.Discard())
+
+	if _, ok := reg.Get("teams"); !ok {
+		t.Fatalf("teams adapter not registered when IRONCLAW_TEAMS_WEBHOOK_URL is set; got %v", reg.List())
+	}
+}
+
+func TestRegisterChannelAdapters_SignalBridgeGating(t *testing.T) {
+	clearChannelEnv(t)
+	t.Setenv("IRONCLAW_SIGNAL_CLI_URL", "http://127.0.0.1:8080")
+	t.Setenv("IRONCLAW_SIGNAL_NUMBER", "+15555550100")
+
+	reg := channels.NewRegistry()
+	registerChannelAdapters(reg, obs.Discard())
+
+	if _, ok := reg.Get("signal"); !ok {
+		t.Fatalf("signal adapter not registered when IRONCLAW_SIGNAL_CLI_URL is set; got %v", reg.List())
+	}
+}
+
+// TestRegisterChannelAdapters_TokenNeverLogged is a security assertion: the
+// registration path logs an adapter-registered line, but the secret token must
+// never appear in any log record.
+func TestRegisterChannelAdapters_TokenNeverLogged(t *testing.T) {
+	clearChannelEnv(t)
+	const secret = "xoxb-super-secret-slack-token-value"
+	t.Setenv("SLACK_BOT_TOKEN", secret)
+
+	var buf bytes.Buffer
+	logger := obs.New(obs.Options{Output: &buf})
+
+	reg := channels.NewRegistry()
+	registerChannelAdapters(reg, logger)
+
+	if strings.Contains(buf.String(), secret) {
+		t.Fatalf("secret token leaked into logs:\n%s", buf.String())
+	}
+	// Sanity: the registration line was emitted (so the absence above is meaningful).
+	if !strings.Contains(buf.String(), "slack") {
+		t.Fatalf("expected a registration log mentioning the slack adapter, got:\n%s", buf.String())
+	}
+}

--- a/internal/smoke/demo_smoke_test.go
+++ b/internal/smoke/demo_smoke_test.go
@@ -1,0 +1,288 @@
+package smoke
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+	hostqueue "github.com/IronSecCo/ironclaw/internal/host/queue"
+	"github.com/IronSecCo/ironclaw/internal/sandbox/loop"
+	"github.com/IronSecCo/ironclaw/internal/sandbox/provider"
+	sandboxqueue "github.com/IronSecCo/ironclaw/internal/sandbox/queue"
+	"github.com/IronSecCo/ironclaw/internal/sandbox/tools"
+)
+
+// demoKey is a fixed per-session key. The demo path uses a real, random key; a
+// deterministic one keeps the test reproducible while still exercising the full
+// encrypted-SQLite (SQLCipher) binding both sides open against.
+func demoKey() contract.SessionKey {
+	var k contract.SessionKey
+	for i := range k {
+		k[i] = byte(i + 1)
+	}
+	return k
+}
+
+// TestZeroCredChatDemoEndToEnd is the smoke test guarding the README hero flow:
+// the zero-credential `mock`-provider chat demo. It wires the same components the
+// running daemon does — the host writes one inbound chat message, the sandbox
+// reasoning loop reads it through the encrypted inbound queue, runs the offline
+// mock provider, and writes the reply to the encrypted outbound queue, which the
+// host reads back — all with no network, no credential, and no Docker.
+//
+// If any link in that chain regresses (queue schema, loop engagement, mock echo
+// contract, outbound routing), this test fails instead of the demo silently
+// breaking for a first-time contributor.
+func TestZeroCredChatDemoEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	key := demoKey()
+	inboundPath := filepath.Join(dir, "inbound.db")
+	outboundPath := filepath.Join(dir, "outbound.db")
+
+	const userText = "hello from the hero demo"
+	const wantReply = "mock-agent received: " + userText
+
+	// Host side (sole inbound writer) seeds one immediate chat message, exactly as
+	// a real chat send would. trigger=1 engages the model on the first poll rather
+	// than accumulating.
+	hostIn, err := hostqueue.OpenInbound(inboundPath, key)
+	if err != nil {
+		t.Fatalf("open host inbound: %v", err)
+	}
+	msgID := contract.MessageID("demo-msg-1")
+	if err := hostIn.WriteMessageIn(contract.MessageIn{
+		ID:        msgID,
+		Seq:       2, // even: host parity
+		Kind:      contract.KindChat,
+		Timestamp: time.Now().UTC(),
+		Status:    contract.StatusQueued,
+		Trigger:   1,
+		Content:   userText,
+	}); err != nil {
+		t.Fatalf("write inbound message: %v", err)
+	}
+	if err := hostIn.Close(); err != nil {
+		t.Fatalf("close host inbound: %v", err)
+	}
+
+	// Sandbox side: read-only inbound view and the outbound writer. Opening the
+	// outbound writer creates the encrypted outbound DB so the host reader below
+	// has a file to open.
+	sbIn, err := sandboxqueue.OpenInbound(inboundPath, key)
+	if err != nil {
+		t.Fatalf("open sandbox inbound: %v", err)
+	}
+	sbOut, err := sandboxqueue.OpenOutbound(outboundPath, key)
+	if err != nil {
+		t.Fatalf("open sandbox outbound: %v", err)
+	}
+
+	// The zero-credential offline backend. It makes no network call — not even to
+	// the host model-proxy socket — so the demo needs no API key.
+	prov, err := provider.New(provider.Config{Kind: provider.KindMock})
+	if err != nil {
+		t.Fatalf("build mock provider: %v", err)
+	}
+
+	lp, err := loop.New(loop.Config{
+		Inbound:       sbIn,
+		Outbound:      sbOut,
+		Provider:      prov,
+		HeartbeatPath: filepath.Join(dir, ".heartbeat"),
+		PollInterval:  5 * time.Millisecond,
+		Logger:        log.New(io.Discard, "", 0),
+	})
+	if err != nil {
+		t.Fatalf("build loop: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	loopDone := make(chan error, 1)
+	go func() { loopDone <- lp.Run(ctx) }()
+
+	// Host reader of the outbound queue (sole outbound reader).
+	hostOut, err := hostqueue.OpenOutbound(outboundPath, key)
+	if err != nil {
+		t.Fatalf("open host outbound: %v", err)
+	}
+	defer hostOut.Close()
+
+	var got []contract.MessageOut
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		msgs, err := hostOut.DueMessages()
+		if err != nil {
+			t.Fatalf("read outbound: %v", err)
+		}
+		if len(msgs) > 0 {
+			got = msgs
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+	select {
+	case <-loopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop did not stop after context cancel")
+	}
+
+	if len(got) == 0 {
+		t.Fatal("no outbound reply within deadline: zero-cred chat demo path is broken")
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d outbound messages, want exactly 1", len(got))
+	}
+	reply := got[0]
+	if reply.Content != wantReply {
+		t.Fatalf("reply content = %q, want %q", reply.Content, wantReply)
+	}
+	if reply.Kind != contract.KindChat {
+		t.Fatalf("reply kind = %q, want %q", reply.Kind, contract.KindChat)
+	}
+	if reply.InReplyTo == nil || *reply.InReplyTo != msgID {
+		t.Fatalf("reply InReplyTo = %v, want %q", reply.InReplyTo, msgID)
+	}
+}
+
+// echoUpperTool is a hermetic in-sandbox tool: it upper-cases its "text" input.
+// It exists only to drive the loop's agentic tool-use path end-to-end with no
+// network — the mock provider's `tool:<name> {json}` directive selects it.
+type echoUpperTool struct{}
+
+func (echoUpperTool) Name() string        { return "echo_upper" }
+func (echoUpperTool) Description() string { return "Upper-cases the provided text." }
+func (echoUpperTool) JSONSchema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}`)
+}
+
+func (echoUpperTool) Invoke(_ context.Context, input json.RawMessage) (string, error) {
+	var in struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return "", err
+	}
+	return strings.ToUpper(in.Text), nil
+}
+
+// TestZeroCredToolUseDemoEndToEnd guards the demo's "agent uses an added tool
+// with no credential" story. With a tool registered, the loop drives the agentic
+// Converse path: the offline mock parses the `tool:echo_upper {json}` directive,
+// emits the tool call, the loop invokes the (hermetic) tool, feeds the result
+// back, and the mock surfaces it. This exercises loop.runAgent + invokeTool +
+// the mock Converse turn — the tool-use integration the README hero shows off —
+// with zero network and zero credentials.
+func TestZeroCredToolUseDemoEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	key := demoKey()
+	inboundPath := filepath.Join(dir, "inbound.db")
+	outboundPath := filepath.Join(dir, "outbound.db")
+
+	const userText = `tool:echo_upper {"text":"ping"}`
+	const wantReply = "mock-agent tool result: PING"
+
+	hostIn, err := hostqueue.OpenInbound(inboundPath, key)
+	if err != nil {
+		t.Fatalf("open host inbound: %v", err)
+	}
+	msgID := contract.MessageID("tool-msg-1")
+	if err := hostIn.WriteMessageIn(contract.MessageIn{
+		ID:        msgID,
+		Seq:       2,
+		Kind:      contract.KindChat,
+		Timestamp: time.Now().UTC(),
+		Status:    contract.StatusQueued,
+		Trigger:   1,
+		Content:   userText,
+	}); err != nil {
+		t.Fatalf("write inbound message: %v", err)
+	}
+	if err := hostIn.Close(); err != nil {
+		t.Fatalf("close host inbound: %v", err)
+	}
+
+	sbIn, err := sandboxqueue.OpenInbound(inboundPath, key)
+	if err != nil {
+		t.Fatalf("open sandbox inbound: %v", err)
+	}
+	sbOut, err := sandboxqueue.OpenOutbound(outboundPath, key)
+	if err != nil {
+		t.Fatalf("open sandbox outbound: %v", err)
+	}
+
+	prov, err := provider.New(provider.Config{Kind: provider.KindMock})
+	if err != nil {
+		t.Fatalf("build mock provider: %v", err)
+	}
+
+	toolReg := tools.NewRegistry()
+	if err := toolReg.Register(echoUpperTool{}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	lp, err := loop.New(loop.Config{
+		Inbound:       sbIn,
+		Outbound:      sbOut,
+		Provider:      prov,
+		Tools:         toolReg,
+		HeartbeatPath: filepath.Join(dir, ".heartbeat"),
+		PollInterval:  5 * time.Millisecond,
+		Logger:        log.New(io.Discard, "", 0),
+	})
+	if err != nil {
+		t.Fatalf("build loop: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	loopDone := make(chan error, 1)
+	go func() { loopDone <- lp.Run(ctx) }()
+
+	hostOut, err := hostqueue.OpenOutbound(outboundPath, key)
+	if err != nil {
+		t.Fatalf("open host outbound: %v", err)
+	}
+	defer hostOut.Close()
+
+	var got []contract.MessageOut
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		msgs, err := hostOut.DueMessages()
+		if err != nil {
+			t.Fatalf("read outbound: %v", err)
+		}
+		// Skip any KindSystem envelopes; we want the chat reply surfacing the tool result.
+		for _, m := range msgs {
+			if m.Kind == contract.KindChat {
+				got = append(got, m)
+			}
+		}
+		if len(got) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+	select {
+	case <-loopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop did not stop after context cancel")
+	}
+
+	if len(got) == 0 {
+		t.Fatal("no outbound chat reply within deadline: zero-cred tool-use demo path is broken")
+	}
+	if got[0].Content != wantReply {
+		t.Fatalf("reply content = %q, want %q", got[0].Content, wantReply)
+	}
+}

--- a/internal/smoke/doc.go
+++ b/internal/smoke/doc.go
@@ -1,0 +1,13 @@
+// Package smoke holds hermetic end-to-end smoke tests that exercise IronClaw's
+// headline flows across package boundaries without any network, credential, or
+// Docker dependency.
+//
+// The flagship test here protects the zero-credential chat demo — the README
+// hero onboarding path — by driving a real encrypted inbound→sandbox-loop→
+// outbound round trip with the offline mock provider, so the demo cannot
+// silently break. Keeping it in its own package (rather than inside host/ or
+// sandbox/) lets a single test legitimately wire together the host queue
+// (inbound writer / outbound reader) and the sandbox tree (loop + provider +
+// queue) the way the running daemon does, while respecting each tree's import
+// discipline in non-test code.
+package smoke


### PR DESCRIPTION
## What

Hermetic, deterministic test coverage for two contributor-confidence surfaces — channel-adapter **auth-env wiring** and the **zero-credential mock-provider chat demo** (README hero path). No network, no secrets, no Docker.

Closes IRO-106.

### `cmd/controlplane/channels_env_test.go` (new, `package main`)
Covers `registerChannelAdapters` — the env→adapter wiring that previously had **no test** (0% → **82.1%**):
- which env var registers which adapter (Slack/Discord/Telegram, table-driven)
- an unset var registers nothing (daemon boots clean in `--dev`)
- Teams (webhook) and Signal (bridge) richer-config gating
- **security:** a bot token never appears in any log line

### `internal/smoke/` (new package)
Two end-to-end smoke tests guarding the README hero zero-cred path. They wire the same components the running daemon does — host inbound writer → **encrypted SQLite (SQLCipher) queue** → sandbox reasoning loop → **offline mock provider** → host outbound reader:
- `TestZeroCredChatDemoEndToEnd` — plain chat echo round trip (`mock-agent received: …`), asserts content, kind, and `InReplyTo`
- `TestZeroCredToolUseDemoEndToEnd` — the agentic tool-use path (`loop.runAgent` + `invokeTool`) the demo shows off, driven by a hermetic in-test tool with zero credentials

## Why
Protects the hero onboarding flow from silent regressions and raises the project's quality/trust signal for OSS adoption.

## Test plan
- `go build ./...` — clean
- `go vet ./internal/smoke/ ./cmd/controlplane/` — clean
- `go test -race ./internal/smoke/` — pass
- `go test ./internal/smoke/ ./cmd/controlplane/ ./internal/host/channels/... ./internal/sandbox/...` — all pass
- Wired into existing CI `go-test` job automatically (`go test ./...`, CGO already enabled). No CI/workflow changes, no secret-gated or Linux-host-only assertions.

Per repo CLAUDE.md, no Paperclip co-author trailer on the commit.