### PR TITLE
docs: Troubleshooting first-run failures + FAQ on docs site (IRO-110)

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -19,6 +19,10 @@ go vet ./...
 go test ./...
 ```
 
+A build that fails with a SQLite / cgo error almost always means the C toolchain or
+`CGO_ENABLED` isn't set up — see
+[Troubleshooting → Build fails with a SQLite / cgo error](troubleshooting.md#build-fails-with-a-sqlite-cgo-error).
+
 ## Encrypted-queue binding (wired)
 
 The per-session encrypted queues are live (**RFC-0001 applied**). `contract.Open*`

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,98 @@
+# FAQ
+
+Short, straight answers to the questions people ask before (and right after) their
+first run. Everything here maps to shipped capability — see the
+[roadmap](roadmap.md) for the single source of truth on what's done versus planned.
+
+## Is it really sandboxed?
+
+Yes. In the supported production posture every agent session runs in its **own
+sandbox** built on **gVisor (`runsc`)** — a user-space kernel that intercepts
+syscalls instead of handing them to the host kernel — with **`network=none`**, so
+the sandbox has no direct network at all. Its only egress is a host-brokered
+model-proxy unix socket. A **Kata Containers** (VM-isolation) backend is also
+available. This is *stronger* isolation than the Docker/host-access model the peer
+projects ship.
+
+Two honest caveats:
+
+- The **5-minute demo** ([Quickstart](quickstart.md)) deliberately relaxes the seal:
+  it runs the sandbox as a **runc** container (shared host kernel), mounts the
+  Docker socket, and pins a well-known token — a laptop convenience, clearly labeled,
+  **not** the production posture. The mandatory approval gateway and encrypted queues
+  stay intact even in the demo.
+- Isolation is verified against a published, STRIDE-based
+  [threat model](threat-model.md) — we describe what's in scope and what isn't,
+  rather than asking you to take "secure" on faith.
+
+## Do I need credentials to try it?
+
+**No.** The fastest path uses the offline **`mock` provider** — no model key, no
+gVisor — and runs the full engage → sandbox → reply loop so you can see an agent
+actually respond:
+
+```sh
+docker compose -f docker-compose.demo.yml up --build -d
+# then chat at http://127.0.0.1:8787/ui/  (token: ironclaw-demo)
+```
+
+To talk to a **real model**, set one provider credential **host-side** (it never
+enters a sandbox) and point an agent group at that provider. See the
+[Quickstart](quickstart.md#a-working-chat-in-5-minutes-no-credentials).
+
+## Which model providers are supported?
+
+**Anthropic, OpenAI, OpenRouter, and Codex**, plus a generic gateway URL
+(`IRONCLAW_MODEL_GATEWAY_URL`) — all reached through the host model-proxy, so keys
+stay host-side and never enter a sandbox. The zero-credential `mock` provider is
+built in for offline demos and tests.
+
+## Which channels are supported?
+
+Twelve delivery surfaces today: **Slack, Discord, Telegram, Microsoft Teams,
+Signal, iMessage, Webhook, WhatsApp, Email/SMTP, Matrix, Google Chat**, plus the
+in-product **web chat playground**. Each built-in adapter and the environment
+variable it reads is listed in the [Channels](channels.md) reference; you can also
+[write your own adapter](writing-a-channel-adapter.md).
+
+## What's the license? Is it really open source?
+
+IronClaw is **open source under the GNU AGPLv3** (`LICENSE`). A **commercial
+dual-license** is available for organisations that can't meet the AGPL's network
+copyleft terms. Contributions are accepted under a
+[Contributor License Agreement](https://github.com/IronSecCo/ironclaw/blob/main/CLA.md)
+that lets the project dual-license your work — the CLA Assistant bot asks you to
+sign it on your first pull request.
+
+## How do I contribute?
+
+Contributions of every kind are welcome — bug reports, fixes, new channel adapters,
+docs, and tests.
+
+1. Read
+   [`CONTRIBUTING.md`](https://github.com/IronSecCo/ironclaw/blob/main/CONTRIBUTING.md)
+   and build with `CGO_ENABLED=1` (see [Building from source](building.md)).
+2. Browse
+   [good first issues](https://github.com/IronSecCo/ironclaw/contribute) to find a
+   starting point.
+3. Open a pull request — the **CLA Assistant** bot will ask you to sign the
+   [CLA](https://github.com/IronSecCo/ironclaw/blob/main/CLA.md) on your first PR.
+
+Questions and ideas are best raised in
+[GitHub Discussions](https://github.com/IronSecCo/ironclaw/discussions).
+
+## How is IronClaw different from openclaw / nanoclaw?
+
+Same job — self-hosted AI agents wired into your channels — but built
+**security-first**: provable gVisor isolation with `network=none`, a **mandatory
+human-approval gateway** that no mutation can bypass, SQLCipher-encrypted
+per-session queues, and **cosign-signed releases with an SBOM and build
+provenance** (a supply-chain story neither peer has claimed). The full side-by-side
+is in the [roadmap comparison](roadmap.md#how-ironclaw-compares).
+
+## Something isn't working — where do I start?
+
+Run **`ironctl doctor`** — a read-only preflight that reports pass/warn/fail for
+runtime, reachability, credentials, channels, and more, each with a fix. Then see
+**[Troubleshooting](troubleshooting.md)**, which maps every doctor check to a
+remediation and covers the common first-run build/Docker/port/userns failures.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -183,5 +183,5 @@ sandboxes.
   `ironctl doctor` diagnoses the common failure modes; the web console is at `/ui/`.
 - **Something not working?** Run `ironctl doctor` — a read-only preflight that
   reports pass/warn/fail for runtime, reachability, credentials, channels and more,
-  each with a fix. See [Troubleshooting](troubleshooting.md).
+  each with a fix. See [Troubleshooting](troubleshooting.md) and the [FAQ](faq.md).
 - **Where it's headed:** the [roadmap](roadmap.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,45 +21,220 @@ Example output from a fresh, not-yet-started checkout:
 ironctl doctor — diagnostics
   [FAIL] control-plane API: dial tcp 127.0.0.1:8787: connect: connection refused
          fix: is the daemon running? check --addr and that the port is reachable
-         see: https://ironsecco.github.io/ironclaw/quickstart/
+         see: https://ironsecco.github.io/ironclaw/troubleshooting/
   [OK  ] build toolchain: go1.23 — control-plane build requires CGO_ENABLED=1 (encrypted SQLite)
   [WARN] model credential: none set — the zero-credential `mock` provider works, but no real model is reachable
          fix: set one of ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, or IRONCLAW_MODEL_GATEWAY_URL on the daemon
-         see: https://ironsecco.github.io/ironclaw/quickstart/
+         see: https://ironsecco.github.io/ironclaw/troubleshooting/
   [WARN] channel adapters: no channel armed from the environment
          ...
 ```
 
-## What each check means
+## What each `ironctl doctor` check means
 
-| Check | Green | Yellow / Red |
-| --- | --- | --- |
-| **control-plane API** | `/healthz` reachable at `--addr`. | Daemon not running, wrong `--addr`, or port blocked. |
-| **API auth / token** | Bearer token accepted. | Ungated API (set `IRONCLAW_API_TOKEN` for defense-in-depth), token missing, or token rejected (`401`). |
-| **readiness** | `/readyz` reports `ready`. | Dependencies still coming up — check the daemon logs if it persists. |
-| **sandbox runtime** | gVisor's `runsc` on `PATH`. Honors `IRONCLAW_RUNTIME` / `--runtime`. | Missing runtime (FAIL on Linux; informational off-Linux), or a **relaxed** runtime (docker/runc) with no gVisor syscall isolation. |
-| **build toolchain** | Reports the Go version and restates the control-plane's build requirement. | — (informational; the daemon needs `CGO_ENABLED=1` and a C toolchain for the encrypted SQLCipher queues). |
-| **model credential** | A provider key or gateway URL is configured host-side. | None set — the zero-credential `mock` provider still serves chat, but no real model is reachable. Set `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, or `IRONCLAW_MODEL_GATEWAY_URL`. |
-| **channel adapters** | At least one adapter armed from the environment. | None armed — channels are optional; set e.g. `SLACK_BOT_TOKEN` / `TELEGRAM_BOT_TOKEN` or wire one with `ironctl registry wiring …`. |
-| **onboard config** | The `0600` token env-file is present and owner-only. | Absent (run `ironctl onboard`), a directory, or readable beyond the owner (`chmod 600`). |
-| **model-proxy socket** | The host model-proxy unix socket accepts a connection. | Socket missing (daemon not started) or present but not accepting connections (restart the control-plane). |
+| Check | Green | Yellow / Red | Fix it below |
+| --- | --- | --- | --- |
+| **control-plane API** | `/healthz` reachable at `--addr`. | Daemon not running, wrong `--addr`, or port blocked. | [Daemon unreachable](#daemon-unreachable-connection-refused) |
+| **API auth / token** | Bearer token accepted. | Ungated API (set `IRONCLAW_API_TOKEN` for defense-in-depth), token missing, or token rejected (`401`). | [API token rejected](#api-token-missing-or-rejected-401) |
+| **readiness** | `/readyz` reports `ready`. | Dependencies still coming up — check the daemon logs if it persists. | [Daemon unreachable](#daemon-unreachable-connection-refused) |
+| **sandbox runtime** | gVisor's `runsc` on `PATH`. Honors `IRONCLAW_RUNTIME` / `--runtime`. | Missing runtime (FAIL on Linux; informational off-Linux), or a **relaxed** runtime (docker/runc) with no gVisor syscall isolation. | [gVisor / runtime missing](#sandbox-runtime-runsc-not-found-gvisor) |
+| **build toolchain** | Reports the Go version and restates the control-plane's build requirement. | — (informational; the daemon needs `CGO_ENABLED=1` and a C toolchain for the encrypted SQLCipher queues). | [CGO / SQLCipher build errors](#build-fails-with-a-sqlite-cgo-error) |
+| **model credential** | A provider key or gateway URL is configured host-side. | None set — the zero-credential `mock` provider still serves chat, but no real model is reachable. Set `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, or `IRONCLAW_MODEL_GATEWAY_URL`. | [No model credentials](#no-model-credentials-and-the-zero-credential-mock-path) |
+| **channel adapters** | At least one adapter armed from the environment. | None armed — channels are optional; set e.g. `SLACK_BOT_TOKEN` / `TELEGRAM_BOT_TOKEN` or wire one with `ironctl registry wiring …`. | [Channel adapter not arming](#channel-adapter-not-arming-env-mismatch) |
+| **onboard config** | The `0600` token env-file is present and owner-only. | Absent (run `ironctl onboard`), a directory, or readable beyond the owner (`chmod 600`). | [onboard config](#onboard-config-missing-or-too-permissive) |
+| **model-proxy socket** | The host model-proxy unix socket accepts a connection. | Socket missing (daemon not started) or present but not accepting connections (restart the control-plane). | [Daemon unreachable](#daemon-unreachable-connection-refused) |
 
 The credential and channel checks read **exactly** the same environment variables
 the control-plane consumes on boot (the detectors are shared with `ironctl
 onboard`), so a check that says "armed" really will light up at runtime — and only
 the *presence* of a secret is ever reported, never its value.
 
-## Common fixes
+---
 
-- **`control-plane API: connection refused`** — start the daemon (`./bin/controlplane
-  --dev` for a loopback dev run, or your service unit), then re-run `ironctl doctor`.
-- **`sandbox runtime: runsc not found` (Linux)** — install
-  [gVisor](https://gvisor.dev/docs/user_guide/install/), or set `IRONCLAW_RUNTIME=docker`
-  for the relaxed runc fallback on hosts without gVisor (not the hardened posture).
-- **`model credential: none set`** — fine for the `mock` demo; for a real model,
-  export a provider key host-side and point your agent group at that provider.
-- **`onboard config: not present`** — run `ironctl onboard` to mint a local API
-  token and write the `0600` config file.
+## First-run failures
 
-See also: [Quickstart](quickstart.md) · [Channels](channels.md) ·
+The fixes for the most common errors people hit going from "found the repo" to
+"running locally," in the rough order you'll meet them.
+
+### Build fails with a SQLite / cgo error
+
+```
+# undefined: sqlite3 …  /  cgo: C compiler "cc" not found  /  exec: "gcc": not found
+```
+
+IronClaw builds with **`CGO_ENABLED=1`** — the encrypted-queue binding (SQLCipher)
+is compiled via cgo and is **unconditional**. You need a C toolchain:
+
+- **macOS:** `xcode-select --install`
+- **Debian / Ubuntu:** `sudo apt-get install build-essential`
+
+Then build with cgo enabled:
+
+```sh
+CGO_ENABLED=1 go build -o bin/ ./cmd/controlplane ./cmd/ironctl
+```
+
+The SQLCipher C amalgamation is **vendored by the driver**, so you do *not* need a
+system `libsqlcipher`. If you see `CGO_ENABLED=0` somewhere in your environment or
+CI, unset it. See [Building from source](building.md).
+
+### Daemon unreachable (`connection refused`)
+
+```
+[FAIL] control-plane API: dial tcp 127.0.0.1:8787: connect: connection refused
+```
+
+The control-plane isn't running (or `--addr` points at the wrong place). Start it:
+
+- **Zero-credential demo:** `docker compose -f docker-compose.demo.yml up --build -d`
+- **Local dev (loopback, no gVisor):** `./bin/controlplane --dev --api-addr 127.0.0.1:8787`
+
+Then re-run `ironctl doctor`. If `ironctl` runs on a different host or port, pass
+`--addr http://<host>:<port>`. A `readiness: not ready` warning right after start
+is normal — give dependencies a moment, then check the daemon logs if it persists.
+
+### Port 8787 already in use
+
+```
+listen tcp 127.0.0.1:8787: bind: address already in use
+```
+
+Something else (often a previous control-plane that didn't shut down) holds the
+port. Find and stop it, or bind elsewhere:
+
+```sh
+lsof -i :8787                                   # see what holds the port (macOS/Linux)
+./bin/controlplane --dev --api-addr 127.0.0.1:8799   # …or pick another port
+```
+
+For the demo compose file, change the published port mapping in
+`docker-compose.demo.yml` and point `ironctl --addr` at the new port.
+
+### Docker / Compose won't start the demo
+
+The 5-minute `mock` path needs Docker running and the sandbox image built:
+
+```sh
+# Docker Desktop (macOS/Windows) must be running, or dockerd on Linux.
+bash container/build.sh                                  # build the sandbox image once (~1–2 min)
+docker compose -f docker-compose.demo.yml up --build -d  # start the demo control-plane
+docker compose -f docker-compose.demo.yml logs -f        # watch it come up / read errors
+```
+
+Common causes: Docker isn't started; the sandbox image wasn't built yet (run
+`container/build.sh` first); or an older `docker-compose` v1 — use the
+`docker compose` (v2) subcommand. The demo mounts the host Docker socket and runs
+the sandbox as a **runc** container — a relaxed, laptop-only posture, *not* the
+sealed production seal. Tear it down with
+`docker compose -f docker-compose.demo.yml down`.
+
+### Sandbox runtime: `runsc` not found (gVisor)
+
+```
+[FAIL] sandbox runtime (runsc): runsc not found on PATH
+```
+
+Production sandboxes run on the **Linux control-plane host** behind gVisor.
+
+- **On Linux:** install [gVisor](https://gvisor.dev/docs/user_guide/install/) so
+  `runsc` is on `PATH`, or pass `--runtime <bin>` to point at it.
+- **Need to run without gVisor right now?** Set `IRONCLAW_RUNTIME=docker` (or pass
+  `--runtime`) for the **relaxed runc fallback** — shares the host kernel, so it is
+  **not** the hardened isolation posture. Use it for a demo, never for real
+  workloads.
+- **On macOS / Windows:** this check is informational — the production sandbox is a
+  Linux-host concern. Use the Docker demo or a Linux host/VM for real isolation.
+
+### Permission / user-namespace (userns) errors
+
+```
+# operation not permitted  /  newuidmap: …  /  failed to create user namespace
+```
+
+gVisor's `runsc` and rootless containers need **unprivileged user namespaces** on
+the Linux host:
+
+- Ensure the host kernel has user namespaces enabled
+  (`sysctl kernel.unprivileged_userns_clone=1` on some distros).
+- For rootless setups, install the `uidmap` package so `newuidmap` / `newgidmap`
+  are present.
+- Confirm `runsc` was installed per the
+  [gVisor install guide](https://gvisor.dev/docs/user_guide/install/) and is being
+  invoked on a Linux host (not inside an unprivileged nested container that blocks
+  userns). The supported production target is a Linux host with containerd + gVisor.
+
+### No model credentials (and the zero-credential `mock` path)
+
+```
+[WARN] model credential: none set — the zero-credential `mock` provider works, but no real model is reachable
+```
+
+This is **fine for trying IronClaw** — the offline `mock-agent` runs the full
+engage → sandbox → reply path with **no key**. To talk to a real model, set one
+provider credential **host-side** (it never enters a sandbox) and point your agent
+group at that provider:
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-...     # or OPENAI_API_KEY / OPENROUTER_API_KEY,
+                                        # or IRONCLAW_MODEL_GATEWAY_URL for a gateway
+```
+
+Restart the daemon and re-run `ironctl doctor` — the check flips to green. See the
+[Quickstart](quickstart.md#a-working-chat-in-5-minutes-no-credentials).
+
+### Channel adapter not arming (env mismatch)
+
+```
+[WARN] channel adapters: no channel armed from the environment
+```
+
+Channels are optional. An adapter arms only when the daemon sees the **exact**
+environment variable it expects — e.g. `SLACK_BOT_TOKEN`, `TELEGRAM_BOT_TOKEN`
+(these are **not** `IRONCLAW_`-prefixed). A frequent mistake is exporting the token
+in the `ironctl` shell instead of the **control-plane's** environment — they must
+be set where the daemon boots. The [Channel adapters](channels.md) reference lists
+every built-in channel and the variable it reads; or wire one explicitly with
+`ironctl registry wiring …`.
+
+### API token missing or rejected (401)
+
+```
+[FAIL] API auth / token: token rejected (401)
+```
+
+The bearer token `ironctl` sends doesn't match what the daemon started with. Export
+the same value the control-plane was launched with (or that `ironctl onboard`
+minted):
+
+```sh
+export IRONCLAW_API_TOKEN=<the token the daemon was started with>
+```
+
+A `WARN` that the API is *ungated* (no token required) is expected in `--dev`; set
+`IRONCLAW_API_TOKEN` on both the daemon and client for defense-in-depth behind the
+mesh. The zero-credential demo uses the fixed loopback token `ironclaw-demo`.
+
+### onboard config missing or too permissive
+
+```
+[WARN] onboard config: not present   (or)   readable beyond the owner
+```
+
+Run `ironctl onboard` to mint a local API token and write the `0600` env-file. If
+the file is readable beyond the owner, tighten it with `chmod 600 <path>`. If a
+directory exists where the file should be, remove it and re-run `ironctl onboard`.
+
+---
+
+## Still stuck?
+
+- Re-run `ironctl doctor` after every fix — it's the fastest way to confirm a check
+  flipped to green.
+- Read the **[FAQ](faq.md)** for the "is it really sandboxed?", "do I need
+  credentials?", providers/channels, and licensing questions.
+- Search or open a thread in
+  [GitHub Discussions](https://github.com/IronSecCo/ironclaw/discussions), or file a
+  [bug report](https://github.com/IronSecCo/ironclaw/issues/new/choose).
+
+See also: [Quickstart](quickstart.md) · [FAQ](faq.md) · [Channels](channels.md) ·
 [Building from source](building.md).

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -31,3 +31,6 @@ one you need.
 Looking for something else? The [Quickstart](../quickstart.md) is the shortest path to a running
 control-plane, and the [Channel adapters](../channels.md) reference lists every built-in channel and
 the credential it needs.
+
+Hit an error? Run `ironctl doctor`, then see [Troubleshooting](../troubleshooting.md) (every check
+mapped to a fix, plus the common build/Docker/port/userns failures) and the [FAQ](../faq.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,8 @@ nav:
   - Get Started:
       - Quickstart: quickstart.md
       - Building from source: building.md
+      - Troubleshooting: troubleshooting.md
+      - FAQ: faq.md
   - Tutorials:
       - Overview: tutorials/index.md
       - Your first sandboxed agent in 5 minutes: tutorials/first-agent.md


### PR DESCRIPTION
## What

Closes the support-friction loop after onboarding tutorials (IRO-105) and `ironctl doctor` (IRO-108). When a new user hits an error, they now get a fast self-serve answer.

- **`docs/troubleshooting.md`** — keeps the `ironctl doctor` check-mapping table (now each row links to a remediation anchor) and adds a **First-run failures** section: CGO/SQLCipher build errors, daemon unreachable (`connection refused`), port 8787 conflicts, Docker/Compose demo, gVisor `runsc` missing + `IRONCLAW_RUNTIME` fallback, permission/userns errors, no-credentials `mock` path, channel env mismatch, 401 token, onboard-config perms.
- **`docs/faq.md`** (new) — is it really sandboxed? · do I need credentials to try it? · which providers/channels are supported? · AGPLv3 + commercial + CLA licensing · how to contribute · how it differs from openclaw/nanoclaw.
- **`mkdocs.yml`** — Troubleshooting + FAQ wired into the **Get Started** nav.
- Cross-linked from **quickstart**, **tutorials index**, and **building.md**.

## Accuracy

Every answer cross-checked against `docs/roadmap.md` (SSoT), `quickstart.md`, `building.md`, and the current `cmd/ironctl/doctor.go` checks. No aspirational entries:
- Providers: Anthropic / OpenAI / OpenRouter / Codex (+ gateway URL) via host model-proxy.
- Channels: 11 adapters + web chat = 12 surfaces.
- Sandbox: gVisor `runsc` + `network=none` (+ Kata backend); demo relaxes to runc, clearly labeled.

## Verification

`mkdocs build --strict` — **green, zero warnings** (mkdocs 1.6.1 / material 9.5.39, pinned).

## Follow-up (not in this PR)

`ironctl doctor`'s `see:` hint URLs currently point at `/quickstart/` etc.; repointing them at the new `/troubleshooting/#anchor` sections is a small Go change owned by Forge — filed separately. The transitive path (doctor → quickstart → troubleshooting) already works today.

Ref: IRO-110.