### PR TITLE
docs: architecture & data-flow diagrams for docs + README (IRO-112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,19 +121,55 @@ verify — not something you take on faith.**
 Two compiled Go programs that never share memory and talk only through a pair of encrypted SQLite
 files per conversation:
 
-```
-                    ┌──────────────────────────────────────────────┐
-   chat platforms   │            CONTROL-PLANE (host)              │
-   ───────────────▶ │  api · gateway · router · delivery · sweep   │
-   (Tailscale only) │  keys · channels · modelproxy · isolation    │
-                    └───────┬───────────────────────────┬──────────┘
-                            │ inbound.db (ro)            │ outbound.db (rw, host reads)
-                            ▼ encrypted, per-session     ▲ encrypted, per-session
-                    ┌──────────────────────────────────────────────┐
-                    │           SANDBOX (gVisor, network=none)      │
-                    │   loop · provider · tools · queue             │
-                    │   model calls ─▶ host modelproxy unix socket  │
-                    └──────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+  CHAT["Chat platforms<br/>12 channel adapters"]
+  CLI["ironctl CLI"]
+  WEB["Web console"]
+
+  subgraph host["Trusted host — control-plane (cmd/controlplane)"]
+    API["HTTP API<br/>Tailscale mesh-only + bearer"]
+    GW["Gateway<br/>deterministic verifiers · human approval"]
+    CORE["Router · delivery · sweep · key custodian"]
+    CHAD["Channel adapters"]
+    MP["Model proxy<br/>holds provider keys"]
+    ISO["Isolation launcher<br/>gVisor / runsc"]
+  end
+
+  subgraph queues["Encrypted SQLCipher queues · per session"]
+    INQ[("inbound.db<br/>read-only to agent")]
+    OUTQ[("outbound.db<br/>append-only by agent")]
+  end
+
+  subgraph box["Agent sandbox · gVisor · network=none"]
+    LOOP["Agent loop · tools · model provider"]
+  end
+
+  PROV["Model providers<br/>Anthropic · OpenAI · OpenRouter"]
+
+  CHAT <--> CHAD
+  CLI -->|mesh only| API
+  WEB -->|mesh only| API
+  CHAD --> CORE
+  API --> GW --> CORE
+  CORE -->|write| INQ
+  OUTQ -->|read| CORE
+  ISO -->|launch| LOOP
+  INQ -->|ro bind mount| LOOP
+  LOOP -->|append| OUTQ
+  LOOP -->|unix socket| MP -->|HTTPS · key injected host-side| PROV
+
+  classDef host fill:#eaf2ff,stroke:#1d4ed8,stroke-width:1px,color:#0b1124;
+  classDef store fill:#b9d4ff,stroke:#1d4ed8,stroke-width:1px,color:#0b1124;
+  classDef box fill:#1d4ed8,stroke:#63a0ff,stroke-width:2px,color:#ffffff;
+  classDef control fill:#16224a,stroke:#63a0ff,stroke-width:2px,color:#ffffff;
+  classDef ext fill:#f4f9ff,stroke:#8fb4ff,stroke-width:1px,color:#16224a;
+
+  class API,CORE,CHAD,MP,ISO host;
+  class GW control;
+  class INQ,OUTQ store;
+  class LOOP box;
+  class CHAT,CLI,WEB,PROV ext;
 ```
 
 - The **control-plane** receives chats, routes them, holds the keys, runs the approval gateway, and
@@ -143,6 +179,45 @@ files per conversation:
   outbox. It can *request* a capability change but can never apply one.
 - The **frozen contract** (`internal/contract`) is the only package both sides import: typed IDs,
   row shapes, the embedded SQL schema, pinned cipher params, and the gateway protocol.
+
+A single message rides a clean loop; anything that would change what the agent *can do* takes the
+separate dashed path through the human-approval **gateway**:
+
+```mermaid
+flowchart LR
+  SENDER["External sender<br/>Slack · email · …"]
+  ADAPTER["Channel adapter"]
+  ROUTER["Router<br/>authorize + fan-out"]
+  INQ[("inbound.db")]
+  LOOP["Agent loop"]
+  MODEL["Model provider"]
+  OUTQ[("outbound.db")]
+  DELIVERY["Delivery"]
+  GW{"Gateway<br/>human approval"}
+  APPLY["Control-plane<br/>applies change"]
+
+  SENDER -->|message| ADAPTER --> ROUTER
+  ROUTER -->|write · encrypted| INQ
+  INQ -->|ro| LOOP
+  LOOP <-->|model call via host proxy| MODEL
+  LOOP -->|reply · append| OUTQ
+  OUTQ --> DELIVERY --> ADAPTER
+  ADAPTER -->|reply| SENDER
+  LOOP -.->|capability-change request| GW
+  GW -.->|approved| APPLY
+
+  classDef host fill:#eaf2ff,stroke:#1d4ed8,stroke-width:1px,color:#0b1124;
+  classDef store fill:#b9d4ff,stroke:#1d4ed8,stroke-width:1px,color:#0b1124;
+  classDef box fill:#1d4ed8,stroke:#63a0ff,stroke-width:2px,color:#ffffff;
+  classDef control fill:#16224a,stroke:#63a0ff,stroke-width:2px,color:#ffffff;
+  classDef ext fill:#f4f9ff,stroke:#8fb4ff,stroke-width:1px,color:#16224a;
+
+  class ADAPTER,ROUTER,DELIVERY,APPLY host;
+  class INQ,OUTQ store;
+  class LOOP box;
+  class GW control;
+  class SENDER,MODEL ext;
+```
 
 For the full design, see [`docs/architecture.md`](docs/architecture.md),
 [`docs/threat-model.md`](docs/threat-model.md), and the plain-language tour in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,143 @@ IronClaw is a security-hardened, open-source assistant platform written entirely
 in Go. A host **control-plane** orchestrates per-session **sandboxes**; the two
 sides communicate only through a pair of encrypted SQLite queues.
 
+## System at a glance
+
+How the pieces fit: operators and chat platforms reach the **control-plane**, which
+owns every privileged action and holds every key; agents run in **gVisor sandboxes**
+that can only read inbound and append outbound across a pair of **encrypted SQLCipher
+queues**. The gateway (highlighted) is the one path that changes what an agent *is*.
+
+```mermaid
+flowchart TB
+  CHAT["Chat platforms<br/>12 channel adapters"]
+  CLI["ironctl CLI"]
+  WEB["Web console"]
+
+  subgraph host["Trusted host — control-plane (cmd/controlplane)"]
+    API["HTTP API<br/>Tailscale mesh-only + bearer"]
+    GW["Gateway<br/>deterministic verifiers · human approval"]
+    CORE["Router · delivery · sweep · key custodian"]
+    CHAD["Channel adapters"]
+    MP["Model proxy<br/>holds provider keys"]
+    ISO["Isolation launcher<br/>gVisor / runsc"]
+  end
+
+  subgraph queues["Encrypted SQLCipher queues · per session"]
+    INQ[("inbound.db<br/>read-only to agent")]
+    OUTQ[("outbound.db<br/>append-only by agent")]
+  end
+
+  subgraph box["Agent sandbox · gVisor · network=none"]
+    LOOP["Agent loop · tools · model provider"]
+  end
+
+  PROV["Model providers<br/>Anthropic · OpenAI · OpenRouter"]
+
+  CHAT <--> CHAD
+  CLI -->|mesh only| API
+  WEB -->|mesh only| API
+  CHAD --> CORE
+  API --> GW --> CORE
+  CORE -->|write| INQ
+  OUTQ -->|read| CORE
+  ISO -->|launch| LOOP
+  INQ -->|ro bind mount| LOOP
+  LOOP -->|append| OUTQ
+  LOOP -->|unix socket| MP -->|HTTPS · key injected host-side| PROV
+
+  classDef host fill:#eaf2ff,stroke:#1d4ed8,stroke-width:1px,color:#0b1124;
+  classDef store fill:#b9d4ff,stroke:#1d4ed8,stroke-width:1px,color:#0b1124;
+  classDef box fill:#1d4ed8,stroke:#63a0ff,stroke-width:2px,color:#ffffff;
+  classDef control fill:#16224a,stroke:#63a0ff,stroke-width:2px,color:#ffffff;
+  classDef ext fill:#f4f9ff,stroke:#8fb4ff,stroke-width:1px,color:#16224a;
+
+  class API,CORE,CHAD,MP,ISO host;
+  class GW control;
+  class INQ,OUTQ store;
+  class LOOP box;
+  class CHAT,CLI,WEB,PROV ext;
+```
+
+## Sandbox isolation
+
+The sandbox has **no network interface** (`network=none`). Its only crossings to the
+outside are two host-owned unix sockets — the model proxy (always) and the egress
+broker (opt-in, deny-by-default) — plus the bind-mounted queue files. The runtime
+hardening (`runsc`) drops all capabilities, sets `no_new_privs`, runs non-root in a
+user namespace, and mounts a read-only rootfs with only `/workspace` writable. The
+per-session key arrives over a tmpfs at launch — never an env var or the image.
+
+```mermaid
+flowchart LR
+  subgraph host["Trusted host"]
+    KEYS["Key custodian<br/>per-session 256-bit keys"]
+    MP["Model proxy<br/>provider keys · allowlist · audit"]
+    EB["Egress broker<br/>opt-in · deny-by-default"]
+  end
+
+  subgraph box["gVisor sandbox (runsc) · network=none · no NIC"]
+    LOOP["Agent loop + tools"]
+    FS["read-only rootfs<br/>+ writable /workspace tmpfs"]
+    LOOP --- FS
+  end
+
+  KEYS -.->|key via tmpfs at launch| LOOP
+  LOOP -->|unix socket| MP -->|HTTPS| PROV["Model providers"]
+  LOOP -.->|unix socket · opt-in| EB -.->|approved hosts only| EXT["Approved external APIs"]
+
+  classDef host fill:#eaf2ff,stroke:#1d4ed8,stroke-width:1px,color:#0b1124;
+  classDef box fill:#1d4ed8,stroke:#63a0ff,stroke-width:2px,color:#ffffff;
+  classDef ext fill:#f4f9ff,stroke:#8fb4ff,stroke-width:1px,color:#16224a;
+
+  class KEYS,MP,EB host;
+  class LOOP,FS box;
+  class PROV,EXT ext;
+```
+
+## Channel message flow
+
+A message rides a clean loop — adapter → router → encrypted inbound queue → agent →
+model → encrypted outbound queue → delivery → adapter. Anything that would change the
+agent's capabilities takes the *separate* dashed path through the **gateway**, where a
+human approves the exact change before the control-plane applies it.
+
+```mermaid
+flowchart LR
+  SENDER["External sender<br/>Slack · email · …"]
+  ADAPTER["Channel adapter"]
+  ROUTER["Router<br/>authorize + fan-out"]
+  INQ[("inbound.db")]
+  LOOP["Agent loop"]
+  MODEL["Model provider"]
+  OUTQ[("outbound.db")]
+  DELIVERY["Delivery"]
+  GW{"Gateway<br/>human approval"}
+  APPLY["Control-plane<br/>applies change"]
+
+  SENDER -->|message| ADAPTER --> ROUTER
+  ROUTER -->|write · encrypted| INQ
+  INQ -->|ro| LOOP
+  LOOP <-->|model call via host proxy| MODEL
+  LOOP -->|reply · append| OUTQ
+  OUTQ --> DELIVERY --> ADAPTER
+  ADAPTER -->|reply| SENDER
+  LOOP -.->|capability-change request| GW
+  GW -.->|approved| APPLY
+
+  classDef host fill:#eaf2ff,stroke:#1d4ed8,stroke-width:1px,color:#0b1124;
+  classDef store fill:#b9d4ff,stroke:#1d4ed8,stroke-width:1px,color:#0b1124;
+  classDef box fill:#1d4ed8,stroke:#63a0ff,stroke-width:2px,color:#ffffff;
+  classDef control fill:#16224a,stroke:#63a0ff,stroke-width:2px,color:#ffffff;
+  classDef ext fill:#f4f9ff,stroke:#8fb4ff,stroke-width:1px,color:#16224a;
+
+  class ADAPTER,ROUTER,DELIVERY,APPLY host;
+  class INQ,OUTQ store;
+  class LOOP box;
+  class GW control;
+  class SENDER,MODEL ext;
+```
+
 ## Components
 
 - **Control-plane (host)** — HTTP API (mesh-only), the mandatory gateway,

--- a/docs/ironclaw-explained.md
+++ b/docs/ironclaw-explained.md
@@ -40,9 +40,9 @@ flowchart LR
     S -->|agent writes| OUT
     S -.model calls.-> PX["Host model proxy"]
     PX -.allowlisted.-> M["Model API"]
-    style S fill:#1f2937,stroke:#ff7a2e,color:#ffffff
-    style IN fill:#fce8e6,stroke:#ea4335
-    style OUT fill:#e6f4ea,stroke:#34a853
+    style S fill:#1d4ed8,stroke:#63a0ff,color:#ffffff
+    style IN fill:#b9d4ff,stroke:#1d4ed8,color:#0b1124
+    style OUT fill:#b9d4ff,stroke:#1d4ed8,color:#0b1124
 ```
 
 > **In plain terms:** Your message reaches the **control plane** (the always-on manager). It writes the message, encrypted, into an "inbox" file the agent can only *read*. The sealed agent thinks, writes its reply into an "outbox" file, and the manager sends it back to you. The agent has no internet of its own — even when it needs the AI model, that call is routed through the manager.
@@ -101,8 +101,8 @@ flowchart TB
     AGENT -->|reads + writes| OUTB[("Outbound queue<br/>ENCRYPTED")]
     OUTB -->|reads| HOST
     KEY -.unlocks at launch.-> AGENT
-    style INB fill:#fce8e6,stroke:#ea4335
-    style OUTB fill:#e6f4ea,stroke:#34a853
+    style INB fill:#b9d4ff,stroke:#1d4ed8,color:#0b1124
+    style OUTB fill:#b9d4ff,stroke:#1d4ed8,color:#0b1124
 ```
 
 Three things make this safe:
@@ -135,8 +135,8 @@ flowchart TB
     end
     AGENT -->|"only path out:<br/>one local socket"| PROXY
     PROXY -->|approved destinations only| NET["AI model API"]
-    style BOX fill:#11161f,stroke:#ff7a2e,color:#ffffff
-    style AGENT fill:#1f2937,stroke:#8b96a6,color:#ffffff
+    style BOX fill:#0b1124,stroke:#63a0ff,color:#ffffff
+    style AGENT fill:#1d4ed8,stroke:#63a0ff,color:#ffffff
 ```
 
 - **Containerized under gVisor.** Each agent runs in a container, and that container is wrapped by gVisor — an extra security layer that sits between the agent and the real computer and intercepts what it tries to do.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,7 +73,14 @@ markdown_extensions:
       anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      # Render ```mermaid fences as diagrams (Material's built-in Mermaid
+      # integration) instead of plain code blocks. GitHub renders the same
+      # fences natively, so a diagram authored once shows on both surfaces.
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.emoji:


### PR DESCRIPTION
## What

Three on-brand (steel-blue) Mermaid diagrams, accurate to current `main`, embedded in `docs/architecture.md` and the README:

1. **System architecture** — control-plane (`cmd/controlplane`), `ironctl`, web console, encrypted SQLCipher queues, gVisor sandboxes, model providers.
2. **Sandbox isolation** — `network=none` agent under gVisor/`runsc` with the two host unix sockets (model proxy + opt-in egress broker) as the only crossings.
3. **Channel message flow** — adapter → router → encrypted inbound queue → agent → model → outbound queue → delivery, with the human-approval **gateway** on the separate capability-change path.

## How

- Diagram-as-code (Mermaid), not binaries — renders on the docs site **and** GitHub natively.
- Enabled Material's Mermaid via the `pymdownx.superfences` `custom_fences` config. This also fixes the **previously-unrendered** Mermaid in `threat-model.md` and `ironclaw-explained.md` (they had no custom_fence, so they showed as raw code on the site).
- Inline `classDef` brand palette (steel `#1d4ed8` / navy `#16224a` / steel-100 `#eaf2ff`) so colors are identical on both surfaces and WCAG-AA (navy-on-light ≥13:1, white-on-steel 6.7:1, white-on-navy 14.6:1). Color is never the only signal — labels + subgraph trust zones carry meaning (color-independence).
- Re-themed the existing `ironclaw-explained.md` diagrams off the retired orange `#ff7a2e` onto steel-blue, now that they render.
- Replaced the README ASCII art with the rendered system diagram + added the message-flow diagram.

## Verification

- `mkdocs build --strict`: **green** (exit 0); architecture page emits 3 `<pre class="mermaid">`, zero raw `language-mermaid` fences.
- Rendered the three full sources in a real browser at 1440×900 via Material's own loaded Mermaid instance (`mermaid.run({nodes})` over the sources extracted from the built HTML): **3/3 SVGs, no errors**. Steel-blue brand confirmed, gateway visually dominant.

Closes IRO-112.