### PR TITLE
docs(deploy): production self-host guide + hardened compose (IRO-111)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ go.work.sum
 
 # Local env / secrets — never commit
 .env
+deploy/.env.prod
 *.local
 *.key
 *.pem

--- a/README.md
+++ b/README.md
@@ -447,6 +447,12 @@ themselves are **not** compose services — the control-plane launches them as g
 (`runsc`) children with `network=none`; running real sandboxes needs a runsc-capable
 host (see [`deploy/README.md`](deploy/README.md)).
 
+Going to production? The **[deployment guide](https://ironsecco.github.io/ironclaw/deployment/)**
+covers the hardened, durable posture: locked-down [`deploy/docker-compose.prod.yml`](deploy/docker-compose.prod.yml)
+(read-only rootfs, dropped caps, resource limits) behind a TLS reverse proxy
+([`deploy/Caddyfile`](deploy/Caddyfile)), secrets via an env-file, encrypted-state
+backup/restore, pinned-digest upgrades, and Prometheus `/metrics`.
+
 ## Quickstart
 
 A fuller local walkthrough — run the control-plane **from source** in dev mode (no gVisor, binds to

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -1,0 +1,44 @@
+# IronClaw production env-file — copy to deploy/.env.prod and edit:
+#
+#   cp deploy/.env.prod.example deploy/.env.prod
+#   chmod 600 deploy/.env.prod
+#   docker compose -f deploy/docker-compose.prod.yml up -d
+#
+# This file holds SECRETS. deploy/.env.prod is git-ignored — never commit it. The
+# variable names mirror .env.example (the daemon reads the same env). Keep it 0600.
+
+# ─── Image (pin by digest in production) ──────────────────────────────────────
+# Resolve the digest of the release tag you want, then pin it so deploys are
+# reproducible and cosign-verifiable:
+#   docker buildx imagetools inspect ghcr.io/ironsecco/ironclaw-controlplane:v0.1.0
+# IRONCLAW_IMAGE=ghcr.io/ironsecco/ironclaw-controlplane@sha256:<digest>
+IRONCLAW_IMAGE=ghcr.io/ironsecco/ironclaw-controlplane:latest
+
+# ─── TLS / reverse proxy ──────────────────────────────────────────────────────
+# Your public FQDN — Caddy gets a Let's Encrypt cert for it automatically. Leave as
+# "localhost" for a private/mesh box (Caddy serves a local self-signed cert).
+IRONCLAW_DOMAIN=localhost
+
+# ─── Admin / API token ────────────────────────────────────────────────────────
+# Bearer token for the control-plane admin API (ironctl + the web console + the
+# Prometheus scraper). Set it from your secrets manager so it is not minted+printed
+# on first run. Generate one: `openssl rand -hex 32`.
+IRONCLAW_API_TOKEN=
+
+# ─── Model credential (held host-side; NEVER enters a sandbox) ────────────────
+# Set at least one so agents can call a model. The model-proxy injects it host-side.
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+OPENROUTER_API_KEY=
+
+# ─── Channel adapters (each registers only when its token/URL is set) ─────────
+SLACK_BOT_TOKEN=
+DISCORD_BOT_TOKEN=
+TELEGRAM_BOT_TOKEN=
+IRONCLAW_TEAMS_WEBHOOK_URL=
+IRONCLAW_SIGNAL_CLI_URL=
+IRONCLAW_SIGNAL_NUMBER=
+
+# ─── Production safety ─────────────────────────────────────────────────────────
+# MUST stay 0 in production: --dev seeds an unauthenticated dev owner/agent-group.
+IRONCLAW_DEV=0

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,37 @@
+# IronClaw — TLS-terminating reverse proxy in front of the control-plane.
+#
+# Used by deploy/docker-compose.prod.yml. Caddy provisions TLS automatically:
+#   - a real public FQDN in IRONCLAW_DOMAIN  -> Let's Encrypt certificate
+#   - "localhost" / a bare host or IP        -> Caddy's local self-signed CA
+#
+# The control-plane serves plain HTTP on the private compose network (its security
+# boundary is the network + the bearer token, not its own TLS); Caddy terminates TLS
+# at the edge and forwards over the internal hop. See docs/deployment.md.
+
+{$IRONCLAW_DOMAIN} {
+	# Forward everything to the control-plane on the private network. This fronts the
+	# web console (/ui/), the gated admin API (/v1/…), the health probes, and the
+	# Prometheus endpoint (/metrics — itself bearer-gated by the control-plane).
+	reverse_proxy controlplane:8787
+
+	# Baseline security headers. The console is same-origin; lock the browser down.
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "no-referrer"
+		# Don't leak the proxy/server banner.
+		-Server
+	}
+
+	# Structured access log; ship it or rotate it as you see fit.
+	log {
+		output stdout
+		format json
+	}
+
+	# OPTIONAL: keep /metrics off the public edge and scrape it on the private
+	# network instead. Uncomment to return 404 for external metrics requests.
+	# @metrics path /metrics
+	# respond @metrics 404
+}

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,0 +1,143 @@
+# IronClaw — hardened production control-plane (Docker Compose).
+#
+#   cp deploy/.env.prod.example deploy/.env.prod   # fill in the real secrets
+#   docker compose -f deploy/docker-compose.prod.yml up -d
+#   docker compose -f deploy/docker-compose.prod.yml logs -f controlplane
+#
+# This is the production-posture compose. It differs from the repo-root
+# docker-compose.yml (a one-command self-host that publishes the API on host
+# loopback) in three ways: the control-plane is NOT published to the host at all —
+# it is reachable only on the private compose network, fronted by a TLS-terminating
+# Caddy reverse proxy; the container is locked down (read-only rootfs, all caps
+# dropped, no-new-privileges, pid + resource ceilings); and the image is meant to be
+# pinned by digest, not :latest. See docs/deployment.md for the full guide.
+#
+# ISOLATION POSTURE — read before changing the network. The sandboxes that run agent
+# code are NOT services in this file. On a runsc-capable host the control-plane
+# launches them as gVisor (runsc) children with network=none, all caps dropped, and a
+# read-only rootfs. Running real gVisor sandboxes from inside this container needs a
+# containerd+runsc host and extra privilege the lockdown below does NOT grant — for
+# full sandbox isolation use the bare-host systemd path (deploy/install.sh,
+# deploy/README.md). This compose hardens and runs the trusted control-plane itself:
+# the mandatory approval gateway, the encrypted (SQLCipher) per-session queues, and
+# host-side model-credential custody. Do NOT put sandboxes on this network or grant
+# them connectivity — that defeats the seal.
+
+name: ironclaw
+
+services:
+  controlplane:
+    # Pin by DIGEST in deploy/.env.prod — IRONCLAW_IMAGE=ghcr.io/ironsecco/
+    # ironclaw-controlplane@sha256:<digest>. A floating :latest is rejected by the
+    # supply-chain posture (cosign-verifiable, attested on the index digest).
+    image: ${IRONCLAW_IMAGE:-ghcr.io/ironsecco/ironclaw-controlplane:latest}
+    # Secrets arrive at runtime via the env-file — NEVER baked into the image. The
+    # daemon env names mirror .env.example (ANTHROPIC_API_KEY, IRONCLAW_API_TOKEN,
+    # channel tokens, …). The file is git-ignored; keep it 0600 on the host.
+    env_file:
+      - path: .env.prod
+        required: true
+    environment:
+      # JSON logs for shippers; the obs logger redacts secrets regardless.
+      IRONCLAW_LOG_FORMAT: json
+    # NO host port. Only Caddy (below) can reach the control-plane, over the private
+    # network. This removes the raw API/console from every host interface.
+    expose:
+      - "8787"
+    networks:
+      - edge
+    volumes:
+      # Durable host state: encrypted (SQLCipher) per-session queues, the gateway
+      # change store, the append-only audit log, sealed per-session keys, and the
+      # minted admin token. Back this up — losing it loses the token and all state.
+      - ironclaw-state:/var/lib/ironclaw/state
+    # Lock the container down. The control-plane needs no Linux capabilities to serve
+    # the API/gateway and custody keys; isolation is applied to the sandboxes it
+    # launches, not to this trusted process.
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    # Read-only rootfs needs writable scratch: the model-proxy unix socket lives under
+    # /run/ironclaw (owned by the image's nonroot uid 65532), plus a small /tmp.
+    tmpfs:
+      - /run/ironclaw:uid=65532,gid=65532,mode=0700
+      - /tmp:mode=1777
+    # Resource ceilings: a runaway control-plane cannot starve the host. Tune to your
+    # box; these suit a small-to-medium single-host deployment.
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 1g
+          pids: 512
+        reservations:
+          memory: 256m
+    restart: unless-stopped
+    # /healthz is unauthenticated by design; curl ships in the image for this check.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8787/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+    # The daemon stops its sandboxes (up to 10s) before exiting — give it headroom.
+    stop_grace_period: 20s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  # TLS-terminating reverse proxy. Only this service is published to the host; it
+  # proxies to the control-plane over the private network. Caddy provisions and
+  # renews certificates automatically (Let's Encrypt for a real IRONCLAW_DOMAIN, or
+  # a local self-signed CA when the domain is a bare host/IP).
+  caddy:
+    image: caddy:2.10-alpine
+    depends_on:
+      controlplane:
+        condition: service_healthy
+    environment:
+      # Set to your FQDN in deploy/.env.prod (e.g. ironclaw.example.com). Leave as the
+      # default to serve self-signed TLS on the host for a private/mesh deployment.
+      IRONCLAW_DOMAIN: ${IRONCLAW_DOMAIN:-localhost}
+    ports:
+      # Bind to all interfaces so the proxy is reachable; restrict with a host
+      # firewall or a tailnet bind (e.g. "${TAILNET_IP}:443:443") for mesh-only.
+      - "443:443"
+      - "80:80"
+    networks:
+      - edge
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data    # certificates + ACME account keys (back this up too)
+      - caddy-config:/config
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE    # bind 80/443 without running privileged
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 256m
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+networks:
+  # Private bridge — the control-plane is never published; only Caddy bridges to it.
+  edge:
+    driver: bridge
+
+volumes:
+  ironclaw-state:
+  caddy-data:
+  caddy-config:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,298 @@
+# Production deployment & self-hosting
+
+The [quickstart](quickstart.md) gets you a working agent in minutes. This guide takes
+you the rest of the way: a **durable, secured, self-hosted** IronClaw you can put real
+traffic and real credentials in front of.
+
+Read [Security & Trust](security.md) first — it explains *why* the boundaries below
+exist. This page is the *how*.
+
+## Pick a deployment path
+
+There are two supported ways to run the control-plane in production. They differ in
+**how much sandbox isolation you get**, because that depends on the host kernel.
+
+| | Bare-host (systemd / launchd) | Hardened Docker Compose |
+|---|---|---|
+| Installer | [`deploy/install.sh`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/install.sh) | [`deploy/docker-compose.prod.yml`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/docker-compose.prod.yml) |
+| Sandbox isolation | **Full gVisor (`runsc`)** — `network=none`, all caps dropped, read-only rootfs, user-namespaced | Control-plane only; sandboxes need a runsc host |
+| Best for | The real production posture: agents executing tool calls under gVisor | Hardened control-plane, gateway, console, channels on any Docker host |
+| Host requirements | Linux + containerd + gVisor (or macOS/launchd for the control-plane) | Any host with Docker + Compose |
+
+!!! important "Where the sandboxes run"
+    IronClaw's security value is that **agent code runs inside a gVisor sandbox** with
+    no network. gVisor sandboxes are launched by the control-plane directly on the host
+    via containerd — they are **not** Docker Compose services and never share the
+    control-plane's network. Running gVisor sandboxes from *inside* the Compose
+    control-plane container needs a containerd+runsc host and more privilege than the
+    hardened Compose grants. So:
+
+    - For **full sandbox isolation**, run the control-plane on a **gVisor-capable host**
+      with the systemd path below.
+    - The **hardened Compose** runs and locks down the *trusted control-plane itself*
+      (the mandatory approval gateway, the encrypted per-session queues, host-side
+      credential custody, the console and channels). On a host that also has runsc, the
+      sandboxes it launches still get the full gVisor seal.
+
+---
+
+## Path A — Bare-host install (full gVisor isolation)
+
+This is the production posture from [`deploy/README.md`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/README.md).
+The control-plane runs as a host service; every agent sandbox runs under gVisor.
+
+### 1. Provision the host
+
+Install the three external dependencies that are intentionally **not** vendored:
+
+- **containerd + gVisor (`runsc`)** — the `io.containerd.runsc.v1` runtime. Every
+  sandbox runs under it with `network=none`, all caps dropped, `no_new_privs`, a
+  user namespace, and a read-only rootfs.
+- **Tailscale (recommended)** — the control-plane API has **no public port**; bind it
+  to the tailnet IP and reach it over the mesh.
+- A C toolchain + Go 1.23+ if you build from source (the encrypted-SQLite binding is cgo).
+
+### 2. Install + enable the service
+
+```sh
+sudo deploy/install.sh
+```
+
+The installer is idempotent: it builds `ironclaw-controlplane` and `ironctl`, installs
+them under `/usr/local/bin`, provisions `/etc/ironclaw/ironclaw.env` (mode `0600`,
+**minting an API token on first run and preserving it on re-install**), and installs +
+enables the host service — [`ironclaw.service`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/ironclaw.service)
+(systemd) or [`io.ironclaw.controlplane.plist`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/io.ironclaw.controlplane.plist)
+(launchd). Tunables (`IRONCLAW_API_ADDR`, `IRONCLAW_STATE_DIR`, `ANTHROPIC_API_KEY`, …)
+go in that env file; the unit files stay static and hold no secrets.
+
+### 3. Pin and pre-pull the sandbox image
+
+The sandbox is a separate, pinned image. Build it and pin the digest:
+
+```sh
+container/build.sh ghcr.io/your-org/ironclaw-sandbox:1.0   # prints the RepoDigest to pin
+ctr -n ironclaw images pull ghcr.io/your-org/ironclaw-sandbox@sha256:<digest>
+```
+
+Pin that digest in `IRONCLAW_SANDBOX_IMAGE` and the provisioner trust policy
+(`PinnedDigestPolicy`). The image is pulled and unpacked **once** host-side (the sandbox
+is `network=none`) into a shared read-only rootfs reused across sessions.
+
+### 4. Per-group persistent storage (optional)
+
+Each agent group can be given durable storage. Lay out the host dirs and chown them to
+the sandbox's mapped non-root uid (`65532`):
+
+```sh
+install -d -m 0700 -o 65532 -g 65532 \
+  /var/lib/ironclaw/groups/<group>/workspace \
+  /var/lib/ironclaw/groups/<group>/memory
+install -d -m 0755 /var/lib/ironclaw/shared    # global, read-only to sandboxes
+```
+
+`/workspace` and `/memory` mount `rw` (with `nosuid,nodev,noexec`); `/shared` is `ro`.
+
+---
+
+## Path B — Hardened Docker Compose
+
+Use [`deploy/docker-compose.prod.yml`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/docker-compose.prod.yml)
+to run a locked-down control-plane behind a TLS-terminating reverse proxy on any Docker
+host. It differs from the one-command root [`docker-compose.yml`](https://github.com/IronSecCo/ironclaw/blob/main/docker-compose.yml)
+(which publishes the API on host loopback for evaluation) in three ways:
+
+- the control-plane is **not published to the host** — only Caddy is, and it proxies
+  over a private network;
+- the container is **locked down** (read-only rootfs, all caps dropped,
+  `no-new-privileges`, pid + CPU + memory ceilings, non-root uid `65532`);
+- the image is **pinned by digest**, not `:latest`.
+
+### 1. Configure secrets
+
+```sh
+cp deploy/.env.prod.example deploy/.env.prod
+chmod 600 deploy/.env.prod
+$EDITOR deploy/.env.prod
+```
+
+`deploy/.env.prod` is **git-ignored** and never baked into the image — secrets arrive
+at runtime via the env-file only. The variable names mirror
+[`.env.example`](https://github.com/IronSecCo/ironclaw/blob/main/.env.example) (the
+daemon reads the same env): `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` /
+`OPENROUTER_API_KEY` for the host-side model credential, `SLACK_BOT_TOKEN` /
+`DISCORD_BOT_TOKEN` / `TELEGRAM_BOT_TOKEN` / `IRONCLAW_TEAMS_WEBHOOK_URL` /
+`IRONCLAW_SIGNAL_*` for channels, and `IRONCLAW_API_TOKEN` for the admin bearer.
+
+!!! tip "Set the admin token yourself"
+    In production set `IRONCLAW_API_TOKEN` (`openssl rand -hex 32`) from your secrets
+    manager. If you leave it blank the control-plane mints one and prints it **once**
+    in the logs — there is no recovery. Either way the model credential is held
+    host-side and **never enters a sandbox**.
+
+### 2. Pin the image by digest
+
+```sh
+docker buildx imagetools inspect ghcr.io/ironsecco/ironclaw-controlplane:v0.1.0
+```
+
+Put the resolved `ghcr.io/ironsecco/ironclaw-controlplane@sha256:<digest>` in
+`IRONCLAW_IMAGE`. The image is published on every release, signed with cosign, and
+attested on the index digest — verify before pinning:
+
+```sh
+cosign verify ghcr.io/ironsecco/ironclaw-controlplane@sha256:<digest> \
+  --certificate-identity-regexp '^https://github.com/IronSecCo/ironclaw' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+### 3. Bring it up
+
+```sh
+docker compose -f deploy/docker-compose.prod.yml up -d
+docker compose -f deploy/docker-compose.prod.yml logs -f controlplane
+```
+
+The control-plane comes up `healthy` (the `/healthz` probe), locked down: read-only
+rootfs, `CapDrop=ALL`, `no-new-privileges`, non-root, with a tmpfs for the model-proxy
+socket. Caddy fronts it on `:443`/`:80`.
+
+---
+
+## Reverse proxy & TLS termination
+
+The control-plane serves **plain HTTP** — its security boundary is the network (mesh or
+private bridge) plus the bearer token, not its own TLS. Terminate TLS at the edge.
+
+The Compose ships [`deploy/Caddyfile`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/Caddyfile):
+set `IRONCLAW_DOMAIN` to your FQDN and Caddy provisions a Let's Encrypt certificate
+automatically (or a local self-signed CA for a bare host/IP). It also sets HSTS and
+basic hardening headers and can hide `/metrics` from the public edge.
+
+Prefer nginx? Terminate TLS and proxy to the control-plane:
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name ironclaw.example.com;
+    ssl_certificate     /etc/letsencrypt/live/ironclaw.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/ironclaw.example.com/privkey.pem;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+    location / {
+        proxy_pass http://127.0.0.1:8787;   # or the control-plane's private address
+        proxy_set_header Host              $host;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+### Bind-address guidance
+
+- **Never expose `8787` to the internet raw.** The default bind is `127.0.0.1:8787`.
+- **Best:** bind to a **Tailscale tailnet IP** (`--api-addr "$(tailscale ip -4):8787"`)
+  so there is no public port at all, and drop inbound to the API port on every
+  interface except the tailnet one with a host firewall.
+- **Compose:** the hardened file publishes only the reverse proxy; the control-plane
+  stays on the private bridge. Restrict the proxy further by binding it to a specific
+  host/tailnet IP (e.g. `"${TAILNET_IP}:443:443"`).
+
+---
+
+## Backups & restore
+
+All durable state lives in **one** place — the state directory (`/var/lib/ironclaw` on a
+bare host, the `ironclaw-state` volume in Compose). It holds the **encrypted (SQLCipher)
+per-session queues**, the gateway change store, the append-only audit log, the sealed
+per-session keys + file master key, and the minted admin token. Losing it loses the
+admin token and all session state.
+
+**Back up** (stop briefly or snapshot for a consistent copy):
+
+```sh
+# Compose: archive the named volume
+docker run --rm -v ironclaw_ironclaw-state:/state -v "$PWD":/backup alpine \
+  tar czf /backup/ironclaw-state-$(date +%F).tgz -C /state .
+
+# Bare host
+sudo systemctl stop ironclaw
+sudo tar czf ironclaw-state-$(date +%F).tgz -C /var/lib/ironclaw .
+sudo systemctl start ironclaw
+```
+
+The archive contains the **encryption keys**, so it is as sensitive as the live state —
+encrypt it at rest and store it in your secrets/backup vault, not next to the host.
+
+**Restore:** stop the stack, extract the archive back into the state dir/volume
+(preserving ownership `65532:65532` and `0700` perms), and start it. The admin token and
+all queues come back intact.
+
+---
+
+## Upgrades
+
+IronClaw is alpha and **not** bound by backward compatibility yet — read the release
+notes before upgrading. The state directory is the durable contract; the binary/image is
+replaceable.
+
+```sh
+# Compose: resolve + verify the new digest, update IRONCLAW_IMAGE in deploy/.env.prod, then
+docker compose -f deploy/docker-compose.prod.yml pull
+docker compose -f deploy/docker-compose.prod.yml up -d   # recreates with the new image
+
+# Bare host: pull the new source/release and re-run the idempotent installer
+git pull && sudo deploy/install.sh   # preserves the env file + token, restarts the service
+```
+
+Take a fresh backup before upgrading. Roll back by pinning the previous digest (Compose)
+or re-installing the previous tag, then restoring the pre-upgrade backup if state changed.
+
+---
+
+## Observability
+
+- **Liveness / readiness:** `GET /healthz` and `GET /readyz` are **unauthenticated** by
+  design (so probes need no credential) and exempt from rate limiting. The Compose
+  healthcheck uses `/healthz`.
+- **Metrics:** `GET /metrics` exposes Prometheus counters and histograms (gateway
+  decisions, model-proxy egress + redactions, queue activity). It is served on the API
+  address and is **bearer-gated** — scrape it with the admin token, ideally over the
+  private network:
+
+  ```yaml
+  scrape_configs:
+    - job_name: ironclaw
+      metrics_path: /metrics
+      authorization:
+        credentials: <IRONCLAW_API_TOKEN>
+      static_configs:
+        - targets: ["controlplane:8787"]
+  ```
+
+  Or keep it off the public edge entirely (the Caddyfile shows how) and scrape the
+  private address.
+- **Logs:** set `IRONCLAW_LOG_FORMAT=json` for shippers (the default in the Compose).
+  The logger **redacts secrets** — model keys and tokens never appear in logs.
+- **Audit:** the gateway writes an append-only audit log under the state dir; surface it
+  with `ironctl … audit` or the console's audit view.
+
+---
+
+## Hardening checklist
+
+- [ ] Control-plane **not** published to the internet — mesh/tailnet bind or private
+      network behind a reverse proxy.
+- [ ] TLS terminated at the edge (Caddy/nginx); HSTS on.
+- [ ] `IRONCLAW_API_TOKEN` set from a secrets manager (not minted-and-printed).
+- [ ] Image **pinned by digest** and cosign-verified.
+- [ ] Secrets only in the `0600` env-file — never baked into images, never committed.
+- [ ] `IRONCLAW_DEV=0` (the dev seed is unauthenticated — local only).
+- [ ] State dir/volume backed up **encrypted**, restore tested.
+- [ ] Sandboxes run under **gVisor** on the host (Path A) — verify `runtime: runsc` in
+      the startup log, not `docker`/`runc`.
+- [ ] Metrics scraped over the private network with the bearer token.
+- [ ] Resource + pid ceilings set (the hardened Compose sets these).
+
+See [Security & Trust](security.md) and the [threat model](threat-model.md) for the
+boundaries each of these protects.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
   - Get Started:
       - Quickstart: quickstart.md
       - Building from source: building.md
+      - Production deployment: deployment.md
       - Troubleshooting: troubleshooting.md
       - FAQ: faq.md
   - Tutorials:


### PR DESCRIPTION
## What

Convert evaluators into deployers (IRO-111). Adds a production / self-host deployment guide and example `deploy/` artifacts on top of the existing demo compose.

### Artifacts
- **`docs/deployment.md`** — wired into the mkdocs nav (Get Started → Production deployment) and linked from the README. Covers:
  - Two deployment paths: bare-host systemd/launchd (full gVisor sandbox isolation) vs. hardened Docker Compose (locked-down control-plane).
  - Persistent state, secrets via env-file (mirroring the daemon's documented env names), reverse-proxy + TLS termination, bind-address guidance.
  - Encrypted-state backup/restore, pinned-digest upgrade path, Prometheus `/metrics` (bearer-gated) + `/healthz`/`/readyz`.
  - A hardening checklist.
- **`deploy/docker-compose.prod.yml`** — hardened control-plane: read-only rootfs, `cap_drop: ALL`, `no-new-privileges`, pid/CPU/memory ceilings, non-root uid 65532, log rotation, named state volume — **not published to the host**, fronted by a TLS-terminating Caddy proxy on a private network.
- **`deploy/Caddyfile`** — auto-TLS reverse proxy (Let's Encrypt / self-signed) with HSTS + security headers.
- **`deploy/.env.prod.example`** — prod secrets template; `deploy/.env.prod` is git-ignored.

## Constraints honored
- Matches shipped reality — no unbuilt features (control-plane serves plain HTTP behind the mesh/proxy; sandboxes are gVisor children, not compose services; metrics are bearer-gated).
- Non-destructive examples. No repo CLAUDE.md Paperclip co-author trailer.

## Verification
- Hardened control-plane **boots healthy**: `docker inspect` confirms `ReadonlyRootfs=true`, `CapDrop=[ALL]`, `no-new-privileges:true`, `PidsLimit=512`, non-root `65532:65532`; rootfs writes blocked; model-proxy socket created on tmpfs; `/healthz` returns `{"status":"ok"}`.
- `docker compose -f deploy/docker-compose.prod.yml config -q` valid.
- `mkdocs build --strict` green (pinned toolchain), deployment page renders.

## Security lenses
Touches **isolation** (documentation) and **secret hygiene** — strengthens posture (lockdown, no host port, env-file-only secrets, encrypted-backup guidance); does not weaken any boundary. Docs/example only — no code changes.

Closes IRO-111.