### PR TITLE
docs: make Mermaid diagrams actually render on the docs site (IRO-112 follow-up)

### DIFF
--- a/docs/javascripts/mermaid-init.js
+++ b/docs/javascripts/mermaid-init.js
@@ -1,0 +1,30 @@
+// Mermaid rendering for the IronClaw docs site.
+//
+// We render Mermaid ourselves (pinned version, ESM import) instead of relying on
+// Material's built-in integration: that integration only detects `pre.mermaid`
+// and, with the `fence_code_format` output, feeds the literal `<code>` wrapper
+// into the parser ("No diagram type detected for text: <code>…"), leaving an
+// empty box. We emit a bare `<div class="mermaid">…` (superfences
+// `fence_div_format`) — exactly what Mermaid expects natively — and drive it
+// from here. GitHub renders the same ```mermaid fences natively, so README and
+// docs stay in sync from one source.
+//
+// Node colors come from inline `classDef` directives inside each diagram (the
+// steel-blue brand palette), so they are identical on GitHub and the docs site.
+// The themeVariables below only style what classDef does not: edge lines and
+// edge-label text, kept readable on both the light and dark (slate) schemes via
+// a solid white label background.
+import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.6.0/dist/mermaid.esm.min.mjs";
+
+mermaid.initialize({
+  startOnLoad: true,
+  securityLevel: "strict",
+  theme: "base",
+  themeVariables: {
+    fontFamily:
+      "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif",
+    lineColor: "#64748b",
+    edgeLabelBackground: "#ffffff",
+  },
+  flowchart: { htmlLabels: true, useMaxWidth: true },
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,12 @@ theme:
 extra_css:
   - stylesheets/brand.css
 
+extra_javascript:
+  # Render the bare <div class="mermaid"> blocks (see superfences config below).
+  # Loaded as an ES module so it can `import` the pinned Mermaid build.
+  - path: javascripts/mermaid-init.js
+    type: module
+
 plugins:
   - search
   - render_swagger:
@@ -74,13 +80,17 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences:
-      # Render ```mermaid fences as diagrams (Material's built-in Mermaid
-      # integration) instead of plain code blocks. GitHub renders the same
-      # fences natively, so a diagram authored once shows on both surfaces.
+      # Render ```mermaid fences as diagrams instead of plain code blocks.
+      # GitHub renders the same fences natively, so a diagram authored once
+      # shows on both surfaces. We use fence_div_format (emits a bare
+      # <div class="mermaid">…), NOT fence_code_format: the latter wraps the
+      # source in <pre><code>, and current Mermaid passes that literal <code>
+      # tag into the parser ("No diagram type detected for text: <code>…"),
+      # leaving an empty box. A bare div is what Mermaid natively expects.
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
+          format: !!python/name:pymdownx.superfences.fence_div_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.emoji:


### PR DESCRIPTION
## Why

PR #153 enabled Mermaid via `pymdownx.superfences` with `fence_code_format`. That emits `<pre class="mermaid"><code>SOURCE</code></pre>`, and current Mermaid feeds the literal `<code>` wrapper into its parser — *"No diagram type detected for text: `<code>flowchart...`"* — leaving an **empty box** on the rendered docs site. (GitHub README is fine — GitHub renders ```mermaid fences natively.)

I caught this with a real-browser render of the deployed site: 3 `.mermaid` elements present, **0 rendered SVGs**.

## Fix

- Emit a bare `<div class="mermaid">SOURCE</div>` via `fence_div_format` — exactly what Mermaid expects natively (no `<code>` wrapper to choke on).
- Drive rendering from a small **pinned** ES-module init (`docs/javascripts/mermaid-init.js`, `mermaid@11.6.0`) wired via `extra_javascript: {type: module}`, instead of Material 9.5.39's built-in path (which only detects `pre.mermaid` and fails on the `<code>` wrapper). Node colors still come from the inline `classDef` brand palette in each diagram, so GitHub and the docs site stay identical.

## Verification (real browser, built site)

- `mkdocs build --strict`: **green**; output is `<div class="mermaid">flowchart TB…`, zero `<pre class="mermaid"><code>`.
- Rendered at **1440×900**: **3/3 diagrams → SVG**, all `data-processed=true`, steel-blue brand intact, gateway emphasized, edge labels readable.
- **Mobile 390-ish**: `useMaxWidth` scales diagrams to fit, no overflow.
- The Mermaid SVG carries its own light backdrop, so it stays legible under both the light and dark (slate) site schemes.

Follow-up to #153, closes the rendering gap on IRO-112.