### PR TITLE
ci: make the control-plane build reproducible — GOMAXPROCS=1 + pre-fetched modules (IRO-44)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,10 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.23.12"
+          # No build-cache restore: a cached archive can carry a symbol order frozen from
+          # an earlier parallel build, which would make the published binary diverge from
+          # an independent reproducible rebuild (IRO-44). Build cold every time.
+          cache: false
 
       - name: Install cross C toolchain
         if: matrix.apt != ''
@@ -119,6 +123,13 @@ jobs:
         shell: bash
         env:
           CGO_ENABLED: "1"
+          # Single-threaded build so the published artifacts are bit-for-bit reproducible:
+          # the Go compiler/linker otherwise resolve ties in symbol ordering (generic
+          # [go.shape...] instantiations, ..stmp_ statics) in the scheduling order of their
+          # GOMAXPROCS-many goroutines, so on a multi-core runner two cold builds of the
+          # same commit differ (it bit the control-plane binary). This is the canonical
+          # reproducible build that reproducibility.yml asserts. (IRO-44)
+          GOMAXPROCS: "1"
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CC_OVERRIDE: ${{ matrix.cc }}
@@ -126,6 +137,10 @@ jobs:
           TAG: ${{ needs.version.outputs.tag }}
         run: |
           set -euo pipefail
+          # Pre-fetch modules so the build doesn't race a module download/extract on its
+          # first (and only) run — the other half of the IRO-44 reproducibility fix
+          # (otherwise a fresh-runner build diverges from a warmed independent rebuild).
+          go mod download all
           # Linux arm64 uses a GNU cross-gcc (matrix.cc); macOS Intel cross-compiles
           # with clang via -arch on the universal SDK (matrix.cgoarch).
           [ -n "${CC_OVERRIDE}" ] && export CC="${CC_OVERRIDE}"

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -2,12 +2,23 @@
 #
 # Proves IronClaw's binaries are bit-for-bit deterministic: build every command twice
 # from a clean checkout with the SAME pinned toolchain and flags the release uses
-# (-trimpath, pinned ldflags, -buildid=, fixed module versions via go.sum), then compare
-# the two SHA256 sets. ironctl + sandbox are hard-asserted reproducible — a drift there
-# means something non-deterministic crept into the build and fails loud. controlplane is
-# a tracked exception (IRO-44): not yet deterministic under the pinned go1.23.12 toolchain
-# though it is under newer Go, so it is reported as a loud ::warning::, never silently
-# skipped, and does not block the rest of the supply-chain guarantees.
+# (-trimpath, -buildid=, -extldflags=-Wl,--build-id=none, GOMAXPROCS=1, fixed module
+# versions via go.sum), then assert the two SHA256 sets are identical. A drift here means
+# something non-deterministic crept into the build (an unpinned tool, a timestamp, a
+# map-iteration order in codegen) and the "reproducible builds" guarantee is broken —
+# fail loud.
+#
+# All three commands (controlplane, ironctl, sandbox) are hard-asserted reproducible.
+# The control-plane binary was previously a tracked exception (IRO-44). Two factors made
+# it — the largest binary, with the most generic [go.shape...] instantiations and ..stmp_
+# statics — non-deterministic on a multi-core runner, both now removed:
+#   1. The Go compiler/linker resolve ties in symbol ordering in the scheduling order of
+#      their GOMAXPROCS-many goroutines. GOMAXPROCS=1 makes that deterministic.
+#   2. The very first `go build` on a fresh runner races module download/extract (go clean
+#      -cache does not touch the module cache), so build #1 differed from build #2+. A
+#      `go mod download` before the builds removes that seed.
+# With both applied, all three commands build bit-for-bit identically, so the exception is
+# gone and controlplane is gated like the others.
 #
 # Runs on PRs to main + weekly so a regression is caught before it ships, without
 # adding cost to the per-push release.
@@ -29,6 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: "1"
+      # Single-threaded build so symbol-ordering ties resolve deterministically — half of
+      # the control-plane reproducibility fix (IRO-44). Must match release.yml.
+      GOMAXPROCS: "1"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -37,11 +51,18 @@ jobs:
           # Must match the exact toolchain pin in ci.yml / release.yml — a different
           # patch can change the emitted binary and is itself a reproducibility break.
           go-version: "1.23.12"
+          # Don't restore a build cache: cached archives can carry a symbol order frozen
+          # from an earlier *parallel* build, which would contaminate the comparison.
+          cache: false
 
       - name: Build twice and compare checksums
         shell: bash
         run: |
           set -euo pipefail
+          # Pre-fetch modules so neither build races a module download/extract on its first
+          # run — the second half of the IRO-44 fix (otherwise build A != build B because
+          # only A pays the download cost).
+          go mod download all
           # Mirror the release build flags. The version string is fixed (not derived
           # from git state) so it can't be the source of a difference here. We also
           # strip the two ELF identifiers that vary across cold rebuilds of a CGO
@@ -50,7 +71,8 @@ jobs:
           #                              shift when the action graph is recompiled cold)
           #   -extldflags=-Wl,--build-id=none  drops the GNU .note.gnu.build-id the
           #                              external linker (ld) stamps in. This is the
-          #                              standard reproducible-build fix for cgo binaries.
+          #                              standard reproducible-build fix for cgo binaries
+          #                              and is valid here because the runner is Linux.
           ldflags="-s -w -buildid= -X github.com/IronSecCo/ironclaw/internal/version.Version=repro-check -extldflags=-Wl,--build-id=none"
           build() {
             local dest="$1"
@@ -71,15 +93,12 @@ jobs:
           echo "== build A =="; cat a.sums
           echo "== build B =="; cat b.sums
 
-          # ironctl + sandbox MUST be bit-for-bit reproducible — a drift there is a hard
-          # failure (a non-pinned input crept in). The control-plane binary is a tracked
-          # exception: under the pinned CI toolchain (go1.23.12, linux/amd64) it is not yet
-          # deterministic, while it IS under newer Go locally — a toolchain-specific linker
-          # non-determinism, NOT a source issue (-trimpath/-buildid=/--build-id=none are all
-          # applied). Tracked in IRO-44. We surface it as a loud ::warning:: (never a silent
-          # skip) and do not block on it, so the rest of the supply-chain guarantees ship.
+          # Every command MUST be bit-for-bit reproducible — a drift in any of them is a
+          # hard failure (a non-pinned input crept in). controlplane is no longer an
+          # exception: with GOMAXPROCS=1 + pre-fetched modules it builds deterministically
+          # (IRO-44 resolved).
           rc=0
-          for bin in ironctl sandbox; do
+          for bin in controlplane ironctl sandbox; do
             a="$(grep "^${bin} " a.sums | awk '{print $2}')"
             b="$(grep "^${bin} " b.sums | awk '{print $2}')"
             if [ "${a}" != "${b}" ]; then
@@ -89,12 +108,4 @@ jobs:
               echo "Reproducible: ${bin} is byte-identical across cold rebuilds (${a})."
             fi
           done
-
-          cpa="$(grep '^controlplane ' a.sums | awk '{print $2}')"
-          cpb="$(grep '^controlplane ' b.sums | awk '{print $2}')"
-          if [ "${cpa}" != "${cpb}" ]; then
-            echo "::warning title=Reproducibility (controlplane)::controlplane is not yet bit-reproducible under go1.23.12 (${cpa} vs ${cpb}) — known toolchain issue tracked in IRO-44. ironctl + sandbox are verified reproducible."
-          else
-            echo "Reproducible: controlplane is byte-identical across cold rebuilds (${cpa}) — IRO-44 may be resolvable; promote it back to a hard assertion."
-          fi
           exit "${rc}"


### PR DESCRIPTION
## What

Fixes **IRO-44**: the `controlplane` binary was not bit-for-bit reproducible on a multi-core runner (linux/amd64) while `ironctl` and `sandbox` were. Promotes `controlplane` back to a **hard assertion** in `reproducibility.yml` (removes the warning-only exception).

## Root cause — two environment-dependent factors (not the toolchain)

Bumping to go1.26.2 did **not** fix it (verified — the ticket's "deterministic under go1.26" was a macOS/ld64 observation; the GNU-ld/linux path still drifts). The real causes:

1. **Parallelism.** The Go compiler/linker resolve **ties** in symbol ordering — generic `[go.shape...]` instantiations and `..stmp_` statics — in the scheduling order of their `GOMAXPROCS`-many goroutines. `controlplane` is the only command with enough such symbols to trip it. `nm` of two drifting binaries shows only those symbols swapping addresses, **pairwise at equal-size slots** (`.text`/`.rodata`/`.data` then shift via relocations; section sizes identical).
2. **First-build module race.** `go clean -cache` doesn't touch the **module** cache, so the very first `go build` on a fresh runner races module download/extract and produced a different binary from build #2+.

### Evidence (native 4-core `ubuntu-latest`, isolated diagnostic workflow)

| configuration | result |
|---|---|
| default, no pre-fetch | two cold builds **DRIFT** |
| `GOMAXPROCS=1`, no pre-fetch | build #1 differs from #2/#3/#4 |
| `GOMAXPROCS=1` + `go mod download` | **4/4 cold builds byte-identical** (incl. the first) |

## Fix (release.yml + reproducibility.yml, in lockstep)

- **`GOMAXPROCS=1`** on the build step → single-threaded, deterministic tie-breaking.
- **`go mod download all`** before building → no first-run module race.
- **setup-go `cache: false`** → a restored cache can carry a symbol order frozen from an earlier *parallel* build and re-contaminate the output.
- **reproducibility.yml**: `controlplane` promoted to a hard assertion; all three commands gated bit-for-bit.

The authoritative linux/amd64 proof is the **Reproducibility** check on this PR: it now builds with the fix and hard-asserts `controlplane`.

## Tradeoff

`GOMAXPROCS=1` + no build cache serializes the build (slower per matrix leg). Acceptable for a verifiable, secured release. `go.mod` stays `go 1.23`; README "Go 1.23+" unchanged.

## Supply-chain lenses

- **Reproducibility** — restores the full bit-for-bit guarantee across all three binaries; removes the tracked exception; pins out the parallelism + first-build variables. The published artifact (release.yml) is built the same canonical way an independent rebuild reproduces.
- **Signing / checksums** — `SHA256SUMS` now covers a binary an independent party can re-derive; signing path unchanged.

## Review

Routing to **@CEO** — supply-chain trust-line change (reproducibility guarantee + release-path build). Please confirm before merge.