### PR TITLE
docs(examples): 3 credential-free end-to-end recipes in /examples (IRO-115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,9 +483,20 @@ same gateway. There is no file-edit path that bypasses it.
 
 ## Examples
 
-Runnable templates that configure a real agent against a running control-plane live in
-[`examples/`](examples/) — each is a directory with a `README.md` and a `setup.sh`:
+Runnable recipes live in [`examples/`](examples/) — each is a directory with a `README.md` and a `setup.sh`.
+Three of them ship a `run-mock.sh` that drives the **whole** inbound → agent → reply pipeline on the
+offline `mock` provider, so a fresh clone runs them with **no model key and no channel tokens**:
 
+```sh
+docker compose -f docker-compose.demo.yml up -d --build   # seeds the offline mock-agent
+./examples/scheduled-report/run-mock.sh                   # cron-style self-scheduling summary
+./examples/webhook-responder/run-mock.sh                  # inbound webhook → agent reply
+./examples/slack-triage/run-mock.sh                       # classify/label every message
+```
+
+- [`scheduled-report/`](examples/scheduled-report/) — wakes itself on a schedule (`schedule_task`), summarizes, posts to a channel. *(credential-free demo)*
+- [`webhook-responder/`](examples/webhook-responder/) — routes an inbound HTTP webhook to an agent that replies. *(credential-free demo)*
+- [`slack-triage/`](examples/slack-triage/) — classifies/labels every incoming Slack message. *(credential-free demo)*
 - [`personal-assistant/`](examples/personal-assistant/) — a private 1:1 assistant on Telegram, plus a walk-through of the mandatory change-approval flow.
 - [`channel-triage/`](examples/channel-triage/) — a Slack triage bot that engages only on `@mention`, only for known senders.
 - [`multi-agent-team/`](examples/multi-agent-team/) — two agents sharing one channel, separated by engage mode and priority.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,78 @@
+---
+title: Examples
+description: Copy-pasteable, runnable agent recipes — three run end-to-end with no credentials.
+---
+
+# Examples
+
+Runnable recipes live in [`examples/`](https://github.com/IronSecCo/ironclaw/tree/main/examples)
+— each is a self-contained directory with a `README.md` (what it does) and a
+`setup.sh` (the exact `ironctl` commands). Three of them also ship a `run-mock.sh`
+that drives the **whole** inbound → agent → reply pipeline against the offline
+`mock` provider, so a fresh clone runs them with **no model key and no channel
+tokens**.
+
+## Run a recipe end-to-end, credential-free
+
+Bring up the [zero-credential demo control-plane](quickstart.md) once — it seeds an
+offline `mock-agent` whose `mock` provider makes no network call and needs no key —
+then run any recipe from the repo root:
+
+```sh
+docker compose -f docker-compose.demo.yml up -d --build   # seeds the offline mock-agent
+./examples/scheduled-report/run-mock.sh                   # cron-style self-scheduling summary
+./examples/webhook-responder/run-mock.sh                  # inbound webhook → agent reply
+./examples/slack-triage/run-mock.sh                       # classify/label every message
+docker compose -f docker-compose.demo.yml down            # tear down
+```
+
+With `mock` the replies are deterministic echoes that prove the pipeline; set a
+real model credential on the control-plane (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+…) and the *same* recipes do real work with no wiring change.
+
+## The recipes
+
+<div class="grid cards" markdown>
+
+-   :material-clock-outline: **[Scheduled report](https://github.com/IronSecCo/ironclaw/tree/main/examples/scheduled-report)** · *credential-free demo*
+
+    An agent that wakes itself on a schedule via the `schedule_task` tool,
+    summarizes, and posts the digest to a channel — no external cron.
+
+-   :material-webhook: **[Webhook responder](https://github.com/IronSecCo/ironclaw/tree/main/examples/webhook-responder)** · *credential-free demo*
+
+    An inbound HTTP webhook routed through the real pipeline to an agent that
+    replies — poll the reply or push it back via a `webhook` destination.
+
+-   :material-label-multiple: **[Slack triage](https://github.com/IronSecCo/ironclaw/tree/main/examples/slack-triage)** · *credential-free demo*
+
+    A bot that classifies/labels **every** incoming Slack message
+    (`bug`/`question`/`feature`/`urgent`).
+
+-   :material-account: **[Personal assistant](https://github.com/IronSecCo/ironclaw/tree/main/examples/personal-assistant)**
+
+    A private 1:1 assistant on Telegram that replies to every message — plus a
+    walk-through of the mandatory change-approval flow.
+
+-   :material-message-text: **[Channel triage](https://github.com/IronSecCo/ironclaw/tree/main/examples/channel-triage)**
+
+    A quiet triage bot in a shared Slack channel: engages only on `@mention`, only
+    for known senders, and accumulates the context it stayed out of.
+
+-   :material-account-group: **[Multi-agent team](https://github.com/IronSecCo/ironclaw/tree/main/examples/multi-agent-team)**
+
+    Two agents sharing one group chat (a frontline responder + a scribe), showing
+    priorities, multi-agent wiring, and where `create_agent` sits.
+
+-   :material-eye-outline: **[Keyword watcher](https://github.com/IronSecCo/ironclaw/tree/main/examples/keyword-watcher)**
+
+    A quiet ops agent in a Discord channel that engages only on a `pattern` match
+    (`deploy`/`incident`/`outage`), one session per incident thread.
+
+</div>
+
+## See also
+
+- [Quickstart](quickstart.md) — the zero-credential demo these recipes build on.
+- [Tutorials](tutorials/index.md) — guided walkthroughs from clone to a running agent.
+- [Channel adapters](channels.md) — the channels a recipe can ingest from and post to.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,12 +5,30 @@ control-plane. Each one is a directory with a `README.md` (what it does and how
 to try it) and a `setup.sh` (the exact `ironctl` commands, idempotent where the
 API allows).
 
-| Template | What it shows |
-|----------|---------------|
-| [`personal-assistant/`](personal-assistant/) | A private 1:1 assistant on Telegram that replies to every message — plus the mandatory change-approval flow. |
-| [`channel-triage/`](channel-triage/) | A triage bot in a shared Slack channel: engages only on `@mention`, only for known senders, and accumulates context from the messages it ignores. |
-| [`multi-agent-team/`](multi-agent-team/) | Two agents wired into one group chat (a frontline responder + a scribe), showing priorities, multi-agent wiring, and where agent-to-agent / `create_agent` sits. |
-| [`keyword-watcher/`](keyword-watcher/) | A quiet ops agent in a Discord channel that engages only on a `pattern` match (`deploy`/`incident`/`outage`), from any sender, one session per incident thread. |
+### Run end-to-end credential-free (mock provider)
+
+Three recipes ship a `run-mock.sh` that exercises the **whole** inbound → agent →
+reply pipeline against the offline `mock` provider — **no model key, no channel
+tokens**. Bring up the zero-credential demo control-plane once, then run any of
+them from the repo root:
+
+```sh
+docker compose -f docker-compose.demo.yml up -d --build   # seeds the offline mock-agent
+./examples/scheduled-report/run-mock.sh
+./examples/webhook-responder/run-mock.sh
+./examples/slack-triage/run-mock.sh
+docker compose -f docker-compose.demo.yml down            # tear down
+```
+
+| Recipe | What it shows | Credential-free demo |
+|--------|---------------|:--------------------:|
+| [`scheduled-report/`](scheduled-report/) | An agent that wakes itself on a schedule (`schedule_task`), summarizes, and posts to a channel. | ✅ `run-mock.sh` |
+| [`webhook-responder/`](webhook-responder/) | An inbound HTTP webhook routed to an agent that replies (poll or push-back via a `webhook` destination). | ✅ `run-mock.sh` |
+| [`slack-triage/`](slack-triage/) | A bot that classifies/labels **every** incoming Slack message. | ✅ `run-mock.sh` |
+| [`personal-assistant/`](personal-assistant/) | A private 1:1 assistant on Telegram that replies to every message — plus the mandatory change-approval flow. | |
+| [`channel-triage/`](channel-triage/) | A triage bot in a shared Slack channel: engages only on `@mention`, only for known senders, and accumulates context from the messages it ignores. | |
+| [`multi-agent-team/`](multi-agent-team/) | Two agents wired into one group chat (a frontline responder + a scribe), showing priorities, multi-agent wiring, and where agent-to-agent / `create_agent` sits. | |
+| [`keyword-watcher/`](keyword-watcher/) | A quiet ops agent in a Discord channel that engages only on a `pattern` match (`deploy`/`incident`/`outage`), from any sender, one session per incident thread. | |
 
 ## Prerequisites
 

--- a/examples/scheduled-report/README.md
+++ b/examples/scheduled-report/README.md
@@ -1,0 +1,57 @@
+# Scheduled report agent
+
+An agent that **wakes itself on a schedule**, summarizes something, and posts the
+result to a channel. The classic "every weekday at 09:00, post a status digest"
+bot — built without any external cron: the agent schedules its *own* recurring
+wake with the sanctioned [`schedule_task`](../../docs/skills.md) tool, and each
+wake runs the summary and delivers it to a configured destination.
+
+> `schedule_task` only re-queues a prompt for the agent's future self — it runs no
+> code. Any privileged action that future prompt then needs still passes through
+> the human-approval gateway. See [`docs/architecture.md`](../../docs/architecture.md).
+
+## Run it credential-free (mock provider, no keys)
+
+The zero-credential demo control-plane seeds an offline `mock-agent` whose `mock`
+provider makes **no network call and needs no model key**, so the whole pipeline
+(inbound → sandbox loop → provider → reply) runs on a stock laptop. From the repo
+root:
+
+```sh
+docker compose -f docker-compose.demo.yml up -d --build   # one-time: build + start
+./examples/scheduled-report/run-mock.sh                   # drive the recipe
+```
+
+`run-mock.sh` asks the agent to schedule a recurring daily summary (you'll see the
+`schedule_task` tool fire and the host accept it), then asks it to summarize a
+sample input. With the `mock` provider the summary is an echo that proves the
+round-trip; swap in a real model (set `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` on the
+control-plane) and the *same* wiring produces a real digest.
+
+Tear down with `docker compose -f docker-compose.demo.yml down`.
+
+## Wire it for production
+
+[`setup.sh`](setup.sh) configures the production shape against a running
+control-plane — an agent group and a delivery destination (e.g. a Slack channel)
+it may post into:
+
+```sh
+export IRONCLAW_API_TOKEN=…          # your control-plane API token
+cd examples/scheduled-report && ./setup.sh
+```
+
+Then ask the agent (through the gateway-approved chat/persona flow) to establish
+its recurring wake, e.g. *"Every weekday at 09:00, summarize yesterday's deploys
+and post it to #ops."* It will call `schedule_task` with `recurrence: daily`; on
+each wake it summarizes and delivers to the destination `setup.sh` registered.
+
+## What to notice
+
+- **No external scheduler.** The recurrence lives inside the agent via
+  `schedule_task` — durable across restarts (the host persists it) and visible
+  with the `list_scheduled_tasks` tool.
+- **The model is swappable.** `mock` proves the plumbing credential-free; a real
+  provider does the actual summarizing with zero wiring changes.
+- **Delivery is gated by a registered destination.** An agent can only post to a
+  channel it has an explicit `destination` for — see `setup.sh`.

--- a/examples/scheduled-report/run-mock.sh
+++ b/examples/scheduled-report/run-mock.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Credential-free end-to-end demo of the scheduled-report recipe.
+#
+# Drives the offline `mock-agent` (seeded by docker-compose.demo.yml) through the
+# chat playground — no model key, no real Slack workspace. Bring the demo up first:
+#
+#   docker compose -f docker-compose.demo.yml up -d --build
+#
+# then run this script. Defaults match the demo (loopback + the fixed demo token).
+set -euo pipefail
+
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+TOKEN="${IRONCLAW_API_TOKEN:-ironclaw-demo}"
+AGENT="mock-agent"
+
+command -v jq >/dev/null || { echo "this demo needs jq (https://jqlang.github.io/jq/)" >&2; exit 1; }
+
+send() { # send <text>
+  curl -fsS -X POST "$ADDR/v1/ui/chat/send" \
+    -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg a "$AGENT" --arg t "$1" '{agentGroupID:$a, text:$t}')" >/dev/null
+}
+
+wait_reply() { # poll until the agent replies (or give up after ~30s)
+  for _ in $(seq 1 30); do
+    out="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
+      -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.text // empty')"
+    if [ -n "$out" ]; then printf '   %s\n' "$out"; return 0; fi
+    sleep 1
+  done
+  echo "   (no reply within 30s — is the demo control-plane up and the sandbox image built?)" >&2
+}
+
+echo "==> 1. Ask the reporter to schedule a recurring daily summary (schedule_task tool)"
+send 'tool:schedule_task {"prompt":"Post the daily incident summary to #ops","recurrence":"daily"}'
+wait_reply
+
+echo "==> 2. Ask it to summarize today's activity"
+echo "       (mock echoes to prove the round-trip; a real model would summarize)"
+send 'Summarize for #ops: 3 deploys, 1 rollback, 0 incidents today.'
+wait_reply
+
+echo
+echo "Done. The schedule_task call above is what a real reporter uses to wake itself"
+echo "every day; with a model credential set on the control-plane the summary is real."

--- a/examples/scheduled-report/setup.sh
+++ b/examples/scheduled-report/setup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Scheduled report agent — see README.md.
+# Wires an agent group plus the channel destination it may post its digest into.
+# The recurring wake itself is established by the agent via the `schedule_task`
+# tool (no external cron); this script sets up the surrounding access + delivery.
+set -euo pipefail
+
+# --- edit these for your setup ---------------------------------------------
+AGENT="reporter"
+POST_CHANNEL="slack"                     # channel type to post the report into
+POST_PLATFORM="C0123OPS"                 # the channel/chat id (e.g. a Slack channel)
+OWNER="slack:U0OWNER"                    # a human owner who can drive/approve it
+# ---------------------------------------------------------------------------
+
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+: "${IRONCLAW_API_TOKEN:?set IRONCLAW_API_TOKEN to your control-plane API token}"
+ic() { ironctl --addr "$ADDR" "$@"; }   # ironctl reads IRONCLAW_API_TOKEN from the env
+
+echo "==> agent group: ${AGENT}"
+ic registry agent-group put --id "$AGENT" --name "Scheduled Reporter" --folder "$AGENT"
+
+echo "==> owner who can drive and approve the agent"
+ic registry user put --id "$OWNER" --kind person --name "Report Owner"
+ic registry member add --user "$OWNER" --agent "$AGENT"
+
+echo "==> destination: allow the agent to post its report into ${POST_CHANNEL}:${POST_PLATFORM}"
+ic registry destination add --agent "$AGENT" --channel "$POST_CHANNEL" --platform "$POST_PLATFORM"
+
+echo
+echo "Done. Next, ask the agent to schedule its recurring wake (through the gateway), e.g.:"
+echo "  \"Every weekday at 09:00, summarize yesterday's deploys and post it to the ops channel.\""
+echo "It will call schedule_task(recurrence: daily). Inspect what was created:"
+echo "  ironctl --addr ${ADDR} registry destination check --agent ${AGENT} --channel ${POST_CHANNEL} --platform ${POST_PLATFORM}"

--- a/examples/slack-triage/README.md
+++ b/examples/slack-triage/README.md
@@ -1,0 +1,51 @@
+# Slack triage bot
+
+A bot that sits in a Slack channel and **classifies/labels every incoming
+message** — e.g. `bug` / `question` / `feature` / `urgent` — so a busy channel
+sorts itself. Unlike [`channel-triage/`](../channel-triage/) (which stays quiet
+and engages only on `@mention`), this one engages on *every* message to label it.
+
+The classification is the model's job, so it runs **credential-free on the `mock`
+provider** for the demo and switches to a real model in production with no wiring
+change.
+
+## Run it credential-free (mock provider, no keys)
+
+The demo control-plane seeds an offline `mock-agent` (provider `mock`, no key, no
+network). From the repo root:
+
+```sh
+docker compose -f docker-compose.demo.yml up -d --build   # one-time: build + start
+./examples/slack-triage/run-mock.sh                       # feed sample messages
+```
+
+`run-mock.sh` sends a handful of sample channel messages and prints what comes
+back. With `mock` the reply is a deterministic echo (it proves each message
+reaches the agent and a reply is delivered); with a real model the *same* setup
+returns an actual label per message.
+
+Tear down with `docker compose -f docker-compose.demo.yml down`.
+
+## Wire it for production
+
+[`setup.sh`](setup.sh) configures the Slack-channel shape: an agent group, a Slack
+messaging group that engages on **every** message (`--engage pattern --pattern .`)
+from **anyone** (`--scope all`), and a destination so it can post the label back.
+
+```sh
+export IRONCLAW_API_TOKEN=…
+cd examples/slack-triage && ./setup.sh   # edit the Slack channel id at the top first
+```
+
+To make it actually classify, give it a persona through the gateway approval flow,
+e.g. *"For each message, reply with exactly one label: bug, question, feature, or
+urgent."*
+
+## What to notice
+
+- **Engages on everything.** `--engage pattern --pattern .` matches any message, so
+  every post gets triaged — contrast with `channel-triage/`'s `--engage mention`.
+- **`--scope all`** triages messages from unregistered senders too (a public
+  channel); switch to `--scope known` to restrict it.
+- **Credential-free by construction.** The demo proves the path on `mock`; a real
+  Slack token (`SLACK_BOT_TOKEN`) and a model key turn it live with no code change.

--- a/examples/slack-triage/run-mock.sh
+++ b/examples/slack-triage/run-mock.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Credential-free end-to-end demo of the slack-triage recipe.
+#
+# Feeds sample channel messages to the offline `mock-agent` (seeded by
+# docker-compose.demo.yml) and prints each reply — no model key, no Slack token.
+# Bring the demo up first:
+#
+#   docker compose -f docker-compose.demo.yml up -d --build
+set -euo pipefail
+
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+TOKEN="${IRONCLAW_API_TOKEN:-ironclaw-demo}"
+AGENT="mock-agent"
+
+command -v jq >/dev/null || { echo "this demo needs jq (https://jqlang.github.io/jq/)" >&2; exit 1; }
+
+# Sample messages a triage bot would label in a real channel.
+MESSAGES=(
+  "the login page 500s when I submit the form"
+  "how do I rotate the API token?"
+  "can we add dark mode to the dashboard?"
+  "PROD IS DOWN, customers can't checkout"
+)
+
+send() {
+  curl -fsS -X POST "$ADDR/v1/ui/chat/send" \
+    -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg a "$AGENT" --arg t "$1" '{agentGroupID:$a, text:$t}')" >/dev/null
+}
+
+wait_reply() {
+  for _ in $(seq 1 30); do
+    out="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
+      -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.text // empty')"
+    if [ -n "$out" ]; then printf '   -> %s\n' "$out"; return 0; fi
+    sleep 1
+  done
+  echo "   (no reply within 30s — is the demo control-plane up and the sandbox image built?)" >&2
+}
+
+echo "Feeding sample channel messages to the triage agent."
+echo "(mock echoes each one to prove delivery; a real model returns a label like 'bug'/'urgent')"
+echo
+for m in "${MESSAGES[@]}"; do
+  echo "==> message: $m"
+  send "classify this channel message: $m"
+  wait_reply
+done

--- a/examples/slack-triage/setup.sh
+++ b/examples/slack-triage/setup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Slack triage bot — see README.md.
+# Classifies/labels EVERY incoming message in a Slack channel: engages on all
+# messages (pattern ".") from any sender, and posts a label back into the channel.
+set -euo pipefail
+
+# --- edit these for your setup ---------------------------------------------
+AGENT="slack-triage"
+SLACK_CHANNEL="C0123ABCD"                # the Slack channel id to triage
+# ---------------------------------------------------------------------------
+
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+: "${IRONCLAW_API_TOKEN:?set IRONCLAW_API_TOKEN to your control-plane API token}"
+ic() { ironctl --addr "$ADDR" "$@"; }
+
+echo "==> agent group: ${AGENT}"
+ic registry agent-group put --id "$AGENT" --name "Slack Triage" --folder "$AGENT"
+
+echo "==> Slack channel messaging group (public: triage messages from anyone)"
+MG="$(ic registry messaging-group create \
+  --channel slack --platform "$SLACK_CHANNEL" --group --policy public | jq -r .ID)"
+echo "    messaging-group id: ${MG}"
+
+echo "==> wiring: engage on EVERY message, any sender, one shared context"
+ic registry wiring create --mg "$MG" --agent "$AGENT" \
+  --engage pattern --pattern '.' --scope all --ignored drop --session shared --priority 5
+
+echo "==> allow the agent to post the label back into the channel"
+ic registry destination add --agent "$AGENT" --channel slack --platform "$SLACK_CHANNEL"
+
+echo
+echo "Done. Inspect it:"
+echo "  ironctl --addr ${ADDR} registry messaging-group wirings --id ${MG}"
+echo "Then give it a labeling persona via the gateway approval flow (see README.md)."

--- a/examples/webhook-responder/README.md
+++ b/examples/webhook-responder/README.md
@@ -1,0 +1,62 @@
+# Webhook responder
+
+An agent that **receives an inbound HTTP message and replies**. Use it to turn any
+system that can POST JSON (a form backend, an alerting tool, a CI hook) into a
+conversation with an agent — the request comes in, the agent processes it, and the
+reply flows back out through the normal delivery path.
+
+IronClaw's chat ingress (`POST /v1/ui/chat/send`) **is** that inbound webhook: it
+feeds the message through the real router (engage → session → encrypted inbound
+queue → sandbox → reply), not a side door. The agent's outbound reply can be
+polled back (as below) or delivered to an external URL via a `webhook`
+[destination](../../docs/channels.md).
+
+## Run it credential-free (mock provider, no keys)
+
+The demo control-plane seeds an offline `mock-agent` (provider `mock`, no model
+key, no network). From the repo root:
+
+```sh
+docker compose -f docker-compose.demo.yml up -d --build   # one-time: build + start
+./examples/webhook-responder/run-mock.sh                  # POST a webhook, read the reply
+```
+
+`run-mock.sh` POSTs a sample webhook payload to the ingress and prints the agent's
+reply. The `mock` provider echoes the request to prove the inbound→reply loop;
+point the control-plane at a real model and the same endpoint becomes a genuine
+"reply to my webhook" agent.
+
+Tear down with `docker compose -f docker-compose.demo.yml down`.
+
+## The inbound contract
+
+```sh
+curl -fsS -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H "Authorization: Bearer $IRONCLAW_API_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"agentGroupID":"responder","text":"deploy #1421 failed on prod"}'
+# → 202 { "conversationId": "...", "engaged": true, ... }
+
+curl -fsS http://127.0.0.1:8787/v1/ui/chat/responder/messages \
+  -H "Authorization: Bearer $IRONCLAW_API_TOKEN"
+# → { "messages": [ { "text": "..." } ] }      # drained once
+```
+
+## Wire it for production
+
+[`setup.sh`](setup.sh) creates the agent group and (optionally) a `webhook`
+**destination** so replies are POSTed to *your* URL instead of being polled:
+
+```sh
+export IRONCLAW_API_TOKEN=…
+cd examples/webhook-responder && ./setup.sh
+```
+
+## What to notice
+
+- **Real pipeline, not a shortcut.** Inbound webhooks traverse the same encrypted
+  queue, engage policy, and approval gateway as every other channel.
+- **Two reply modes.** Poll `/messages` (pull) or register a `webhook` destination
+  to have replies POSTed to you (push).
+- **The model is swappable.** `mock` proves the loop credential-free; a real
+  provider answers for real with no wiring change.

--- a/examples/webhook-responder/run-mock.sh
+++ b/examples/webhook-responder/run-mock.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Credential-free end-to-end demo of the webhook-responder recipe.
+#
+# POSTs an inbound webhook to the offline `mock-agent` (seeded by
+# docker-compose.demo.yml) and reads the agent's reply — no model key needed.
+# Bring the demo up first:
+#
+#   docker compose -f docker-compose.demo.yml up -d --build
+set -euo pipefail
+
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+TOKEN="${IRONCLAW_API_TOKEN:-ironclaw-demo}"
+AGENT="mock-agent"
+
+command -v jq >/dev/null || { echo "this demo needs jq (https://jqlang.github.io/jq/)" >&2; exit 1; }
+
+# A sample inbound webhook payload (what an external system would POST).
+EVENT='{"source":"ci","event":"deploy_failed","ref":"#1421","env":"prod"}'
+
+echo "==> Inbound webhook -> agent"
+echo "    payload: $EVENT"
+curl -fsS -X POST "$ADDR/v1/ui/chat/send" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg a "$AGENT" --arg t "incoming webhook: $EVENT — what should we do?" \
+        '{agentGroupID:$a, text:$t}')" >/dev/null
+
+echo "==> Agent reply (polled back; a real model would triage the event):"
+for _ in $(seq 1 30); do
+  out="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
+    -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.text // empty')"
+  if [ -n "$out" ]; then printf '   %s\n' "$out"; exit 0; fi
+  sleep 1
+done
+echo "   (no reply within 30s — is the demo control-plane up and the sandbox image built?)" >&2
+exit 1

--- a/examples/webhook-responder/setup.sh
+++ b/examples/webhook-responder/setup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Webhook responder — see README.md.
+# Creates the agent group that answers inbound webhooks, and (optionally) a
+# `webhook` destination so replies are POSTed to your URL instead of polled.
+set -euo pipefail
+
+# --- edit these for your setup ---------------------------------------------
+AGENT="responder"
+OWNER="webhook:ops"                      # a known sender allowed to invoke it
+REPLY_URL=""                             # optional: POST replies here (leave empty to poll)
+# ---------------------------------------------------------------------------
+
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+: "${IRONCLAW_API_TOKEN:?set IRONCLAW_API_TOKEN to your control-plane API token}"
+ic() { ironctl --addr "$ADDR" "$@"; }
+
+echo "==> agent group: ${AGENT}"
+ic registry agent-group put --id "$AGENT" --name "Webhook Responder" --folder "$AGENT"
+
+echo "==> known sender allowed to invoke it"
+ic registry user put --id "$OWNER" --kind service --name "Webhook Source"
+ic registry member add --user "$OWNER" --agent "$AGENT"
+
+if [ -n "$REPLY_URL" ]; then
+  echo "==> push replies to ${REPLY_URL} via a webhook destination"
+  ic registry destination add --agent "$AGENT" --channel webhook --platform "$REPLY_URL"
+else
+  echo "==> no REPLY_URL set — poll replies from GET /v1/ui/chat/${AGENT}/messages"
+fi
+
+echo
+echo "Done. Send an inbound webhook (see README.md):"
+echo "  curl -X POST ${ADDR}/v1/ui/chat/send -H \"Authorization: Bearer \$IRONCLAW_API_TOKEN\" \\"
+echo "       -H 'Content-Type: application/json' -d '{\"agentGroupID\":\"${AGENT}\",\"text\":\"...\"}'"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
       - Your first sandboxed agent in 5 minutes: tutorials/first-agent.md
       - Connect IronClaw to Slack: tutorials/connect-slack.md
       - Write a custom channel adapter: tutorials/custom-channel-adapter.md
+  - Examples: examples.md
   - Concepts:
       - IronClaw, Explained: ironclaw-explained.md
       - Architecture: architecture.md


### PR DESCRIPTION
## What

Adds three self-contained, runnable example recipes under `/examples`, each with a `README.md`, a production-wiring `setup.sh`, and a `run-mock.sh` that drives the **whole** inbound → agent → reply pipeline against the offline `mock` provider — **no model key, no channel tokens** (builds on `docker-compose.demo.yml`'s seeded `mock-agent` and the `/v1/ui/chat` playground ingress).

| Recipe | Scenario |
|--------|----------|
| `scheduled-report/` | Agent self-schedules a recurring wake via `schedule_task`, summarizes, posts to a channel destination. |
| `webhook-responder/` | Inbound HTTP webhook routed through the real pipeline to an agent that replies (poll, or push back via a `webhook` destination). |
| `slack-triage/` | Classifies/labels **every** incoming message (`--engage pattern --pattern .` / `--scope all`) — distinct from the mention-only `channel-triage` example. |

Honest about the mock provider: it echoes (proving the round-trip); a real model credential makes the same wiring do real summarizing/classifying with no change.

## Cross-links

- Root `README.md` Examples section.
- New docs-site gallery `docs/examples.md`, wired into the mkdocs nav.
- `examples/README.md` index table.

## Verification

- `go build ./...` green (no Go changes).
- `shellcheck` clean on all six scripts; `bash -n` passes.
- `mkdocs build --strict` exits 0 with all internal links resolving.

Closes IRO-115.