### PR TITLE
fix(onboard): doctor real model-proxy socket path + quickstart --dev wording (IRO-121)

### DIFF
--- a/cmd/ironctl/doctor.go
+++ b/cmd/ironctl/doctor.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -45,7 +46,7 @@ type checkResult struct {
 // scripts.
 func cmdDoctor(addr string, args []string) error {
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
-	socket := fs.String("model-proxy-socket", "/run/ironclaw/modelproxy.sock",
+	socket := fs.String("model-proxy-socket", defaultModelProxySocket(),
 		"model-proxy unix socket to probe")
 	// The runtime defaults to the same resolution the control-plane uses:
 	// $IRONCLAW_RUNTIME, else gVisor's runsc. An explicit --runtime wins.
@@ -286,6 +287,24 @@ func checkConfig() checkResult {
 	r.Status = checkOK
 	r.Detail = "present and owner-only at " + path
 	return r
+}
+
+// defaultModelProxySocket mirrors the control-plane's defaultModelProxySocket
+// (cmd/controlplane) so `ironctl doctor` probes the same path the daemon actually
+// binds when neither side passes --model-proxy-socket. On Linux the daemon runs
+// under systemd with RuntimeDirectory=ironclaw, so /run/ironclaw is its home;
+// off-Linux (macOS --dev — there is no creatable /run at the SIP-protected root)
+// it falls back to the user cache dir. Keeping the two in sync avoids a false WARN
+// where doctor probes the Linux path while a macOS --dev daemon serves the cache
+// path. Production passes --model-proxy-socket explicitly on both sides.
+func defaultModelProxySocket() string {
+	if runtime.GOOS == "linux" {
+		return "/run/ironclaw/modelproxy.sock"
+	}
+	if d, err := os.UserCacheDir(); err == nil {
+		return filepath.Join(d, "ironclaw", "run", "modelproxy.sock")
+	}
+	return filepath.Join(os.TempDir(), "ironclaw", "modelproxy.sock")
 }
 
 // checkModelProxy verifies the model-proxy unix socket exists and accepts a

--- a/cmd/ironctl/doctor_test.go
+++ b/cmd/ironctl/doctor_test.go
@@ -24,6 +24,29 @@ func TestCheckAPI(t *testing.T) {
 	}
 }
 
+// TestDefaultModelProxySocket guards against reintroducing a hardcoded Linux
+// socket path: off-Linux (e.g. macOS --dev) doctor must resolve the user-cache
+// path the daemon actually binds, not /run/ironclaw, or it reports a false WARN.
+func TestDefaultModelProxySocket(t *testing.T) {
+	got := defaultModelProxySocket()
+	if runtime.GOOS == "linux" {
+		if got != "/run/ironclaw/modelproxy.sock" {
+			t.Errorf("defaultModelProxySocket() on linux = %q, want /run/ironclaw/modelproxy.sock", got)
+		}
+		return
+	}
+	// Off Linux it must NOT be the systemd path; it should sit under a writable dir.
+	if got == "/run/ironclaw/modelproxy.sock" {
+		t.Errorf("defaultModelProxySocket() on %s returned the Linux /run path; expected a user-writable path", runtime.GOOS)
+	}
+	if d, err := os.UserCacheDir(); err == nil {
+		want := filepath.Join(d, "ironclaw", "run", "modelproxy.sock")
+		if got != want {
+			t.Errorf("defaultModelProxySocket() = %q, want %q (mirrors the daemon)", got, want)
+		}
+	}
+}
+
 func TestCheckReadiness(t *testing.T) {
 	token = ""
 	srv, _, _ := newStatusServer(t)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -76,8 +76,9 @@ and reading the audit log** — entirely on your machine, in `--dev` mode (loopb
 
 - **Go 1.23+** and a **C toolchain** — IronClaw builds with `CGO_ENABLED=1` (the encrypted-queue
   binding, SQLCipher, is unconditional). macOS: `xcode-select --install`. Debian/Ubuntu: `sudo apt-get install build-essential`.
-- **An Anthropic API key** (`ANTHROPIC_API_KEY`) — held host-side; it never enters a sandbox. For this
-  `--dev` walkthrough you won't actually call the model, but the daemon expects the variable to be set.
+- **An Anthropic API key** (`ANTHROPIC_API_KEY`) — held host-side; it never enters a sandbox. *Optional
+  for this `--dev` walkthrough:* the gateway flow never calls a model, so `--dev` boots and serves
+  `/healthz` with no key set. You'll want one once you wire a real agent to a provider.
 - **`openssl`** (almost always preinstalled) — used to mint a local API token.
 
 Check Go:
@@ -102,15 +103,17 @@ If the build fails with an SQLite/cgo error, your C toolchain isn't set up — s
 ## 2. Start the control-plane (Terminal 1)
 
 ```sh
-export ANTHROPIC_API_KEY=sk-ant-...                 # held host-side; never enters the sandbox
+export ANTHROPIC_API_KEY=sk-ant-...                 # optional in --dev (the gateway flow never calls a model)
 export IRONCLAW_API_TOKEN=$(openssl rand -hex 32)   # bearer token for the admin API
 echo "API token: $IRONCLAW_API_TOKEN"               # copy this — you need it in Terminal 2
 
 ./bin/controlplane --dev --api-addr 127.0.0.1:8787
 ```
 
-`--dev` binds to loopback and uses in-memory backends — **no gVisor, no containerd, no root**. Leave this
-running. You should see the daemon log that it has started and is serving on `127.0.0.1:8787`.
+`--dev` binds to loopback with an in-memory registry — **no gVisor, no containerd, no root**. The gateway
+change store and audit log are still durable files on disk (under the state dir, e.g.
+`~/Library/Caches/ironclaw/state/{changes,audit.jsonl}` on macOS), so the trail you build below survives a
+restart. Leave this running. You should see the daemon log that it has started and is serving on `127.0.0.1:8787`.
 
 ## 3. Point `ironctl` at it (Terminal 2)
 


### PR DESCRIPTION
First-run polish (3 nits found during the IRO-119 QA pass). All small, non-breaking accuracy fixes to the documented `--dev` quickstart.

## Changes

1. **`ironctl doctor` false WARN on the model-proxy socket (macOS `--dev`).** `doctor` hardcoded the Linux systemd path `/run/ironclaw/modelproxy.sock`, but the daemon's `defaultModelProxySocket()` resolves a user-cache path off Linux — on macOS `--dev` it binds `~/Library/Caches/ironclaw/run/modelproxy.sock`. So `doctor` always reported `[WARN] socket not present` even with a healthy `--dev` daemon serving it. The default now mirrors the control-plane's resolution (an explicit `--model-proxy-socket` still wins).

2. **quickstart: `ANTHROPIC_API_KEY` is optional for the `--dev` walkthrough.** The gateway flow never calls a model; `--dev` boots and serves `/healthz` with no key. Prerequisites + the step-2 export comment now say so.

3. **quickstart: `--dev` is not purely "in-memory backends".** Only the registry is in-memory; the gateway **change store + audit log are durable files** under the state dir (`~/Library/Caches/ironclaw/state/{changes,audit.jsonl}`) and survive a restart. Step 2 reworded.

## Verification
- `CGO_ENABLED=1 go build ./cmd/ironctl` ✅, `go vet` ✅, `go test ./cmd/ironctl/` 47 pass ✅
- New `TestDefaultModelProxySocket` guards against reintroducing the hardcoded Linux path.
- **End-to-end:** started `controlplane --dev` on macOS, ran `ironctl doctor` → model-proxy check now reports `[OK] reachable at /Users/.../Library/Caches/ironclaw/run/modelproxy.sock` (previously a false WARN).

## Security lenses
None of the trust boundaries are touched — `doctor` is read-only and prints presence only (no socket connection is widened, no secret logged). Docs-only for (2)/(3).

Closes IRO-121.