### PR TITLE
feat(observability): make a missing chat reply diagnosable (IRO-128)

### DIFF
--- a/internal/sandbox/loop/loop.go
+++ b/internal/sandbox/loop/loop.go
@@ -351,6 +351,13 @@ func (l *Loop) engage(ctx context.Context) error {
 		ids[i] = m.ID
 	}
 
+	// Liveness logging (IRO-128): announce engagement so `docker logs ic-sbx-…`
+	// distinguishes a working loop from a stalled one. The loop is otherwise silent
+	// on clean polls/engage/reply, which made a missing reply indistinguishable from
+	// "still thinking". Log counts and ids only — never message content (secret
+	// hygiene); plaintext chat must not leak into host-readable container logs.
+	l.cfg.Logger.Printf("sandbox/loop: engaging %d message(s) [%s]", len(working), joinIDs(ids))
+
 	if err := l.cfg.Outbound.MarkProcessing(ids); err != nil {
 		return fmt.Errorf("mark processing: %w", err)
 	}
@@ -389,6 +396,15 @@ func (l *Loop) engage(ctx context.Context) error {
 			if err := l.writeReply(resp, chat[len(chat)-1].ID, routing); err != nil {
 				return err
 			}
+			// Positive signal that a reply was produced and written to the outbound
+			// queue for the host to deliver. Byte count only, never the text.
+			l.cfg.Logger.Printf("sandbox/loop: wrote reply (%d bytes) in reply to %s", len(resp), chat[len(chat)-1].ID)
+		} else {
+			// The model engaged but produced no text (e.g. a tool-only turn that ended
+			// without a final message, or an empty completion). This is exactly the
+			// "silent" failure mode IRO-128 calls out — surface it so an absent reply is
+			// diagnosable from the logs instead of looking identical to "still thinking".
+			l.cfg.Logger.Printf("sandbox/loop: model produced no reply text for %d chat message(s); nothing written to outbound", len(chat))
 		}
 		// Forward any capability-change requests the agent made to the host
 		// gateway as system messages — the sandbox never applies them itself.
@@ -696,4 +712,15 @@ func messageHeader(m contract.MessageIn) string {
 // isSlashCommand reports whether content is a slash command.
 func isSlashCommand(content string) bool {
 	return strings.HasPrefix(strings.TrimSpace(content), "/")
+}
+
+// joinIDs renders message ids for a liveness log line. Ids are opaque queue
+// identifiers (not content), so they are safe to log and let an operator
+// correlate an engage with the inbound rows it consumed.
+func joinIDs(ids []contract.MessageID) string {
+	parts := make([]string, len(ids))
+	for i, id := range ids {
+		parts[i] = string(id)
+	}
+	return strings.Join(parts, ",")
 }

--- a/internal/sandbox/loop/loop_test.go
+++ b/internal/sandbox/loop/loop_test.go
@@ -612,3 +612,67 @@ func TestDoneIDsSurviveRestart(t *testing.T) {
 		t.Fatalf("m1 was reprocessed after restart: calls=%d, want 1", prov.calls)
 	}
 }
+
+// newTestLoopWithLog builds a loop whose Logger writes to the returned buffer, so
+// tests can assert the liveness log lines (IRO-128).
+func newTestLoopWithLog(t *testing.T, in *fakeInbound, out *fakeOutbound, prov *fakeProvider) (*Loop, *strings.Builder) {
+	t.Helper()
+	buf := &strings.Builder{}
+	l, err := New(Config{
+		Inbound:       in,
+		Outbound:      out,
+		Provider:      prov,
+		HeartbeatPath: filepath.Join(t.TempDir(), "heartbeat"),
+		Clock:         func() time.Time { return time.Date(2026, 6, 16, 0, 0, 0, 0, time.UTC) },
+		Logger:        log.New(buf, "", 0),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return l, buf
+}
+
+// TestLivenessLoggingOnEngageAndReply asserts the loop logs engagement and a
+// reply write, so `docker logs ic-sbx-…` distinguishes a working loop from a
+// stalled one (IRO-128). The log must carry counts/ids, never message content.
+func TestLivenessLoggingOnEngageAndReply(t *testing.T) {
+	in := &fakeInbound{pending: []contract.MessageIn{msg("m1", "secret question", 1)}}
+	out := &fakeOutbound{}
+	prov := &fakeProvider{reply: "the answer"}
+	l, logs := newTestLoopWithLog(t, in, out, prov)
+
+	if err := l.poll(context.Background(), false); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	got := logs.String()
+	if !strings.Contains(got, "engaging 1 message(s) [m1]") {
+		t.Fatalf("missing engage log line; got:\n%s", got)
+	}
+	if !strings.Contains(got, "wrote reply (10 bytes) in reply to m1") {
+		t.Fatalf("missing reply log line; got:\n%s", got)
+	}
+	// Secret hygiene: neither the inbound content nor the reply text may appear.
+	if strings.Contains(got, "secret question") || strings.Contains(got, "the answer") {
+		t.Fatalf("liveness log leaked message content; got:\n%s", got)
+	}
+}
+
+// TestLivenessLoggingOnEmptyReply asserts that an engaged turn producing no reply
+// text is logged distinctly — this is the "silent failure" IRO-128 targets.
+func TestLivenessLoggingOnEmptyReply(t *testing.T) {
+	in := &fakeInbound{pending: []contract.MessageIn{msg("m1", "hello", 1)}}
+	out := &fakeOutbound{}
+	prov := &fakeProvider{reply: ""} // model engaged but returned nothing
+	l, logs := newTestLoopWithLog(t, in, out, prov)
+
+	if err := l.poll(context.Background(), false); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(out.writes) != 0 {
+		t.Fatalf("empty reply should write nothing, got %d writes", len(out.writes))
+	}
+	got := logs.String()
+	if !strings.Contains(got, "model produced no reply text") {
+		t.Fatalf("missing empty-reply diagnostic; got:\n%s", got)
+	}
+}

--- a/web/static/chat.js
+++ b/web/static/chat.js
@@ -9,6 +9,14 @@
 const Chat = (() => {
   const $ = (id) => document.getElementById(id);
   let timer = null;
+  // Liveness tracking (IRO-128): once a send engages we await a reply. Without
+  // this the transcript shows nothing whether the agent is working, still
+  // thinking, or has silently failed — indistinguishable bare empty state. We
+  // surface elapsed "working…" feedback and a staleness hint with a concrete
+  // diagnostic if no reply lands within STALE_AFTER_MS.
+  const STALE_AFTER_MS = 30000;
+  let awaitingSince = 0; // ms epoch of the last engaged send still awaiting a reply
+  let staleNoted = false; // ensures the staleness diagnostic is appended once
 
   function avatarFor(who) {
     return who === "you" ? "U" : who === "agent" ? "✦" : "!";
@@ -54,6 +62,8 @@ const Chat = (() => {
     }
     $("chat-transcript").innerHTML = "";
     $("chat-status").textContent = "ready — say hello";
+    awaitingSince = 0;
+    staleNoted = false;
   }
 
   async function send() {
@@ -68,7 +78,14 @@ const Chat = (() => {
         method: "POST",
         body: JSON.stringify({ agentGroupID: ag, text }),
       });
-      $("chat-status").textContent = res && res.engaged ? "engaged — awaiting reply…" : "sent (no wiring engaged for this agent)";
+      if (res && res.engaged) {
+        awaitingSince = Date.now();
+        staleNoted = false;
+        $("chat-status").textContent = "agent is working…";
+      } else {
+        awaitingSince = 0;
+        $("chat-status").textContent = "sent (no wiring engaged for this agent)";
+      }
       poll();
     } catch (e) {
       setStatus(String(e.message || e), "error");
@@ -91,9 +108,41 @@ const Chat = (() => {
     if (!ag) return;
     try {
       const res = await api("/v1/ui/chat/" + encodeURIComponent(ag) + "/messages");
-      for (const m of (res && res.messages) || []) renderReply(m);
+      const msgs = (res && res.messages) || [];
+      for (const m of msgs) renderReply(m);
+      if (msgs.length) {
+        // A reply landed — the agent is alive. Stop awaiting.
+        awaitingSince = 0;
+        staleNoted = false;
+        $("chat-status").textContent = "reply received";
+      } else if (awaitingSince) {
+        liveness();
+      }
     } catch (e) {
       setStatus(String(e.message || e), "error");
+    }
+  }
+
+  // liveness updates the status line while awaiting a reply: elapsed "working…"
+  // feedback, then a one-time staleness diagnostic if nothing lands within
+  // STALE_AFTER_MS so a silent failure is distinguishable from "still thinking".
+  function liveness() {
+    const secs = Math.round((Date.now() - awaitingSince) / 1000);
+    if (Date.now() - awaitingSince >= STALE_AFTER_MS) {
+      $("chat-status").textContent = "no reply after " + secs + "s — the agent may have stalled";
+      if (!staleNoted) {
+        staleNoted = true;
+        append(bubble("error",
+          "No reply after " + secs + "s. The agent engaged but has not replied — it may still be thinking, " +
+          "or it may have silently failed.\n\nTo diagnose, on the host find the sandbox container and read its logs:\n" +
+          "  docker ps --filter name=ic-sbx-\n" +
+          "  docker logs --tail 50 <container>\n" +
+          "(look for `engaging N message(s)` and `wrote reply …`; an `engaging` line with no following " +
+          "`wrote reply` means the turn produced no output — `model produced no reply text` confirms it). " +
+          "You can also run `ironctl doctor` to verify the sandbox image, mounts, and model-proxy socket."));
+      }
+    } else {
+      $("chat-status").textContent = "agent is working… (" + secs + "s)";
     }
   }
 
@@ -116,6 +165,8 @@ const Chat = (() => {
     if (sel) sel.addEventListener("change", () => {
       $("chat-transcript").innerHTML = "";
       $("chat-status").textContent = conv() ? "ready — say hello" : "pick an agent group";
+      awaitingSince = 0;
+      staleNoted = false;
     });
   }
 


### PR DESCRIPTION
## What & why

Observability follow-up from [IRO-120](/IRO/issues/IRO-120). The headline first-run chat path gave **no way to tell a working agent from a silently-failed one**:

- the sandbox poll loop logged nothing on engage or reply, so `docker logs ic-sbx-…` looked identical whether the loop was working or stalled;
- the console chat playground showed a bare empty `messages` array whether the agent was *still thinking* or had *silently failed*.

That non-discriminating state is exactly what led to the IRO-120 misdiagnosis.

## Changes

**Sandbox loop** (`internal/sandbox/loop/loop.go`):
- `engaging N message(s) [ids]` when a turn engages.
- `wrote reply (N bytes) in reply to <id>` on a successful reply.
- `model produced no reply text …` when an engaged turn produces nothing — the **silent-failure** case made explicit.
- Logs carry **counts and opaque message ids only, never message content** (secret hygiene: plaintext chat must not leak into host-readable container logs).

**Console chat playground** (`web/static/chat.js`):
- After an engaged send → `agent is working… (Ns)`.
- No reply within 30s → staleness hint + a concrete diagnostic (find the `ic-sbx-` container, read its logs for the engage/reply markers, run `ironctl doctor`).

## Acceptance (from IRO-128)

A first-run user or QA who sends a chat message can now tell — without reading source — whether the agent is *working*, *still thinking*, or *silently failed*, and on failure has at least one concrete diagnostic to act on. ✅

## Security review bar

Observability-only. No change to the trust boundary, mandatory gateway, encrypted queues, isolation, or egress. Logs expose opaque ids and byte counts, never plaintext content — verified by a test asserting neither the inbound text nor the reply text appears in the log.

## Verification

- `CGO_ENABLED=1 go build ./...` — green.
- `CGO_ENABLED=1 go test ./internal/sandbox/loop/ ./internal/host/api/ ./internal/host/channels/` — 158 pass (incl. 2 new loop tests).
- `node --check web/static/chat.js` — ok. `web/static` is `go:embed`-ed into the control-plane binary, so the console change ships on the normal build/install flow.