### PR TITLE
feat(console): unified structured empty states + reduced-motion (IRO-130)

### DIFF
--- a/web/static/agents.js
+++ b/web/static/agents.js
@@ -225,7 +225,7 @@ const Agents = (() => {
       if (!list || !list.length) {
         const box = emptyState("No agents yet",
           "Create your first agent — pick a template, tweak its persona and tools, and it's ready to chat.",
-          "＋ New agent", "agents");
+          "＋ New agent", "agents", EMPTY_ICONS.agents);
         const cta = box.querySelector("button");
         if (cta) cta.addEventListener("click", openNew); // open the modal, not just switch panel
         grid.append(box);

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -65,11 +65,29 @@ function el(tag, attrs = {}, ...children) {
   return node;
 }
 
-// emptyState renders a friendly placeholder with an optional call to action.
-function emptyState(title, sub, ctaLabel, ctaPanel) {
-  const box = el("div", { class: "empty" },
-    el("h3", { text: title }),
-    el("p", { class: "muted", text: sub || "" }));
+// Inline SVG glyphs for empty states — stroke-based, single color (currentColor),
+// so they inherit .empty .ico's faint tone and stay crisp at any size. Kept here
+// so every "nothing here yet" surface draws from one consistent set.
+const EMPTY_ICONS = {
+  sessions:  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="14" rx="2"/><path d="M8 9l3 3-3 3M13 15h4"/></svg>',
+  audit:     '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z"/><path d="M14 3v5h5M9 13h6M9 17h6"/></svg>',
+  approvals: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v5c0 4.5-3 7.5-7 9-4-1.5-7-4.5-7-9V6z"/><path d="M9 12l2 2 4-4"/></svg>',
+  channels:  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H8l-4 4V5a2 2 0 0 1 2-2h13a2 2 0 0 1 2 2z"/></svg>',
+  skills:    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l2.4 4.9 5.4.8-3.9 3.8.9 5.4-4.8-2.5-4.8 2.5.9-5.4L4.2 7.7l5.4-.8z"/></svg>',
+  mcp:       '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><path d="M17.5 14v3.5H21"/></svg>',
+  agents:    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="3.2"/><path d="M5 20c0-3.3 3.1-6 7-6s7 2.7 7 6"/></svg>',
+  offline:   '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12.5a7 7 0 0 1 14 0M8.5 16a3.5 3.5 0 0 1 7 0M2 9a11 11 0 0 1 20 0"/><path d="M3 3l18 18"/></svg>',
+};
+
+// emptyState renders a friendly placeholder: an optional icon, a title, a one-line
+// scent, and an optional call to action. icon is an inline SVG string (e.g.
+// EMPTY_ICONS.sessions) — pass it so list/grid surfaces read as deliberate empty
+// states, not bare muted text.
+function emptyState(title, sub, ctaLabel, ctaPanel, icon) {
+  const box = el("div", { class: "empty" });
+  if (icon) box.append(el("div", { class: "ico", html: icon }));
+  box.append(el("h3", { text: title }));
+  box.append(el("p", { class: "muted", text: sub || "" }));
   if (ctaLabel) {
     const b = el("button", { class: "btn-primary", type: "button", text: ctaLabel });
     b.addEventListener("click", () => goPanel(ctaPanel));

--- a/web/static/approvals.js
+++ b/web/static/approvals.js
@@ -90,7 +90,9 @@ const Approvals = (() => {
       // dashboard is revisited, since only Dashboard.load() set it before).
       if (typeof updateApprovalsBadge === "function") updateApprovalsBadge(items.length);
       if (items.length === 0) {
-        host.replaceChildren(el("p", { class: "muted", text: "No pending changes." }));
+        host.replaceChildren(emptyState("Nothing waiting",
+          "Capability changes that need a human decision show up here. You're all caught up.",
+          null, null, EMPTY_ICONS.approvals));
         return;
       }
       host.replaceChildren(...items.map(renderRow));

--- a/web/static/audit.js
+++ b/web/static/audit.js
@@ -118,7 +118,13 @@ const Audit = (() => {
     const count = document.getElementById("audit-count");
     if (count) count.textContent = "showing " + rows.length + " of " + entries.length;
     if (rows.length === 0) {
-      host.replaceChildren(el("p", { class: "muted", text: entries.length ? "No entries match the filter." : "No audit entries." }));
+      // A filter that matches nothing is a transient result (keep it terse); an
+      // empty log is a genuine first-run state (give it structure + scent).
+      host.replaceChildren(entries.length
+        ? el("p", { class: "muted", text: "No entries match the filter." })
+        : emptyState("Nothing audited yet",
+            "Every gateway decision (approvals, capability changes, channel events) lands here as an append-only record.",
+            null, null, EMPTY_ICONS.audit));
       return;
     }
     host.replaceChildren(...rows.map(renderRow));

--- a/web/static/channels.js
+++ b/web/static/channels.js
@@ -29,7 +29,9 @@ const Channels = (() => {
       );
       const wirings = view.wirings || [];
       const rows = wirings.length === 0
-        ? [el("p", { class: "muted", text: "No wirings." })]
+        ? [emptyState("No wirings yet",
+            "Wire a connected chat surface to an agent in step 2 to see it here.",
+            null, null, EMPTY_ICONS.channels)]
         : wirings.map((w) => el("div", { class: "card" },
             el("div", { class: "card-head" },
               el("span", { class: "kind", text: w.EngageMode || "?" }),

--- a/web/static/mcp.js
+++ b/web/static/mcp.js
@@ -166,16 +166,19 @@ const MCP = (() => {
       const servers = await api("/v1/ui/mcp-servers");
       list.replaceChildren();
       if (!servers || servers.length === 0) {
-        list.append(el("p", { class: "muted", text: "No MCP servers configured yet. Add one above." }));
+        list.append(emptyState("No MCP servers yet",
+          "Add a Model Context Protocol server above to grant agents host-side tools (gated by human approval).",
+          null, null, EMPTY_ICONS.mcp));
         return;
       }
       for (const v of servers) list.append(renderCard(v));
     } catch (e) {
       const msg = String(e.message || e);
-      list.replaceChildren(el("p", { class: "muted",
-        text: msg.indexOf("503") === 0
-          ? "MCP is not enabled on this control-plane (start the daemon with --mcp-catalog, or use --dev)."
-          : "Could not load MCP servers: " + msg }));
+      list.replaceChildren(msg.indexOf("503") === 0
+        ? emptyState("MCP not enabled",
+            "MCP loads when the host is started with --mcp-catalog (or use --dev). See the docs to enable it.",
+            null, null, EMPTY_ICONS.offline)
+        : el("p", { class: "error", text: "Could not load MCP servers: " + msg }));
     }
   }
 

--- a/web/static/sessions.js
+++ b/web/static/sessions.js
@@ -65,7 +65,9 @@ const Sessions = (() => {
     try {
       const items = (await api("/v1/ui/sessions")) || [];
       if (items.length === 0) {
-        host.replaceChildren(el("p", { class: "muted", text: "No active sessions." }));
+        host.replaceChildren(emptyState("No sessions yet",
+          "A session — a live, isolated sandbox — starts the moment an agent first replies. Create an agent and open Chat to begin.",
+          "Open Chat", "chat", EMPTY_ICONS.sessions));
         return;
       }
       host.replaceChildren(...items.map(renderRow));

--- a/web/static/skills.js
+++ b/web/static/skills.js
@@ -11,7 +11,9 @@ const Skills = (() => {
     const list = document.getElementById("skills-list");
     list.replaceChildren();
     if (!skills || skills.length === 0) {
-      list.append(el("p", { class: "muted", text: "No skills in the curated catalog." }));
+      list.append(emptyState("Catalog is empty",
+        "No skills in the curated catalog yet. Add a signed skill above — installs go through human approval before they apply.",
+        null, null, EMPTY_ICONS.skills));
       return;
     }
     for (const s of skills) {
@@ -32,10 +34,11 @@ const Skills = (() => {
       renderList(skills || []);
     } catch (e) {
       const msg = String(e.message || e);
-      list.replaceChildren(el("p", { class: "muted",
-        text: msg.indexOf("503") === 0
-          ? "Skills are not enabled on this control-plane (start the daemon with --skills-dir and --skills-trust-key)."
-          : "Could not load skills: " + msg }));
+      list.replaceChildren(msg.indexOf("503") === 0
+        ? emptyState("Skills not enabled",
+            "Skills load when the host is started with --skills-dir and --skills-trust-key. See the Skills docs to enable them.",
+            null, null, EMPTY_ICONS.offline)
+        : el("p", { class: "error", text: "Could not load skills: " + msg }));
     }
   }
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -169,9 +169,14 @@ code {
 /* ---- Content ----------------------------------------------------------- */
 .content { flex: 1; min-width: 0; }
 main { padding: 30px 34px 60px; max-width: 1080px; margin: 0 auto; }
-.panel { display: none; animation: fade 0.18s ease; }
+.panel { display: none; }
 .panel.active { display: block; }
-@keyframes fade { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+/* Honor reduced-motion: only animate the panel transition when the user has not
+   asked the OS to minimize motion (WCAG 2.3.3). */
+@media (prefers-reduced-motion: no-preference) {
+  .panel.active { animation: fade 0.18s ease; }
+  @keyframes fade { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+}
 
 .page-head { margin-bottom: 22px; }
 .page-head h1 { font-size: 23px; margin: 0; letter-spacing: -0.02em; }
@@ -415,12 +420,18 @@ details[open] > summary { margin-bottom: 8px; }
 
 /* ---- Empty state ------------------------------------------------------- */
 .empty {
-  text-align: center; padding: 54px 20px; color: var(--muted);
+  text-align: center; padding: 54px 24px; color: var(--muted);
   border: 1px dashed var(--border); border-radius: var(--radius); background: rgba(255,255,255,0.012);
+  max-width: 520px; margin: 28px auto;
 }
+/* An empty state inside a card grid (e.g. Agents) must span every column so it
+   centers in the panel instead of being trapped in the first ~280px track. */
+.agent-grid > .empty { grid-column: 1 / -1; }
 .empty .ico { width: 46px; height: 46px; margin: 0 auto 14px; color: var(--faint); }
+.empty .ico svg { width: 100%; height: 100%; display: block; }
 .empty h3 { color: var(--text-2); font-size: 15px; margin-bottom: 6px; }
-.empty .btn { margin-top: 16px; }
+.empty p { line-height: 1.5; }
+.empty .btn-primary { margin-top: 18px; }
 
 /* ---- Chat -------------------------------------------------------------- */
 .chat-wrap { display: flex; flex-direction: column; height: calc(100vh - 200px); min-height: 420px; }


### PR DESCRIPTION
## What

Ships the highest-leverage, lowest-risk items from the **IRO-107** first-run / empty-state audit backlog (F3, F5, F7, F9). Console CSS/JS only (`go:embed`), no backend, no gated decisions.

| F | Finding | Fix |
|---|---|---|
| **F3 / F7** | Only Agents used the rich empty state; Sessions/Audit/Approvals/Channels/Skills/MCP fell back to a bare muted `<p>` ("No active sessions.") | Route all through `emptyState()` with a consistent icon + scent + next-step. Distinguishes "connected but empty" from "not enabled" (Skills/MCP 503 → offline glyph + enable hint). |
| **F5** | Agents empty card was trapped in a ~280px grid column (orphaned top-left); icon never rendered | `emptyState()` gains an optional inline SVG icon; empty card spans the grid (`grid-column: 1 / -1`) and centers (`max-width: 520px; margin: auto`). |
| **F9** | Panel fade animation had no reduced-motion guard | Wrapped in `@media (prefers-reduced-motion: no-preference)` (WCAG 2.3.3). |

Deferred (noted on IRO-130): F4 (wizard copy-chip affordances — larger, touches `setup.js` clipboard logic), F6 (security-posture chip), F10 (CLI banner — separate Go surface). F8 (chat picker guidance) already shipped ("No agents yet — create one").

## Verification (visual-truth)

Built `controlplane` from this branch, ran `--dev` at **1440×900** desktop and **390×844** mobile. Every targeted surface renders a structured empty state with icon, title, scent, and CTA where applicable. `go test ./internal/host/api/...` green. Screenshots attached to [IRO-130](/IRO/issues/IRO-130).

**Authority:** ungated polish, self-merge on green CI per trunk policy.