### PR TITLE
feat(console): first-run wizard affordances + security-posture chip (IRO-132)

### DIFF
--- a/web/static/app.js
+++ b/web/static/app.js
@@ -211,7 +211,8 @@ async function boot(announce) {
 }
 
 // applyAuthState shows the first-run connect prompt and opens the sidebar token
-// control only when a token is actually needed (gated API, no/invalid token).
+// control only when a token is actually needed (gated API, no/invalid token), and
+// reflects the security posture in the sidebar chip.
 function applyAuthState() {
   const needsToken = lastAuthState === "unauth";
   const fr = document.getElementById("firstrun");
@@ -222,6 +223,30 @@ function applyAuthState() {
   } else {
     clearTokenError();
   }
+  applyPosture();
+}
+
+// POSTURE maps a connection state to the security-posture chip: token-gated (good)
+// vs open-on-loopback (acceptable on localhost, risky behind a mesh). Other states
+// (offline / token-required / error) are already carried by the connection label,
+// so the chip stays hidden to avoid a second, redundant alarm.
+const POSTURE = {
+  authed: { tone: "ok", label: "Token-gated", tip: "Requests carry a bearer token — the API is authenticated." },
+  open: { tone: "warn", label: "Open API (loopback)", tip: "No bearer token required — fine on localhost; set IRONCLAW_API_TOKEN behind a mesh." },
+};
+
+// applyPosture renders the security-posture chip from lastAuthState. Color carries
+// a quick read; the text label keeps it legible without color (WCAG 1.4.1).
+function applyPosture() {
+  const box = document.getElementById("posture");
+  if (!box) return;
+  const p = POSTURE[lastAuthState];
+  if (!p) { box.hidden = true; box.removeAttribute("title"); return; }
+  box.hidden = false;
+  box.className = "posture " + p.tone;
+  box.title = p.tip;
+  const label = document.getElementById("posture-label");
+  if (label) label.textContent = p.label;
 }
 
 function setTokenError(msg) {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -71,6 +71,14 @@
           <span class="dot" aria-hidden="true"></span>
           <span id="status" class="conn-label" role="status">idle</span>
         </div>
+        <!-- Security-posture chip: surfaces whether the API is token-gated or open
+             on loopback. Trust-critical state for a security product, so it gets a
+             color-coded chip with a text label (color-independent) and a tooltip,
+             not buried micro-text. Set by applyAuthState() in app.js. -->
+        <div class="posture" id="posture" role="status" hidden>
+          <span class="posture-dot" aria-hidden="true"></span>
+          <span class="posture-label" id="posture-label"></span>
+        </div>
         <details class="conn-token">
           <summary>API token</summary>
           <div class="token-row">

--- a/web/static/setup.js
+++ b/web/static/setup.js
@@ -32,6 +32,90 @@ const Setup = (() => {
     return status === "ok" || status === "skipped";
   }
 
+  // isPending marks a step that is still the operator's to-do (would act, or needs
+  // a manual action) — these get a left accent border so the real to-do list
+  // stands out from satisfied rows (Von Restorff).
+  function isPending(status) {
+    return status === "action" || status === "planned";
+  }
+
+  // statusLabel gives the badge its human text. A "skipped" step is a satisfied,
+  // idempotent re-run (reused token, image already present) — it reads as "ready"
+  // so it isn't mistaken for a bypassed/abandoned step. The word itself carries
+  // the state, so the meaning survives without color (WCAG color-independence).
+  function statusLabel(s) {
+    return String(s) === "skipped" ? "ready" : String(s);
+  }
+
+  // DOCS is the public docs site the wizard links pending steps to. The console is
+  // served from the binary (no local docs tree), so deep help points at the site.
+  const DOCS = "https://ironsecco.github.io/ironclaw/";
+
+  // STEP_AFFORDANCE hands a pending step its concrete fix: the exact env line(s) to
+  // copy and the doc that explains them, so the to-do is actionable in-place
+  // instead of only described. Only steps with a single copy-paste remedy appear —
+  // runtime / image-build / API-reachability steps carry their command in the
+  // detail text and need no chip.
+  const STEP_AFFORDANCE = {
+    "model-credential": {
+      intro: "Set one provider credential in the control-plane's environment, then restart it:",
+      snippets: [
+        "export ANTHROPIC_API_KEY=sk-ant-…",
+        "export OPENAI_API_KEY=sk-…",
+        "export OPENROUTER_API_KEY=sk-or-…",
+      ],
+      docLabel: "Model setup",
+      docHref: DOCS + "quickstart/",
+    },
+    channel: {
+      intro: "Arm a channel by exporting its bot token host-side, then restart:",
+      snippets: [
+        "export SLACK_BOT_TOKEN=xoxb-…",
+        "export TELEGRAM_BOT_TOKEN=…",
+      ],
+      docLabel: "Channel setup",
+      docHref: DOCS + "channels/",
+    },
+  };
+
+  // copyChip renders a monospace command with a one-click Copy button. The
+  // clipboard API needs a secure context (https / localhost); on a plain-http
+  // remote it falls back to execCommand so copy still works.
+  function copyChip(snippet) {
+    const btn = el("button", { class: "ghost btn-sm copy-btn", type: "button", text: "Copy" });
+    const flash = (txt) => { btn.textContent = txt; setTimeout(() => { btn.textContent = "Copy"; }, 1600); };
+    btn.addEventListener("click", async () => {
+      try {
+        await navigator.clipboard.writeText(snippet);
+        flash("Copied ✓");
+      } catch (_) {
+        const ta = el("textarea", { class: "visually-hidden", "aria-hidden": "true" });
+        ta.value = snippet;
+        document.body.append(ta);
+        ta.select();
+        let ok = false;
+        try { ok = document.execCommand("copy"); } catch (_) { ok = false; }
+        ta.remove();
+        flash(ok ? "Copied ✓" : "Copy failed");
+      }
+    });
+    return el("div", { class: "copy-row" }, el("code", { class: "copy-snip", text: snippet }), btn);
+  }
+
+  // stepAffordance builds the actionable block under a pending step's detail: the
+  // copy chips and a doc link. Returns null for steps with no chip-able remedy.
+  function stepAffordance(name) {
+    const a = STEP_AFFORDANCE[name];
+    if (!a) return null;
+    const box = el("div", { class: "step-affordance" }, el("p", { class: "hint", text: a.intro }));
+    for (const s of a.snippets) box.append(copyChip(s));
+    box.append(el("a", {
+      class: "doc-link", href: a.docHref, target: "_blank", rel: "noopener noreferrer",
+      text: a.docLabel + " ↗",
+    }));
+    return box;
+  }
+
   // STEP_LABELS gives each wizard step a human title; unknown steps fall back to
   // their raw name so a newly-added step still renders.
   const STEP_LABELS = {
@@ -60,12 +144,19 @@ const Setup = (() => {
       const summary = el("div", { class: "onboard-summary" },
         el("span", { class: "kind " + (allReady ? "ok" : "warn"), text: ready + " / " + steps.length + " ready" }),
         el("span", { class: "muted", text: allReady ? "Host is ready to run agents." : "Some steps need an operator action." }));
-      const cards = steps.map((s) =>
-        el("div", { class: "card onboard-step" },
+      const cards = steps.map((s) => {
+        const pending = isPending(s.status);
+        const card = el("div", { class: "card onboard-step" + (pending ? " pending" : "") },
           el("div", { class: "card-head" },
             el("strong", { text: STEP_LABELS[s.name] || s.name }),
-            el("span", { class: "kind " + statusClass(s.status), text: String(s.status) })),
-          el("p", { class: "muted", text: s.detail || "" })));
+            el("span", { class: "kind " + statusClass(s.status), text: statusLabel(s.status) })),
+          el("p", { class: "muted", text: s.detail || "" }));
+        if (pending) {
+          const aff = stepAffordance(s.name);
+          if (aff) card.append(aff);
+        }
+        return card;
+      });
       host.replaceChildren(summary, ...cards);
     } catch (e) {
       host.replaceChildren(el("p", { class: "error", text: String(e.message || e) }));

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -147,6 +147,31 @@ code {
 .token-err { font-size: 11.5px; margin: 6px 4px 0; }
 .token-err[hidden] { display: none; }
 
+/* ---- Security-posture chip -------------------------------------------------
+   Surfaces whether the API is token-gated (good) or open on loopback (fine on
+   localhost, risky behind a mesh). Trust-critical for a security product, so it's
+   a color-coded chip — but the text label carries the meaning without color
+   (WCAG 1.4.1), and a tooltip explains the implication. */
+.posture {
+  display: inline-flex; align-items: center; gap: 7px; margin: 8px 8px 0;
+  padding: 3px 10px; border-radius: 999px; font-size: 11.5px; font-weight: 550;
+  border: 1px solid var(--border); background: var(--surface-3); color: var(--text-2);
+  cursor: default;
+}
+.posture[hidden] { display: none; }
+.posture-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--faint); }
+.posture.ok { color: var(--ok); background: var(--ok-soft); border-color: rgba(53, 214, 160, 0.35); }
+.posture.ok .posture-dot { background: var(--ok); box-shadow: 0 0 8px var(--ok); }
+.posture.warn { color: var(--warn); background: rgba(247, 193, 75, 0.12); border-color: rgba(247, 193, 75, 0.35); }
+.posture.warn .posture-dot { background: var(--warn); box-shadow: 0 0 8px var(--warn); }
+
+/* visually-hidden: off-screen but available to the clipboard fallback textarea and
+   assistive tech (never display:none, which would break selection/copy). */
+.visually-hidden {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+}
+
 /* ---- First-run connect prompt ----------------------------------------- */
 .firstrun {
   display: flex; gap: 16px; align-items: flex-start;
@@ -260,6 +285,23 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 .onboard-summary { display: flex; align-items: center; gap: 10px; margin: 4px 0 2px; }
 .onboard-step .card-head { justify-content: space-between; margin-bottom: 6px; }
 .onboard-step p { margin: 0; font-size: 13px; }
+/* Pending steps (action / planned) are the real to-do list: a left accent border
+   makes them outrank satisfied rows at a glance (Von Restorff). The badge keeps the
+   text status, so the distinction never relies on color alone (WCAG 1.4.1). */
+.onboard-step.pending { border-left: 3px solid var(--accent); }
+/* Actionable affordance: the exact command(s) to copy + a doc link, set off from the
+   detail text so the fix reads as a distinct, do-this block. */
+.step-affordance { margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--border-soft); }
+.step-affordance .hint { margin: 0 0 6px; color: var(--text-2); }
+.copy-row { display: flex; align-items: center; gap: 8px; margin: 0 0 6px; }
+.copy-snip {
+  flex: 1; min-width: 0; font-size: 12px; color: var(--text);
+  background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-xs);
+  padding: 4px 8px; overflow-x: auto; white-space: nowrap;
+}
+.copy-btn { flex: 0 0 auto; }
+.doc-link { display: inline-block; margin-top: 2px; font-size: 12.5px; color: var(--accent-2); }
+.doc-link:hover { text-decoration: underline; }
 
 .meta { display: grid; grid-template-columns: max-content 1fr; gap: 4px 14px; margin: 0 0 12px; font-size: 13px; }
 .meta dt { color: var(--muted); }


### PR DESCRIPTION
Closes IRO-132. Follow-up from IRO-130 — the two first-run items (F4, F6) deferred from the IRO-107 audit because they are larger / stateful than a bounded polish increment.

## F4 — First-run wizard actionable steps (`web/static/setup.js`)
- **Model credential** / **Channel** `action` steps now render copy-to-clipboard chips for the exact `export …` lines (e.g. `export ANTHROPIC_API_KEY=…`, `export SLACK_BOT_TOKEN=…`) plus a docs link (**Model setup** → quickstart, **Channel setup** → channels). The clipboard write falls back to `execCommand` on a plain-http remote where the async Clipboard API needs a secure context.
- `action`/`planned` cards get a **left accent border** (Von Restorff) so the real to-do list outranks satisfied rows; the text status badge stays for color-independence.
- `skipped` steps (reused token / image present) now read **"ready"**, not "skipped", so they don't look bypassed.

## F6 — Security-posture chip (`app.js` + `index.html` + `style.css`)
- Promotes the buried `connected · open API` / `API token` micro-text to a color-coded sidebar chip: green **"Token-gated"** vs amber **"Open API (loopback)"**, with a one-line tooltip ("No bearer token required — fine on localhost; set `IRONCLAW_API_TOKEN` behind a mesh").
- Text label carries the meaning without color (WCAG 1.4.1). The chip is driven by the existing authenticated probe (`lastAuthState`); offline/token-required/error states stay carried by the connection label, so the chip doesn't double-alarm.

## Verification
Built `controlplane` (assets are `go:embed`) and ran `--dev` on a clean first-run state-dir with the model/channel env vars unset:
- `/v1/ui/onboard` returns `model-credential` + `channel` as `action`; both render copy chips + doc link and carry the accent border.
- `api-token` + `sandbox-image` (`skipped`) render as **ready**.
- Posture chip switches **amber "Open API (loopback)"** (no token) ↔ **green "Token-gated"** (token set), tooltip correct.

Before/after screenshots (desktop 1440×900 + mobile 390×844) attached to the IRO-132 issue thread.

Ungated console polish — self-merge on green CI.