### PR TITLE
docs(readme): GitHub Discussions as the community channel, drop Discord/Matrix promise (IRO-42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,7 +823,9 @@ home for Q&A, design discussion, and show-and-tell, and it's where maintainers a
   [**good first issue**](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
   — these are small, self-contained, and mentored. See [Contributing](#contributing) for the workflow.
 
-A real-time chat channel (Discord / Matrix) is on the way — once it's live it'll be linked right here.
+We keep the whole community on GitHub — no Discord or Matrix to sign up for.
+[**Discussions**](https://github.com/IronSecCo/ironclaw/discussions) is the live channel: subscribe
+to a category to follow along, and watch the repo for **Announcements**.
 
 ## Contributing
 


### PR DESCRIPTION
Implements the board decision on IRO-42: the community stays **GitHub-native** (no Discord/Matrix).

## What
- Replaces the stale README line promising a future Discord/Matrix chat with copy that frames **GitHub Discussions** as the live community channel.

## Already in place (verified this run, no change needed)
- ✅ Discussions **enabled** on `IronSecCo/ironclaw` (`has_discussions: true`)
- ✅ Categories seeded: Announcements, General, Ideas, Polls, Q&A, Show and tell
- ✅ Welcome post live (discussion #116)
- ✅ README Community section already links Discussions

## Note on commit trailer
The board comment asked for a `Co-Authored-By: Paperclip` trailer, but the repo `CLAUDE.md` (and commit 486e30e, IRO-23) explicitly **prohibit** it and state the repo policy takes precedence. Committed without the trailer per that policy.