### PR TITLE
docs(site): emit branded og:image / twitter card meta (IRO-137)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,12 +13,14 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - "overrides/**"
       - "api/openapi.yaml"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - "overrides/**"
       - "api/openapi.yaml"
       - ".github/workflows/docs.yml"
   workflow_dispatch:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,9 @@ hooks:
 theme:
   name: material
   language: en
+  # Static OG/Twitter social-card meta lives in overrides/main.html (avoids the
+  # material[imaging] system-lib dep that per-page social-card generation needs).
+  custom_dir: overrides
   # Light-wordmark logo so it reads on the steel-blue / navy header bar.
   logo: assets/logo-light.svg
   # Square curved-claw shield — legible at 16px, unlike the wide wordmark.

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{#-
+  Static Open Graph / Twitter card meta. We use a custom_dir override rather than
+  Material's per-page social plugin so the build does not pull in the
+  material[imaging] system-library (Cairo/Pango) dependency. The card image is a
+  single branded asset (docs/assets/social-preview.png, 1280x640) referenced at an
+  absolute URL — unfurlers (X / LinkedIn / Slack) require an absolute og:image.
+  `extrahead` is empty in Material's base.html, so these tags are purely additive.
+-#}
+{% block extrahead %}
+  {#- `page` is None on theme-rendered pages such as 404.html, so guard every
+      page.* access (default(..., true) also replaces empty strings). -#}
+  {% set _title = (page.title if page else none) | default(config.site_name, true) %}
+  {% set _descr = (page.meta.description if page and page.meta else none) | default(config.site_description, true) %}
+  {% set _url = (page.canonical_url if page else none) | default(config.site_url, true) %}
+  {% set _image = config.site_url ~ "assets/social-preview.png" %}
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="{{ config.site_name }}">
+  <meta property="og:title" content="{{ _title }}">
+  <meta property="og:description" content="{{ _descr }}">
+  <meta property="og:url" content="{{ _url }}">
+  <meta property="og:image" content="{{ _image }}">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="1280">
+  <meta property="og:image:height" content="640">
+  <meta property="og:image:alt" content="IronClaw — isolation you can prove, not just promise.">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ _title }}">
+  <meta name="twitter:description" content="{{ _descr }}">
+  <meta name="twitter:image" content="{{ _image }}">
+{% endblock %}


### PR DESCRIPTION
## What

The MkDocs docs site emitted **no** Open Graph / Twitter meta, so links to
https://ironsecco.github.io/ironclaw/ unfurled as a generic card on X /
LinkedIn / Slack (verified against the live site and `origin/main` source).

This adds a `custom_dir` template override (`overrides/main.html`) that injects
static `og:`/`twitter:` tags referencing the on-brand
`docs/assets/social-preview.png` (1280×640, already in tree) at an **absolute**
URL — required by unfurlers.

## Why a static override (not Material's social plugin)

The per-page social-card plugin pulls in the `material[imaging]` (Cairo/Pango)
system-library dependency. A static override needs none and the card asset
already exists.

## Hardening beyond the spec

- The override **guards every `page.*` access** so the theme-rendered
  `404.html` (where `page` is `None`) still builds under `--strict` and carries
  the card. The naive spec template failed here with
  `'None' has no attribute 'meta'` — caught by a local strict build.
- Added `overrides/**` to the Docs workflow `paths:` filter so future
  template-only edits trigger the build gate (the new dir is outside `docs/**`).

## Verification

```
$ mkdocs build --strict --site-dir _site   # exit 0
$ grep og:image _site/index.html
  <meta property="og:image" content="https://ironsecco.github.io/ironclaw/assets/social-preview.png">
```

- `mkdocs build --strict` green; absolute PNG URL present on all 25 built pages
  **including** the `None`-page `404.html`.
- Asset lands in the build output (`_site/assets/social-preview.png`).

## Lenses
Docs-site only — does not touch signing / attestation / required-checks /
installer verification. Self-merge on green CI per trunk flow.

Spun off from IRO-135 — comment back so Growth can do the final live-unfurl
verification (opengraph.xyz / X / LinkedIn / Slack) after Pages deploy.

Closes IRO-137.