### PR TITLE
feat(vault): durable per-group vault-policy store across restart (IRO-139)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -140,6 +140,26 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Durable per-group vault policy (threat-model §11): persisted in its own
+	// encrypted SQLCipher DB under the state dir so an approved {credential -> hosts}
+	// grant survives a control-plane restart (deny-by-default still holds for any
+	// group with no row). The DB key is derived from the host master with a distinct
+	// purpose label — never the raw master or a per-session key — so it is stable
+	// across restarts and isolated from the session keystore.
+	master, err := keySource.Master()
+	if err != nil {
+		logger.Error("master key", "error", err)
+		os.Exit(1)
+	}
+	vaultPolicyKey := keys.DeriveSubKey(master, "ironclaw/vault-policy-db/v1")
+	vaultPolicyPath := filepath.Join(*stateDir, "vault-policies.db")
+	vaultPolicies, err := registry.OpenDurableVaultPolicyStore(vaultPolicyPath, vaultPolicyKey)
+	if err != nil {
+		logger.Error("vault policy store", "path", vaultPolicyPath, "error", err)
+		os.Exit(1)
+	}
+	defer vaultPolicies.Close()
+
 	// Registry: the control-plane data model (in-memory dev backend until the
 	// durable, encrypted store is selected at startup).
 	reg := registry.NewMemRegistry()
@@ -363,9 +383,8 @@ func main() {
 	// credential against which host", deny-by-default. Mutated only here, through the
 	// gateway apply path after a human approves a vault-policy change; read by the
 	// broker/injector before a credential is used (broker enforcement is wired
-	// separately). In-memory today (the registry itself is in-memory in this flow);
-	// durable persistence is tracked as a follow-up.
-	vaultPolicies := registry.NewVaultPolicyStore()
+	// separately). Backed by the durable, encrypted store opened above, so an
+	// approved grant survives a restart (IRO-139).
 	var capApplier contract.Applier = gateway.NewLogApplier()
 	capApplier = gateway.NewPersonaApplier(func(id contract.AgentGroupID, persona string) error {
 		return registry.SetPersona(reg, id, persona)

--- a/internal/host/keys/derive_test.go
+++ b/internal/host/keys/derive_test.go
@@ -1,0 +1,34 @@
+package keys
+
+import "testing"
+
+func TestDeriveSubKeyStableAndDomainSeparated(t *testing.T) {
+	var master [32]byte
+	for i := range master {
+		master[i] = byte(i)
+	}
+
+	a1 := DeriveSubKey(master, "ironclaw/vault-policy-db/v1")
+	a2 := DeriveSubKey(master, "ironclaw/vault-policy-db/v1")
+	if a1 != a2 {
+		t.Fatal("same master + purpose must derive the same key (stable across restarts)")
+	}
+
+	b := DeriveSubKey(master, "ironclaw/registry-db/v1")
+	if a1 == b {
+		t.Fatal("a different purpose must derive an unrelated key (domain separation)")
+	}
+
+	var other [32]byte
+	for i := range other {
+		other[i] = byte(255 - i)
+	}
+	if DeriveSubKey(other, "ironclaw/vault-policy-db/v1") == a1 {
+		t.Fatal("a different master must derive a different key")
+	}
+
+	// The derived key must never be the raw master.
+	if a1 == master {
+		t.Fatal("derived key must not equal the raw master key")
+	}
+}

--- a/internal/host/keys/source.go
+++ b/internal/host/keys/source.go
@@ -1,7 +1,9 @@
 package keys
 
 import (
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +11,21 @@ import (
 	"path/filepath"
 	"sync"
 )
+
+// DeriveSubKey deterministically derives a 32-byte host-internal subkey from the
+// master key for a named purpose, via HMAC-SHA256(master, purpose). It gives each
+// host-internal encrypted store (e.g. the durable vault-policy DB, a future
+// durable registry DB) its own stable, domain-separated key without ever reusing
+// the raw master or a per-session key as a database key. The result is stable
+// across restarts for a fixed master, and a distinct purpose yields an unrelated
+// key. The returned key is a secret: never log it.
+func DeriveSubKey(master [32]byte, purpose string) [32]byte {
+	mac := hmac.New(sha256.New, master[:])
+	mac.Write([]byte(purpose))
+	var out [32]byte
+	copy(out[:], mac.Sum(nil))
+	return out
+}
 
 // KeySource supplies the 32-byte host master key under which the session
 // keystore is sealed. It is the pluggable seam between an ephemeral in-process

--- a/internal/host/registry/vaultpolicy_durable.go
+++ b/internal/host/registry/vaultpolicy_durable.go
@@ -1,0 +1,167 @@
+package registry
+
+// DurableVaultPolicyStore persists per-group vault policy across a control-plane
+// restart. Like SQLRegistry it is host-internal — the sandbox never sees the
+// policy store — so it is NOT bound by the frozen queue contract and owns its own
+// SQLCipher database and schema.
+//
+// Design mirrors durable.go: an in-memory VaultPolicyStore is the working set and
+// the single source of truth for reads (Allows/Get), so the deny-by-default
+// decision logic and validation are reused verbatim and stay exercised by the
+// existing vaultpolicy_test.go. Every mutation is mirrored write-through to the
+// encrypted DB as a single-row upsert/delete, and the whole policy set is reloaded
+// into a fresh in-memory store on Open.
+//
+// Durability is write-through best-effort: the in-memory mutation is applied first
+// (it validates and normalizes), then persisted. If the persist fails the call
+// returns the error; the in-memory state is momentarily ahead of disk and the lost
+// change is simply absent after a restart (the DB is authoritative on reload).
+
+import (
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	_ "github.com/mutecomm/go-sqlcipher/v4" // registers the "sqlite3" SQLCipher driver
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+)
+
+// vaultPolicySchema is the host-internal DDL for the durable policy store. One row
+// per agent group holds that group's normalized rules as JSON; a group with no row
+// is denied everything (deny-by-default), exactly as an empty in-memory store.
+const vaultPolicySchema = `
+CREATE TABLE IF NOT EXISTS vault_policies (
+    agent_group_id TEXT PRIMARY KEY,
+    rules_json     TEXT NOT NULL
+);
+`
+
+// DurableVaultPolicyStore is a VaultPolicyStore backed by an encrypted SQLCipher
+// database. Reads (Allows/Get) answer from the in-memory working set; mutations
+// (Set/Delete) write through to disk.
+type DurableVaultPolicyStore struct {
+	mem *VaultPolicyStore
+	db  *sql.DB
+}
+
+// OpenDurableVaultPolicyStore opens (creating if absent) the encrypted vault-policy
+// database at path, keyed by key, and loads its contents into the working set.
+// Opening with the wrong key fails (SQLITE_NOTADB on the forced page read) rather
+// than silently returning an empty — i.e. fully-permissive-by-omission — store. The
+// key is a secret derived from the host master (see keys.DeriveSubKey); never log
+// it.
+func OpenDurableVaultPolicyStore(path string, key [32]byte) (*DurableVaultPolicyStore, error) {
+	q := url.Values{}
+	// Raw-key mode (no KDF) via the DSN so every pooled connection is keyed before
+	// any page is read.
+	q.Set("_pragma_key", `x'`+hex.EncodeToString(key[:])+`'`)
+	q.Set("_busy_timeout", "5000")
+	dsn := "file:" + path + "?" + q.Encode()
+
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("host/registry: open %q: %w", path, err)
+	}
+	// Host-local single writer; one connection keeps writes serialized and avoids
+	// multiple keyed handles racing on the file.
+	db.SetMaxOpenConns(1)
+	// Force a real page read so a wrong key fails here rather than at first query.
+	if _, err := db.Exec("SELECT count(*) FROM sqlite_master;"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("host/registry: open encrypted vault-policy db %q (wrong key?): %w", path, err)
+	}
+	if _, err := db.Exec(vaultPolicySchema); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("host/registry: apply vault-policy schema: %w", err)
+	}
+
+	s := &DurableVaultPolicyStore{mem: NewVaultPolicyStore(), db: db}
+	if err := s.load(); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return s, nil
+}
+
+// load hydrates the in-memory working set from the encrypted DB. A row that fails
+// validation (e.g. a corrupt or tampered policy) fails the open rather than being
+// silently dropped or admitted — fail-closed for an authorization store.
+func (s *DurableVaultPolicyStore) load() error {
+	rows, err := s.db.Query(`SELECT agent_group_id, rules_json FROM vault_policies`)
+	if err != nil {
+		return fmt.Errorf("host/registry: load vault policies: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, rj string
+		if err := rows.Scan(&id, &rj); err != nil {
+			return fmt.Errorf("host/registry: scan vault policy: %w", err)
+		}
+		var rules []VaultRule
+		if err := json.Unmarshal([]byte(rj), &rules); err != nil {
+			return fmt.Errorf("host/registry: decode vault policy for %q: %w", id, err)
+		}
+		// Re-validate and normalize through the in-memory store so a tampered or
+		// stale row cannot install a malformed (and thus unevaluable) rule set.
+		if err := s.mem.Set(VaultPolicy{AgentGroupID: contract.AgentGroupID(id), Rules: rules}); err != nil {
+			return fmt.Errorf("host/registry: invalid persisted vault policy for %q: %w", id, err)
+		}
+	}
+	return rows.Err()
+}
+
+// Set installs or replaces a group's policy: validate+normalize in memory first,
+// then persist the normalized form as a single-row upsert. Call site: the gateway
+// apply step for an approved vault-policy change.
+func (s *DurableVaultPolicyStore) Set(p VaultPolicy) error {
+	if err := s.mem.Set(p); err != nil {
+		return err
+	}
+	// Persist exactly what the in-memory store holds (normalized), so a reload
+	// reconstructs the identical decision.
+	norm, _ := s.mem.Get(p.AgentGroupID)
+	blob, err := json.Marshal(norm.Rules)
+	if err != nil {
+		return fmt.Errorf("host/registry: encode vault policy for %q: %w", p.AgentGroupID, err)
+	}
+	if _, err := s.db.Exec(`
+		INSERT INTO vault_policies (agent_group_id, rules_json) VALUES (?,?)
+		ON CONFLICT(agent_group_id) DO UPDATE SET rules_json=excluded.rules_json`,
+		string(p.AgentGroupID), string(blob)); err != nil {
+		return fmt.Errorf("host/registry: persist vault policy for %q: %w", p.AgentGroupID, err)
+	}
+	return nil
+}
+
+// Delete removes a group's policy in memory and on disk (idempotent). Unlike the
+// in-memory store's Delete it returns the persistence error so a failed write-
+// through is not silently swallowed. Gateway-apply only.
+func (s *DurableVaultPolicyStore) Delete(group contract.AgentGroupID) error {
+	s.mem.Delete(group)
+	if _, err := s.db.Exec(`DELETE FROM vault_policies WHERE agent_group_id=?`, string(group)); err != nil {
+		return fmt.Errorf("host/registry: delete vault policy for %q: %w", group, err)
+	}
+	return nil
+}
+
+// Get returns a group's stored (normalized) policy from the working set.
+func (s *DurableVaultPolicyStore) Get(group contract.AgentGroupID) (VaultPolicy, bool) {
+	return s.mem.Get(group)
+}
+
+// Allows answers the deny-by-default authorization decision from the working set,
+// identically to the in-memory store.
+func (s *DurableVaultPolicyStore) Allows(group contract.AgentGroupID, credential, host string) bool {
+	return s.mem.Allows(group, credential, host)
+}
+
+// Close closes the underlying database handle.
+func (s *DurableVaultPolicyStore) Close() error {
+	if s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}

--- a/internal/host/registry/vaultpolicy_durable_test.go
+++ b/internal/host/registry/vaultpolicy_durable_test.go
@@ -1,0 +1,171 @@
+package registry
+
+import (
+	"database/sql"
+	"encoding/hex"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+)
+
+func vaultKey(b byte) [32]byte {
+	var k [32]byte
+	for i := range k {
+		k[i] = b
+	}
+	return k
+}
+
+// TestDurableVaultPolicyReload is the headline acceptance: an approved grant
+// survives a control-plane restart (close + reopen with the same key), and the
+// deny-by-default decision is reconstructed identically.
+func TestDurableVaultPolicyReload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vault-policies.db")
+	key := vaultKey(0x11)
+
+	s, err := OpenDurableVaultPolicyStore(path, key)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := s.Set(VaultPolicy{AgentGroupID: grpA, Rules: []VaultRule{
+		{Credential: "github", Hosts: []string{"api.github.com"}},
+		{Credential: "pagerduty", Hosts: []string{"api.pagerduty.com", "events.pagerduty.com"}},
+	}}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Reopen — a fresh process would see exactly this.
+	s2, err := OpenDurableVaultPolicyStore(path, key)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer s2.Close()
+
+	if !s2.Allows(grpA, "github", "api.github.com") {
+		t.Error("granted credential+host must survive restart")
+	}
+	if !s2.Allows(grpA, "pagerduty", "events.pagerduty.com") {
+		t.Error("second granted host must survive restart")
+	}
+	// Deny-by-default preserved across the reload.
+	if s2.Allows(grpA, "github", "evil.example.com") {
+		t.Error("un-granted host must stay denied after restart")
+	}
+	if s2.Allows(grpA, "stripe", "api.github.com") {
+		t.Error("un-granted credential must stay denied after restart")
+	}
+	if s2.Allows(grpB, "github", "api.github.com") {
+		t.Error("a group with no policy must stay denied after restart")
+	}
+	got, ok := s2.Get(grpA)
+	if !ok || len(got.Rules) != 2 {
+		t.Errorf("Get after reload = %+v, ok=%v; want 2 rules", got, ok)
+	}
+}
+
+// TestDurableVaultPolicyDeleteAcrossReopen verifies a deleted policy does not
+// resurrect after restart.
+func TestDurableVaultPolicyDeleteAcrossReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vault-policies.db")
+	key := vaultKey(0x22)
+
+	s, err := OpenDurableVaultPolicyStore(path, key)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := s.Set(VaultPolicy{AgentGroupID: grpA, Rules: []VaultRule{
+		{Credential: "github", Hosts: []string{"api.github.com"}},
+	}}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := s.Delete(grpA); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if s.Allows(grpA, "github", "api.github.com") {
+		t.Fatal("deleted policy must deny immediately")
+	}
+	s.Close()
+
+	s2, err := OpenDurableVaultPolicyStore(path, key)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer s2.Close()
+	if s2.Allows(grpA, "github", "api.github.com") {
+		t.Error("deleted policy must not resurrect after restart")
+	}
+}
+
+// TestDurableVaultPolicyWrongKey verifies opening the persisted DB with the wrong
+// key fails loudly rather than silently returning an empty (fully-permissive-by-
+// omission) store.
+func TestDurableVaultPolicyWrongKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vault-policies.db")
+
+	s, err := OpenDurableVaultPolicyStore(path, vaultKey(0x33))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := s.Set(VaultPolicy{AgentGroupID: grpA, Rules: []VaultRule{
+		{Credential: "github", Hosts: []string{"api.github.com"}},
+	}}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	s.Close()
+
+	if _, err := OpenDurableVaultPolicyStore(path, vaultKey(0x44)); err == nil {
+		t.Fatal("opening with the wrong key must fail, not return an empty store")
+	}
+}
+
+// TestDurableVaultPolicyRejectsTamperedRow verifies the store fails closed on a
+// persisted row that does not validate (e.g. a tampered host), rather than loading
+// an unevaluable policy or silently dropping it.
+func TestDurableVaultPolicyRejectsTamperedRow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vault-policies.db")
+	key := vaultKey(0x55)
+
+	// Create the encrypted DB with the store, then inject a malformed row directly.
+	s, err := OpenDurableVaultPolicyStore(path, key)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	s.Close()
+
+	q := url.Values{}
+	q.Set("_pragma_key", `x'`+hex.EncodeToString(key[:])+`'`)
+	db, err := sql.Open("sqlite3", "file:"+path+"?"+q.Encode())
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	// A wildcard host is rejected by validVaultHost — an unevaluable, dangerous rule.
+	if _, err := db.Exec(`INSERT INTO vault_policies (agent_group_id, rules_json) VALUES (?,?)`,
+		string(grpA), `[{"Credential":"github","Hosts":["*.github.com"]}]`); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	db.Close()
+
+	if _, err := OpenDurableVaultPolicyStore(path, key); err == nil {
+		t.Fatal("a malformed persisted policy must fail the open, not be admitted")
+	}
+}
+
+// TestDurableVaultPolicyEmptyStartDenies verifies a freshly created store denies
+// everything (deny-by-default) before any grant is written.
+func TestDurableVaultPolicyEmptyStartDenies(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vault-policies.db")
+	s, err := OpenDurableVaultPolicyStore(path, vaultKey(0x66))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+	var anyGroup contract.AgentGroupID = "unconfigured"
+	if s.Allows(anyGroup, "github", "api.github.com") {
+		t.Fatal("a brand-new store must deny by default")
+	}
+}


### PR DESCRIPTION
## What

Persists per-group vault policy across a control-plane restart (child of IRO-133, item 2 persistence half). Closes the Finding B gap: `cmd/controlplane` previously held vault policy only in memory, so an approved `{credential -> hosts}` grant was lost on restart.

Scope decision: per the issue's "**OR** scope a vault-policy-only durable store", this implements a focused vault-policy-only durable store rather than wiring the whole `SQLRegistry` (which is the broader, still-open decision 3). It fully satisfies IRO-139 acceptance without entangling registry-wide durability.

## Changes
- **`registry.DurableVaultPolicyStore`** (`vaultpolicy_durable.go`): its own encrypted SQLCipher DB (`vault_policies` table), load-on-open + write-through on `Set`/`Delete`, wrapping the in-memory `VaultPolicyStore` as the read/decision working set. Mirrors the `durable.go` pattern.
- **`keys.DeriveSubKey`**: `HMAC-SHA256(master, purpose)` — gives the vault DB a stable, domain-separated key derived from the host master (never the raw master or a per-session key). Stable across restarts, isolated from the session keystore.
- **`cmd/controlplane`**: opens the durable store under the state dir (key derived from the master custody already set up) and backs the IRO-133 gateway-apply setter (PR #167) with it; `defer Close`.

## Security lenses
- **Encryption at rest**: vault policy persisted in a SQLCipher DB, raw-key mode, same discipline as the per-session queues. Wrong-key open fails (SQLITE_NOTADB) rather than silently returning an empty (fully-permissive-by-omission) store.
- **Key custody**: DB key derived from the host master via domain-separated HMAC; never logged. Master-derived ⇒ rotating the master re-keys the vault DB story alongside the keystore.
- **Deny-by-default**: preserved — a group with no row is denied; a malformed/tampered persisted row fails the open (fail-closed) instead of loading an unevaluable rule.
- **Trust boundary**: store is host-internal; the sandbox never sees it (unchanged).

## Tests (CGO_ENABLED=1, all green)
- `TestDurableVaultPolicyReload` — policy survives close+reopen; deny-by-default reconstructed.
- `TestDurableVaultPolicyDeleteAcrossReopen` — deleted policy does not resurrect.
- `TestDurableVaultPolicyWrongKey` — wrong-key open fails.
- `TestDurableVaultPolicyRejectsTamperedRow` — malformed persisted row fails closed.
- `TestDurableVaultPolicyEmptyStartDenies` — fresh store denies.
- `TestDeriveSubKeyStableAndDomainSeparated`.

## Verification (normal install/run path, NOT just --dev)
Built `cmd/controlplane`, ran non-dev with a temp state dir: it creates `vault-policies.db` with a SQLCipher header (not plaintext `SQLite format 3`), no startup errors, process stays alive.

## Stacking
Base is `forge/iro-133-vault` (PR #167, the gateway-apply path this builds on). When #167 merges to `main`, this PR retargets to `main`. **QA sign-off required before merge** (per IRO-139 acceptance).