### PR TITLE
feat(vault): credential-management UX — gateway-gated policy CRUD (IRO-140)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -428,7 +428,7 @@ func main() {
 	// WithRegistry attaches the control-plane registry so the /v1/registry admin
 	// endpoints are live and the approvals read-model (/v1/ui/approvals) can
 	// resolve agent-group/requester names instead of showing raw ids.
-	server := api.New(gw).WithHistory(store).WithAuditPath(auditPath).WithMetrics(m.Handler()).WithRegistry(reg)
+	server := api.New(gw).WithHistory(store).WithAuditPath(auditPath).WithMetrics(m.Handler()).WithRegistry(reg).WithVault(vaultPolicies)
 	// Optional bearer-token auth (defense-in-depth behind the tailnet). Read from
 	// the host environment; never logged.
 	apiToken := os.Getenv("IRONCLAW_API_TOKEN")

--- a/cmd/ironctl/main.go
+++ b/cmd/ironctl/main.go
@@ -116,6 +116,11 @@ parse:
 		return cmdMCP(addr, args[1:])
 	}
 
+	// Top-level "vault" command (per-group credential policy: list/grant/revoke/set).
+	if args[0] == "vault" {
+		return cmdVault(addr, args[1:])
+	}
+
 	// Top-level "agent" command (friendly one-shot agent create/list/show/templates).
 	if args[0] == "agent" {
 		return cmdAgent(addr, args[1:])
@@ -303,6 +308,10 @@ func usage() {
   ironctl [--addr URL] [--token T] mcp probe <name>
   ironctl [--addr URL] [--token T] mcp grant <server> --group <id> [--tools a,b] [--by <user>]
   ironctl [--addr URL] [--token T] mcp remove <name>
+  ironctl [--addr URL] [--token T] vault list --group <id> [--json]
+  ironctl [--addr URL] [--token T] vault grant --group <id> --credential C --host H [--host H2]... [--by <user>]
+  ironctl [--addr URL] [--token T] vault revoke --group <id> --credential C [--host H]... [--by <user>]
+  ironctl [--addr URL] [--token T] vault set --group <id> --rule C=h1,h2 [--rule ...] [--by <user>]
 
   --addr  defaults to `+defaultAddr+`
   --token defaults to $IRONCLAW_API_TOKEN

--- a/cmd/ironctl/vault.go
+++ b/cmd/ironctl/vault.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// cmdVault drives the per-group vault credential-management surface over the
+// control-plane API. The vault policy — "which agent group may use which logical
+// credential against which host" (threat-model §11) — is deny-by-default config,
+// never a secret. READING it (`list`) is a plain admin GET; CHANGING it
+// (`grant`/`revoke`/`set`) goes through the gateway's human-approval floor (it rides
+// a permissions-class change carrying a `vaultPolicy` body), so those verbs only
+// PROPOSE the change and print the change id — the grant takes effect after a human
+// approves it. ironctl is a thin client; the daemon owns the verifier + applier +
+// store.
+//
+// The actual credential (the key) is never held or rotated here: it lives only in
+// the host-side injector (see internal/host/egress/vault.go). Rotating the
+// injector's held secret is an injector operation, not a control-plane one.
+func cmdVault(addr string, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("expected: vault <list|grant|revoke|set>")
+	}
+	switch args[0] {
+	case "list", "ls", "show":
+		return cmdVaultList(addr, args[1:])
+	case "grant", "add":
+		return cmdVaultGrant(addr, args[1:])
+	case "revoke", "rm", "remove":
+		return cmdVaultRevoke(addr, args[1:])
+	case "set":
+		return cmdVaultSet(addr, args[1:])
+	default:
+		return fmt.Errorf("unknown vault subcommand %q (want list|grant|revoke|set)", args[0])
+	}
+}
+
+// vaultRule mirrors the API read model: a logical credential NAME and the bare
+// upstream hosts it may be used against.
+type vaultRule struct {
+	Credential string   `json:"credential"`
+	Hosts      []string `json:"hosts"`
+}
+
+// vaultPolicyDoc is the GET /v1/vault/policy/{group} response.
+type vaultPolicyDoc struct {
+	AgentGroupID  string      `json:"agentGroupId"`
+	DenyByDefault bool        `json:"denyByDefault"`
+	HasPolicy     bool        `json:"hasPolicy"`
+	Rules         []vaultRule `json:"rules"`
+}
+
+// cmdVaultList prints a group's deny-by-default state and active grants.
+func cmdVaultList(addr string, args []string) error {
+	fs := flag.NewFlagSet("vault list", flag.ContinueOnError)
+	group := fs.String("group", "", "agent group id")
+	asJSON := fs.Bool("json", false, "print the raw policy JSON")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *group == "" {
+		return fmt.Errorf("vault list requires --group")
+	}
+	doc, raw, err := fetchVaultPolicy(addr, *group)
+	if err != nil {
+		return err
+	}
+	if *asJSON {
+		fmt.Println(strings.TrimSpace(string(raw)))
+		return nil
+	}
+	fmt.Printf("vault policy for group %q (deny-by-default)\n", doc.AgentGroupID)
+	if len(doc.Rules) == 0 {
+		fmt.Println("  no grants — every vault:// request is denied")
+		return nil
+	}
+	for _, r := range doc.Rules {
+		fmt.Printf("  %s -> %s\n", r.Credential, strings.Join(r.Hosts, ", "))
+	}
+	return nil
+}
+
+// cmdVaultGrant proposes adding (credential -> host[,host...]) to a group's policy.
+// It reads the current policy, unions the new grant in, and submits the FULL updated
+// policy as a gateway change (the store replaces a group's policy wholesale).
+//
+//	ironctl vault grant --group <id> --credential github --host api.github.com [--host ...] [--by <user>]
+func cmdVaultGrant(addr string, args []string) error {
+	fs := flag.NewFlagSet("vault grant", flag.ContinueOnError)
+	group := fs.String("group", "", "target agent group id")
+	cred := fs.String("credential", "", "logical credential name (e.g. github) — never a key")
+	by := fs.String("by", "", "requesting user id (channel:handle)")
+	var hosts multiFlag
+	fs.Var(&hosts, "host", "an upstream host the credential may be used against (repeatable)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *group == "" || *cred == "" || len(hosts) == 0 {
+		return fmt.Errorf("vault grant requires --group, --credential, and at least one --host")
+	}
+	doc, _, err := fetchVaultPolicy(addr, *group)
+	if err != nil {
+		return err
+	}
+	rules := applyVaultGrant(doc.Rules, *cred, hosts)
+	return submitVaultPolicy(addr, *group, *by, rules)
+}
+
+// cmdVaultRevoke proposes removing a grant from a group's policy. With one or more
+// --host, it removes those hosts from the credential (dropping the credential if no
+// host remains); with no --host, it removes the whole credential.
+//
+//	ironctl vault revoke --group <id> --credential github [--host api.github.com ...] [--by <user>]
+func cmdVaultRevoke(addr string, args []string) error {
+	fs := flag.NewFlagSet("vault revoke", flag.ContinueOnError)
+	group := fs.String("group", "", "target agent group id")
+	cred := fs.String("credential", "", "logical credential name to revoke")
+	by := fs.String("by", "", "requesting user id (channel:handle)")
+	var hosts multiFlag
+	fs.Var(&hosts, "host", "an upstream host to revoke (repeatable; omit to revoke the whole credential)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *group == "" || *cred == "" {
+		return fmt.Errorf("vault revoke requires --group and --credential")
+	}
+	doc, _, err := fetchVaultPolicy(addr, *group)
+	if err != nil {
+		return err
+	}
+	rules := applyVaultRevoke(doc.Rules, *cred, hosts)
+	return submitVaultPolicy(addr, *group, *by, rules)
+}
+
+// cmdVaultSet proposes replacing a group's ENTIRE policy declaratively. Each --rule
+// is "credential=host1,host2". With no --rule it proposes an empty policy (revoke
+// all). This is the low-level form behind grant/revoke.
+//
+//	ironctl vault set --group <id> --rule github=api.github.com --rule stripe=api.stripe.com [--by <user>]
+func cmdVaultSet(addr string, args []string) error {
+	fs := flag.NewFlagSet("vault set", flag.ContinueOnError)
+	group := fs.String("group", "", "target agent group id")
+	by := fs.String("by", "", "requesting user id (channel:handle)")
+	var ruleArgs multiFlag
+	fs.Var(&ruleArgs, "rule", "credential=host1,host2 (repeatable)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *group == "" {
+		return fmt.Errorf("vault set requires --group")
+	}
+	rules, err := parseVaultRules(ruleArgs)
+	if err != nil {
+		return err
+	}
+	return submitVaultPolicy(addr, *group, *by, rules)
+}
+
+// fetchVaultPolicy GETs a group's current policy and returns it parsed + raw.
+func fetchVaultPolicy(addr, group string) (vaultPolicyDoc, []byte, error) {
+	resp, err := httpGet(addr + "/v1/vault/policy/" + url.PathEscape(group))
+	if err != nil {
+		return vaultPolicyDoc{}, nil, err
+	}
+	defer resp.Body.Close()
+	raw := mustReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return vaultPolicyDoc{}, nil, fmt.Errorf("read vault policy: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	var doc vaultPolicyDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return vaultPolicyDoc{}, nil, fmt.Errorf("decode vault policy: %w", err)
+	}
+	return doc, raw, nil
+}
+
+// submitVaultPolicy proposes the given full rule set for a group as a gateway change.
+// It rides a permissions-class change carrying a `vaultPolicy` body, which the
+// daemon's VaultPolicyVerifier validates and AlwaysRequireHuman holds for approval.
+func submitVaultPolicy(addr, group, by string, rules []vaultRule) error {
+	if rules == nil {
+		rules = []vaultRule{}
+	}
+	return postJSON(addr+"/v1/ui/config/change", map[string]any{
+		"kind":         "permissions",
+		"agentGroupID": group,
+		"requestedBy":  by,
+		"after":        map[string]any{"vaultPolicy": map[string]any{"rules": rules}},
+	})
+}
+
+// applyVaultGrant returns rules with (cred -> hosts) unioned in: it finds or creates
+// the credential's rule and adds any hosts not already present. Credential and hosts
+// are lowercased/trimmed so the union dedupes the way the server normalizes.
+func applyVaultGrant(rules []vaultRule, cred string, hosts []string) []vaultRule {
+	cred = strings.ToLower(strings.TrimSpace(cred))
+	out := cloneVaultRules(rules)
+	idx := -1
+	for i := range out {
+		if strings.ToLower(strings.TrimSpace(out[i].Credential)) == cred {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		out = append(out, vaultRule{Credential: cred})
+		idx = len(out) - 1
+	}
+	for _, h := range hosts {
+		h = strings.ToLower(strings.TrimSpace(h))
+		if h == "" || containsStr(out[idx].Hosts, h) {
+			continue
+		}
+		out[idx].Hosts = append(out[idx].Hosts, h)
+	}
+	sort.Strings(out[idx].Hosts)
+	return out
+}
+
+// applyVaultRevoke returns rules with the grant removed. With hosts given, it removes
+// those hosts from the credential and drops the credential if none remain; with no
+// hosts, it drops the whole credential.
+func applyVaultRevoke(rules []vaultRule, cred string, hosts []string) []vaultRule {
+	cred = strings.ToLower(strings.TrimSpace(cred))
+	drop := map[string]bool{}
+	for _, h := range hosts {
+		if h = strings.ToLower(strings.TrimSpace(h)); h != "" {
+			drop[h] = true
+		}
+	}
+	out := make([]vaultRule, 0, len(rules))
+	for _, r := range cloneVaultRules(rules) {
+		if strings.ToLower(strings.TrimSpace(r.Credential)) != cred {
+			out = append(out, r)
+			continue
+		}
+		if len(drop) == 0 {
+			continue // revoke the whole credential
+		}
+		kept := make([]string, 0, len(r.Hosts))
+		for _, h := range r.Hosts {
+			if !drop[strings.ToLower(strings.TrimSpace(h))] {
+				kept = append(kept, h)
+			}
+		}
+		if len(kept) > 0 {
+			out = append(out, vaultRule{Credential: r.Credential, Hosts: kept})
+		}
+	}
+	return out
+}
+
+// parseVaultRules parses "credential=host1,host2" entries into rules.
+func parseVaultRules(entries []string) ([]vaultRule, error) {
+	var out []vaultRule
+	for _, e := range entries {
+		cred, hostCSV, ok := strings.Cut(e, "=")
+		cred = strings.ToLower(strings.TrimSpace(cred))
+		if !ok || cred == "" {
+			return nil, fmt.Errorf("invalid --rule %q (want credential=host1,host2)", e)
+		}
+		var hosts []string
+		for _, h := range strings.Split(hostCSV, ",") {
+			if h = strings.ToLower(strings.TrimSpace(h)); h != "" && !containsStr(hosts, h) {
+				hosts = append(hosts, h)
+			}
+		}
+		if len(hosts) == 0 {
+			return nil, fmt.Errorf("--rule %q must grant at least one host", e)
+		}
+		sort.Strings(hosts)
+		out = append(out, vaultRule{Credential: cred, Hosts: hosts})
+	}
+	return out, nil
+}
+
+func cloneVaultRules(rules []vaultRule) []vaultRule {
+	out := make([]vaultRule, 0, len(rules))
+	for _, r := range rules {
+		out = append(out, vaultRule{Credential: r.Credential, Hosts: append([]string{}, r.Hosts...)})
+	}
+	return out
+}
+
+func containsStr(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/ironctl/vault_test.go
+++ b/cmd/ironctl/vault_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestApplyVaultGrant_NewCredential(t *testing.T) {
+	got := applyVaultGrant(nil, "GitHub", []string{"API.github.com"})
+	want := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestApplyVaultGrant_UnionsHostsDedup(t *testing.T) {
+	start := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}
+	got := applyVaultGrant(start, "github", []string{"api.github.com", "uploads.github.com"})
+	want := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com", "uploads.github.com"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestApplyVaultGrant_DoesNotMutateInput(t *testing.T) {
+	start := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}
+	_ = applyVaultGrant(start, "github", []string{"uploads.github.com"})
+	if len(start[0].Hosts) != 1 {
+		t.Fatalf("input mutated: %+v", start)
+	}
+}
+
+func TestApplyVaultGrant_AddsSecondCredential(t *testing.T) {
+	start := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}
+	got := applyVaultGrant(start, "stripe", []string{"api.stripe.com"})
+	if len(got) != 2 {
+		t.Fatalf("want 2 rules, got %+v", got)
+	}
+}
+
+func TestApplyVaultRevoke_WholeCredential(t *testing.T) {
+	start := []vaultRule{
+		{Credential: "github", Hosts: []string{"api.github.com"}},
+		{Credential: "stripe", Hosts: []string{"api.stripe.com"}},
+	}
+	got := applyVaultRevoke(start, "github", nil)
+	want := []vaultRule{{Credential: "stripe", Hosts: []string{"api.stripe.com"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestApplyVaultRevoke_SingleHostKeepsCredential(t *testing.T) {
+	start := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com", "uploads.github.com"}}}
+	got := applyVaultRevoke(start, "github", []string{"uploads.github.com"})
+	want := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestApplyVaultRevoke_LastHostDropsCredential(t *testing.T) {
+	start := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}
+	got := applyVaultRevoke(start, "github", []string{"api.github.com"})
+	if len(got) != 0 {
+		t.Fatalf("want empty, got %+v", got)
+	}
+}
+
+func TestApplyVaultRevoke_UnknownCredentialIsNoop(t *testing.T) {
+	start := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}
+	got := applyVaultRevoke(start, "stripe", nil)
+	if !reflect.DeepEqual(got, start) {
+		t.Fatalf("got %+v, want unchanged %+v", got, start)
+	}
+}
+
+func TestParseVaultRules_OK(t *testing.T) {
+	got, err := parseVaultRules([]string{"github=api.github.com,uploads.github.com", "stripe=api.stripe.com"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []vaultRule{
+		{Credential: "github", Hosts: []string{"api.github.com", "uploads.github.com"}},
+		{Credential: "stripe", Hosts: []string{"api.stripe.com"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestParseVaultRules_RejectsMalformed(t *testing.T) {
+	for _, bad := range []string{"github", "=api.github.com", "github="} {
+		if _, err := parseVaultRules([]string{bad}); err == nil {
+			t.Errorf("parseVaultRules(%q) = nil err, want error", bad)
+		}
+	}
+}

--- a/docs/security.md
+++ b/docs/security.md
@@ -46,6 +46,36 @@ what the agent does:
 - **Append-only audit.** Every approve/reject decision and every gated action is
   recorded. See [Architecture](architecture.md).
 
+## Credential vault: agents use keys without holding them
+
+An agent reaches a vaulted API by **logical name** — `vault://<cred>/<path>` — and
+never by holding the key. The egress broker forwards the call to a separate host-side
+*injector* that attaches the real credential; the broker (and the sandbox) inject
+nothing. Access is **deny-by-default and per agent group**: a group may use a
+credential against a host only if an approved policy grant says so.
+
+Those grants are **config, never secrets** — every rule names a credential, never
+holds one — and they are managed through the gateway like any other capability
+change, so a grant is held until a human approves it and is recorded in the audit
+log. Manage them with `ironctl vault`:
+
+```bash
+# See a group's deny-by-default state and active grants (no secret is ever shown):
+ironctl vault list --group <agent-group>
+
+# Propose a grant (held at the gateway for human approval):
+ironctl vault grant  --group <agent-group> --credential github --host api.github.com --by you
+ironctl change approve <change-id> --by you
+
+# Narrow or remove a grant (also gateway-gated):
+ironctl vault revoke --group <agent-group> --credential github --host api.github.com --by you
+```
+
+Rotating the **secret value** behind a credential is an *injector* operation — the
+control plane never holds the key, so there is nothing for it to rotate. Point the
+broker at an injector with `--vault-endpoint`. The threat model's §11 has the full
+model.
+
 ## The supply chain is part of the promise
 
 A release a user cannot verify is not a secured release. IronClaw's published

--- a/internal/host/api/api.go
+++ b/internal/host/api/api.go
@@ -44,6 +44,7 @@ type Server struct {
 	skills     *skills.Resolver         // curated, signature-verifying skills resolver; nil = skills disabled
 	mcpCatalog *mcp.Catalog             // operator-configured MCP server catalog; nil = MCP disabled
 	mcpBroker  *mcp.Broker              // host MCP broker, for probe/discovery; nil = MCP disabled
+	vault      *registry.VaultPolicyStore // per-group vault policy, for the read surface; nil = vault read disabled
 	mux        *http.ServeMux
 
 	// Hardening (all opt-in; see hardening.go). Zero values disable the feature.
@@ -157,6 +158,7 @@ func (s *Server) routes() {
 	s.uiCatalogRoutes()   // built-in tool catalog + starter templates at /v1/ui/{tools,templates} (see ui_catalog.go)
 	s.skillsRoutes()      // skills install/list/remove at /v1/skills (see skills.go)
 	s.mcpRoutes()         // MCP server CRUD/probe + read-model at /v1/registry/mcp-servers|/v1/ui/mcp-servers (see mcp.go)
+	s.vaultRoutes()       // per-group vault policy read surface at /v1/vault/policy (see vault.go)
 }
 
 // auth wraps h with optional bearer-token authentication. With no token set, the

--- a/internal/host/api/api.go
+++ b/internal/host/api/api.go
@@ -44,7 +44,7 @@ type Server struct {
 	skills     *skills.Resolver         // curated, signature-verifying skills resolver; nil = skills disabled
 	mcpCatalog *mcp.Catalog             // operator-configured MCP server catalog; nil = MCP disabled
 	mcpBroker  *mcp.Broker              // host MCP broker, for probe/discovery; nil = MCP disabled
-	vault      *registry.VaultPolicyStore // per-group vault policy, for the read surface; nil = vault read disabled
+	vault      VaultPolicyReader        // per-group vault policy, for the read surface; nil = vault read disabled
 	mux        *http.ServeMux
 
 	// Hardening (all opt-in; see hardening.go). Zero values disable the feature.

--- a/internal/host/api/vault.go
+++ b/internal/host/api/vault.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+	"github.com/IronSecCo/ironclaw/internal/host/registry"
+)
+
+// Vault credential-management read surface. The per-group vault policy — "which
+// agent group may use which logical credential against which host" (threat-model
+// §11) — is host-side authorization CONFIG, never a secret: every rule names a
+// credential, never holds one. This endpoint exposes that config read-only so an
+// operator (console or `ironctl vault list`) can see the deny-by-default state and a
+// group's active grants before proposing a change.
+//
+// MUTATION is deliberately NOT here. A policy change is a capability change like any
+// other: clients propose it through the gateway's human-approval floor by submitting
+// a permissions-class change carrying a `vaultPolicy` body (POST /v1/ui/config/change
+// or POST /v1/changes), which the gateway's VaultPolicyVerifier + VaultPolicyApplier
+// validate, human-approve, and materialize. This read endpoint can therefore never be
+// a back-channel that sets policy — it only reflects what the gateway has approved.
+//
+// No secret is ever returned: the store holds credential NAMES and host allowlists,
+// not keys (the real credential lives only in the host-side injector — see
+// internal/host/egress/vault.go).
+
+// WithVault attaches the host-side per-group vault policy store that backs the
+// GET /v1/vault/policy read surface. nil (the default) leaves the read surface
+// disabled (503), mirroring the other opt-in subsystems.
+func (s *Server) WithVault(store *registry.VaultPolicyStore) *Server {
+	s.vault = store
+	return s
+}
+
+func (s *Server) vaultRoutes() {
+	s.mux.HandleFunc("GET /v1/vault/policy/{agentGroupId}", s.handleVaultPolicyGet)
+}
+
+// vaultRuleView is one approved grant in the read model: a logical credential NAME
+// (never a key) and the bare upstream hosts it may be used against.
+type vaultRuleView struct {
+	Credential string   `json:"credential"`
+	Hosts      []string `json:"hosts"`
+}
+
+// vaultPolicyView is a group's complete vault authorization state. DenyByDefault is
+// always true — it is the invariant the store enforces — and is surfaced explicitly
+// so the UI can show "deny-by-default; these are the only grants". HasPolicy
+// distinguishes "group has an (empty) policy record" from "group is unconfigured";
+// both deny everything not listed.
+type vaultPolicyView struct {
+	AgentGroupID  string          `json:"agentGroupId"`
+	DenyByDefault bool            `json:"denyByDefault"`
+	HasPolicy     bool            `json:"hasPolicy"`
+	Rules         []vaultRuleView `json:"rules"`
+}
+
+// handleVaultPolicyGet returns a group's current vault policy (deny-by-default state
+// + active grants). It is read-only and returns no secret. With no vault store wired
+// it returns 503; an unknown group returns a well-formed empty (deny-everything)
+// policy rather than 404, so the UI can render "no grants yet" uniformly.
+func (s *Server) handleVaultPolicyGet(w http.ResponseWriter, r *http.Request) {
+	if s.vault == nil {
+		http.Error(w, "the vault is not enabled on this control-plane", http.StatusServiceUnavailable)
+		return
+	}
+	id := contract.AgentGroupID(r.PathValue("agentGroupId"))
+	if id == "" {
+		http.Error(w, "agentGroupId is required", http.StatusBadRequest)
+		return
+	}
+	view := vaultPolicyView{
+		AgentGroupID:  string(id),
+		DenyByDefault: true,
+		Rules:         []vaultRuleView{},
+	}
+	if p, ok := s.vault.Get(id); ok {
+		view.HasPolicy = true
+		for _, rule := range p.Rules {
+			hosts := append([]string{}, rule.Hosts...)
+			view.Rules = append(view.Rules, vaultRuleView{Credential: rule.Credential, Hosts: hosts})
+		}
+	}
+	writeJSON(w, http.StatusOK, view)
+}

--- a/internal/host/api/vault.go
+++ b/internal/host/api/vault.go
@@ -25,10 +25,19 @@ import (
 // not keys (the real credential lives only in the host-side injector — see
 // internal/host/egress/vault.go).
 
+// VaultPolicyReader is the read-only view the API needs over the vault policy
+// store. The read surface only ever calls Get, so accepting the interface lets
+// either the in-memory *registry.VaultPolicyStore or the durable
+// *registry.DurableVaultPolicyStore back it — both satisfy this — without the
+// wiring in cmd/controlplane caring which one is configured.
+type VaultPolicyReader interface {
+	Get(contract.AgentGroupID) (registry.VaultPolicy, bool)
+}
+
 // WithVault attaches the host-side per-group vault policy store that backs the
 // GET /v1/vault/policy read surface. nil (the default) leaves the read surface
 // disabled (503), mirroring the other opt-in subsystems.
-func (s *Server) WithVault(store *registry.VaultPolicyStore) *Server {
+func (s *Server) WithVault(store VaultPolicyReader) *Server {
 	s.vault = store
 	return s
 }

--- a/internal/host/api/vault_test.go
+++ b/internal/host/api/vault_test.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+	"github.com/IronSecCo/ironclaw/internal/host/gateway"
+	"github.com/IronSecCo/ironclaw/internal/host/registry"
+)
+
+// newVaultTestServer returns a Server with a vault store wired and a no-op gateway.
+func newVaultTestServer(t *testing.T) (*Server, *registry.VaultPolicyStore) {
+	t.Helper()
+	gw := gateway.New(gateway.VerifierChain{}, gateway.NewManualApprover(), gateway.NewLogApplier(), gateway.NewMemoryStore())
+	store := registry.NewVaultPolicyStore()
+	s := New(gw).WithVault(store)
+	return s, store
+}
+
+func TestVaultPolicyGet_DenyByDefaultWhenUnconfigured(t *testing.T) {
+	s, _ := newVaultTestServer(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/vault/policy/group-a", nil)
+	s.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var got vaultPolicyView
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.DenyByDefault {
+		t.Errorf("DenyByDefault = false, want true")
+	}
+	if got.HasPolicy {
+		t.Errorf("HasPolicy = true for an unconfigured group, want false")
+	}
+	if len(got.Rules) != 0 {
+		t.Errorf("Rules = %v, want empty", got.Rules)
+	}
+	if got.AgentGroupID != "group-a" {
+		t.Errorf("AgentGroupID = %q, want group-a", got.AgentGroupID)
+	}
+}
+
+func TestVaultPolicyGet_ReflectsApprovedGrants(t *testing.T) {
+	s, store := newVaultTestServer(t)
+	if err := store.Set(registry.VaultPolicy{
+		AgentGroupID: "group-a",
+		Rules:        []registry.VaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}},
+	}); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/vault/policy/group-a", nil)
+	s.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var got vaultPolicyView
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.HasPolicy {
+		t.Errorf("HasPolicy = false, want true")
+	}
+	if len(got.Rules) != 1 || got.Rules[0].Credential != "github" {
+		t.Fatalf("Rules = %+v, want one github rule", got.Rules)
+	}
+	if len(got.Rules[0].Hosts) != 1 || got.Rules[0].Hosts[0] != "api.github.com" {
+		t.Errorf("Hosts = %v, want [api.github.com]", got.Rules[0].Hosts)
+	}
+}
+
+// A read of one group must never leak another group's policy.
+func TestVaultPolicyGet_IsolatedPerGroup(t *testing.T) {
+	s, store := newVaultTestServer(t)
+	_ = store.Set(registry.VaultPolicy{
+		AgentGroupID: "group-a",
+		Rules:        []registry.VaultRule{{Credential: "stripe", Hosts: []string{"api.stripe.com"}}},
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/vault/policy/group-b", nil)
+	s.Handler().ServeHTTP(rr, req)
+
+	var got vaultPolicyView
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if got.HasPolicy || len(got.Rules) != 0 {
+		t.Errorf("group-b leaked group-a policy: %+v", got)
+	}
+}
+
+func TestVaultPolicyGet_DisabledWhenNoStore(t *testing.T) {
+	gw := gateway.New(gateway.VerifierChain{}, gateway.NewManualApprover(), gateway.NewLogApplier(), gateway.NewMemoryStore())
+	s := New(gw) // no WithVault
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/vault/policy/group-a", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rr.Code)
+	}
+}
+
+// Ensure the read model carries no field that could ever hold a secret value — it is
+// credential NAMES + hosts only.
+func TestVaultPolicyView_ShapeHasNoSecretField(t *testing.T) {
+	b, _ := json.Marshal(vaultPolicyView{
+		AgentGroupID:  "g",
+		DenyByDefault: true,
+		HasPolicy:     true,
+		Rules:         []vaultRuleView{{Credential: "github", Hosts: []string{"api.github.com"}}},
+	})
+	var m map[string]any
+	_ = json.Unmarshal(b, &m)
+	for _, banned := range []string{"secret", "key", "token", "value", "password"} {
+		if _, ok := m[banned]; ok {
+			t.Errorf("read model exposes a %q field", banned)
+		}
+	}
+	_ = contract.AgentGroupID("") // keep contract import meaningful
+}


### PR DESCRIPTION
## Item 4 of the credential vault (IRO-133) — credential-management UX

Stacked on **#167** (`forge/iro-133-vault`, the gateway-apply path). Adds the operator-facing surface to manage the **per-group vault policy** — *"which agent group may use which logical credential against which host"* (threat-model §11) — through the gateway's human-approval floor.

### What changed
- **Read surface** — `GET /v1/vault/policy/{agentGroupId}` (`internal/host/api/vault.go`): a group's **deny-by-default** state + active grants. Returns credential **names** + host allowlists only — **never a secret** (the key lives solely in the host-side injector). `503` when no vault store is wired. `Server.WithVault(store)`; `cmd/controlplane` wires the existing in-memory `VaultPolicyStore`.
- **CLI** — `ironctl vault list|grant|revoke|set` (`cmd/ironctl/vault.go`):
  - `list` reads the policy and prints deny-by-default + grants.
  - `grant`/`revoke`/`set` **propose** a change — they ride a permissions-class change carrying a `vaultPolicy` body, which #167's `VaultPolicyVerifier` validates and `AlwaysRequireHuman` holds for approval. `grant`/`revoke` read the current policy and submit the full updated rule set (the store replaces wholesale).
- **Docs** — `docs/security.md` gains a credential-vault section (deny-by-default + `ironctl vault`).

### Security lenses
- **Mandatory gateway** — every mutation is a deterministic, human-approved, audited change. The read endpoint is read-only and can never set policy (no back-channel). ✅
- **No plaintext secrets** — the store and the wire model hold credential names + hosts, never keys; a test asserts the read model carries no `secret`/`key`/`token`/`value`/`password` field. ✅
- **Trust boundary** — target group is the trusted `ChangeRequest.AgentGroupID`, never the payload; the sandbox cannot set policy. ✅

### Deliberately split out
**Secret-value rotation** is an *injector* operation — the control plane never holds the key, so there is nothing for it to rotate. Tracked as a follow-up child **blocked on the injector contract (item 3)**.

### Verification
- `CGO_ENABLED=1 go build ./...` ✅ · `go vet` ✅
- New tests: 5 API handler + 10 CLI merge-logic, all passing.
- **End-to-end on a live `--dev` control plane:** `vault grant` → `change pending` → `change approve` → grant materializes in `vault list` → `vault grant` 2nd host → `vault revoke` one host. Every mutation held at the gateway until approved; deny-by-default held before approval.

Touches a gateway-gated mutation surface → requesting maintainer/CEO review (consistent with #167). Coordinate with QA before merge.