### PR TITLE
feat(vault): secure per-session enforcement in egress broker + reference injector (IRO-138)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/IronSecCo/ironclaw/internal/host/session"
 	"github.com/IronSecCo/ironclaw/internal/host/skills"
 	"github.com/IronSecCo/ironclaw/internal/host/sweep"
+	"github.com/IronSecCo/ironclaw/internal/host/vaultinjector"
 	"github.com/IronSecCo/ironclaw/internal/obs"
 	"github.com/IronSecCo/ironclaw/internal/sandbox/tools"
 	"github.com/IronSecCo/ironclaw/internal/version"
@@ -86,6 +87,8 @@ func main() {
 		"comma-separated hostnames the egress broker permits (deny-by-default; only used with --egress-socket)")
 	vaultEndpoint := flag.String("vault-endpoint", "",
 		"OPT-IN: host-local credential-injector URL; enables vault://<cred>/<path> routing through the egress broker. Requires --egress-socket")
+	vaultInjectorConfig := flag.String("vault-injector-config", "",
+		"path to the JSON injector config (cred -> {upstream, secretEnv}); supplies the cred->upstream-host map the broker enforces vault policy against. Required with --vault-endpoint")
 	searchBackend := flag.String("search-backend", "",
 		"web_search provider given to each sandbox: duckduckgo (keyless) or brave[:cred] (keyed via the vault). Requires --egress-socket; its host is auto-added to the egress allowlist. Empty disables web_search (--dev defaults it to duckduckgo)")
 	skillsDir := flag.String("skills-dir", "",
@@ -261,6 +264,25 @@ func main() {
 		logger.Error("egress broker", "error", err)
 		os.Exit(1)
 	}
+	// Vault enforcement: with --vault-endpoint set, load the injector config so the
+	// broker can enforce per-group policy against the credential's UPSTREAM host (the
+	// host dimension of VaultPolicyStore.Allows). The injector config is the one fact
+	// the broker side shares with the injector: cred -> upstream host. Fail fast on a
+	// missing/invalid config so vault is never enabled without enforceable policy.
+	var vaultCredHosts map[string]string
+	if *vaultEndpoint != "" {
+		if *vaultInjectorConfig == "" {
+			logger.Error("vault", "error", "--vault-endpoint requires --vault-injector-config (cred->upstream host map for policy enforcement)")
+			os.Exit(1)
+		}
+		cfg, cerr := vaultinjector.LoadConfig(*vaultInjectorConfig)
+		if cerr != nil {
+			logger.Error("vault injector config", "error", cerr)
+			os.Exit(1)
+		}
+		vaultCredHosts = cfg.CredHosts()
+		logger.Info("vault enforcement enabled", "credentials", len(vaultCredHosts))
+	}
 	// When a search backend is configured, approve its egress host so web_search is not
 	// present-but-403 (selecting a backend IS the operator opting into reaching it). A
 	// vault-routed backend returns "" here — its injector endpoint is allowlisted via
@@ -366,6 +388,25 @@ func main() {
 	// separately). In-memory today (the registry itself is in-memory in this flow);
 	// durable persistence is tracked as a follow-up.
 	vaultPolicies := registry.NewVaultPolicyStore()
+	// Wire the broker's vault guard: it enforces per-group policy on a HOST-TRUSTED
+	// session->group mapping (the per-session socket identity, never the spoofable
+	// header). The guard resolves the trusted session's group, looks up the
+	// credential's approved upstream host, and consults the gateway-approved
+	// VaultPolicyStore — deny-by-default on any miss. A revoked grant stops working
+	// immediately (the store is read live).
+	if broker != nil && *vaultEndpoint != "" {
+		broker.SetVaultGuard(func(session, cred string) (string, bool) {
+			host, known := vaultCredHosts[strings.ToLower(strings.TrimSpace(cred))]
+			if !known {
+				return "", false
+			}
+			sess, ok := reg.GetSession(contract.SessionID(session))
+			if !ok {
+				return host, false
+			}
+			return host, vaultPolicies.Allows(sess.AgentGroupID, cred, host)
+		})
+	}
 	var capApplier contract.Applier = gateway.NewLogApplier()
 	capApplier = gateway.NewPersonaApplier(func(id contract.AgentGroupID, persona string) error {
 		return registry.SetPersona(reg, id, persona)
@@ -478,6 +519,14 @@ func main() {
 	if mcpBroker != nil {
 		mcpProvisioner = mcpBroker
 	}
+	// Vault enforcement requires a host-trusted session identity, so when vault is
+	// enabled the manager provisions a PER-SESSION egress socket per sandbox (the
+	// socket identity, not the spoofable header). Otherwise it binds the single shared
+	// EgressSocket as before.
+	var egressProvisioner session.EgressProvisioner
+	if broker != nil && *vaultEndpoint != "" {
+		egressProvisioner = broker
+	}
 	manager, err := session.New(session.Config{
 		Factory:          factory,
 		Keys:             custodian,
@@ -486,10 +535,12 @@ func main() {
 		SelectModel:      selectModelFromRegistry(reg),
 		ModelProxySocket: *socket,
 		EgressSocket:     *egressSocket,
+		EgressBroker:     egressProvisioner,
 		SearchBackend:    *searchBackend,
 		SkillsDir:        *skillsDir,
 		MCPBroker:        mcpProvisioner,
 		MCPSocketDir:     filepath.Join(filepath.Dir(*socket), "mcp"),
+		EgressSocketDir:  filepath.Join(filepath.Dir(*socket), "egress"),
 		Image:            *sandboxImage,
 		KeyDir:           filepath.Join(*stateDir, "keys"),
 		WorkspaceRoot:    filepath.Join(*stateDir, "workspaces"),

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -447,7 +447,7 @@ func main() {
 	// WithRegistry attaches the control-plane registry so the /v1/registry admin
 	// endpoints are live and the approvals read-model (/v1/ui/approvals) can
 	// resolve agent-group/requester names instead of showing raw ids.
-	server := api.New(gw).WithHistory(store).WithAuditPath(auditPath).WithMetrics(m.Handler()).WithRegistry(reg)
+	server := api.New(gw).WithHistory(store).WithAuditPath(auditPath).WithMetrics(m.Handler()).WithRegistry(reg).WithVault(vaultPolicies)
 	// Optional bearer-token auth (defense-in-depth behind the tailnet). Read from
 	// the host environment; never logged.
 	apiToken := os.Getenv("IRONCLAW_API_TOKEN")

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -140,6 +140,26 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Durable per-group vault policy (threat-model §11): persisted in its own
+	// encrypted SQLCipher DB under the state dir so an approved {credential -> hosts}
+	// grant survives a control-plane restart (deny-by-default still holds for any
+	// group with no row). The DB key is derived from the host master with a distinct
+	// purpose label — never the raw master or a per-session key — so it is stable
+	// across restarts and isolated from the session keystore.
+	master, err := keySource.Master()
+	if err != nil {
+		logger.Error("master key", "error", err)
+		os.Exit(1)
+	}
+	vaultPolicyKey := keys.DeriveSubKey(master, "ironclaw/vault-policy-db/v1")
+	vaultPolicyPath := filepath.Join(*stateDir, "vault-policies.db")
+	vaultPolicies, err := registry.OpenDurableVaultPolicyStore(vaultPolicyPath, vaultPolicyKey)
+	if err != nil {
+		logger.Error("vault policy store", "path", vaultPolicyPath, "error", err)
+		os.Exit(1)
+	}
+	defer vaultPolicies.Close()
+
 	// Registry: the control-plane data model (in-memory dev backend until the
 	// durable, encrypted store is selected at startup).
 	reg := registry.NewMemRegistry()
@@ -363,9 +383,8 @@ func main() {
 	// credential against which host", deny-by-default. Mutated only here, through the
 	// gateway apply path after a human approves a vault-policy change; read by the
 	// broker/injector before a credential is used (broker enforcement is wired
-	// separately). In-memory today (the registry itself is in-memory in this flow);
-	// durable persistence is tracked as a follow-up.
-	vaultPolicies := registry.NewVaultPolicyStore()
+	// separately). Backed by the durable, encrypted store opened above, so an
+	// approved grant survives a restart (IRO-139).
 	var capApplier contract.Applier = gateway.NewLogApplier()
 	capApplier = gateway.NewPersonaApplier(func(id contract.AgentGroupID, persona string) error {
 		return registry.SetPersona(reg, id, persona)

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -359,6 +359,13 @@ func main() {
 	// registry; when egress is enabled, an approved change's egress grants (e.g. a
 	// skill install's bundle) are materialized into the broker's allowlist so the
 	// grant takes effect; every other kind is logged.
+	// Per-group vault policy (threat-model §11): "which agent group may use which
+	// credential against which host", deny-by-default. Mutated only here, through the
+	// gateway apply path after a human approves a vault-policy change; read by the
+	// broker/injector before a credential is used (broker enforcement is wired
+	// separately). In-memory today (the registry itself is in-memory in this flow);
+	// durable persistence is tracked as a follow-up.
+	vaultPolicies := registry.NewVaultPolicyStore()
 	var capApplier contract.Applier = gateway.NewLogApplier()
 	capApplier = gateway.NewPersonaApplier(func(id contract.AgentGroupID, persona string) error {
 		return registry.SetPersona(reg, id, persona)
@@ -386,6 +393,16 @@ func main() {
 	capApplier = gateway.NewMCPAccessApplier(func(id contract.AgentGroupID, server string, tools []string) error {
 		return registry.SetGrantedMCP(reg, id, server, tools)
 	}, capApplier)
+	// An approved vault-policy change records the per-group {credential -> hosts} rules
+	// so subsequent vaulted calls are authorized deny-by-default. The target group is
+	// the change's trusted AgentGroupID, never the payload.
+	capApplier = gateway.NewVaultPolicyApplier(func(id contract.AgentGroupID, rules []gateway.VaultRule) error {
+		rr := make([]registry.VaultRule, 0, len(rules))
+		for _, r := range rules {
+			rr = append(rr, registry.VaultRule{Credential: r.Credential, Hosts: r.Hosts})
+		}
+		return vaultPolicies.Set(registry.VaultPolicy{AgentGroupID: id, Rules: rr})
+	}, capApplier)
 	if broker != nil {
 		capApplier = gateway.NewEgressApplier(broker, capApplier)
 	}
@@ -400,6 +417,7 @@ func main() {
 			gateway.PackageNameVerifier{},
 			gateway.NewCreateAgentVerifier(agentExists),
 			gateway.NewMCPServerVerifier(mcpServerKnown),
+			gateway.VaultPolicyVerifier{},
 			gateway.AlwaysRequireHuman{},
 		},
 		gateway.NewManualApprover(),

--- a/cmd/ironclaw-vault-injector/main.go
+++ b/cmd/ironclaw-vault-injector/main.go
@@ -1,0 +1,99 @@
+// Command ironclaw-vault-injector is IronClaw's minimal reference credential
+// injector: the SEPARATE host-side principal the egress broker forwards a vault://
+// request TO. It holds the credentials (read from the host environment) and attaches
+// them host-side, so the egress broker injects nothing and the sandbox never sees a
+// key (threat model §11).
+//
+// Run it as its OWN OS user (NOT the control-plane user), listening on a loopback
+// port or unix socket the broker reaches via --vault-endpoint. The control-plane and
+// the injector share ONE config file (cred -> {upstream, secretEnv}): the broker reads
+// it for the cred->upstream-host policy map, the injector reads it to attach secrets.
+//
+//	ironclaw-vault-injector --config vault-injector.json --addr 127.0.0.1:8200
+//
+// Config example (secrets live in the environment, NEVER in the file):
+//
+//	{ "creds": { "github": { "upstream": "https://api.github.com",
+//	                          "secretEnv": "VAULT_GITHUB_TOKEN" } } }
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/IronSecCo/ironclaw/internal/host/vaultinjector"
+)
+
+func main() {
+	cfgPath := flag.String("config", "", "path to the JSON injector config (cred -> {upstream, secretEnv})")
+	addr := flag.String("addr", "127.0.0.1:8200", "TCP address to listen on (use a loopback port the broker allowlists)")
+	socket := flag.String("socket", "", "unix socket to listen on instead of --addr (bound into the broker's reach)")
+	flag.Parse()
+
+	if *cfgPath == "" {
+		log.Fatal("ironclaw-vault-injector: --config is required")
+	}
+	cfg, err := vaultinjector.LoadConfig(*cfgPath)
+	if err != nil {
+		log.Fatalf("ironclaw-vault-injector: %v", err)
+	}
+	inj, err := vaultinjector.New(cfg, os.LookupEnv, vaultinjector.WithAudit(func(rec vaultinjector.AuditRecord) {
+		// Audit carries the credential NAME + correlation id — never the secret value.
+		log.Printf("inject cred=%q upstream=%q path=%q status=%d allowed=%v corr=%q dur_ms=%d",
+			rec.Credential, rec.Upstream, rec.Path, rec.Status, rec.Allowed, rec.CorrelationID, rec.Duration.Milliseconds())
+	}))
+	if err != nil {
+		log.Fatalf("ironclaw-vault-injector: %v", err)
+	}
+	log.Printf("ironclaw-vault-injector: ready with %d credential(s): %s", len(inj.Creds()), strings.Join(inj.Creds(), ", "))
+
+	ln, err := listen(*socket, *addr)
+	if err != nil {
+		log.Fatalf("ironclaw-vault-injector: listen: %v", err)
+	}
+	srv := &http.Server{Handler: inj.Handler()}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Serve(ln) }()
+
+	where := *addr
+	if *socket != "" {
+		where = "unix:" + *socket
+	}
+	log.Printf("ironclaw-vault-injector: listening on %s", where)
+
+	select {
+	case <-ctx.Done():
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+		if *socket != "" {
+			_ = os.Remove(*socket)
+		}
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("ironclaw-vault-injector: serve: %v", err)
+		}
+	}
+}
+
+// listen opens a unix socket when socket is set (removing any stale file first),
+// otherwise a TCP listener on addr.
+func listen(socket, addr string) (net.Listener, error) {
+	if socket != "" {
+		_ = os.Remove(socket)
+		return net.Listen("unix", socket)
+	}
+	return net.Listen("tcp", addr)
+}

--- a/cmd/ironctl/main.go
+++ b/cmd/ironctl/main.go
@@ -116,6 +116,11 @@ parse:
 		return cmdMCP(addr, args[1:])
 	}
 
+	// Top-level "vault" command (per-group credential policy: list/grant/revoke/set).
+	if args[0] == "vault" {
+		return cmdVault(addr, args[1:])
+	}
+
 	// Top-level "agent" command (friendly one-shot agent create/list/show/templates).
 	if args[0] == "agent" {
 		return cmdAgent(addr, args[1:])
@@ -303,6 +308,10 @@ func usage() {
   ironctl [--addr URL] [--token T] mcp probe <name>
   ironctl [--addr URL] [--token T] mcp grant <server> --group <id> [--tools a,b] [--by <user>]
   ironctl [--addr URL] [--token T] mcp remove <name>
+  ironctl [--addr URL] [--token T] vault list --group <id> [--json]
+  ironctl [--addr URL] [--token T] vault grant --group <id> --credential C --host H [--host H2]... [--by <user>]
+  ironctl [--addr URL] [--token T] vault revoke --group <id> --credential C [--host H]... [--by <user>]
+  ironctl [--addr URL] [--token T] vault set --group <id> --rule C=h1,h2 [--rule ...] [--by <user>]
 
   --addr  defaults to `+defaultAddr+`
   --token defaults to $IRONCLAW_API_TOKEN

--- a/cmd/ironctl/vault.go
+++ b/cmd/ironctl/vault.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// cmdVault drives the per-group vault credential-management surface over the
+// control-plane API. The vault policy — "which agent group may use which logical
+// credential against which host" (threat-model §11) — is deny-by-default config,
+// never a secret. READING it (`list`) is a plain admin GET; CHANGING it
+// (`grant`/`revoke`/`set`) goes through the gateway's human-approval floor (it rides
+// a permissions-class change carrying a `vaultPolicy` body), so those verbs only
+// PROPOSE the change and print the change id — the grant takes effect after a human
+// approves it. ironctl is a thin client; the daemon owns the verifier + applier +
+// store.
+//
+// The actual credential (the key) is never held or rotated here: it lives only in
+// the host-side injector (see internal/host/egress/vault.go). Rotating the
+// injector's held secret is an injector operation, not a control-plane one.
+func cmdVault(addr string, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("expected: vault <list|grant|revoke|set>")
+	}
+	switch args[0] {
+	case "list", "ls", "show":
+		return cmdVaultList(addr, args[1:])
+	case "grant", "add":
+		return cmdVaultGrant(addr, args[1:])
+	case "revoke", "rm", "remove":
+		return cmdVaultRevoke(addr, args[1:])
+	case "set":
+		return cmdVaultSet(addr, args[1:])
+	default:
+		return fmt.Errorf("unknown vault subcommand %q (want list|grant|revoke|set)", args[0])
+	}
+}
+
+// vaultRule mirrors the API read model: a logical credential NAME and the bare
+// upstream hosts it may be used against.
+type vaultRule struct {
+	Credential string   `json:"credential"`
+	Hosts      []string `json:"hosts"`
+}
+
+// vaultPolicyDoc is the GET /v1/vault/policy/{group} response.
+type vaultPolicyDoc struct {
+	AgentGroupID  string      `json:"agentGroupId"`
+	DenyByDefault bool        `json:"denyByDefault"`
+	HasPolicy     bool        `json:"hasPolicy"`
+	Rules         []vaultRule `json:"rules"`
+}
+
+// cmdVaultList prints a group's deny-by-default state and active grants.
+func cmdVaultList(addr string, args []string) error {
+	fs := flag.NewFlagSet("vault list", flag.ContinueOnError)
+	group := fs.String("group", "", "agent group id")
+	asJSON := fs.Bool("json", false, "print the raw policy JSON")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *group == "" {
+		return fmt.Errorf("vault list requires --group")
+	}
+	doc, raw, err := fetchVaultPolicy(addr, *group)
+	if err != nil {
+		return err
+	}
+	if *asJSON {
+		fmt.Println(strings.TrimSpace(string(raw)))
+		return nil
+	}
+	fmt.Printf("vault policy for group %q (deny-by-default)\n", doc.AgentGroupID)
+	if len(doc.Rules) == 0 {
+		fmt.Println("  no grants — every vault:// request is denied")
+		return nil
+	}
+	for _, r := range doc.Rules {
+		fmt.Printf("  %s -> %s\n", r.Credential, strings.Join(r.Hosts, ", "))
+	}
+	return nil
+}
+
+// cmdVaultGrant proposes adding (credential -> host[,host...]) to a group's policy.
+// It reads the current policy, unions the new grant in, and submits the FULL updated
+// policy as a gateway change (the store replaces a group's policy wholesale).
+//
+//	ironctl vault grant --group <id> --credential github --host api.github.com [--host ...] [--by <user>]
+func cmdVaultGrant(addr string, args []string) error {
+	fs := flag.NewFlagSet("vault grant", flag.ContinueOnError)
+	group := fs.String("group", "", "target agent group id")
+	cred := fs.String("credential", "", "logical credential name (e.g. github) — never a key")
+	by := fs.String("by", "", "requesting user id (channel:handle)")
+	var hosts multiFlag
+	fs.Var(&hosts, "host", "an upstream host the credential may be used against (repeatable)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *group == "" || *cred == "" || len(hosts) == 0 {
+		return fmt.Errorf("vault grant requires --group, --credential, and at least one --host")
+	}
+	doc, _, err := fetchVaultPolicy(addr, *group)
+	if err != nil {
+		return err
+	}
+	rules := applyVaultGrant(doc.Rules, *cred, hosts)
+	return submitVaultPolicy(addr, *group, *by, rules)
+}
+
+// cmdVaultRevoke proposes removing a grant from a group's policy. With one or more
+// --host, it removes those hosts from the credential (dropping the credential if no
+// host remains); with no --host, it removes the whole credential.
+//
+//	ironctl vault revoke --group <id> --credential github [--host api.github.com ...] [--by <user>]
+func cmdVaultRevoke(addr string, args []string) error {
+	fs := flag.NewFlagSet("vault revoke", flag.ContinueOnError)
+	group := fs.String("group", "", "target agent group id")
+	cred := fs.String("credential", "", "logical credential name to revoke")
+	by := fs.String("by", "", "requesting user id (channel:handle)")
+	var hosts multiFlag
+	fs.Var(&hosts, "host", "an upstream host to revoke (repeatable; omit to revoke the whole credential)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *group == "" || *cred == "" {
+		return fmt.Errorf("vault revoke requires --group and --credential")
+	}
+	doc, _, err := fetchVaultPolicy(addr, *group)
+	if err != nil {
+		return err
+	}
+	rules := applyVaultRevoke(doc.Rules, *cred, hosts)
+	return submitVaultPolicy(addr, *group, *by, rules)
+}
+
+// cmdVaultSet proposes replacing a group's ENTIRE policy declaratively. Each --rule
+// is "credential=host1,host2". With no --rule it proposes an empty policy (revoke
+// all). This is the low-level form behind grant/revoke.
+//
+//	ironctl vault set --group <id> --rule github=api.github.com --rule stripe=api.stripe.com [--by <user>]
+func cmdVaultSet(addr string, args []string) error {
+	fs := flag.NewFlagSet("vault set", flag.ContinueOnError)
+	group := fs.String("group", "", "target agent group id")
+	by := fs.String("by", "", "requesting user id (channel:handle)")
+	var ruleArgs multiFlag
+	fs.Var(&ruleArgs, "rule", "credential=host1,host2 (repeatable)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *group == "" {
+		return fmt.Errorf("vault set requires --group")
+	}
+	rules, err := parseVaultRules(ruleArgs)
+	if err != nil {
+		return err
+	}
+	return submitVaultPolicy(addr, *group, *by, rules)
+}
+
+// fetchVaultPolicy GETs a group's current policy and returns it parsed + raw.
+func fetchVaultPolicy(addr, group string) (vaultPolicyDoc, []byte, error) {
+	resp, err := httpGet(addr + "/v1/vault/policy/" + url.PathEscape(group))
+	if err != nil {
+		return vaultPolicyDoc{}, nil, err
+	}
+	defer resp.Body.Close()
+	raw := mustReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return vaultPolicyDoc{}, nil, fmt.Errorf("read vault policy: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	var doc vaultPolicyDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return vaultPolicyDoc{}, nil, fmt.Errorf("decode vault policy: %w", err)
+	}
+	return doc, raw, nil
+}
+
+// submitVaultPolicy proposes the given full rule set for a group as a gateway change.
+// It rides a permissions-class change carrying a `vaultPolicy` body, which the
+// daemon's VaultPolicyVerifier validates and AlwaysRequireHuman holds for approval.
+func submitVaultPolicy(addr, group, by string, rules []vaultRule) error {
+	if rules == nil {
+		rules = []vaultRule{}
+	}
+	return postJSON(addr+"/v1/ui/config/change", map[string]any{
+		"kind":         "permissions",
+		"agentGroupID": group,
+		"requestedBy":  by,
+		"after":        map[string]any{"vaultPolicy": map[string]any{"rules": rules}},
+	})
+}
+
+// applyVaultGrant returns rules with (cred -> hosts) unioned in: it finds or creates
+// the credential's rule and adds any hosts not already present. Credential and hosts
+// are lowercased/trimmed so the union dedupes the way the server normalizes.
+func applyVaultGrant(rules []vaultRule, cred string, hosts []string) []vaultRule {
+	cred = strings.ToLower(strings.TrimSpace(cred))
+	out := cloneVaultRules(rules)
+	idx := -1
+	for i := range out {
+		if strings.ToLower(strings.TrimSpace(out[i].Credential)) == cred {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		out = append(out, vaultRule{Credential: cred})
+		idx = len(out) - 1
+	}
+	for _, h := range hosts {
+		h = strings.ToLower(strings.TrimSpace(h))
+		if h == "" || containsStr(out[idx].Hosts, h) {
+			continue
+		}
+		out[idx].Hosts = append(out[idx].Hosts, h)
+	}
+	sort.Strings(out[idx].Hosts)
+	return out
+}
+
+// applyVaultRevoke returns rules with the grant removed. With hosts given, it removes
+// those hosts from the credential and drops the credential if none remain; with no
+// hosts, it drops the whole credential.
+func applyVaultRevoke(rules []vaultRule, cred string, hosts []string) []vaultRule {
+	cred = strings.ToLower(strings.TrimSpace(cred))
+	drop := map[string]bool{}
+	for _, h := range hosts {
+		if h = strings.ToLower(strings.TrimSpace(h)); h != "" {
+			drop[h] = true
+		}
+	}
+	out := make([]vaultRule, 0, len(rules))
+	for _, r := range cloneVaultRules(rules) {
+		if strings.ToLower(strings.TrimSpace(r.Credential)) != cred {
+			out = append(out, r)
+			continue
+		}
+		if len(drop) == 0 {
+			continue // revoke the whole credential
+		}
+		kept := make([]string, 0, len(r.Hosts))
+		for _, h := range r.Hosts {
+			if !drop[strings.ToLower(strings.TrimSpace(h))] {
+				kept = append(kept, h)
+			}
+		}
+		if len(kept) > 0 {
+			out = append(out, vaultRule{Credential: r.Credential, Hosts: kept})
+		}
+	}
+	return out
+}
+
+// parseVaultRules parses "credential=host1,host2" entries into rules.
+func parseVaultRules(entries []string) ([]vaultRule, error) {
+	var out []vaultRule
+	for _, e := range entries {
+		cred, hostCSV, ok := strings.Cut(e, "=")
+		cred = strings.ToLower(strings.TrimSpace(cred))
+		if !ok || cred == "" {
+			return nil, fmt.Errorf("invalid --rule %q (want credential=host1,host2)", e)
+		}
+		var hosts []string
+		for _, h := range strings.Split(hostCSV, ",") {
+			if h = strings.ToLower(strings.TrimSpace(h)); h != "" && !containsStr(hosts, h) {
+				hosts = append(hosts, h)
+			}
+		}
+		if len(hosts) == 0 {
+			return nil, fmt.Errorf("--rule %q must grant at least one host", e)
+		}
+		sort.Strings(hosts)
+		out = append(out, vaultRule{Credential: cred, Hosts: hosts})
+	}
+	return out, nil
+}
+
+func cloneVaultRules(rules []vaultRule) []vaultRule {
+	out := make([]vaultRule, 0, len(rules))
+	for _, r := range rules {
+		out = append(out, vaultRule{Credential: r.Credential, Hosts: append([]string{}, r.Hosts...)})
+	}
+	return out
+}
+
+func containsStr(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/ironctl/vault_test.go
+++ b/cmd/ironctl/vault_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestApplyVaultGrant_NewCredential(t *testing.T) {
+	got := applyVaultGrant(nil, "GitHub", []string{"API.github.com"})
+	want := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestApplyVaultGrant_UnionsHostsDedup(t *testing.T) {
+	start := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}
+	got := applyVaultGrant(start, "github", []string{"api.github.com", "uploads.github.com"})
+	want := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com", "uploads.github.com"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestApplyVaultGrant_DoesNotMutateInput(t *testing.T) {
+	start := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}
+	_ = applyVaultGrant(start, "github", []string{"uploads.github.com"})
+	if len(start[0].Hosts) != 1 {
+		t.Fatalf("input mutated: %+v", start)
+	}
+}
+
+func TestApplyVaultGrant_AddsSecondCredential(t *testing.T) {
+	start := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}
+	got := applyVaultGrant(start, "stripe", []string{"api.stripe.com"})
+	if len(got) != 2 {
+		t.Fatalf("want 2 rules, got %+v", got)
+	}
+}
+
+func TestApplyVaultRevoke_WholeCredential(t *testing.T) {
+	start := []vaultRule{
+		{Credential: "github", Hosts: []string{"api.github.com"}},
+		{Credential: "stripe", Hosts: []string{"api.stripe.com"}},
+	}
+	got := applyVaultRevoke(start, "github", nil)
+	want := []vaultRule{{Credential: "stripe", Hosts: []string{"api.stripe.com"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestApplyVaultRevoke_SingleHostKeepsCredential(t *testing.T) {
+	start := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com", "uploads.github.com"}}}
+	got := applyVaultRevoke(start, "github", []string{"uploads.github.com"})
+	want := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestApplyVaultRevoke_LastHostDropsCredential(t *testing.T) {
+	start := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}
+	got := applyVaultRevoke(start, "github", []string{"api.github.com"})
+	if len(got) != 0 {
+		t.Fatalf("want empty, got %+v", got)
+	}
+}
+
+func TestApplyVaultRevoke_UnknownCredentialIsNoop(t *testing.T) {
+	start := []vaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}
+	got := applyVaultRevoke(start, "stripe", nil)
+	if !reflect.DeepEqual(got, start) {
+		t.Fatalf("got %+v, want unchanged %+v", got, start)
+	}
+}
+
+func TestParseVaultRules_OK(t *testing.T) {
+	got, err := parseVaultRules([]string{"github=api.github.com,uploads.github.com", "stripe=api.stripe.com"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []vaultRule{
+		{Credential: "github", Hosts: []string{"api.github.com", "uploads.github.com"}},
+		{Credential: "stripe", Hosts: []string{"api.stripe.com"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestParseVaultRules_RejectsMalformed(t *testing.T) {
+	for _, bad := range []string{"github", "=api.github.com", "github="} {
+		if _, err := parseVaultRules([]string{bad}); err == nil {
+			t.Errorf("parseVaultRules(%q) = nil err, want error", bad)
+		}
+	}
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -100,7 +100,7 @@ Press the security advantage — several of these are wins neither peer has clai
 | Examples gallery + templates | ✅ |
 | Public roadmap + comparison (this page) | ✅ |
 | Third-party security audit | 👤 |
-| End-user credential vault | 👤 |
+| End-user credential vault | ✅ |
 
 ### What "1.0" means
 
@@ -134,7 +134,7 @@ will evolve — corrections welcome via an issue.
 | Skills / plugin registry | yes (ClawHub) | host-side, signed, gateway-gated capability bundles | ✅ shipped |
 | MCP / external tool servers | yes (blind approval surface) | host-brokered, isolated, **per-tool human-approved** + audited | ✅ **ahead** |
 | Guided onboarding | wizard | `ironctl onboard` + quickstart | ✅ at parity |
-| Credential vault (arbitrary APIs) | yes | model credential + gateway-approved egress broker | 👤 partial (vault planned) |
+| Credential vault (arbitrary APIs) | yes | logical-name `vault://` injection via a separate host-side injector behind the gateway-approved egress broker (per-group deny-by-default, agent never holds a key) | ✅ **shipped** (1.0) |
 | Multiple LLM providers | drop-in modules | Anthropic / OpenAI / OpenRouter / Codex via host proxy | ✅ at parity |
 | In-product diagnostics | `/status` `/usage` | Prometheus metrics + audit + `ironctl status`/`doctor` | ✅ at parity |
 | **Signed releases + SBOM + provenance** | neither peer | cosign-signed releases + SBOM + build provenance, reproducible `ironctl`/`sandbox` | ✅ **shipped** (a win neither peer has claimed) |

--- a/docs/security.md
+++ b/docs/security.md
@@ -46,6 +46,36 @@ what the agent does:
 - **Append-only audit.** Every approve/reject decision and every gated action is
   recorded. See [Architecture](architecture.md).
 
+## Credential vault: agents use keys without holding them
+
+An agent reaches a vaulted API by **logical name** — `vault://<cred>/<path>` — and
+never by holding the key. The egress broker forwards the call to a separate host-side
+*injector* that attaches the real credential; the broker (and the sandbox) inject
+nothing. Access is **deny-by-default and per agent group**: a group may use a
+credential against a host only if an approved policy grant says so.
+
+Those grants are **config, never secrets** — every rule names a credential, never
+holds one — and they are managed through the gateway like any other capability
+change, so a grant is held until a human approves it and is recorded in the audit
+log. Manage them with `ironctl vault`:
+
+```bash
+# See a group's deny-by-default state and active grants (no secret is ever shown):
+ironctl vault list --group <agent-group>
+
+# Propose a grant (held at the gateway for human approval):
+ironctl vault grant  --group <agent-group> --credential github --host api.github.com --by you
+ironctl change approve <change-id> --by you
+
+# Narrow or remove a grant (also gateway-gated):
+ironctl vault revoke --group <agent-group> --credential github --host api.github.com --by you
+```
+
+Rotating the **secret value** behind a credential is an *injector* operation — the
+control plane never holds the key, so there is nothing for it to rotate. Point the
+broker at an injector with `--vault-endpoint`. The threat model's §11 has the full
+model.
+
 ## The supply chain is part of the promise
 
 A release a user cannot verify is not a secured release. IronClaw's published

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -1,0 +1,96 @@
+# Credential vault (request-time injection)
+
+Long-running agents often need credentials for the third-party APIs they call. IronClaw
+lets an agent reach a credential by **logical name** — `vault://<cred>/<path>` — while
+**never holding the key**. The secret is attached host-side by a *separate* principal,
+so neither the sandbox nor the egress broker ever becomes a secret sink (threat model
+[§11](threat-model.md)).
+
+## How a vaulted request flows
+
+```
+sandbox ──vault://github/repos/acme──▶ egress broker ──▶ vault injector ──▶ api.github.com
+  (no key)                              (per-session     (holds the key,      (sees the
+                                         socket, policy    attaches it)         real token)
+                                         enforcement)
+```
+
+1. The agent addresses `vault://<cred>/<path>`. The sandbox holds no key.
+2. The **egress broker** receives the request on a **per-session socket** whose identity
+   the host created at launch — *not* the spoofable `X-Ironclaw-Session` header. It
+   resolves that trusted session to its agent group and enforces the gateway-approved
+   **vault policy** (`registry.VaultPolicyStore.Allows(group, cred, host)`),
+   **deny-by-default**: an un-granted credential, an unknown session, or a request on
+   the shared (non per-session) socket is refused `403`, audited with the credential
+   NAME (never the key) and a correlation id.
+3. On approval the broker rewrites the request to the **injector** (stripping any
+   sandbox-supplied `Authorization`, adding only the credential name + correlation id)
+   and forwards it. The injector endpoint is itself deny-by-default on the broker
+   allowlist.
+4. The **injector** — a distinct OS principal — maps `<cred>` to its upstream + secret,
+   attaches the secret host-side, and reverse-proxies to the real upstream. It is the
+   ONE place a real key is added. The response is redacted on the broker→sandbox hop so
+   an injected credential can never echo back.
+
+## Why per-session sockets
+
+The egress broker is a single shared instance bound into every sandbox. Attributing a
+request to a session by a request header would be **spoofable** — a compromised sandbox
+could set another group's session id and borrow its credentials. Mirroring the MCP
+broker, vault enforcement instead runs over a **per-session unix socket** the host
+created, so the session→group mapping the policy is keyed on is host-trusted and cannot
+be escalated by a header.
+
+## The broker ⇄ injector contract
+
+The injector is **swappable**: IronClaw ships a minimal reference
+(`cmd/ironclaw-vault-injector`, package `internal/host/vaultinjector`), or an operator
+may point the broker at an external injector (e.g. OneCLI) that honours the same
+contract:
+
+| Hop | Header / field | Meaning |
+| --- | --- | --- |
+| broker → injector | `X-Ironclaw-Vault-Cred` | the logical credential NAME (never a key) |
+| broker → injector | `X-Ironclaw-Vault-Request-Id` | host-authored correlation id for audit |
+| broker → injector | request path | the upstream path from `vault://<cred>/<path>` |
+| broker → injector | `Authorization` | **stripped** — the broker forwards no credential |
+| injector → upstream | configured header (default `Authorization: Bearer …`) | the host-held secret, attached host-side |
+
+The injector refuses an unknown credential `403` and never writes the secret into its
+response.
+
+## Running it
+
+The control-plane and the injector share **one config file** (`cred → {upstream,
+secretEnv}`). Secrets live in the **environment**, never in the file:
+
+```json
+{
+  "creds": {
+    "github": { "upstream": "https://api.github.com", "secretEnv": "VAULT_GITHUB_TOKEN" }
+  }
+}
+```
+
+Run the injector as its own OS user, then start the control-plane pointing at it:
+
+```sh
+# 1) the injector (separate principal; holds the secrets)
+VAULT_GITHUB_TOKEN=ghp_… ironclaw-vault-injector \
+  --config vault-injector.json --addr 127.0.0.1:8200
+
+# 2) the control-plane (enforces policy; holds no secret)
+controlplane \
+  --egress-socket /run/ironclaw/egress.sock \
+  --vault-endpoint http://127.0.0.1:8200 \
+  --vault-injector-config vault-injector.json
+```
+
+`--vault-endpoint` requires `--vault-injector-config`: without the cred→upstream-host
+map the broker cannot enforce vault policy, so the daemon refuses to enable vault rather
+than run it unenforced.
+
+A group is granted a credential through the gateway's human-approval path (a vault-policy
+change is a capability change like any other); see
+[`ironctl vault`](channels.md) for the management commands. With no grant, vault stays
+deny-by-default.

--- a/internal/host/api/api.go
+++ b/internal/host/api/api.go
@@ -44,6 +44,7 @@ type Server struct {
 	skills     *skills.Resolver         // curated, signature-verifying skills resolver; nil = skills disabled
 	mcpCatalog *mcp.Catalog             // operator-configured MCP server catalog; nil = MCP disabled
 	mcpBroker  *mcp.Broker              // host MCP broker, for probe/discovery; nil = MCP disabled
+	vault      VaultPolicyReader        // per-group vault policy, for the read surface; nil = vault read disabled
 	mux        *http.ServeMux
 
 	// Hardening (all opt-in; see hardening.go). Zero values disable the feature.
@@ -157,6 +158,7 @@ func (s *Server) routes() {
 	s.uiCatalogRoutes()   // built-in tool catalog + starter templates at /v1/ui/{tools,templates} (see ui_catalog.go)
 	s.skillsRoutes()      // skills install/list/remove at /v1/skills (see skills.go)
 	s.mcpRoutes()         // MCP server CRUD/probe + read-model at /v1/registry/mcp-servers|/v1/ui/mcp-servers (see mcp.go)
+	s.vaultRoutes()       // per-group vault policy read surface at /v1/vault/policy (see vault.go)
 }
 
 // auth wraps h with optional bearer-token authentication. With no token set, the

--- a/internal/host/api/vault.go
+++ b/internal/host/api/vault.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+	"github.com/IronSecCo/ironclaw/internal/host/registry"
+)
+
+// Vault credential-management read surface. The per-group vault policy — "which
+// agent group may use which logical credential against which host" (threat-model
+// §11) — is host-side authorization CONFIG, never a secret: every rule names a
+// credential, never holds one. This endpoint exposes that config read-only so an
+// operator (console or `ironctl vault list`) can see the deny-by-default state and a
+// group's active grants before proposing a change.
+//
+// MUTATION is deliberately NOT here. A policy change is a capability change like any
+// other: clients propose it through the gateway's human-approval floor by submitting
+// a permissions-class change carrying a `vaultPolicy` body (POST /v1/ui/config/change
+// or POST /v1/changes), which the gateway's VaultPolicyVerifier + VaultPolicyApplier
+// validate, human-approve, and materialize. This read endpoint can therefore never be
+// a back-channel that sets policy — it only reflects what the gateway has approved.
+//
+// No secret is ever returned: the store holds credential NAMES and host allowlists,
+// not keys (the real credential lives only in the host-side injector — see
+// internal/host/egress/vault.go).
+
+// VaultPolicyReader is the read-only view the API needs over the vault policy
+// store. The read surface only ever calls Get, so accepting the interface lets
+// either the in-memory *registry.VaultPolicyStore or the durable
+// *registry.DurableVaultPolicyStore back it — both satisfy this — without the
+// wiring in cmd/controlplane caring which one is configured.
+type VaultPolicyReader interface {
+	Get(contract.AgentGroupID) (registry.VaultPolicy, bool)
+}
+
+// WithVault attaches the host-side per-group vault policy store that backs the
+// GET /v1/vault/policy read surface. nil (the default) leaves the read surface
+// disabled (503), mirroring the other opt-in subsystems.
+func (s *Server) WithVault(store VaultPolicyReader) *Server {
+	s.vault = store
+	return s
+}
+
+func (s *Server) vaultRoutes() {
+	s.mux.HandleFunc("GET /v1/vault/policy/{agentGroupId}", s.handleVaultPolicyGet)
+}
+
+// vaultRuleView is one approved grant in the read model: a logical credential NAME
+// (never a key) and the bare upstream hosts it may be used against.
+type vaultRuleView struct {
+	Credential string   `json:"credential"`
+	Hosts      []string `json:"hosts"`
+}
+
+// vaultPolicyView is a group's complete vault authorization state. DenyByDefault is
+// always true — it is the invariant the store enforces — and is surfaced explicitly
+// so the UI can show "deny-by-default; these are the only grants". HasPolicy
+// distinguishes "group has an (empty) policy record" from "group is unconfigured";
+// both deny everything not listed.
+type vaultPolicyView struct {
+	AgentGroupID  string          `json:"agentGroupId"`
+	DenyByDefault bool            `json:"denyByDefault"`
+	HasPolicy     bool            `json:"hasPolicy"`
+	Rules         []vaultRuleView `json:"rules"`
+}
+
+// handleVaultPolicyGet returns a group's current vault policy (deny-by-default state
+// + active grants). It is read-only and returns no secret. With no vault store wired
+// it returns 503; an unknown group returns a well-formed empty (deny-everything)
+// policy rather than 404, so the UI can render "no grants yet" uniformly.
+func (s *Server) handleVaultPolicyGet(w http.ResponseWriter, r *http.Request) {
+	if s.vault == nil {
+		http.Error(w, "the vault is not enabled on this control-plane", http.StatusServiceUnavailable)
+		return
+	}
+	id := contract.AgentGroupID(r.PathValue("agentGroupId"))
+	if id == "" {
+		http.Error(w, "agentGroupId is required", http.StatusBadRequest)
+		return
+	}
+	view := vaultPolicyView{
+		AgentGroupID:  string(id),
+		DenyByDefault: true,
+		Rules:         []vaultRuleView{},
+	}
+	if p, ok := s.vault.Get(id); ok {
+		view.HasPolicy = true
+		for _, rule := range p.Rules {
+			hosts := append([]string{}, rule.Hosts...)
+			view.Rules = append(view.Rules, vaultRuleView{Credential: rule.Credential, Hosts: hosts})
+		}
+	}
+	writeJSON(w, http.StatusOK, view)
+}

--- a/internal/host/api/vault_test.go
+++ b/internal/host/api/vault_test.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+	"github.com/IronSecCo/ironclaw/internal/host/gateway"
+	"github.com/IronSecCo/ironclaw/internal/host/registry"
+)
+
+// newVaultTestServer returns a Server with a vault store wired and a no-op gateway.
+func newVaultTestServer(t *testing.T) (*Server, *registry.VaultPolicyStore) {
+	t.Helper()
+	gw := gateway.New(gateway.VerifierChain{}, gateway.NewManualApprover(), gateway.NewLogApplier(), gateway.NewMemoryStore())
+	store := registry.NewVaultPolicyStore()
+	s := New(gw).WithVault(store)
+	return s, store
+}
+
+func TestVaultPolicyGet_DenyByDefaultWhenUnconfigured(t *testing.T) {
+	s, _ := newVaultTestServer(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/vault/policy/group-a", nil)
+	s.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var got vaultPolicyView
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.DenyByDefault {
+		t.Errorf("DenyByDefault = false, want true")
+	}
+	if got.HasPolicy {
+		t.Errorf("HasPolicy = true for an unconfigured group, want false")
+	}
+	if len(got.Rules) != 0 {
+		t.Errorf("Rules = %v, want empty", got.Rules)
+	}
+	if got.AgentGroupID != "group-a" {
+		t.Errorf("AgentGroupID = %q, want group-a", got.AgentGroupID)
+	}
+}
+
+func TestVaultPolicyGet_ReflectsApprovedGrants(t *testing.T) {
+	s, store := newVaultTestServer(t)
+	if err := store.Set(registry.VaultPolicy{
+		AgentGroupID: "group-a",
+		Rules:        []registry.VaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}},
+	}); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/vault/policy/group-a", nil)
+	s.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var got vaultPolicyView
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.HasPolicy {
+		t.Errorf("HasPolicy = false, want true")
+	}
+	if len(got.Rules) != 1 || got.Rules[0].Credential != "github" {
+		t.Fatalf("Rules = %+v, want one github rule", got.Rules)
+	}
+	if len(got.Rules[0].Hosts) != 1 || got.Rules[0].Hosts[0] != "api.github.com" {
+		t.Errorf("Hosts = %v, want [api.github.com]", got.Rules[0].Hosts)
+	}
+}
+
+// A read of one group must never leak another group's policy.
+func TestVaultPolicyGet_IsolatedPerGroup(t *testing.T) {
+	s, store := newVaultTestServer(t)
+	_ = store.Set(registry.VaultPolicy{
+		AgentGroupID: "group-a",
+		Rules:        []registry.VaultRule{{Credential: "stripe", Hosts: []string{"api.stripe.com"}}},
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/vault/policy/group-b", nil)
+	s.Handler().ServeHTTP(rr, req)
+
+	var got vaultPolicyView
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if got.HasPolicy || len(got.Rules) != 0 {
+		t.Errorf("group-b leaked group-a policy: %+v", got)
+	}
+}
+
+func TestVaultPolicyGet_DisabledWhenNoStore(t *testing.T) {
+	gw := gateway.New(gateway.VerifierChain{}, gateway.NewManualApprover(), gateway.NewLogApplier(), gateway.NewMemoryStore())
+	s := New(gw) // no WithVault
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/vault/policy/group-a", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rr.Code)
+	}
+}
+
+// Ensure the read model carries no field that could ever hold a secret value — it is
+// credential NAMES + hosts only.
+func TestVaultPolicyView_ShapeHasNoSecretField(t *testing.T) {
+	b, _ := json.Marshal(vaultPolicyView{
+		AgentGroupID:  "g",
+		DenyByDefault: true,
+		HasPolicy:     true,
+		Rules:         []vaultRuleView{{Credential: "github", Hosts: []string{"api.github.com"}}},
+	})
+	var m map[string]any
+	_ = json.Unmarshal(b, &m)
+	for _, banned := range []string{"secret", "key", "token", "value", "password"} {
+		if _, ok := m[banned]; ok {
+			t.Errorf("read model exposes a %q field", banned)
+		}
+	}
+	_ = contract.AgentGroupID("") // keep contract import meaningful
+}

--- a/internal/host/egress/egress.go
+++ b/internal/host/egress/egress.go
@@ -71,7 +71,23 @@ type Broker struct {
 	vault      *Vault      // optional vault:// routing to a host-local injector
 	correlator *Correlator // optional broker<->vault audit correlation
 	redactor   *Redactor   // optional broker->sandbox response redaction
+	guard      VaultGuard  // optional per-group vault policy enforcement (trusted session)
+
+	socksMu sync.Mutex
+	socks   map[string]*sessionSock // per-session sockets (host-trusted session identity)
 }
+
+// VaultGuard authorizes a vault-addressed request for a HOST-TRUSTED session, after
+// Forward has resolved the logical credential name. It returns the upstream host the
+// credential targets (for audit) and whether the session's agent group is granted
+// that credential against that host. Deny-by-default: ok is false on any miss
+// (unknown session, group, credential, host, or un-granted policy).
+//
+// Host-side it closes over the session->group registry plus the gateway-approved
+// VaultPolicyStore (registry.VaultPolicyStore.Allows), so a revoked grant stops
+// working immediately. The session passed in is the one the broker TRUSTS — the
+// per-session socket's fixed identity, never the spoofable X-Ironclaw-Session header.
+type VaultGuard func(session, credential string) (upstreamHost string, ok bool)
 
 // Option configures a Broker at construction.
 type Option func(*Broker)
@@ -126,6 +142,29 @@ func WithResponseRedactor(rd *Redactor) Option {
 	return func(b *Broker) { b.redactor = rd }
 }
 
+// WithVaultGuard enables per-group vault policy enforcement. When set, a vault://
+// request is permitted only over a PER-SESSION socket (SocketForSession) whose
+// identity the host created — never the shared Handler socket, where the session is
+// only the spoofable header — and only after the guard authorizes the trusted
+// session's group for the credential. Deny-by-default: an un-granted or un-wired
+// vault is refused 403. Only meaningful alongside WithVault.
+func WithVaultGuard(g VaultGuard) Option {
+	return func(b *Broker) {
+		if g != nil {
+			b.guard = g
+		}
+	}
+}
+
+// SetVaultGuard wires the vault guard after construction (the policy store and the
+// session registry are typically assembled after the broker). Idempotent; a nil
+// guard is ignored so enforcement is never silently dropped.
+func (b *Broker) SetVaultGuard(g VaultGuard) {
+	if g != nil {
+		b.guard = g
+	}
+}
+
 // sessionHeader is the request header the sandbox may set to attribute an egress
 // call to its session in the audit log. It is advisory (audit only) and never a
 // security control.
@@ -145,6 +184,7 @@ func New(approvedHosts []string, opts ...Option) *Broker {
 		allowed:   m,
 		transport: http.DefaultTransport,
 		identify:  func(r *http.Request) string { return r.Header.Get(sessionHeader) },
+		socks:     map[string]*sessionSock{},
 	}
 	for _, o := range opts {
 		o(b)
@@ -200,95 +240,142 @@ func (b *Broker) Allowed(host string) bool {
 
 // Handler returns the http.Handler that enforces the allowlist and reverse-proxies
 // allowed requests to their upstream over HTTPS. Exported so it can be mounted in
-// tests without a real socket.
+// tests without a real socket. This is the SHARED socket: the session is read from
+// the advisory header, so it is UNTRUSTED — vault enforcement (WithVaultGuard) refuses
+// vault addressing here and only honors it on a per-session socket.
 func (b *Broker) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		start := time.Now()
-		session := b.identify(r)
+		b.serve(w, r, b.identify(r), false)
+	})
+}
 
-		// Vault routing: a vault://<cred>/<path> request is rewritten to the
-		// configured host-local injector — a SEPARATE principal that holds the
-		// credential. Forward injects no secret (it strips Authorization and tags only
-		// the credential NAME); a correlation id joins this hop to the injector's own
-		// audit. After this, the request targets the injector, which is itself subject
-		// to the allowlist below (deny-by-default like any host).
-		var correlationID, vaultCred string
-		if b.vault != nil {
-			scheme := ""
-			if r.URL != nil {
-				scheme = r.URL.Scheme
+// serve enforces vault policy + the allowlist for one request. session is the id the
+// broker attributes the call to; trusted reports whether that id is host-established
+// (a per-session socket) rather than the advisory header. Vault addressing is honored
+// only on a trusted session when a guard is wired (the spoof defense).
+func (b *Broker) serve(w http.ResponseWriter, r *http.Request, session string, trusted bool) {
+	start := time.Now()
+
+	// Vault routing: a vault://<cred>/<path> request is rewritten to the
+	// configured host-local injector — a SEPARATE principal that holds the
+	// credential. Forward injects no secret (it strips Authorization and tags only
+	// the credential NAME); a correlation id joins this hop to the injector's own
+	// audit. After this, the request targets the injector, which is itself subject
+	// to the allowlist below (deny-by-default like any host).
+	var correlationID, vaultCred string
+	if b.vault != nil {
+		scheme := ""
+		if r.URL != nil {
+			scheme = r.URL.Scheme
+		}
+		if IsVaultAddressed(r.Host, scheme) {
+			// Enforcement requires a host-trusted session. On the shared (untrusted)
+			// socket a vault address is refused outright: a compromised sandbox cannot
+			// reach a credential by spoofing X-Ironclaw-Session — vault is reachable
+			// only over the per-session socket whose identity the host created.
+			if b.guard != nil && !trusted {
+				http.Error(w, "egress: vault requires a per-session binding", http.StatusForbidden)
+				b.emitAudit(AuditRecord{
+					Time: start, Session: session, Method: r.Method, Host: hostLabel(r.Host), Path: pathOf(r),
+					Status: http.StatusForbidden, Allowed: false, RequestBytes: r.ContentLength,
+					Duration: time.Since(start),
+				})
+				return
 			}
-			if IsVaultAddressed(r.Host, scheme) {
-				cred, err := b.vault.Forward(r)
-				if err != nil {
-					http.Error(w, "egress: "+err.Error(), http.StatusForbidden)
+			cred, err := b.vault.Forward(r)
+			if err != nil {
+				http.Error(w, "egress: "+err.Error(), http.StatusForbidden)
+				b.emitAudit(AuditRecord{
+					Time: start, Session: session, Method: r.Method, Host: hostLabel(r.Host), Path: pathOf(r),
+					Status: http.StatusForbidden, Allowed: false, RequestBytes: r.ContentLength,
+					Duration: time.Since(start),
+				})
+				return
+			}
+			vaultCred = cred
+			// Per-group policy, keyed on the host-TRUSTED session->group mapping: the
+			// group must be granted this credential against its upstream host. Deny-by-
+			// default — an un-granted credential is refused 403, audited with the cred
+			// NAME (never a key).
+			if b.guard != nil {
+				upstreamHost, ok := b.guard(session, cred)
+				if !ok {
+					http.Error(w, "egress: vault credential not granted for this agent", http.StatusForbidden)
 					b.emitAudit(AuditRecord{
-						Time: start, Session: session, Method: r.Method, Host: hostLabel(r.Host), Path: pathOf(r),
+						Time: start, Session: session, Method: r.Method, Host: vaultHostFallback(upstreamHost, r.Host), Path: pathOf(r),
 						Status: http.StatusForbidden, Allowed: false, RequestBytes: r.ContentLength,
-						Duration: time.Since(start),
+						Duration: time.Since(start), VaultCredential: vaultCred,
 					})
 					return
 				}
-				vaultCred = cred
-				if b.correlator != nil {
-					if id, e := b.correlator.Stamp(r); e == nil {
-						correlationID = id
-					}
+			}
+			if b.correlator != nil {
+				if id, e := b.correlator.Stamp(r); e == nil {
+					correlationID = id
 				}
 			}
 		}
+	}
 
-		host := r.Host
-		if r.URL != nil && r.URL.Host != "" {
-			host = r.URL.Host
-		}
-		path := pathOf(r)
+	host := r.Host
+	if r.URL != nil && r.URL.Host != "" {
+		host = r.URL.Host
+	}
+	path := pathOf(r)
 
-		if !b.Allowed(host) {
-			http.Error(w, "egress: destination not on allowlist", http.StatusForbidden)
-			b.emitAudit(AuditRecord{
-				Time: start, Session: session, Method: r.Method, Host: host, Path: path,
-				Status: http.StatusForbidden, Allowed: false, RequestBytes: r.ContentLength,
-				Duration: time.Since(start), CorrelationID: correlationID, VaultCredential: vaultCred,
-			})
-			return
-		}
-
-		// Upstream target: external hosts are dialed over HTTPS with the port implied
-		// (the allowlist is bare-host). The host-local vault injector keeps the exact
-		// scheme AND host:port Forward set on it (it may be plain http on a loopback
-		// port).
-		scheme, targetHost := "https", hostOnly(host)
-		if vaultCred != "" && r.URL != nil {
-			scheme, targetHost = r.URL.Scheme, r.URL.Host
-		}
-		target := &url.URL{Scheme: scheme, Host: targetHost}
-		rp := &httputil.ReverseProxy{
-			Director: func(req *http.Request) {
-				req.URL.Scheme = target.Scheme
-				req.URL.Host = target.Host
-				req.Host = target.Host
-				// The audit-only session header is host-internal; never forward it
-				// to the external API.
-				req.Header.Del(sessionHeader)
-			},
-			Transport: b.transport,
-		}
-		if b.redactor != nil {
-			// Scrub configured secrets + credential headers from the response before
-			// it reaches the sandbox.
-			rp.ModifyResponse = b.redactor.Redact
-		}
-
-		rec := &countingRW{ResponseWriter: w}
-		rp.ServeHTTP(rec, r)
+	if !b.Allowed(host) {
+		http.Error(w, "egress: destination not on allowlist", http.StatusForbidden)
 		b.emitAudit(AuditRecord{
 			Time: start, Session: session, Method: r.Method, Host: host, Path: path,
-			Status: rec.status, Allowed: true, RequestBytes: r.ContentLength,
-			ResponseBytes: rec.n, Duration: time.Since(start),
-			CorrelationID: correlationID, VaultCredential: vaultCred,
+			Status: http.StatusForbidden, Allowed: false, RequestBytes: r.ContentLength,
+			Duration: time.Since(start), CorrelationID: correlationID, VaultCredential: vaultCred,
 		})
+		return
+	}
+
+	// Upstream target: external hosts are dialed over HTTPS with the port implied
+	// (the allowlist is bare-host). The host-local vault injector keeps the exact
+	// scheme AND host:port Forward set on it (it may be plain http on a loopback
+	// port).
+	scheme, targetHost := "https", hostOnly(host)
+	if vaultCred != "" && r.URL != nil {
+		scheme, targetHost = r.URL.Scheme, r.URL.Host
+	}
+	target := &url.URL{Scheme: scheme, Host: targetHost}
+	rp := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			req.Host = target.Host
+			// The audit-only session header is host-internal; never forward it
+			// to the external API.
+			req.Header.Del(sessionHeader)
+		},
+		Transport: b.transport,
+	}
+	if b.redactor != nil {
+		// Scrub configured secrets + credential headers from the response before
+		// it reaches the sandbox.
+		rp.ModifyResponse = b.redactor.Redact
+	}
+
+	rec := &countingRW{ResponseWriter: w}
+	rp.ServeHTTP(rec, r)
+	b.emitAudit(AuditRecord{
+		Time: start, Session: session, Method: r.Method, Host: host, Path: path,
+		Status: rec.status, Allowed: true, RequestBytes: r.ContentLength,
+		ResponseBytes: rec.n, Duration: time.Since(start),
+		CorrelationID: correlationID, VaultCredential: vaultCred,
 	})
+}
+
+// vaultHostFallback returns the upstream host for audit on a vault denial: the guard's
+// resolved host when known, else the request's labelled host (e.g. "vault").
+func vaultHostFallback(upstreamHost, reqHost string) string {
+	if upstreamHost != "" {
+		return upstreamHost
+	}
+	return hostLabel(reqHost)
 }
 
 // pathOf safely reads the request path.

--- a/internal/host/egress/session.go
+++ b/internal/host/egress/session.go
@@ -1,0 +1,105 @@
+package egress
+
+// Per-session egress sockets. The egress broker serves a SHARED socket for ordinary
+// allowlist traffic, but vault enforcement needs a session identity the broker can
+// TRUST. Mirroring internal/host/mcp.Broker.SocketForSession, the broker serves a
+// distinct unix socket per session whose handler fixes the session id to the one the
+// host established at launch — not the spoofable X-Ironclaw-Session header. A request
+// arriving on that socket is attributed to that session no matter what header it sets,
+// so a compromised sandbox cannot borrow another group's vault grants.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// sessionSock is a per-session serving socket and its listener.
+type sessionSock struct {
+	path string
+	ln   net.Listener
+	srv  *http.Server
+}
+
+// SocketForSession creates (idempotently) and serves a per-session unix socket under
+// dir and returns its path, for the launch layer to bind into that one sandbox. The
+// socket serves the allowlist + vault handler with the session id FIXED to session, so
+// the broker trusts that identity for vault policy regardless of any request header.
+func (b *Broker) SocketForSession(session, dir string) (string, error) {
+	if session == "" {
+		return "", errors.New("host/egress: SocketForSession needs a session id")
+	}
+	b.socksMu.Lock()
+	defer b.socksMu.Unlock()
+	if s, ok := b.socks[session]; ok {
+		return s.path, nil
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("host/egress: socket dir: %w", err)
+	}
+	path := sessionSocketPath(dir, session)
+	_ = os.Remove(path)
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		return "", fmt.Errorf("host/egress: listen %s: %w", path, err)
+	}
+	srv := &http.Server{Handler: b.sessionHandler(session)}
+	go func() { _ = srv.Serve(ln) }()
+	b.socks[session] = &sessionSock{path: path, ln: ln, srv: srv}
+	return path, nil
+}
+
+// CloseSession stops serving and removes a session's socket (idempotent).
+func (b *Broker) CloseSession(session string) {
+	b.socksMu.Lock()
+	s := b.socks[session]
+	delete(b.socks, session)
+	b.socksMu.Unlock()
+	if s != nil {
+		shutdownSessionSock(s)
+	}
+}
+
+// CloseSessions stops every per-session socket (best-effort). The shared Serve socket
+// is governed by its own ctx; this only tears down the per-session ones.
+func (b *Broker) CloseSessions() {
+	b.socksMu.Lock()
+	socks := b.socks
+	b.socks = map[string]*sessionSock{}
+	b.socksMu.Unlock()
+	for _, s := range socks {
+		shutdownSessionSock(s)
+	}
+}
+
+// sessionHandler serves the allowlist + vault handler for one fixed, host-trusted
+// session id.
+func (b *Broker) sessionHandler(session string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b.serve(w, r, session, true)
+	})
+}
+
+func shutdownSessionSock(s *sessionSock) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_ = s.srv.Shutdown(ctx)
+	_ = os.Remove(s.path)
+}
+
+// sessionSocketPath builds a filesystem-safe, short per-session socket path (the unix
+// socket path length is bounded ~104 bytes), mirroring the MCP broker.
+func sessionSocketPath(dir, session string) string {
+	safe := strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			return r
+		}
+		return '-'
+	}, session)
+	return dir + "/egress-" + safe + ".sock"
+}

--- a/internal/host/egress/vault_enforcement_test.go
+++ b/internal/host/egress/vault_enforcement_test.go
@@ -1,0 +1,205 @@
+package egress
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/host/vaultinjector"
+)
+
+// mustHost returns the bare host (no port) of a URL, for asserting the upstream the
+// vault policy is enforced against.
+func mustHost(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return u.Hostname()
+}
+
+// buildVaultStack wires a real upstream + the reference injector + a policy-enforcing
+// broker, returning the broker, the injector endpoint host, the upstream host, and a
+// pointer to the last Authorization the upstream observed.
+func buildVaultStack(t *testing.T, secret string, guard VaultGuard) (*Broker, string, *string, *[]AuditRecord) {
+	t.Helper()
+
+	gotUpstreamAuth := new(string)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*gotUpstreamAuth = r.Header.Get("Authorization")
+		if r.Header.Get("Authorization") != "Bearer "+secret {
+			http.Error(w, "upstream: bad credential", http.StatusUnauthorized)
+			return
+		}
+		_, _ = io.WriteString(w, "ok from upstream; secret was "+secret)
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamHost := mustHost(t, upstream.URL)
+
+	cfg := &vaultinjector.Config{Creds: map[string]vaultinjector.CredSpec{
+		"github": {Upstream: upstream.URL, SecretEnv: "VAULT_GITHUB_TOKEN"},
+	}}
+	inj, err := vaultinjector.New(cfg, func(string) (string, bool) { return secret, true })
+	if err != nil {
+		t.Fatalf("vaultinjector.New: %v", err)
+	}
+	injector := httptest.NewServer(inj.Handler())
+	t.Cleanup(injector.Close)
+
+	vault, err := NewVault(injector.URL)
+	if err != nil {
+		t.Fatalf("NewVault: %v", err)
+	}
+	audits := new([]AuditRecord)
+	b := New(nil,
+		WithVault(vault),
+		WithVaultGuard(guard),
+		WithCorrelator(NewCorrelator()),
+		WithResponseRedactor(NewRedactor(secret)),
+		WithAudit(func(rec AuditRecord) { *audits = append(*audits, rec) }),
+	)
+	b.Allow(vault.Endpoint())
+	_ = upstreamHost
+	return b, vault.Endpoint(), gotUpstreamAuth, audits
+}
+
+// TestVaultGrantedResolvesEndToEnd: a gateway-approved policy lets a TRUSTED session
+// reach a credential end-to-end through the broker -> injector -> upstream, the agent
+// never holding a key, and the secret never echoing back.
+func TestVaultGrantedResolvesEndToEnd(t *testing.T) {
+	const secret = "real-upstream-secret"
+	guard := func(session, cred string) (string, bool) {
+		return "api.example.test", session == "s1" && cred == "github"
+	}
+	b, _, gotUpstreamAuth, audits := buildVaultStack(t, secret, guard)
+
+	// Per-session socket for s1: the broker TRUSTS the socket identity. The request
+	// even forges the advisory header to another session — it must be ignored.
+	h := b.sessionHandler("s1")
+	req := httptest.NewRequest(http.MethodGet, "http://vault/github/repos/acme", nil)
+	req.Host = "vault"
+	req.Header.Set(sessionHeader, "s2-attacker")
+	req.Header.Set("Authorization", "Bearer sandbox-forged")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	// The upstream saw the host-injected real credential, NOT the sandbox's forged one.
+	if *gotUpstreamAuth != "Bearer "+secret {
+		t.Errorf("upstream Authorization = %q, want host-injected %q", *gotUpstreamAuth, "Bearer "+secret)
+	}
+	// Response redaction: the secret never reaches the sandbox even if reflected.
+	if body := rec.Body.String(); strings.Contains(body, secret) {
+		t.Errorf("secret leaked to sandbox: %q", body)
+	}
+	// Audit records the use with the credential NAME + a correlation id, allowed.
+	last := (*audits)[len(*audits)-1]
+	if last.VaultCredential != "github" || last.CorrelationID == "" || !last.Allowed {
+		t.Fatalf("audit not correlated/allowed: %+v", last)
+	}
+}
+
+// TestVaultDenyByDefaultUngrantedSession: a TRUSTED session whose group has no grant
+// for the credential is refused 403 — deny-by-default — and the upstream is never hit.
+func TestVaultDenyByDefaultUngrantedSession(t *testing.T) {
+	const secret = "real-upstream-secret"
+	guard := func(session, cred string) (string, bool) {
+		return "api.example.test", session == "s1" && cred == "github" // s2 granted nothing
+	}
+	b, _, gotUpstreamAuth, audits := buildVaultStack(t, secret, guard)
+
+	h := b.sessionHandler("s2") // un-granted group
+	req := httptest.NewRequest(http.MethodGet, "http://vault/github/repos/acme", nil)
+	req.Host = "vault"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (deny-by-default)", rec.Code)
+	}
+	if *gotUpstreamAuth != "" {
+		t.Errorf("upstream was reached on a denied request (auth=%q)", *gotUpstreamAuth)
+	}
+	last := (*audits)[len(*audits)-1]
+	if last.Allowed || last.VaultCredential != "github" {
+		t.Fatalf("denied audit must record the cred name and not-allowed: %+v", last)
+	}
+}
+
+// TestVaultSpoofedSessionCannotEscalate: a compromised sandbox on an UN-granted
+// per-session socket cannot borrow a granted group's credential by forging the
+// X-Ironclaw-Session header — the broker keys policy on the socket identity, not the
+// header.
+func TestVaultSpoofedSessionCannotEscalate(t *testing.T) {
+	const secret = "real-upstream-secret"
+	guard := func(session, cred string) (string, bool) {
+		return "api.example.test", session == "granted" && cred == "github"
+	}
+	b, _, gotUpstreamAuth, _ := buildVaultStack(t, secret, guard)
+
+	// Socket bound for the un-granted "victimless" session; the request forges the
+	// header of the granted session.
+	h := b.sessionHandler("attacker")
+	req := httptest.NewRequest(http.MethodGet, "http://vault/github/repos/acme", nil)
+	req.Host = "vault"
+	req.Header.Set(sessionHeader, "granted") // spoof the granted session id
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 — spoofed session must not escalate", rec.Code)
+	}
+	if *gotUpstreamAuth != "" {
+		t.Errorf("upstream reached via spoofed session (auth=%q)", *gotUpstreamAuth)
+	}
+}
+
+// TestVaultRefusedOnSharedUntrustedSocket: with enforcement wired, the shared Handler
+// socket (session only from the spoofable header) refuses vault addressing entirely —
+// a credential is reachable only over a host-created per-session socket.
+func TestVaultRefusedOnSharedUntrustedSocket(t *testing.T) {
+	const secret = "real-upstream-secret"
+	guard := func(session, cred string) (string, bool) {
+		return "api.example.test", true // would allow if it ran — but it must not
+	}
+	b, _, gotUpstreamAuth, _ := buildVaultStack(t, secret, guard)
+
+	req := httptest.NewRequest(http.MethodGet, "http://vault/github/repos/acme", nil)
+	req.Host = "vault"
+	req.Header.Set(sessionHeader, "anything")
+	rec := httptest.NewRecorder()
+	b.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 — vault must not be served on the shared socket", rec.Code)
+	}
+	if *gotUpstreamAuth != "" {
+		t.Errorf("upstream reached over the untrusted shared socket (auth=%q)", *gotUpstreamAuth)
+	}
+}
+
+// TestVaultUngrantedCredentialRefused: even a trusted, otherwise-granted session is
+// refused a credential its group is not granted (per-credential deny-by-default).
+func TestVaultUngrantedCredentialRefused(t *testing.T) {
+	const secret = "real-upstream-secret"
+	guard := func(session, cred string) (string, bool) {
+		return "api.example.test", session == "s1" && cred == "github" // only github
+	}
+	b, _, _, _ := buildVaultStack(t, secret, guard)
+
+	h := b.sessionHandler("s1")
+	req := httptest.NewRequest(http.MethodGet, "http://vault/gitlab/projects", nil)
+	req.Host = "vault"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for an un-granted credential", rec.Code)
+	}
+}

--- a/internal/host/gateway/vault_policy_applier.go
+++ b/internal/host/gateway/vault_policy_applier.go
@@ -1,0 +1,157 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+)
+
+// Vault-policy gateway integration. "Which agent group may use which credential
+// against which host" (threat-model §11) is host-side authorization CONFIG, never a
+// secret — every rule names a credential, never holds one. A policy change is a
+// capability change like any other: it rides the gateway's mandatory human-approval
+// floor and is materialized only after a human approves it.
+//
+// The change carries a vaultPolicy payload on an existing permissions-class change
+// (no frozen-contract edit): the After body names the per-group rules and the target
+// group is taken from the trusted ChangeRequest.AgentGroupID — never the payload — so
+// a change can only ever set policy for the group it is submitted against. The
+// applier records the approved policy in the host-side VaultPolicyStore (read-only to
+// the sandbox); the broker/injector consult that store before a credential is used.
+
+// VaultRule is the gateway-local shape of one approved grant: a logical credential
+// NAME (never a key) and the bare upstream hosts it may be used against. It mirrors
+// registry.VaultRule but is defined here so the gateway stays decoupled from the
+// registry package (the EgressApplier/Allower pattern).
+type VaultRule struct {
+	Credential string   `json:"credential"`
+	Hosts      []string `json:"hosts"`
+}
+
+// SetVaultPolicyFunc records an approved per-group vault policy host-side. Satisfied
+// by registry.VaultPolicyStore.Set via a small adapter in cmd/controlplane; a seam so
+// the gateway does not depend on the registry package.
+type SetVaultPolicyFunc func(id contract.AgentGroupID, rules []VaultRule) error
+
+// vaultPolicyPayload is the vault portion of a change's After body. A change with no
+// vaultPolicy field is not a vault-policy change and passes through untouched.
+type vaultPolicyPayload struct {
+	VaultPolicy *struct {
+		Rules []VaultRule `json:"rules"`
+	} `json:"vaultPolicy"`
+}
+
+// VaultPolicyApplier materializes an approved vault-policy change by recording the
+// per-group rules in the host-side store, so subsequent vaulted calls are authorized
+// deny-by-default against exactly the approved (credential, host) pairs. It is
+// kind-agnostic (it keys off the payload, like EgressApplier): any approved change
+// carrying a vaultPolicy body sets that group's policy; every other payload and kind
+// passes through to next unchanged.
+type VaultPolicyApplier struct {
+	set  SetVaultPolicyFunc
+	next contract.Applier
+}
+
+// NewVaultPolicyApplier wraps next. set may be nil (a recognized vault-policy change
+// then errors rather than silently dropping the grant); next may be nil.
+func NewVaultPolicyApplier(set SetVaultPolicyFunc, next contract.Applier) *VaultPolicyApplier {
+	return &VaultPolicyApplier{set: set, next: next}
+}
+
+// Apply records an approved vault policy, then delegates. The gateway only invokes
+// Apply for approved changes, so reaching here means a human granted the policy.
+func (a *VaultPolicyApplier) Apply(ctx context.Context, req contract.ChangeRequest, d contract.Decision) error {
+	if len(req.After) > 0 {
+		var p vaultPolicyPayload
+		// Best-effort: a payload with no "vaultPolicy" field simply yields none.
+		if err := json.Unmarshal(req.After, &p); err == nil && p.VaultPolicy != nil {
+			if a.set == nil {
+				return fmt.Errorf("vault policy apply: no policy setter wired")
+			}
+			if strings.TrimSpace(string(req.AgentGroupID)) == "" {
+				return fmt.Errorf("vault policy apply: change has no agent group id")
+			}
+			if err := a.set(req.AgentGroupID, p.VaultPolicy.Rules); err != nil {
+				return fmt.Errorf("vault policy apply: %w", err)
+			}
+		}
+	}
+	if a.next != nil {
+		return a.next.Apply(ctx, req, d)
+	}
+	return nil
+}
+
+// VaultPolicyVerifier rejects a malformed vault-policy change before it ever reaches a
+// human, and marks a well-formed one as requiring human approval (a credential grant
+// is privileged — it is never auto-approved). It is deterministic (a pure shape check,
+// no I/O) and additive like every verifier: a change with no vaultPolicy body passes
+// through untouched. The authoritative normalization/validation still happens at apply
+// time in registry.VaultPolicyStore.Set; this is the pre-approval guard so obvious
+// mistakes or injection attempts are refused without bothering a human.
+type VaultPolicyVerifier struct{}
+
+// Name identifies the verifier.
+func (VaultPolicyVerifier) Name() string { return "vault-policy" }
+
+// Verify checks a vault-policy change's shape. Non-vault changes pass through.
+func (VaultPolicyVerifier) Verify(ctx context.Context, req contract.ChangeRequest) (contract.Verdict, string, error) {
+	if len(req.After) == 0 {
+		return contract.VerdictPass, "", nil
+	}
+	var p vaultPolicyPayload
+	if err := json.Unmarshal(req.After, &p); err != nil || p.VaultPolicy == nil {
+		// Not a vault-policy change (or an unrelated payload); nothing to say.
+		return contract.VerdictPass, "", nil
+	}
+	if strings.TrimSpace(string(req.AgentGroupID)) == "" {
+		return contract.VerdictReject, "vault_policy change must target an agent group", nil
+	}
+	for _, r := range p.VaultPolicy.Rules {
+		if !validVaultCredName(r.Credential) {
+			return contract.VerdictReject, fmt.Sprintf("invalid vault credential name %q", r.Credential), nil
+		}
+		if len(r.Hosts) == 0 {
+			return contract.VerdictReject, fmt.Sprintf("vault credential %q must grant at least one host", r.Credential), nil
+		}
+		for _, h := range r.Hosts {
+			if !validVaultHostName(h) {
+				return contract.VerdictReject, fmt.Sprintf("invalid vault host %q for credential %q", h, r.Credential), nil
+			}
+		}
+	}
+	return contract.VerdictRequireHuman, "vault policy grant requires human approval", nil
+}
+
+// validVaultCredName mirrors the egress broker / registry credential-name rule: a
+// non-empty logical label (letters, digits, -, _, .) with no path traversal.
+func validVaultCredName(s string) bool {
+	if s == "" || len(s) > 128 || s == "." || s == ".." || strings.Contains(s, "..") {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		ok := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.'
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// validVaultHostName accepts a bare hostname only: no scheme, port, path, or wildcard.
+// The authoritative DNS-label check is registry.validVaultHost at apply time; this is
+// a cheap pre-approval reject of the obviously-wrong (scheme/wildcard/port/space).
+func validVaultHostName(h string) bool {
+	if h == "" || len(h) > 253 {
+		return false
+	}
+	if strings.ContainsAny(h, "*/:\\?#@ \t") {
+		return false
+	}
+	return true
+}

--- a/internal/host/gateway/vault_policy_applier_test.go
+++ b/internal/host/gateway/vault_policy_applier_test.go
@@ -1,0 +1,161 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+)
+
+func vaultAfter(t *testing.T, rules []VaultRule) json.RawMessage {
+	t.Helper()
+	body := map[string]any{"vaultPolicy": map[string]any{"rules": rules}}
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+func TestVaultPolicyApplierRecordsApprovedGrant(t *testing.T) {
+	var gotID contract.AgentGroupID
+	var gotRules []VaultRule
+	called := 0
+	set := func(id contract.AgentGroupID, rules []VaultRule) error {
+		called++
+		gotID = id
+		gotRules = rules
+		return nil
+	}
+	a := NewVaultPolicyApplier(set, nil)
+	req := contract.ChangeRequest{
+		Kind:         contract.ChangePermissions,
+		AgentGroupID: "grp-1",
+		After:        vaultAfter(t, []VaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}),
+	}
+	if err := a.Apply(context.Background(), req, contract.Decision{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("setter called %d times, want 1", called)
+	}
+	if gotID != "grp-1" {
+		t.Fatalf("group id = %q, want grp-1 (must come from req, not payload)", gotID)
+	}
+	if len(gotRules) != 1 || gotRules[0].Credential != "github" || len(gotRules[0].Hosts) != 1 {
+		t.Fatalf("rules = %+v, want one github rule", gotRules)
+	}
+}
+
+func TestVaultPolicyApplierPassesThroughNonVaultPayload(t *testing.T) {
+	called := 0
+	set := func(contract.AgentGroupID, []VaultRule) error { called++; return nil }
+	a := NewVaultPolicyApplier(set, nil)
+	// A payload with no vaultPolicy field is not a vault change.
+	req := contract.ChangeRequest{
+		Kind:         contract.ChangeMCPAccess,
+		AgentGroupID: "grp-1",
+		After:        json.RawMessage(`{"server":"weather","tools":["forecast"]}`),
+	}
+	if err := a.Apply(context.Background(), req, contract.Decision{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if called != 0 {
+		t.Fatalf("setter called %d times for a non-vault payload, want 0", called)
+	}
+}
+
+func TestVaultPolicyApplierErrorsWhenSetterMissing(t *testing.T) {
+	a := NewVaultPolicyApplier(nil, nil)
+	req := contract.ChangeRequest{
+		Kind:         contract.ChangePermissions,
+		AgentGroupID: "grp-1",
+		After:        vaultAfter(t, []VaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}),
+	}
+	if err := a.Apply(context.Background(), req, contract.Decision{}); err == nil {
+		t.Fatal("expected error when a recognized vault change has no setter, got nil")
+	}
+}
+
+func TestVaultPolicyApplierErrorsWhenNoGroup(t *testing.T) {
+	set := func(contract.AgentGroupID, []VaultRule) error { return nil }
+	a := NewVaultPolicyApplier(set, nil)
+	req := contract.ChangeRequest{
+		Kind:  contract.ChangePermissions,
+		After: vaultAfter(t, []VaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}}),
+	}
+	if err := a.Apply(context.Background(), req, contract.Decision{}); err == nil {
+		t.Fatal("expected error when a vault change has no agent group id, got nil")
+	}
+}
+
+func TestVaultPolicyVerifierRequiresHumanForValidGrant(t *testing.T) {
+	v := VaultPolicyVerifier{}
+	req := contract.ChangeRequest{
+		AgentGroupID: "grp-1",
+		After:        vaultAfter(t, []VaultRule{{Credential: "github", Hosts: []string{"api.github.com", "uploads.github.com"}}}),
+	}
+	verdict, _, err := v.Verify(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if verdict != contract.VerdictRequireHuman {
+		t.Fatalf("verdict = %v, want RequireHuman", verdict)
+	}
+}
+
+func TestVaultPolicyVerifierPassesNonVaultChange(t *testing.T) {
+	v := VaultPolicyVerifier{}
+	req := contract.ChangeRequest{
+		AgentGroupID: "grp-1",
+		After:        json.RawMessage(`{"persona":"helpful"}`),
+	}
+	verdict, _, err := v.Verify(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if verdict != contract.VerdictPass {
+		t.Fatalf("verdict = %v, want Pass for a non-vault change", verdict)
+	}
+}
+
+func TestVaultPolicyVerifierRejectsMalformed(t *testing.T) {
+	v := VaultPolicyVerifier{}
+	cases := []struct {
+		name  string
+		rules []VaultRule
+		group contract.AgentGroupID
+	}{
+		{"bad cred traversal", []VaultRule{{Credential: "../etc", Hosts: []string{"api.github.com"}}}, "grp-1"},
+		{"empty cred", []VaultRule{{Credential: "", Hosts: []string{"api.github.com"}}}, "grp-1"},
+		{"no hosts", []VaultRule{{Credential: "github", Hosts: nil}}, "grp-1"},
+		{"host with scheme", []VaultRule{{Credential: "github", Hosts: []string{"https://api.github.com"}}}, "grp-1"},
+		{"host with wildcard", []VaultRule{{Credential: "github", Hosts: []string{"*.github.com"}}}, "grp-1"},
+		{"host with port", []VaultRule{{Credential: "github", Hosts: []string{"api.github.com:443"}}}, "grp-1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := contract.ChangeRequest{AgentGroupID: tc.group, After: vaultAfter(t, tc.rules)}
+			verdict, reason, err := v.Verify(context.Background(), req)
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if verdict != contract.VerdictReject {
+				t.Fatalf("verdict = %v (reason %q), want Reject", verdict, reason)
+			}
+		})
+	}
+}
+
+func TestVaultPolicyVerifierRejectsMissingGroup(t *testing.T) {
+	v := VaultPolicyVerifier{}
+	req := contract.ChangeRequest{After: vaultAfter(t, []VaultRule{{Credential: "github", Hosts: []string{"api.github.com"}}})}
+	verdict, _, err := v.Verify(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if verdict != contract.VerdictReject {
+		t.Fatalf("verdict = %v, want Reject when group id is missing", verdict)
+	}
+}

--- a/internal/host/keys/derive_test.go
+++ b/internal/host/keys/derive_test.go
@@ -1,0 +1,34 @@
+package keys
+
+import "testing"
+
+func TestDeriveSubKeyStableAndDomainSeparated(t *testing.T) {
+	var master [32]byte
+	for i := range master {
+		master[i] = byte(i)
+	}
+
+	a1 := DeriveSubKey(master, "ironclaw/vault-policy-db/v1")
+	a2 := DeriveSubKey(master, "ironclaw/vault-policy-db/v1")
+	if a1 != a2 {
+		t.Fatal("same master + purpose must derive the same key (stable across restarts)")
+	}
+
+	b := DeriveSubKey(master, "ironclaw/registry-db/v1")
+	if a1 == b {
+		t.Fatal("a different purpose must derive an unrelated key (domain separation)")
+	}
+
+	var other [32]byte
+	for i := range other {
+		other[i] = byte(255 - i)
+	}
+	if DeriveSubKey(other, "ironclaw/vault-policy-db/v1") == a1 {
+		t.Fatal("a different master must derive a different key")
+	}
+
+	// The derived key must never be the raw master.
+	if a1 == master {
+		t.Fatal("derived key must not equal the raw master key")
+	}
+}

--- a/internal/host/keys/source.go
+++ b/internal/host/keys/source.go
@@ -1,7 +1,9 @@
 package keys
 
 import (
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +11,21 @@ import (
 	"path/filepath"
 	"sync"
 )
+
+// DeriveSubKey deterministically derives a 32-byte host-internal subkey from the
+// master key for a named purpose, via HMAC-SHA256(master, purpose). It gives each
+// host-internal encrypted store (e.g. the durable vault-policy DB, a future
+// durable registry DB) its own stable, domain-separated key without ever reusing
+// the raw master or a per-session key as a database key. The result is stable
+// across restarts for a fixed master, and a distinct purpose yields an unrelated
+// key. The returned key is a secret: never log it.
+func DeriveSubKey(master [32]byte, purpose string) [32]byte {
+	mac := hmac.New(sha256.New, master[:])
+	mac.Write([]byte(purpose))
+	var out [32]byte
+	copy(out[:], mac.Sum(nil))
+	return out
+}
 
 // KeySource supplies the 32-byte host master key under which the session
 // keystore is sealed. It is the pluggable seam between an ephemeral in-process

--- a/internal/host/registry/vaultpolicy_durable.go
+++ b/internal/host/registry/vaultpolicy_durable.go
@@ -1,0 +1,167 @@
+package registry
+
+// DurableVaultPolicyStore persists per-group vault policy across a control-plane
+// restart. Like SQLRegistry it is host-internal — the sandbox never sees the
+// policy store — so it is NOT bound by the frozen queue contract and owns its own
+// SQLCipher database and schema.
+//
+// Design mirrors durable.go: an in-memory VaultPolicyStore is the working set and
+// the single source of truth for reads (Allows/Get), so the deny-by-default
+// decision logic and validation are reused verbatim and stay exercised by the
+// existing vaultpolicy_test.go. Every mutation is mirrored write-through to the
+// encrypted DB as a single-row upsert/delete, and the whole policy set is reloaded
+// into a fresh in-memory store on Open.
+//
+// Durability is write-through best-effort: the in-memory mutation is applied first
+// (it validates and normalizes), then persisted. If the persist fails the call
+// returns the error; the in-memory state is momentarily ahead of disk and the lost
+// change is simply absent after a restart (the DB is authoritative on reload).
+
+import (
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	_ "github.com/mutecomm/go-sqlcipher/v4" // registers the "sqlite3" SQLCipher driver
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+)
+
+// vaultPolicySchema is the host-internal DDL for the durable policy store. One row
+// per agent group holds that group's normalized rules as JSON; a group with no row
+// is denied everything (deny-by-default), exactly as an empty in-memory store.
+const vaultPolicySchema = `
+CREATE TABLE IF NOT EXISTS vault_policies (
+    agent_group_id TEXT PRIMARY KEY,
+    rules_json     TEXT NOT NULL
+);
+`
+
+// DurableVaultPolicyStore is a VaultPolicyStore backed by an encrypted SQLCipher
+// database. Reads (Allows/Get) answer from the in-memory working set; mutations
+// (Set/Delete) write through to disk.
+type DurableVaultPolicyStore struct {
+	mem *VaultPolicyStore
+	db  *sql.DB
+}
+
+// OpenDurableVaultPolicyStore opens (creating if absent) the encrypted vault-policy
+// database at path, keyed by key, and loads its contents into the working set.
+// Opening with the wrong key fails (SQLITE_NOTADB on the forced page read) rather
+// than silently returning an empty — i.e. fully-permissive-by-omission — store. The
+// key is a secret derived from the host master (see keys.DeriveSubKey); never log
+// it.
+func OpenDurableVaultPolicyStore(path string, key [32]byte) (*DurableVaultPolicyStore, error) {
+	q := url.Values{}
+	// Raw-key mode (no KDF) via the DSN so every pooled connection is keyed before
+	// any page is read.
+	q.Set("_pragma_key", `x'`+hex.EncodeToString(key[:])+`'`)
+	q.Set("_busy_timeout", "5000")
+	dsn := "file:" + path + "?" + q.Encode()
+
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("host/registry: open %q: %w", path, err)
+	}
+	// Host-local single writer; one connection keeps writes serialized and avoids
+	// multiple keyed handles racing on the file.
+	db.SetMaxOpenConns(1)
+	// Force a real page read so a wrong key fails here rather than at first query.
+	if _, err := db.Exec("SELECT count(*) FROM sqlite_master;"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("host/registry: open encrypted vault-policy db %q (wrong key?): %w", path, err)
+	}
+	if _, err := db.Exec(vaultPolicySchema); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("host/registry: apply vault-policy schema: %w", err)
+	}
+
+	s := &DurableVaultPolicyStore{mem: NewVaultPolicyStore(), db: db}
+	if err := s.load(); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return s, nil
+}
+
+// load hydrates the in-memory working set from the encrypted DB. A row that fails
+// validation (e.g. a corrupt or tampered policy) fails the open rather than being
+// silently dropped or admitted — fail-closed for an authorization store.
+func (s *DurableVaultPolicyStore) load() error {
+	rows, err := s.db.Query(`SELECT agent_group_id, rules_json FROM vault_policies`)
+	if err != nil {
+		return fmt.Errorf("host/registry: load vault policies: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, rj string
+		if err := rows.Scan(&id, &rj); err != nil {
+			return fmt.Errorf("host/registry: scan vault policy: %w", err)
+		}
+		var rules []VaultRule
+		if err := json.Unmarshal([]byte(rj), &rules); err != nil {
+			return fmt.Errorf("host/registry: decode vault policy for %q: %w", id, err)
+		}
+		// Re-validate and normalize through the in-memory store so a tampered or
+		// stale row cannot install a malformed (and thus unevaluable) rule set.
+		if err := s.mem.Set(VaultPolicy{AgentGroupID: contract.AgentGroupID(id), Rules: rules}); err != nil {
+			return fmt.Errorf("host/registry: invalid persisted vault policy for %q: %w", id, err)
+		}
+	}
+	return rows.Err()
+}
+
+// Set installs or replaces a group's policy: validate+normalize in memory first,
+// then persist the normalized form as a single-row upsert. Call site: the gateway
+// apply step for an approved vault-policy change.
+func (s *DurableVaultPolicyStore) Set(p VaultPolicy) error {
+	if err := s.mem.Set(p); err != nil {
+		return err
+	}
+	// Persist exactly what the in-memory store holds (normalized), so a reload
+	// reconstructs the identical decision.
+	norm, _ := s.mem.Get(p.AgentGroupID)
+	blob, err := json.Marshal(norm.Rules)
+	if err != nil {
+		return fmt.Errorf("host/registry: encode vault policy for %q: %w", p.AgentGroupID, err)
+	}
+	if _, err := s.db.Exec(`
+		INSERT INTO vault_policies (agent_group_id, rules_json) VALUES (?,?)
+		ON CONFLICT(agent_group_id) DO UPDATE SET rules_json=excluded.rules_json`,
+		string(p.AgentGroupID), string(blob)); err != nil {
+		return fmt.Errorf("host/registry: persist vault policy for %q: %w", p.AgentGroupID, err)
+	}
+	return nil
+}
+
+// Delete removes a group's policy in memory and on disk (idempotent). Unlike the
+// in-memory store's Delete it returns the persistence error so a failed write-
+// through is not silently swallowed. Gateway-apply only.
+func (s *DurableVaultPolicyStore) Delete(group contract.AgentGroupID) error {
+	s.mem.Delete(group)
+	if _, err := s.db.Exec(`DELETE FROM vault_policies WHERE agent_group_id=?`, string(group)); err != nil {
+		return fmt.Errorf("host/registry: delete vault policy for %q: %w", group, err)
+	}
+	return nil
+}
+
+// Get returns a group's stored (normalized) policy from the working set.
+func (s *DurableVaultPolicyStore) Get(group contract.AgentGroupID) (VaultPolicy, bool) {
+	return s.mem.Get(group)
+}
+
+// Allows answers the deny-by-default authorization decision from the working set,
+// identically to the in-memory store.
+func (s *DurableVaultPolicyStore) Allows(group contract.AgentGroupID, credential, host string) bool {
+	return s.mem.Allows(group, credential, host)
+}
+
+// Close closes the underlying database handle.
+func (s *DurableVaultPolicyStore) Close() error {
+	if s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}

--- a/internal/host/registry/vaultpolicy_durable_test.go
+++ b/internal/host/registry/vaultpolicy_durable_test.go
@@ -1,0 +1,171 @@
+package registry
+
+import (
+	"database/sql"
+	"encoding/hex"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+)
+
+func vaultKey(b byte) [32]byte {
+	var k [32]byte
+	for i := range k {
+		k[i] = b
+	}
+	return k
+}
+
+// TestDurableVaultPolicyReload is the headline acceptance: an approved grant
+// survives a control-plane restart (close + reopen with the same key), and the
+// deny-by-default decision is reconstructed identically.
+func TestDurableVaultPolicyReload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vault-policies.db")
+	key := vaultKey(0x11)
+
+	s, err := OpenDurableVaultPolicyStore(path, key)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := s.Set(VaultPolicy{AgentGroupID: grpA, Rules: []VaultRule{
+		{Credential: "github", Hosts: []string{"api.github.com"}},
+		{Credential: "pagerduty", Hosts: []string{"api.pagerduty.com", "events.pagerduty.com"}},
+	}}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Reopen — a fresh process would see exactly this.
+	s2, err := OpenDurableVaultPolicyStore(path, key)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer s2.Close()
+
+	if !s2.Allows(grpA, "github", "api.github.com") {
+		t.Error("granted credential+host must survive restart")
+	}
+	if !s2.Allows(grpA, "pagerduty", "events.pagerduty.com") {
+		t.Error("second granted host must survive restart")
+	}
+	// Deny-by-default preserved across the reload.
+	if s2.Allows(grpA, "github", "evil.example.com") {
+		t.Error("un-granted host must stay denied after restart")
+	}
+	if s2.Allows(grpA, "stripe", "api.github.com") {
+		t.Error("un-granted credential must stay denied after restart")
+	}
+	if s2.Allows(grpB, "github", "api.github.com") {
+		t.Error("a group with no policy must stay denied after restart")
+	}
+	got, ok := s2.Get(grpA)
+	if !ok || len(got.Rules) != 2 {
+		t.Errorf("Get after reload = %+v, ok=%v; want 2 rules", got, ok)
+	}
+}
+
+// TestDurableVaultPolicyDeleteAcrossReopen verifies a deleted policy does not
+// resurrect after restart.
+func TestDurableVaultPolicyDeleteAcrossReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vault-policies.db")
+	key := vaultKey(0x22)
+
+	s, err := OpenDurableVaultPolicyStore(path, key)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := s.Set(VaultPolicy{AgentGroupID: grpA, Rules: []VaultRule{
+		{Credential: "github", Hosts: []string{"api.github.com"}},
+	}}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := s.Delete(grpA); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if s.Allows(grpA, "github", "api.github.com") {
+		t.Fatal("deleted policy must deny immediately")
+	}
+	s.Close()
+
+	s2, err := OpenDurableVaultPolicyStore(path, key)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer s2.Close()
+	if s2.Allows(grpA, "github", "api.github.com") {
+		t.Error("deleted policy must not resurrect after restart")
+	}
+}
+
+// TestDurableVaultPolicyWrongKey verifies opening the persisted DB with the wrong
+// key fails loudly rather than silently returning an empty (fully-permissive-by-
+// omission) store.
+func TestDurableVaultPolicyWrongKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vault-policies.db")
+
+	s, err := OpenDurableVaultPolicyStore(path, vaultKey(0x33))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := s.Set(VaultPolicy{AgentGroupID: grpA, Rules: []VaultRule{
+		{Credential: "github", Hosts: []string{"api.github.com"}},
+	}}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	s.Close()
+
+	if _, err := OpenDurableVaultPolicyStore(path, vaultKey(0x44)); err == nil {
+		t.Fatal("opening with the wrong key must fail, not return an empty store")
+	}
+}
+
+// TestDurableVaultPolicyRejectsTamperedRow verifies the store fails closed on a
+// persisted row that does not validate (e.g. a tampered host), rather than loading
+// an unevaluable policy or silently dropping it.
+func TestDurableVaultPolicyRejectsTamperedRow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vault-policies.db")
+	key := vaultKey(0x55)
+
+	// Create the encrypted DB with the store, then inject a malformed row directly.
+	s, err := OpenDurableVaultPolicyStore(path, key)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	s.Close()
+
+	q := url.Values{}
+	q.Set("_pragma_key", `x'`+hex.EncodeToString(key[:])+`'`)
+	db, err := sql.Open("sqlite3", "file:"+path+"?"+q.Encode())
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	// A wildcard host is rejected by validVaultHost — an unevaluable, dangerous rule.
+	if _, err := db.Exec(`INSERT INTO vault_policies (agent_group_id, rules_json) VALUES (?,?)`,
+		string(grpA), `[{"Credential":"github","Hosts":["*.github.com"]}]`); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	db.Close()
+
+	if _, err := OpenDurableVaultPolicyStore(path, key); err == nil {
+		t.Fatal("a malformed persisted policy must fail the open, not be admitted")
+	}
+}
+
+// TestDurableVaultPolicyEmptyStartDenies verifies a freshly created store denies
+// everything (deny-by-default) before any grant is written.
+func TestDurableVaultPolicyEmptyStartDenies(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vault-policies.db")
+	s, err := OpenDurableVaultPolicyStore(path, vaultKey(0x66))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+	var anyGroup contract.AgentGroupID = "unconfigured"
+	if s.Allows(anyGroup, "github", "api.github.com") {
+		t.Fatal("a brand-new store must deny by default")
+	}
+}

--- a/internal/host/session/manager.go
+++ b/internal/host/session/manager.go
@@ -57,8 +57,15 @@ type Config struct {
 	// bound into each sandbox so an agent can reach operator-approved external APIs
 	// (and vault://-addressed credentials). Empty (the default) binds no egress
 	// socket, leaving the sandbox sealed to the model proxy alone; the sandbox stays
-	// network=none either way.
+	// network=none either way. Ignored when EgressBroker is set (per-session sockets).
 	EgressSocket string
+	// EgressBroker, when set, provisions a PER-SESSION egress socket per sandbox
+	// instead of binding the single shared EgressSocket. This is required for vault
+	// policy enforcement: the per-session socket gives the broker a host-trusted
+	// session identity (not the spoofable X-Ironclaw-Session header), so per-group
+	// vault grants cannot be escalated by a compromised sandbox. Nil keeps the legacy
+	// shared-socket behavior (allowlist egress only, no per-group vault enforcement).
+	EgressBroker EgressProvisioner
 	// SearchBackend selects the web_search tool's provider ("duckduckgo" or
 	// "brave[:cred]") for every session. It only takes effect alongside EgressSocket
 	// (web_search rides the egress broker); empty registers no search tool.
@@ -76,6 +83,9 @@ type Config struct {
 	// alongside the model-proxy socket in production). Defaults to
 	// <os.TempDir>/ironclaw/mcp.
 	MCPSocketDir string
+	// EgressSocketDir is where per-session egress sockets are created when EgressBroker
+	// is set. Defaults to <os.TempDir>/ironclaw/egress.
+	EgressSocketDir string
 	// Image is the sandbox container image reference recorded in the OCI spec.
 	Image string
 	// KeyDir is where per-session key files are written for hand-off to the sandbox
@@ -108,6 +118,18 @@ type MCPProvisioner interface {
 	// returns its host path, to be bound into that one sandbox.
 	SocketForSession(session, dir string) (string, error)
 	// CloseSession stops serving and removes a session's MCP socket.
+	CloseSession(session string)
+}
+
+// EgressProvisioner provisions a per-session egress broker socket so the broker can
+// trust the session identity for vault policy (the socket identity, not a header).
+// Satisfied host-side by *egress.Broker; a tiny interface so the session package does
+// not import the egress package.
+type EgressProvisioner interface {
+	// SocketForSession creates (idempotently) a per-session egress socket under dir and
+	// returns its host path, to be bound into that one sandbox.
+	SocketForSession(session, dir string) (string, error)
+	// CloseSession stops serving and removes a session's egress socket.
 	CloseSession(session string)
 }
 
@@ -164,6 +186,9 @@ func New(cfg Config) (*Manager, error) {
 	}
 	if cfg.MCPSocketDir == "" {
 		cfg.MCPSocketDir = filepath.Join(os.TempDir(), "ironclaw", "mcp")
+	}
+	if cfg.EgressSocketDir == "" {
+		cfg.EgressSocketDir = filepath.Join(os.TempDir(), "ironclaw", "egress")
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = time.Now
@@ -346,8 +371,20 @@ func (m *Manager) Wake(id contract.SessionID) error {
 	}
 	// Bind the egress-broker socket when the daemon configured one (opt-in); the
 	// sandbox then gets the http_fetch tool and can reach approved hosts + vault://
-	// credentials. Empty keeps the sealed default.
-	if m.cfg.EgressSocket != "" {
+	// credentials. Empty keeps the sealed default. When an EgressBroker is wired,
+	// provision a PER-SESSION socket so the broker can enforce per-group vault policy
+	// against a host-trusted session identity rather than the spoofable header; fall
+	// back to the shared EgressSocket otherwise.
+	if m.cfg.EgressBroker != nil {
+		if sock, err := m.cfg.EgressBroker.SocketForSession(string(id), m.egressSocketDir()); err != nil {
+			// Best-effort: a per-session socket failure leaves the sandbox without egress
+			// rather than blocking launch (the trigger message is already queued).
+			m.cfg.Logger.Printf("host/session: egress socket for %s deferred: %v", id, err)
+		} else {
+			spec.EgressSocket = sock
+			spec.SearchBackend = m.cfg.SearchBackend
+		}
+	} else if m.cfg.EgressSocket != "" {
 		spec.EgressSocket = m.cfg.EgressSocket
 		// web_search rides the egress broker, so the search backend only takes effect
 		// here, alongside a bound egress socket.
@@ -478,6 +515,14 @@ func (m *Manager) Kill(id contract.SessionID, action sweep.StuckAction) error {
 	return m.Stop(context.Background(), id)
 }
 
+// egressSocketDir returns the directory for per-session egress sockets.
+func (m *Manager) egressSocketDir() string {
+	if m.cfg.EgressSocketDir != "" {
+		return m.cfg.EgressSocketDir
+	}
+	return filepath.Join(os.TempDir(), "ironclaw", "egress")
+}
+
 // Stop stops and untracks the sandbox for a session. It is a no-op (nil) if the
 // session is not currently running.
 func (m *Manager) Stop(ctx context.Context, id contract.SessionID) error {
@@ -491,6 +536,10 @@ func (m *Manager) Stop(ctx context.Context, id contract.SessionID) error {
 	// handle was tracked, so resources are freed and a relaunch provisions a fresh one.
 	if m.cfg.MCPBroker != nil {
 		m.cfg.MCPBroker.CloseSession(string(id))
+	}
+	// Tear down the per-session egress socket too, so a relaunch provisions a fresh one.
+	if m.cfg.EgressBroker != nil {
+		m.cfg.EgressBroker.CloseSession(string(id))
 	}
 	if !ok {
 		return nil

--- a/internal/host/vaultinjector/injector.go
+++ b/internal/host/vaultinjector/injector.go
@@ -1,0 +1,307 @@
+// Package vaultinjector is IronClaw's minimal in-tree reference credential injector:
+// the SEPARATE host-side principal the egress broker forwards a vault:// request TO.
+// It is the sole holder of a credential and the only component that attaches it,
+// host-side — the broker injects nothing and the sandbox never sees a key (threat
+// model §11).
+//
+// Contract with the broker (internal/host/egress/vault.go):
+//   - The broker rewrites a vault://<cred>/<path> request to target this injector,
+//     sets X-Ironclaw-Vault-Cred: <cred> (the logical NAME, never a key), strips any
+//     sandbox-supplied Authorization, and stamps X-Ironclaw-Correlation for audit.
+//   - The injector maps <cred> to its configured upstream + secret, attaches the
+//     secret host-side, and reverse-proxies to the real upstream over its own scheme.
+//   - An unknown credential is refused 403 (deny-by-default). The secret is read from
+//     the host environment, NEVER from the config file, and is never echoed back.
+//
+// An operator may instead point the broker at an external injector (e.g. OneCLI) that
+// honours the same contract; this package is the default, swappable reference.
+package vaultinjector
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Headers the injector reads, matching the broker's vault forwarding.
+const (
+	// CredHeader carries the logical credential name from the broker. Mirrors
+	// egress.VaultCredHeader (kept local so this package does not import egress).
+	CredHeader = "X-Ironclaw-Vault-Cred"
+	// CorrelationHeader joins the injector's audit to the broker's. Mirrors
+	// egress.CorrelationHeader.
+	CorrelationHeader = "X-Ironclaw-Vault-Request-Id"
+)
+
+// CredSpec configures one logical credential. The secret itself is NEVER in the file:
+// SecretEnv names the host environment variable that holds it.
+type CredSpec struct {
+	// Upstream is the real API base URL the credential is used against
+	// (e.g. "https://api.github.com"). Its host is what the control-plane's vault
+	// policy is enforced against.
+	Upstream string `json:"upstream"`
+	// SecretEnv is the host env var holding the secret value (e.g. "VAULT_GITHUB_TOKEN").
+	SecretEnv string `json:"secretEnv"`
+	// Header is the request header the secret is attached to. Default "Authorization".
+	Header string `json:"header,omitempty"`
+	// Scheme is the value prefix (e.g. "Bearer "). Default "Bearer ".
+	Scheme string `json:"scheme,omitempty"`
+}
+
+// Config is the injector's credential catalog: logical name -> spec.
+type Config struct {
+	Creds map[string]CredSpec `json:"creds"`
+}
+
+// LoadConfig reads and validates a JSON injector config from path.
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("vaultinjector: read config %q: %w", path, err)
+	}
+	var c Config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("vaultinjector: parse config %q: %w", path, err)
+	}
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func (c *Config) validate() error {
+	for name, spec := range c.Creds {
+		if !validCredName(name) {
+			return fmt.Errorf("vaultinjector: invalid credential name %q", name)
+		}
+		u, err := url.Parse(strings.TrimSpace(spec.Upstream))
+		if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+			return fmt.Errorf("vaultinjector: credential %q has invalid upstream %q", name, spec.Upstream)
+		}
+		if strings.TrimSpace(spec.SecretEnv) == "" {
+			return fmt.Errorf("vaultinjector: credential %q must name a secretEnv", name)
+		}
+	}
+	return nil
+}
+
+// UpstreamHost returns the bare upstream host a credential targets, for the
+// control-plane's vault-policy enforcement (the host dimension of
+// VaultPolicyStore.Allows). This is the one config fact the broker side shares with
+// the injector: the policy maps (group, cred) -> approved upstream host.
+func (c *Config) UpstreamHost(cred string) (string, bool) {
+	spec, ok := c.Creds[strings.ToLower(strings.TrimSpace(cred))]
+	if !ok {
+		return "", false
+	}
+	u, err := url.Parse(spec.Upstream)
+	if err != nil || u.Host == "" {
+		return "", false
+	}
+	return strings.ToLower(u.Hostname()), true
+}
+
+// CredHosts returns the cred -> upstream-host map, a convenience for wiring the
+// broker's VaultGuard host resolution.
+func (c *Config) CredHosts() map[string]string {
+	out := make(map[string]string, len(c.Creds))
+	for name := range c.Creds {
+		if h, ok := c.UpstreamHost(name); ok {
+			out[strings.ToLower(name)] = h
+		}
+	}
+	return out
+}
+
+// AuditRecord is one injection decision, emitted to an AuditSink. It carries the
+// credential NAME and correlation id — never the secret value.
+type AuditRecord struct {
+	Time          time.Time     `json:"time"`
+	Credential    string        `json:"credential"`
+	CorrelationID string        `json:"correlationId,omitempty"`
+	Upstream      string        `json:"upstream,omitempty"`
+	Path          string        `json:"path"`
+	Status        int           `json:"status"`
+	Allowed       bool          `json:"allowed"`
+	Duration      time.Duration `json:"durationNanos"`
+}
+
+// AuditSink receives one record per injection. Must be safe for concurrent use.
+type AuditSink func(AuditRecord)
+
+// resolved is one credential ready to attach: upstream + the secret value pulled from
+// the environment at construction.
+type resolved struct {
+	upstream *url.URL
+	secret   string
+	header   string
+	scheme   string
+}
+
+// Injector attaches host-held credentials to broker-forwarded requests. It holds the
+// secret values resolved from the environment; the config file never does.
+type Injector struct {
+	creds     map[string]resolved
+	transport http.RoundTripper
+	audit     AuditSink
+}
+
+// Option configures an Injector.
+type Option func(*Injector)
+
+// WithTransport overrides the upstream RoundTripper (tests). WithAudit sets the sink.
+func WithTransport(rt http.RoundTripper) Option {
+	return func(i *Injector) {
+		if rt != nil {
+			i.transport = rt
+		}
+	}
+}
+func WithAudit(sink AuditSink) Option { return func(i *Injector) { i.audit = sink } }
+
+// New builds an Injector from cfg, resolving each credential's secret via lookupEnv
+// (default os.LookupEnv). A credential whose secret env var is unset is a
+// configuration error: the injector fails closed rather than serving a credential it
+// cannot attach.
+func New(cfg *Config, lookupEnv func(string) (string, bool), opts ...Option) (*Injector, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("vaultinjector: nil config")
+	}
+	if lookupEnv == nil {
+		lookupEnv = os.LookupEnv
+	}
+	i := &Injector{creds: make(map[string]resolved, len(cfg.Creds)), transport: http.DefaultTransport}
+	for name, spec := range cfg.Creds {
+		u, err := url.Parse(strings.TrimSpace(spec.Upstream))
+		if err != nil {
+			return nil, fmt.Errorf("vaultinjector: credential %q upstream: %w", name, err)
+		}
+		secret, ok := lookupEnv(spec.SecretEnv)
+		if !ok || secret == "" {
+			return nil, fmt.Errorf("vaultinjector: credential %q secret env %q is unset", name, spec.SecretEnv)
+		}
+		header := spec.Header
+		if strings.TrimSpace(header) == "" {
+			header = "Authorization"
+		}
+		scheme := spec.Scheme
+		if scheme == "" {
+			scheme = "Bearer "
+		}
+		i.creds[strings.ToLower(name)] = resolved{upstream: u, secret: secret, header: header, scheme: scheme}
+	}
+	for _, o := range opts {
+		o(i)
+	}
+	return i, nil
+}
+
+// Creds returns the configured credential names (sorted), for diagnostics. Never
+// returns secrets.
+func (i *Injector) Creds() []string {
+	out := make([]string, 0, len(i.creds))
+	for name := range i.creds {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Handler serves the injector: it reads the credential name, attaches the host-held
+// secret, and reverse-proxies to the real upstream. Deny-by-default: an unknown or
+// missing credential is refused 403. The secret is attached only on the upstream hop
+// and never written to the response.
+func (i *Injector) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		cred := strings.ToLower(strings.TrimSpace(r.Header.Get(CredHeader)))
+		corr := r.Header.Get(CorrelationHeader)
+		path := "/"
+		if r.URL != nil {
+			path = r.URL.Path
+		}
+		res, ok := i.creds[cred]
+		if cred == "" || !ok {
+			http.Error(w, "vaultinjector: unknown credential", http.StatusForbidden)
+			i.emit(AuditRecord{Time: start, Credential: cred, CorrelationID: corr, Path: path, Status: http.StatusForbidden, Allowed: false, Duration: time.Since(start)})
+			return
+		}
+
+		target := *res.upstream
+		secret := res.secret
+		header := res.header
+		scheme := res.scheme
+		rp := &httputil.ReverseProxy{
+			Director: func(req *http.Request) {
+				req.URL.Scheme = target.Scheme
+				req.URL.Host = target.Host
+				req.Host = target.Host
+				// Preserve the upstream's own base path if it has one, then the request path.
+				req.URL.Path = singleJoin(target.Path, path)
+				// The credential name + correlation id are host-internal; do not leak
+				// them upstream.
+				req.Header.Del(CredHeader)
+				req.Header.Del(CorrelationHeader)
+				// Attach the host-held credential — the ONE place a real key is added.
+				req.Header.Set(header, scheme+secret)
+			},
+			Transport: i.transport,
+		}
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		rp.ServeHTTP(rec, r)
+		i.emit(AuditRecord{Time: start, Credential: cred, CorrelationID: corr, Upstream: target.Host, Path: path, Status: rec.status, Allowed: true, Duration: time.Since(start)})
+	})
+}
+
+func (i *Injector) emit(rec AuditRecord) {
+	if i.audit != nil {
+		i.audit(rec)
+	}
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
+}
+
+// singleJoin joins a base path and a request path with exactly one slash.
+func singleJoin(base, p string) string {
+	base = strings.TrimSuffix(base, "/")
+	if p == "" {
+		if base == "" {
+			return "/"
+		}
+		return base
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return base + p
+}
+
+// validCredName mirrors the egress broker's credential-name rule.
+func validCredName(s string) bool {
+	if s == "" || len(s) > 128 || s == "." || s == ".." || strings.Contains(s, "..") {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		ok := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.'
+		if !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/host/vaultinjector/injector_test.go
+++ b/internal/host/vaultinjector/injector_test.go
@@ -1,0 +1,169 @@
+package vaultinjector
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeEnv builds a lookupEnv over a map.
+func fakeEnv(m map[string]string) func(string) (string, bool) {
+	return func(k string) (string, bool) { v, ok := m[k]; return v, ok }
+}
+
+// TestInjectorAttachesSecretHostSide: the injector adds the host-held credential on the
+// upstream hop, the request carrying only the credential NAME from the broker.
+func TestInjectorAttachesSecretHostSide(t *testing.T) {
+	const secret = "s3cr3t-token"
+	var gotAuth, gotPath, gotCredHeader string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		gotCredHeader = r.Header.Get(CredHeader)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{Creds: map[string]CredSpec{"github": {Upstream: upstream.URL, SecretEnv: "TOK"}}}
+	inj, err := New(cfg, fakeEnv(map[string]string{"TOK": secret}))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	srv := httptest.NewServer(inj.Handler())
+	defer srv.Close()
+
+	client := &http.Client{}
+	r2, _ := http.NewRequest(http.MethodGet, srv.URL+"/repos/acme", nil)
+	r2.Header.Set(CredHeader, "github")
+	r2.Header.Set(CorrelationHeader, "corr-123")
+	resp2, err := client.Do(r2)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp2.StatusCode)
+	}
+	if gotAuth != "Bearer "+secret {
+		t.Errorf("upstream Authorization = %q, want %q", gotAuth, "Bearer "+secret)
+	}
+	if gotPath != "/repos/acme" {
+		t.Errorf("upstream path = %q, want /repos/acme", gotPath)
+	}
+	// Host-internal headers must not leak upstream.
+	if gotCredHeader != "" {
+		t.Errorf("cred header leaked upstream: %q", gotCredHeader)
+	}
+}
+
+// TestInjectorDenyUnknownCredential: an unknown credential is refused 403 and never
+// reaches an upstream.
+func TestInjectorDenyUnknownCredential(t *testing.T) {
+	cfg := &Config{Creds: map[string]CredSpec{"github": {Upstream: "https://api.github.com", SecretEnv: "TOK"}}}
+	inj, err := New(cfg, fakeEnv(map[string]string{"TOK": "x"}))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	srv := httptest.NewServer(inj.Handler())
+	defer srv.Close()
+
+	client := &http.Client{}
+	r, _ := http.NewRequest(http.MethodGet, srv.URL+"/x", nil)
+	r.Header.Set(CredHeader, "gitlab") // not configured
+	resp, err := client.Do(r)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for unknown credential", resp.StatusCode)
+	}
+}
+
+// TestInjectorMissingCredentialHeader: a request with no credential header is refused.
+func TestInjectorMissingCredentialHeader(t *testing.T) {
+	cfg := &Config{Creds: map[string]CredSpec{"github": {Upstream: "https://api.github.com", SecretEnv: "TOK"}}}
+	inj, _ := New(cfg, fakeEnv(map[string]string{"TOK": "x"}))
+	srv := httptest.NewServer(inj.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/x")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 with no credential header", resp.StatusCode)
+	}
+}
+
+// TestInjectorFailsClosedOnUnsetSecret: a credential whose secret env var is unset is a
+// construction error — the injector never serves a credential it cannot attach.
+func TestInjectorFailsClosedOnUnsetSecret(t *testing.T) {
+	cfg := &Config{Creds: map[string]CredSpec{"github": {Upstream: "https://api.github.com", SecretEnv: "MISSING"}}}
+	if _, err := New(cfg, fakeEnv(map[string]string{})); err == nil {
+		t.Fatal("New must fail when a credential's secret env var is unset")
+	}
+}
+
+// TestConfigUpstreamHost: the control-plane reads cred -> upstream host for policy.
+func TestConfigUpstreamHost(t *testing.T) {
+	cfg := &Config{Creds: map[string]CredSpec{"github": {Upstream: "https://api.github.com:443", SecretEnv: "TOK"}}}
+	if err := cfg.validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	host, ok := cfg.UpstreamHost("github")
+	if !ok || host != "api.github.com" {
+		t.Fatalf("UpstreamHost = %q,%v, want api.github.com,true", host, ok)
+	}
+	if _, ok := cfg.UpstreamHost("nope"); ok {
+		t.Error("UpstreamHost should report false for an unknown credential")
+	}
+	if got := cfg.CredHosts()["github"]; got != "api.github.com" {
+		t.Errorf("CredHosts[github] = %q, want api.github.com", got)
+	}
+}
+
+// TestConfigValidateRejectsBadUpstream: a non-http(s) or hostless upstream is rejected.
+func TestConfigValidateRejectsBadUpstream(t *testing.T) {
+	bad := []CredSpec{
+		{Upstream: "ftp://x", SecretEnv: "T"},
+		{Upstream: "not a url", SecretEnv: "T"},
+		{Upstream: "https://api.github.com", SecretEnv: ""},
+	}
+	for i, spec := range bad {
+		cfg := &Config{Creds: map[string]CredSpec{"c": spec}}
+		if err := cfg.validate(); err == nil {
+			t.Errorf("case %d: validate accepted invalid spec %+v", i, spec)
+		}
+	}
+}
+
+// TestInjectorDoesNotEchoSecret: a quick guard that the configured secret value is not
+// written into the response by the injector itself (the broker redactor is the
+// belt-and-braces backstop, but the injector adds the secret only on the upstream hop).
+func TestInjectorDoesNotEchoSecret(t *testing.T) {
+	const secret = "must-not-appear"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "upstream body without the token")
+	}))
+	defer upstream.Close()
+	cfg := &Config{Creds: map[string]CredSpec{"c": {Upstream: upstream.URL, SecretEnv: "TOK"}}}
+	inj, _ := New(cfg, fakeEnv(map[string]string{"TOK": secret}))
+	srv := httptest.NewServer(inj.Handler())
+	defer srv.Close()
+	client := &http.Client{}
+	r, _ := http.NewRequest(http.MethodGet, srv.URL+"/", nil)
+	r.Header.Set(CredHeader, "c")
+	resp, err := client.Do(r)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(body), secret) {
+		t.Errorf("injector echoed the secret in its response: %q", string(body))
+	}
+}


### PR DESCRIPTION
## Summary

Implements the **trust-critical core of the credential vault** (parent IRO-133, item 1+3). An agent reaches a credential by logical name `vault://<cred>/<path>` and **never holds a key**; the secret is attached host-side by a *separate* principal.

**Stacked on #167** (gateway-apply half) — base branch `forge/iro-133-vault`. Review/merge #167 first.

## What landed

- **Per-session egress sockets** (`SocketForSession`/`CloseSession`), mirroring the MCP broker, so vault policy is enforced against a **host-trusted** session→group mapping — *not* the spoofable `X-Ironclaw-Session` header.
- **`WithVaultGuard`** enforces `registry.VaultPolicyStore.Allows(group, cred, host)` after `Forward()` resolves the credential: **deny-by-default 403** on miss, audited with the credential **NAME** + correlation id. Vault addressing is refused entirely on the shared (untrusted) socket.
- **Reference injector** (`internal/host/vaultinjector` + `cmd/ironclaw-vault-injector`): a distinct OS principal that holds the secret (from the env, never the config file) and attaches it host-side. The broker injects nothing; deny-by-default on unknown creds; fails closed on an unset secret.
- **Run-flow wiring**: session manager provisions a per-session egress socket per sandbox when an `EgressBroker` is set; control-plane wires the guard + cred→upstream-host map from `--vault-injector-config` (required with `--vault-endpoint`, so vault is never enabled unenforced).
- **`docs/vault.md`** documents the broker⇄injector contract + run flow.

## Tests (all green, CGO)

- `TestVaultGrantedResolvesEndToEnd` — gateway-approved policy resolves broker→injector→upstream; agent never holds a key; secret never echoes back.
- `TestVaultDenyByDefaultUngrantedSession` / `TestVaultUngrantedCredentialRefused` — deny-by-default refuses un-granted vault.
- `TestVaultSpoofedSessionCannotEscalate` — a forged `X-Ironclaw-Session` on an un-granted per-session socket cannot escalate.
- `TestVaultRefusedOnSharedUntrustedSocket` — vault refused on the shared socket.
- Injector unit tests: attach/deny-unknown/missing-header/fail-closed/no-echo + config validation.

## Acceptance mapping

- `vault://<cred>/<path>` resolves end-to-end through the broker against an allowlisted injector ✅
- Agent never holds a key ✅ (broker strips Authorization; injector is the sole key holder)
- Deny-by-default refuses un-wired/un-granted vault ✅

## Gates (do NOT merge yet)

1. **IRO-133 design confirmation** (decisions 1 & 4 — per-session binding + reference injector). The design here *is* the recommended path from the IRO-133 plan; the issue scope itself prescribes the per-session-socket mirror.
2. **QA sign-off** (per the issue acceptance).
