### PR TITLE
feat(mcp): gated mcp_register change kind (RFC-0007, IRO-145)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -386,6 +386,21 @@ func main() {
 	capApplier = gateway.NewMCPAccessApplier(func(id contract.AgentGroupID, server string, tools []string) error {
 		return registry.SetGrantedMCP(reg, id, server, tools)
 	}, capApplier)
+	// An approved ChangeMCPRegister lands the proposed server in the host catalog and
+	// drops any cached broker connection so the next use reconnects with it. It grants
+	// the proposing agent NOTHING — access stays the separate ChangeMCPAccess approval.
+	capApplier = gateway.NewMCPRegisterApplier(func(cfg mcp.ServerConfig) error {
+		if mcpCatalogStore == nil {
+			return fmt.Errorf("mcp register: MCP is not enabled")
+		}
+		if err := mcpCatalogStore.Put(cfg); err != nil {
+			return err
+		}
+		if mcpBroker != nil {
+			mcpBroker.Invalidate(cfg.Name)
+		}
+		return nil
+	}, capApplier)
 	if broker != nil {
 		capApplier = gateway.NewEgressApplier(broker, capApplier)
 	}
@@ -400,6 +415,7 @@ func main() {
 			gateway.PackageNameVerifier{},
 			gateway.NewCreateAgentVerifier(agentExists),
 			gateway.NewMCPServerVerifier(mcpServerKnown),
+			gateway.NewMCPRegisterVerifier(func() bool { return mcpCatalogStore != nil }),
 			gateway.AlwaysRequireHuman{},
 		},
 		gateway.NewManualApprover(),

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -330,6 +330,7 @@ Per-kind `payload` shape:
 | `permissions` | object (role/member grants) | none yet (human reviews) |
 | `mcp_access` | `{"server":"<name>","tools":["<tool>",...]}` (omit `tools` = all the server's declared tools) | `MCPServerVerifier` rejects an unknown server / a tool the server does not declare |
 | `skill_install` | `{"skill":"<name>","version":"<version>"}` | host RESOLVES the named skill (curated source + minisign trust root); an unknown/unsigned/out-of-policy skill is refused before the gateway |
+| `mcp_register` | `{"name","transport":"stdio"\|"http", stdio: "command","args","image","env" \| http: "url","headers"}` | `MCPRegisterVerifier` rejects when MCP is disabled / a malformed def (reusing the catalog's `ServerConfig.Validate`); else require-human |
 
 ### RFC-0005: approval-gated MCP-server access — `ChangeMCPAccess`
 
@@ -377,6 +378,35 @@ operator-only (out-of-session `ironctl skill add` / `POST /v1/skills/install`).
   unknown/unsigned/out-of-policy, the proposal is refused host-side and never reaches the
   gateway. The sandbox can *ask*; only a curated+signed skill an operator provisioned can
   be proposed, and a human still approves it.
+
+### RFC-0007: in-session MCP-server registration — `ChangeMCPRegister`
+
+`mcp_access` (RFC-0005) lets an agent ask for tools on a server **an operator already
+configured**. OpenClaw's full loop is *register → approve → access → execute*: the
+assistant can propose a brand-new server endpoint in chat, a human approves it, and only
+then is it usable. RFC-0007 closes that first hop — **without** weakening the blind-MCP
+gate RFC-0005 closed.
+
+- **One new contract value:** `ChangeMCPRegister = "mcp_register"`. It rides the existing
+  `SystemAction` envelope (`action == "mcp_register"`); the agent reaches it from chat via
+  `request_capability_change` (kind `mcp_register`). `delivery.authorizeSystemAction` maps
+  it (privileged → gateway).
+- **The agent only PROPOSES the endpoint.** The `After` payload is an `mcp.ServerConfig`
+  definition (name + transport + the stdio `command`/`args`/`image` or http `url`/
+  `headers`). The `MCPRegisterVerifier` is **deny-by-default** (reject when MCP is
+  disabled), rejects a malformed def by reusing the catalog's own `ServerConfig.Validate`
+  (empty name, not exactly one of command/url, non-`https` url to a non-loopback host,
+  unknown fields), and otherwise returns **require-human** — never auto-approved.
+- **The human approves the EXACT command/url.** Registering a server introduces a new
+  code-execution / egress surface, so the approval card surfaces the full endpoint
+  definition (secrets in `env`/`headers` masked via `ServerConfig.Public`). On approval the
+  `MCPRegisterApplier` calls `catalog.Put` + `broker.Invalidate(name)`.
+- **Registration grants the proposing agent NOTHING.** An approved register lands the
+  server in the catalog only; the agent must still obtain its tools through the separate,
+  also-human-gated `mcp_access` approval (least-privilege — registering an endpoint and
+  being allowed to call it are two independent human decisions). The server still runs
+  **host-side** behind the per-session broker socket, so the sandbox stays `network=none`
+  and never speaks MCP itself.
 
 Kinds with no automated verifier still pass through the deterministic chain and
 the always-require-human floor; they are simply approved by a human without an

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -125,9 +125,14 @@ expose.
 
 The agent gets ordinary tools named `‹server›__‹tool›` with the server's own JSON
 schema. Calling one forwards to the broker; a policy denial or an upstream error comes
-back as a tool error the model can read. An agent that wants a server it does not have
-can ask for it with the `request_capability_change` tool (kind `mcp_access`) — which is
-still just a request a human must approve.
+back as a tool error the model can read. An agent that wants tools on a *configured*
+server can ask for them with the `request_capability_change` tool (kind `mcp_access`).
+If no configured server has what it needs, it can go one step earlier and *propose a
+brand-new server endpoint* (kind `mcp_register`, RFC-0007): the human approves the exact
+`command`/`image` or `url` before it lands in the catalog, and the agent then requests
+its tools via the separate `mcp_access` approval. Both are just requests a human must
+approve — closing the OpenClaw register→approve→access→execute loop without a blind
+approval surface.
 
 ## Trying it without a real server
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -414,8 +414,9 @@ The reference design IronClaw hardens treated MCP as a **blind approval surface*
 "approve this server" pulled in whatever tools and reach it chose. IronClaw keeps
 MCP entirely **host-side and
 gateway-gated**, so it adds tool reach without adding a boundary the sandbox can
-cross. Design + how-to: [mcp.md](mcp.md); the one frozen-contract value is RFC-0005
-(`ChangeMCPAccess`) in [contract.md](contract.md).
+cross. Design + how-to: [mcp.md](mcp.md); the frozen-contract values are RFC-0005
+(`ChangeMCPAccess`, grant tools on a configured server) and RFC-0007
+(`ChangeMCPRegister`, propose a new server endpoint) in [contract.md](contract.md).
 
 ### The MCP boundary (a new trust edge: broker ↔ MCP server)
 
@@ -458,9 +459,44 @@ or an egress response (§1):
   name (`-e KEY`), never in the argv (no `ps` leak). The broker is **not** a credential
   vault for the agent — it injects the server's own configured auth toward the server,
   never launders a host secret back to the sandbox (the B4-E posture).
-- **Operator-configured catalog, not an agent-supplied URL.** A sandbox can only name a
-  server an operator already configured; it can never point the broker at an arbitrary
-  endpoint.
+- **Human-approved catalog, not an agent-supplied URL.** A sandbox can never silently
+  point the broker at an arbitrary endpoint. A server enters the catalog only via an
+  operator (`ironctl`/API) **or** via an agent's `mcp_register` *proposal* that a human
+  approves — see the next section. Either way, the endpoint the broker dials is one a
+  human chose.
+
+### Registering a new server: `mcp_register` (RFC-0007)
+
+`mcp_access` grants tools on a server **already in the catalog**. `mcp_register`
+(`ChangeMCPRegister`) lets a sandbox *propose a brand-new server endpoint* from chat,
+closing OpenClaw's register→approve→access→execute loop. It is the riskiest MCP edge — a
+proposal can name an arbitrary `command`/`image` (a would-be host RCE) or an arbitrary
+`url` (a would-be egress channel) — so it is gated the hardest:
+
+- **It is a PROPOSAL, never an action.** Like `create_agent`/`mcp_access`, the sandbox can
+  only *emit* an `mcp_register` request (B3); delivery refuses to act on it and routes it
+  to the gateway as a `ChangeMCPRegister` ChangeRequest.
+- **Deny-by-default + validate + require-human.** `MCPRegisterVerifier` rejects when MCP
+  is disabled (an agent cannot turn MCP on), rejects a malformed def by reusing the
+  catalog's own `ServerConfig.Validate` (empty name, not exactly one of command/url,
+  non-`https` url to a non-loopback host, unknown/smuggled fields), and otherwise returns
+  **require-human** — it is never auto-approved.
+- **The human approves the EXACT endpoint.** The approval card surfaces the full
+  definition — `command`/`args`/`image` (stdio) or `url`/`headers` (http) — with secrets
+  in `env`/`headers` masked (`ServerConfig.Public`). The human is approving precisely the
+  code that will run or the host that will be dialed; there is no blind "register whatever
+  the agent typed".
+- **No new execution/egress surface bypasses existing isolation.** An approved local
+  server still runs in the same hardened, `network=none` container as any operator-added
+  local server (above); an approved remote server is still TLS-only and dialed host-side.
+  Registering does not change *where* MCP code runs or *how* it is isolated — it only adds
+  a human-approved entry to the same gated catalog.
+- **Registration grants the proposer nothing.** An approved register lands the server in
+  the catalog and invalidates the broker's cached connection — and stops there. The
+  proposing agent gets **no** tools until a *separate* `mcp_access` approval (the
+  least-privilege split: registering an endpoint and being allowed to call it are two
+  independent human decisions). So even a maliciously-crafted-but-approved server is inert
+  until a second human approval explicitly grants a named tool subset.
 
 ### Residual risk
 

--- a/internal/contract/enums.go
+++ b/internal/contract/enums.go
@@ -99,6 +99,21 @@ const (
 	// a skill that is unknown, unsigned, out-of-policy, or proposed when skills are not
 	// enabled is refused host-side and never reaches the gateway.
 	ChangeSkillInstall ChangeKind = "skill_install"
+	// ChangeMCPRegister lets an agent PROPOSE a brand-new MCP (Model Context Protocol)
+	// server endpoint from chat (RFC-0007), closing the OpenClaw register->approve->
+	// access->execute parity gap for MCP servers. Privileged: registering a new server
+	// introduces a new code-execution / egress surface (a stdio subprocess the host
+	// spawns, or a remote HTTP endpoint the host dials), so it ALWAYS routes through the
+	// gateway's mandatory human-approval floor — the human approves the EXACT command/
+	// args/image (stdio) or url/headers (http), never a blind "whatever the agent typed"
+	// endpoint. It rides the existing SystemAction envelope (action == "mcp_register");
+	// the payload is an mcp.ServerConfig-shaped definition (see docs/contract.md). The
+	// agent only PROPOSES the endpoint: an approved register lands the server in the host
+	// catalog but grants the proposing agent NOTHING — the agent must still obtain its
+	// tools through the separate, also-human-gated ChangeMCPAccess path (least-privilege).
+	// MCP servers run HOST-SIDE (network=none sandbox never speaks MCP), so this kind never
+	// widens what the sandbox itself can reach. This is the only frozen-contract change.
+	ChangeMCPRegister ChangeKind = "mcp_register"
 )
 
 // Verdict is the deterministic result of a single verifier in the gateway chain.

--- a/internal/host/api/ui_approvals.go
+++ b/internal/host/api/ui_approvals.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/IronSecCo/ironclaw/internal/contract"
+	"github.com/IronSecCo/ironclaw/internal/host/mcp"
 )
 
 // approvalView is the read-model the approvals inbox renders: a pending
@@ -51,7 +52,7 @@ func (s *Server) handleUIApprovals(w http.ResponseWriter, r *http.Request) {
 			RequestedBy:  c.RequestedBy,
 			CreatedAt:    c.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
 			Before:       c.Before,
-			After:        c.After,
+			After:        maskApprovalAfter(c.Kind, c.After),
 		}
 		// Best-effort name resolution; absent registry or unknown ids leave the
 		// names empty and the UI shows the raw id.
@@ -66,4 +67,27 @@ func (s *Server) handleUIApprovals(w http.ResponseWriter, r *http.Request) {
 		views = append(views, v)
 	}
 	writeJSON(w, http.StatusOK, views)
+}
+
+// maskApprovalAfter masks secret-bearing values in an approval's After payload before
+// it crosses to the browser. For a ChangeMCPRegister the payload is a proposed MCP
+// ServerConfig that may carry raw credentials in env/headers; the human approver must
+// see the FULL endpoint definition (command/args/image/url/headers — the load-bearing
+// control), but never a plaintext secret. ServerConfig.Public() preserves keys and
+// ${VAR} references while masking raw values. A payload that does not parse is returned
+// unchanged (the verifier already rejected a malformed register, so it never reaches an
+// approval card; this only guards a best-effort projection). Other kinds pass through.
+func maskApprovalAfter(kind contract.ChangeKind, after json.RawMessage) json.RawMessage {
+	if kind != contract.ChangeMCPRegister || len(after) == 0 {
+		return after
+	}
+	var cfg mcp.ServerConfig
+	if err := json.Unmarshal(after, &cfg); err != nil {
+		return after
+	}
+	masked, err := json.Marshal(cfg.Public())
+	if err != nil {
+		return after
+	}
+	return masked
 }

--- a/internal/host/api/ui_approvals_test.go
+++ b/internal/host/api/ui_approvals_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -70,6 +71,54 @@ func TestUIApprovalsEnrichesNames(t *testing.T) {
 	}
 	if string(v.After) != `{"persona":"helpful"}` {
 		t.Errorf("after payload = %s", v.After)
+	}
+}
+
+// TestUIApprovalsMasksMCPRegisterSecrets: an mcp_register approval card must show the
+// FULL proposed endpoint (the load-bearing control the human approves) but never a
+// plaintext secret — raw env/header values are masked, while ${VAR} references and the
+// command/url are preserved.
+func TestUIApprovalsMasksMCPRegisterSecrets(t *testing.T) {
+	store := gateway.NewMemoryStore()
+	gw := gateway.New(
+		gateway.VerifierChain{gateway.AlwaysRequireHuman{}},
+		gateway.NewManualApprover(),
+		gateway.NewLogApplier(),
+		store,
+	)
+	if err := seedPending(store, contract.ChangeRequest{
+		ID:           "reg1",
+		Kind:         contract.ChangeMCPRegister,
+		AgentGroupID: "grp1",
+		RequestedBy:  "user1",
+		After:        json.RawMessage(`{"name":"weather","transport":"http","url":"https://weather.example.com/mcp","headers":{"Authorization":"sk-RAWSECRET","X-Env":"${WEATHER_TOKEN}"}}`),
+		CreatedAt:    time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	h := New(gw).Handler()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/ui/approvals", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", rec.Code)
+	}
+	var views []approvalView
+	if err := json.Unmarshal(rec.Body.Bytes(), &views); err != nil {
+		t.Fatal(err)
+	}
+	if len(views) != 1 {
+		t.Fatalf("got %d views, want 1", len(views))
+	}
+	body := string(views[0].After)
+	if !strings.Contains(body, `"weather"`) || !strings.Contains(body, "weather.example.com/mcp") {
+		t.Errorf("endpoint definition not surfaced: %s", body)
+	}
+	if strings.Contains(body, "sk-RAWSECRET") {
+		t.Errorf("raw secret leaked to approval card: %s", body)
+	}
+	if !strings.Contains(body, "${WEATHER_TOKEN}") {
+		t.Errorf("env reference should be preserved (non-secret): %s", body)
 	}
 }
 

--- a/internal/host/delivery/delivery.go
+++ b/internal/host/delivery/delivery.go
@@ -491,6 +491,13 @@ func authorizeSystemAction(action string) (contract.ChangeKind, bool) {
 		// widens the agent's tool surface with externally-served tools, always
 		// privileged → gateway (a human approves the named server and tools).
 		return contract.ChangeMCPAccess, true
+	case "mcp_register", "add_mcp_server", "register_mcp":
+		// Proposing a brand-new MCP server endpoint from chat (RFC-0007): introduces a
+		// new code-execution/egress surface (a host subprocess or a remote endpoint the
+		// host dials), always privileged → gateway. The MCPRegisterVerifier holds it for a
+		// human who approves the EXACT command/url before it lands in the catalog; an
+		// approved register grants the proposing agent nothing (it must still mcp_access).
+		return contract.ChangeMCPRegister, true
 	case "skill_install":
 		// Proposing a curated, signed skill install from chat (RFC-0006). Delivery
 		// special-cases this BEFORE this switch (handleSkillInstall) because it needs a

--- a/internal/host/gateway/mcp_register.go
+++ b/internal/host/gateway/mcp_register.go
@@ -1,0 +1,122 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+	"github.com/IronSecCo/ironclaw/internal/host/mcp"
+)
+
+// MCPRegisterEnabled reports whether MCP is enabled host-side (a catalog is
+// configured). With MCP disabled there is nowhere for a registered server to live, so
+// a register proposal is deny-by-default. Satisfied by a closure over the daemon's MCP
+// catalog (cmd/controlplane).
+type MCPRegisterEnabled func() bool
+
+// MCPRegisterVerifier handles a ChangeMCPRegister — an agent's proposal to add a
+// BRAND-NEW MCP server endpoint to the host catalog (RFC-0007). It is deny-by-default
+// and never auto-approves:
+//
+//   - MCP disabled (no catalog wired) → reject. There is nowhere to register a server,
+//     and an agent should not be able to turn MCP on.
+//   - malformed definition (empty/invalid name, not exactly one of command/url for the
+//     transport, non-https url to a non-loopback host, …) → reject, reusing the
+//     catalog's own ServerConfig.Validate so the gateway and the catalog never disagree
+//     on what a valid server is.
+//   - otherwise → VerdictRequireHuman. Registering a server introduces a new
+//     code-execution/egress surface, so a human must approve the EXACT command/args/
+//     image or url/headers before it lands. It is NEVER auto-approved.
+//
+// Like every verifier it is additive: it runs before AlwaysRequireHuman and only ever
+// adds a rejection. Other kinds pass through untouched. It is deterministic (a parse +
+// in-memory policy check, no I/O).
+type MCPRegisterVerifier struct {
+	enabled MCPRegisterEnabled
+}
+
+// NewMCPRegisterVerifier constructs the verifier. A nil enabled check is treated as
+// "MCP disabled" so a missing wiring fails closed (every register is rejected).
+func NewMCPRegisterVerifier(enabled MCPRegisterEnabled) MCPRegisterVerifier {
+	return MCPRegisterVerifier{enabled: enabled}
+}
+
+// Name identifies the verifier.
+func (MCPRegisterVerifier) Name() string { return "mcp-register" }
+
+// Verify enforces the deny-by-default / validate / require-human policy for a
+// ChangeMCPRegister. Other kinds pass through untouched.
+func (v MCPRegisterVerifier) Verify(ctx context.Context, req contract.ChangeRequest) (contract.Verdict, string, error) {
+	if req.Kind != contract.ChangeMCPRegister {
+		return contract.VerdictPass, "", nil
+	}
+	if v.enabled == nil || !v.enabled() {
+		return contract.VerdictReject, "mcp registration is disabled (no MCP catalog configured)", nil
+	}
+	cfg, err := parseMCPRegister(req.After)
+	if err != nil {
+		return contract.VerdictReject, fmt.Sprintf("mcp_register payload is malformed: %v", err), nil
+	}
+	if err := cfg.Validate(); err != nil {
+		return contract.VerdictReject, err.Error(), nil
+	}
+	return contract.VerdictRequireHuman, "new MCP server endpoint — human must approve the exact command/url", nil
+}
+
+// MCPRegisterFunc lands an APPROVED MCP server in the host catalog and drops any cached
+// broker connection for that name so the next use reconnects with the new config.
+// Satisfied host-side by a closure over the catalog + broker (cmd/controlplane); a seam
+// so the gateway stays decoupled from concrete catalog/broker wiring.
+type MCPRegisterFunc func(cfg mcp.ServerConfig) error
+
+// MCPRegisterApplier materializes an approved ChangeMCPRegister by storing the proposed
+// server in the catalog. It deliberately does NOT grant the proposing agent access to
+// the new server's tools — that stays the separate, also-human-gated ChangeMCPAccess
+// path (least-privilege: registering an endpoint and being allowed to call it are two
+// independent approvals). Every other kind, and a ChangeMCPRegister with an empty
+// payload, passes through untouched.
+type MCPRegisterApplier struct {
+	register MCPRegisterFunc
+	next     contract.Applier
+}
+
+// NewMCPRegisterApplier wraps next. register may be nil (a recognized register then
+// errors rather than silently dropping); next may be nil.
+func NewMCPRegisterApplier(register MCPRegisterFunc, next contract.Applier) *MCPRegisterApplier {
+	return &MCPRegisterApplier{register: register, next: next}
+}
+
+// Apply stores an approved MCP server, then delegates.
+func (a *MCPRegisterApplier) Apply(ctx context.Context, req contract.ChangeRequest, d contract.Decision) error {
+	if req.Kind == contract.ChangeMCPRegister && len(req.After) > 0 {
+		cfg, err := parseMCPRegister(req.After)
+		if err != nil {
+			return fmt.Errorf("mcp register apply: %w", err)
+		}
+		if a.register == nil {
+			return fmt.Errorf("mcp register apply: no registrar wired")
+		}
+		if err := a.register(cfg); err != nil {
+			return fmt.Errorf("mcp register apply: %w", err)
+		}
+	}
+	if a.next != nil {
+		return a.next.Apply(ctx, req, d)
+	}
+	return nil
+}
+
+// parseMCPRegister decodes a ChangeMCPRegister After payload into a server config.
+// Disallows unknown fields so a typo'd or padded definition is a loud error rather than
+// a silently-ignored field — the human approves exactly what is parsed.
+func parseMCPRegister(after json.RawMessage) (mcp.ServerConfig, error) {
+	var cfg mcp.ServerConfig
+	dec := json.NewDecoder(bytes.NewReader(after))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		return mcp.ServerConfig{}, err
+	}
+	return cfg, nil
+}

--- a/internal/host/gateway/mcp_register_test.go
+++ b/internal/host/gateway/mcp_register_test.go
@@ -1,0 +1,154 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+	"github.com/IronSecCo/ironclaw/internal/host/mcp"
+)
+
+func TestMCPRegisterVerifier(t *testing.T) {
+	stdio := `{"name":"local","transport":"stdio","command":"server"}`
+	httpsRemote := `{"name":"remote","transport":"http","url":"https://mcp.example.com"}`
+
+	cases := []struct {
+		name    string
+		enabled bool
+		req     contract.ChangeRequest
+		want    contract.Verdict
+	}{
+		{"disabled rejects valid register", false,
+			contract.ChangeRequest{Kind: contract.ChangeMCPRegister, After: json.RawMessage(stdio)}, contract.VerdictReject},
+		{"valid stdio requires human", true,
+			contract.ChangeRequest{Kind: contract.ChangeMCPRegister, After: json.RawMessage(stdio)}, contract.VerdictRequireHuman},
+		{"valid https requires human", true,
+			contract.ChangeRequest{Kind: contract.ChangeMCPRegister, After: json.RawMessage(httpsRemote)}, contract.VerdictRequireHuman},
+		{"empty name rejected", true,
+			contract.ChangeRequest{Kind: contract.ChangeMCPRegister, After: json.RawMessage(`{"transport":"stdio","command":"x"}`)}, contract.VerdictReject},
+		{"stdio without command rejected", true,
+			contract.ChangeRequest{Kind: contract.ChangeMCPRegister, After: json.RawMessage(`{"name":"local","transport":"stdio"}`)}, contract.VerdictReject},
+		{"both command and url rejected", true,
+			contract.ChangeRequest{Kind: contract.ChangeMCPRegister, After: json.RawMessage(`{"name":"x","transport":"stdio","command":"c","url":"https://e.com"}`)}, contract.VerdictReject},
+		{"http non-loopback http url rejected", true,
+			contract.ChangeRequest{Kind: contract.ChangeMCPRegister, After: json.RawMessage(`{"name":"x","transport":"http","url":"http://mcp.example.com"}`)}, contract.VerdictReject},
+		{"unknown field rejected", true,
+			contract.ChangeRequest{Kind: contract.ChangeMCPRegister, After: json.RawMessage(`{"name":"x","transport":"stdio","command":"c","evil":true}`)}, contract.VerdictReject},
+		{"unparseable rejected", true,
+			contract.ChangeRequest{Kind: contract.ChangeMCPRegister, After: json.RawMessage(`not json`)}, contract.VerdictReject},
+		{"other kind passes", true,
+			contract.ChangeRequest{Kind: contract.ChangePersona, After: json.RawMessage(`{}`)}, contract.VerdictPass},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			v := NewMCPRegisterVerifier(func() bool { return c.enabled })
+			got, _, err := v.Verify(context.Background(), c.req)
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if got != c.want {
+				t.Fatalf("verdict = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestMCPRegisterVerifier_NilEnabledFailsClosed asserts a missing enabled wiring is
+// treated as disabled (deny-by-default), never as "allowed".
+func TestMCPRegisterVerifier_NilEnabledFailsClosed(t *testing.T) {
+	v := NewMCPRegisterVerifier(nil)
+	got, _, err := v.Verify(context.Background(),
+		contract.ChangeRequest{Kind: contract.ChangeMCPRegister, After: json.RawMessage(`{"name":"x","transport":"stdio","command":"c"}`)})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got != contract.VerdictReject {
+		t.Fatalf("verdict = %v, want VerdictReject (nil enabled must fail closed)", got)
+	}
+}
+
+func TestMCPRegisterApplier_StoresServer(t *testing.T) {
+	var got mcp.ServerConfig
+	register := func(cfg mcp.ServerConfig) error { got = cfg; return nil }
+	a := NewMCPRegisterApplier(register, nil)
+
+	req := contract.ChangeRequest{
+		Kind:  contract.ChangeMCPRegister,
+		After: json.RawMessage(`{"name":"local","transport":"stdio","command":"server","args":["--port","0"]}`),
+	}
+	if err := a.Apply(context.Background(), req, contract.Decision{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got.Name != "local" || got.Transport != mcp.TransportStdio || got.Command != "server" || len(got.Args) != 2 {
+		t.Fatalf("registered config = %+v", got)
+	}
+
+	// A non-register change passes through without touching the registrar.
+	got = mcp.ServerConfig{}
+	other := contract.ChangeRequest{Kind: contract.ChangePersona, After: json.RawMessage(`{"instructions":"x"}`)}
+	if err := a.Apply(context.Background(), other, contract.Decision{}); err != nil {
+		t.Fatalf("Apply persona: %v", err)
+	}
+	if got.Name != "" {
+		t.Fatal("persona change should not invoke the MCP registrar")
+	}
+}
+
+func TestMCPRegisterApplier_NilRegistrarErrors(t *testing.T) {
+	a := NewMCPRegisterApplier(nil, nil)
+	req := contract.ChangeRequest{Kind: contract.ChangeMCPRegister, After: json.RawMessage(`{"name":"x","transport":"stdio","command":"c"}`)}
+	if err := a.Apply(context.Background(), req, contract.Decision{}); err == nil {
+		t.Fatal("expected an error when no registrar is wired")
+	}
+}
+
+// TestMCPRegisterEndToEnd_GatewayToCatalog drives a register proposal through the real
+// gateway: the verifier holds it for a human, and only on approval does the applier land
+// the server in a real catalog. It also asserts the server is NOT in the catalog before
+// approval (no auto-apply).
+func TestMCPRegisterEndToEnd_GatewayToCatalog(t *testing.T) {
+	cat, err := mcp.NewCatalog("")
+	if err != nil {
+		t.Fatalf("NewCatalog: %v", err)
+	}
+	register := func(cfg mcp.ServerConfig) error { return cat.Put(cfg) }
+	verifier := NewMCPRegisterVerifier(func() bool { return true })
+	applier := NewMCPRegisterApplier(register, NewLogApplier())
+	store := NewMemoryStore()
+	gw := New(VerifierChain{verifier, AlwaysRequireHuman{}}, NewManualApprover(), applier, store)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := gw.Submit(context.Background(), contract.ChangeRequest{
+			ID:    "reg1",
+			Kind:  contract.ChangeMCPRegister,
+			After: json.RawMessage(`{"name":"weather","transport":"http","url":"https://weather.example.com/mcp"}`),
+		})
+		errCh <- err
+	}()
+	waitPending(t, store, "reg1")
+
+	// Before approval, the server must NOT exist in the catalog.
+	if _, ok := cat.Get("weather"); ok {
+		t.Fatal("server landed in catalog before human approval")
+	}
+
+	if err := gw.Decide("reg1", contract.Decision{Outcome: OutcomeApprove, DecidedBy: "owner", DecidedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+	if st, _ := store.Status("reg1"); st != string(statusApplied) {
+		t.Fatalf("status = %q, want applied", st)
+	}
+	got, ok := cat.Get("weather")
+	if !ok {
+		t.Fatal("server not in catalog after approval")
+	}
+	if got.Transport != mcp.TransportHTTP || got.URL != "https://weather.example.com/mcp" {
+		t.Fatalf("registered server = %+v", got)
+	}
+}

--- a/internal/integration/mcp_test.go
+++ b/internal/integration/mcp_test.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/IronSecCo/ironclaw/internal/contract"
+	"github.com/IronSecCo/ironclaw/internal/host/gateway"
 	"github.com/IronSecCo/ironclaw/internal/host/mcp"
 	"github.com/IronSecCo/ironclaw/internal/sandbox/tools"
 )
@@ -84,6 +87,137 @@ func TestMCPToolThroughRealBroker(t *testing.T) {
 	if len(none) != 0 {
 		t.Fatalf("s2 discovered %d tools, want 0 (granted nothing)", len(none))
 	}
+}
+
+// TestMCPRegisterToExecuteEndToEnd closes the full OpenClaw register→approve→access→
+// execute loop across the real gateway, catalog, broker, and in-sandbox tool:
+//
+//  1. REGISTER: a ChangeMCPRegister proposal flows through the real gateway. The
+//     MCPRegisterVerifier holds it for a human (never auto-approved); only on approval
+//     does the MCPRegisterApplier land the server in the catalog. The server is absent
+//     before approval.
+//  2. ACCESS: an approved grant (the separate, also-human-gated ChangeMCPAccess, here
+//     applied via the grants seam) lets one session call one tool on the new server.
+//  3. EXECUTE: the in-sandbox tool discovers exactly that tool over the per-session
+//     broker socket and invokes it round-trip — proving registration grants nothing by
+//     itself and the new endpoint is reachable only after BOTH approvals.
+func TestMCPRegisterToExecuteEndToEnd(t *testing.T) {
+	upstream := httptest.NewServer(mcp.SampleServer().Handler())
+	defer upstream.Close()
+
+	cat, err := mcp.NewCatalog("")
+	if err != nil {
+		t.Fatalf("NewCatalog: %v", err)
+	}
+	// The broker shares the catalog instance the register applier writes to, so an
+	// approved register is visible to broker sessions after Invalidate.
+	grants := func(session string) []mcp.Grant {
+		if session == "s1" {
+			return []mcp.Grant{{Server: "sample", Tools: []string{"echo"}}}
+		}
+		return nil
+	}
+	broker := mcp.New(context.Background(), cat, grants)
+	defer broker.Close()
+
+	// --- 1. REGISTER through the real gateway ---
+	register := func(cfg mcp.ServerConfig) error {
+		if err := cat.Put(cfg); err != nil {
+			return err
+		}
+		broker.Invalidate(cfg.Name)
+		return nil
+	}
+	gw := gateway.New(
+		gateway.VerifierChain{
+			gateway.NewMCPRegisterVerifier(func() bool { return true }),
+			gateway.AlwaysRequireHuman{},
+		},
+		gateway.NewManualApprover(),
+		gateway.NewMCPRegisterApplier(register, gateway.NewLogApplier()),
+		gateway.NewMemoryStore(),
+	)
+
+	after := `{"name":"sample","transport":"http","url":"` + upstream.URL + `"}`
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := gw.Submit(context.Background(), contract.ChangeRequest{
+			ID: "reg1", Kind: contract.ChangeMCPRegister, After: json.RawMessage(after),
+		})
+		errCh <- err
+	}()
+
+	// Wait for the change to be held pending (not auto-applied), then assert absence.
+	waitForPending(t, gw, "reg1")
+	if _, ok := cat.Get("sample"); ok {
+		t.Fatal("server registered before human approval")
+	}
+
+	if err := gw.Decide("reg1", contract.Decision{Outcome: gateway.OutcomeApprove, DecidedBy: "owner", DecidedAt: time.Now()}); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if _, ok := cat.Get("sample"); !ok {
+		t.Fatal("server not in catalog after approval")
+	}
+
+	// --- 2 & 3. ACCESS + EXECUTE through the real broker + sandbox tool ---
+	dir := t.TempDir()
+	sock, err := broker.SocketForSession("s1", dir)
+	if err != nil {
+		t.Fatalf("SocketForSession: %v", err)
+	}
+	mcpTools, err := tools.MCPTools(sock)
+	if err != nil {
+		t.Fatalf("MCPTools: %v", err)
+	}
+	if len(mcpTools) != 1 || mcpTools[0].Name() != "sample__echo" {
+		t.Fatalf("discovered %d tools (%v), want only sample__echo", len(mcpTools), toolNames(mcpTools))
+	}
+	out, err := mcpTools[0].Invoke(context.Background(), json.RawMessage(`{"text":"registered+approved"}`))
+	if err != nil {
+		t.Fatalf("Invoke echo: %v", err)
+	}
+	if out != "registered+approved" {
+		t.Fatalf("echo returned %q", out)
+	}
+
+	// A session with no grant sees nothing on the freshly-registered server — register
+	// did not widen anyone's surface.
+	sock2, err := broker.SocketForSession("s2", dir)
+	if err != nil {
+		t.Fatalf("SocketForSession s2: %v", err)
+	}
+	none, err := tools.MCPTools(sock2)
+	if err != nil {
+		t.Fatalf("MCPTools s2: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("s2 saw %d tools after register, want 0 (register grants nothing)", len(none))
+	}
+}
+
+// waitForPending blocks until the gateway reports the given change id as pending, so a
+// blocking Submit running in a goroutine has reached the human-approval floor before the
+// test decides it.
+func waitForPending(t *testing.T, gw *gateway.Gateway, id contract.ChangeID) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		pending, err := gw.Pending()
+		if err != nil {
+			t.Fatalf("Pending: %v", err)
+		}
+		for _, p := range pending {
+			if p.ID == id {
+				return
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("change %q never became pending", id)
 }
 
 func toolNames(ts []tools.Tool) []string {

--- a/internal/sandbox/tools/capability.go
+++ b/internal/sandbox/tools/capability.go
@@ -36,6 +36,7 @@ var validChangeKinds = map[contract.ChangeKind]struct{}{
 	contract.ChangeMounts:       {},
 	contract.ChangeMCPAccess:    {},
 	contract.ChangeSkillInstall: {},
+	contract.ChangeMCPRegister:  {},
 }
 
 type requestCapabilityChangeInput struct {
@@ -74,12 +75,17 @@ func (t *RequestCapabilityChangeTool) Description() string {
 		"NAME a skill the operator has curated and signed — you cannot author skill content. The host resolves and " +
 		"signature-verifies the named skill, the human approves the exact persona/tools/egress it grants, and it then " +
 		"mounts and takes effect on your next message (same session).\n" +
+		"- Register a brand-new MCP server endpoint (when no operator-configured server has the tools you need): kind " +
+		"\"mcp_register\", payload {\"name\": \"<label>\", \"transport\": \"stdio\"|\"http\", and for stdio {\"command\", \"args\", " +
+		"\"image\", \"env\"} or for http {\"url\", \"headers\"}}. You only PROPOSE the endpoint — the human approves the EXACT " +
+		"command/args/image or url before it is added to the catalog, and registering grants you NOTHING by itself: once it " +
+		"is approved you still request its tools via a separate \"mcp_access\" change.\n" +
 		"Also supports persona, packages, permissions, and mounts. Always include a clear reason for the human approver."
 }
 
 func (t *RequestCapabilityChangeTool) JSONSchema() json.RawMessage {
 	return json.RawMessage(`{"type":"object","properties":{` +
-		`"kind":{"type":"string","enum":["persona","enabled_tools","packages","wiring","permissions","mounts","mcp_access","skill_install"],"description":"The kind of control-plane change requested."},` +
+		`"kind":{"type":"string","enum":["persona","enabled_tools","packages","wiring","permissions","mounts","mcp_access","skill_install","mcp_register"],"description":"The kind of control-plane change requested."},` +
 		`"payload":{"type":"object","description":"The proposed new configuration for this kind."},` +
 		`"reason":{"type":"string","description":"Why the change is needed (shown to the human approver)."}` +
 		`},"required":["kind","payload"],"additionalProperties":false}`)

--- a/internal/sandbox/tools/capability_test.go
+++ b/internal/sandbox/tools/capability_test.go
@@ -1,0 +1,68 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+)
+
+// TestRequestCapabilityChange_MCPRegisterRoundTrip proves the in-sandbox tool accepts an
+// mcp_register proposal, validates the kind, and re-renders it into the frozen host
+// system-action wire format with the action discriminator and payload preserved — the
+// exact envelope host delivery parses and routes through the mandatory gateway.
+func TestRequestCapabilityChange_MCPRegisterRoundTrip(t *testing.T) {
+	tool := NewRequestCapabilityChangeTool()
+	payload := `{"name":"weather","transport":"http","url":"https://weather.example.com/mcp","headers":{"Authorization":"${WEATHER_TOKEN}"}}`
+	input := json.RawMessage(`{"kind":"mcp_register","payload":` + payload + `,"reason":"need weather data"}`)
+
+	out, err := tool.Invoke(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	// The envelope parses and carries the mcp_register kind.
+	cc, err := ParseCapabilityChange(out)
+	if err != nil {
+		t.Fatalf("ParseCapabilityChange: %v", err)
+	}
+	if cc.Kind != contract.ChangeMCPRegister {
+		t.Fatalf("kind = %q, want mcp_register", cc.Kind)
+	}
+
+	// ToHostAction renders the host system-action wire format.
+	hostAction, err := tool.ToHostAction(out)
+	if err != nil {
+		t.Fatalf("ToHostAction: %v", err)
+	}
+	a := contract.ParseSystemAction(hostAction)
+	if a.Action != "mcp_register" {
+		t.Fatalf("system action = %q, want mcp_register", a.Action)
+	}
+	if a.Reason != "need weather data" {
+		t.Fatalf("reason = %q, want preserved", a.Reason)
+	}
+	// The proposed definition survives verbatim so the gateway verifier and human
+	// approver see the real endpoint.
+	var got, want map[string]any
+	if err := json.Unmarshal(a.Payload, &got); err != nil {
+		t.Fatalf("payload not JSON: %v", err)
+	}
+	if err := json.Unmarshal([]byte(payload), &want); err != nil {
+		t.Fatalf("want payload not JSON: %v", err)
+	}
+	if got["name"] != want["name"] || got["transport"] != want["transport"] || got["url"] != want["url"] {
+		t.Fatalf("payload not preserved: got %v", got)
+	}
+}
+
+// TestRequestCapabilityChange_RejectsUnknownKind guards the in-sandbox allowlist: a kind
+// the contract does not define is rejected before it can reach the queue.
+func TestRequestCapabilityChange_RejectsUnknownKind(t *testing.T) {
+	tool := NewRequestCapabilityChangeTool()
+	_, err := tool.Invoke(context.Background(), json.RawMessage(`{"kind":"mcp_takeover","payload":{}}`))
+	if err == nil {
+		t.Fatal("expected an unknown-kind rejection")
+	}
+}


### PR DESCRIPTION
## Summary

Implements the board-approved **Option 2** from [IRO-50](/IRO/issues/IRO-50): a gated `mcp_register` change kind that lets an agent **propose a brand-new MCP server endpoint from chat**, closing the OpenClaw `register → approve → access → execute` parity gap without weakening the blind-MCP gate IronClaw exists to close.

Mirrors the existing `create_agent` / `mcp_access` / `skill_install` privileged-change pattern.

### Trust model (the gate)
- The agent only **proposes**; delivery refuses to act on `mcp_register` and routes it to the gateway as a `ChangeMCPRegister`.
- `MCPRegisterVerifier` is **deny-by-default** (reject when MCP disabled), rejects a malformed def by reusing the catalog's own `ServerConfig.Validate`, and otherwise returns **require-human** — never auto-approved.
- The human approves the **exact** `command`/`args`/`image` (stdio) or `url`/`headers` (http). The approval card masks `env`/`headers` secrets via `ServerConfig.Public`.
- An approved register **grants the proposing agent nothing** — it must still obtain tools via the separate, also-human-gated `mcp_access` approval (least-privilege).
- MCP servers still run **host-side** behind the per-session broker socket; the sandbox stays `network=none`.

### Changes
- **contract** (`internal/contract/enums.go`): add `ChangeMCPRegister = "mcp_register"` — the only frozen-contract edit.
- **sandbox tool** (`internal/sandbox/tools/capability.go`): add to `validChangeKinds` + JSON-schema enum + description.
- **delivery** (`internal/host/delivery/delivery.go`): `authorizeSystemAction` maps it (privileged → gateway).
- **gateway** (`internal/host/gateway/mcp_register.go`): `MCPRegisterVerifier` + `MCPRegisterApplier`.
- **read-model** (`internal/host/api/ui_approvals.go`): mask secrets on `mcp_register` approval cards.
- **wiring** (`cmd/controlplane/main.go`): verifier before `AlwaysRequireHuman`; applier → `catalog.Put` + `broker.Invalidate`.
- **docs**: `contract.md` (RFC-0007 + payload table), `threat-model.md` (RCE/egress analysis), `mcp.md` parity note.

### Tests
- Verifier (deny/reject/require-human + nil-enabled fail-closed), applier, sandbox envelope round-trip, secret-masking read-model, and an **integration e2e** driving `register → approve → access → execute` across the real gateway, catalog, broker, and in-sandbox tool.
- Full suite green: **931 tests pass across 40 packages** (`CGO_ENABLED=1`).

### Security review bar touched
Trust-boundary integrity, mandatory gateway, isolation, egress least-privilege, secret hygiene. **Frozen-contract change + new privileged proposal channel — routed to CEO for trust-model review before merge (do not self-merge).**

Closes IRO-145.