### PR TITLE
ci(review): machine reviewer of record — end the single-identity self-approval bottleneck (IRO-148)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# IronClaw code owners.
+#
+# Documents ownership of the security-critical supply-chain / release surface and
+# the repository's review controls. It also lets GitHub auto-request review from
+# the right owners on matching PRs.
+#
+# Status: ADVISORY. main's ruleset currently has `require_code_owner_review:
+# false`, so these lines do not block merges yet. They are the ready-to-activate
+# path for Option B (a dedicated reviewer account/team). The RECOMMENDED reviewer
+# is the `ironclaw-reviewer` GitHub App (Option A) — a GitHub App cannot be a
+# CODEOWNER, so it is driven by .github/workflows/reviewer-approve.yml instead.
+# See docs/pr-review-process.md.
+#
+# NOTE: the `@IronSecCo/reviewers` team must exist for these owners to resolve;
+# until then GitHub shows a (non-blocking) "unknown owner" notice. Creating the
+# team is step 6 of the human handoff in docs/pr-review-process.md.
+
+# Release & supply-chain pipeline
+/.github/workflows/        @IronSecCo/reviewers
+/.github/rulesets/         @IronSecCo/reviewers
+/.github/CODEOWNERS        @IronSecCo/reviewers
+/.github/reviewer-app-manifest.yml  @IronSecCo/reviewers
+/scripts/install.sh        @IronSecCo/reviewers
+/scripts/install.ps1       @IronSecCo/reviewers
+/docs/pr-review-process.md @IronSecCo/reviewers
+/docs/release-runbook.md   @IronSecCo/reviewers

--- a/.github/reviewer-app-manifest.yml
+++ b/.github/reviewer-app-manifest.yml
@@ -1,0 +1,34 @@
+# GitHub App manifest for the IronClaw "machine reviewer of record".
+#
+# This is documentation + the source of truth for the App's settings. GitHub App
+# creation requires an interactive browser session (and yields a private key an
+# agent must never handle), so the App is created by a human following the
+# click-by-click steps in docs/pr-review-process.md. The fields below MUST match
+# what is entered there.
+#
+# Purpose: provide a distinct reviewer actor (ironclaw-reviewer[bot]) so that
+# main's required-review gate can be satisfied without admin bypass, while every
+# agent still operates under the single omerzamir identity. See
+# docs/pr-review-process.md for the full rationale and flow.
+
+name: ironclaw-reviewer
+url: https://github.com/IronSecCo/ironclaw
+description: >-
+  Posts the approving review of record on IronClaw PRs after a human/board
+  review is recorded in Paperclip. Driven only by the manually dispatched
+  reviewer-approve.yml workflow; never auto-approves.
+
+# No webhook: the App is driven by Actions, not events.
+hook_attributes:
+  active: false
+
+public: false
+
+# Least privilege. Only what is needed to post an approving review.
+default_permissions:
+  pull_requests: write   # submit the APPROVE review
+  contents: read         # read PR head / repo metadata
+  metadata: read         # mandatory baseline
+
+# The App is event-driven by nothing; it subscribes to no events.
+default_events: []

--- a/.github/workflows/reviewer-approve.yml
+++ b/.github/workflows/reviewer-approve.yml
@@ -1,0 +1,115 @@
+# Machine reviewer of record.
+#
+# Posts an approving review on a PR as the ironclaw-reviewer[bot] GitHub App so
+# that main's required-review gate (required_approving_review_count: 1) is
+# satisfied by an actor that is NOT the PR author — without admin bypass.
+#
+# This is NOT an auto-approver. It runs only on manual dispatch by a repo admin
+# and requires a `review_of_record` reference (the Paperclip approval id/URL of
+# the human/board decision). The GitHub approval mechanically reflects that
+# recorded decision. See docs/pr-review-process.md.
+#
+# Inert until the App is installed: without the REVIEWER_APP_* secrets a dispatch
+# fails fast with a clear message. It never runs on push/PR, so it adds no
+# required-check surface and changes no current behaviour.
+
+name: Reviewer approval
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to approve"
+        required: true
+        type: string
+      review_of_record:
+        description: "Paperclip approval id or URL of the recorded review of record"
+        required: true
+        type: string
+
+# Default to no privileges; grant the minimum per job.
+permissions: {}
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Validate inputs and reviewer-App configuration
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.actor }}
+          PR: ${{ inputs.pr }}
+          ROR: ${{ inputs.review_of_record }}
+          APP_ID: ${{ secrets.REVIEWER_APP_ID }}
+          APP_KEY: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${ROR// }" ]; then
+            echo "::error::review_of_record is required (the Paperclip approval id/URL)." >&2
+            exit 1
+          fi
+          case "$PR" in
+            ''|*[!0-9]*) echo "::error::pr must be a numeric PR number." >&2; exit 1 ;;
+          esac
+
+          if [ -z "${APP_ID:-}" ] || [ -z "${APP_KEY:-}" ]; then
+            echo "::error::Reviewer App not installed: set REVIEWER_APP_ID and REVIEWER_APP_PRIVATE_KEY secrets first (see docs/pr-review-process.md)." >&2
+            exit 1
+          fi
+
+          # Tighten dispatch (which only requires write) to repo admins.
+          PERM=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${ACTOR}/permission" --jq '.permission')
+          if [ "$PERM" != "admin" ]; then
+            echo "::error::${ACTOR} is '${PERM}', not 'admin'. Only a repo admin may dispatch the reviewer approval." >&2
+            exit 1
+          fi
+
+          # PR must be open.
+          STATE=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" --jq '.state')
+          if [ "$STATE" != "open" ]; then
+            echo "::error::PR #${PR} is '${STATE}', not open." >&2
+            exit 1
+          fi
+
+      - name: Mint reviewer-App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.REVIEWER_APP_ID }}
+          private-key: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
+
+      - name: Post approving review as the reviewer App
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ inputs.pr }}
+          ROR: ${{ inputs.review_of_record }}
+          ACTOR: ${{ github.actor }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+
+          # Guard: the App must not be the PR author (author == approver defeats the gate).
+          APP_LOGIN="${APP_SLUG}[bot]"
+          PR_AUTHOR=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" --jq '.user.login')
+          if [ "$PR_AUTHOR" = "$APP_LOGIN" ]; then
+            echo "::error::Reviewer App is the PR author; refusing to self-approve." >&2
+            exit 1
+          fi
+
+          BODY="Approved by the IronClaw machine reviewer of record.
+
+          Review of record: ${ROR}
+          Dispatched by repo admin: @${ACTOR}
+
+          This approval mechanically reflects a human/board review recorded in Paperclip.
+          See docs/pr-review-process.md."
+
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/reviews" \
+            -f event=APPROVE \
+            -f body="$BODY"
+
+          echo "Posted approving review as ${APP_LOGIN} on PR #${PR}."

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -1,0 +1,176 @@
+# PR review & the machine reviewer of record
+
+> **Status:** decision recorded; automatable config landed. One irreducible
+> human step remains (create/install the reviewer GitHub App) — see
+> [Human handoff](#human-handoff-one-time-setup).
+
+## Why this exists
+
+`main` is protected by a branch ruleset
+([`.github/rulesets/main.json`](https://github.com/IronSecCo/ironclaw/blob/main/.github/rulesets/main.json))
+that requires **one approving review** plus the `build` and `CodeQL` status
+checks before any PR can merge. That is the gate that keeps unreviewed code off
+`main`.
+
+Today every IronClaw agent (Forge, Relay, QA, …) drives Git/GitHub under the
+**single `omerzamir` GitHub identity**. GitHub will not let an identity approve
+its own pull request. So when an agent opens a PR as `omerzamir`, *no agent* can
+post the approving review the ruleset requires — the author and every available
+reviewer are the same actor. Security-critical PRs that have a recorded
+Paperclip review of record still cannot satisfy the GitHub gate, and the only
+escape valve is an admin bypass (the repo-admin `bypass_actors` entry).
+
+Admin bypass is a band-aid: it lets a green PR merge **without any second-actor
+approval being recorded on GitHub at all**, which is exactly the property the
+gate exists to guarantee. This document is the durable fix: a **distinct,
+trusted reviewer actor** that is not the PR author, so the required-review gate
+is satisfied honestly — no bypass.
+
+## What "review of record" means here
+
+The judgement — *should this change merge?* — is made and recorded in
+**Paperclip** (a board approval, a QA sign-off, or an execution-policy review
+stage). That is the review of record. GitHub's approving review is a
+**mechanical reflection** of that decision by a distinct actor, so branch
+protection can verify "author ≠ approver" cryptographically.
+
+The reviewer actor is therefore **not** a rubber stamp that auto-approves every
+PR. It only approves when a human/board review of record already exists and is
+referenced. The gating lives in *who can trigger the approval* and *what they
+must supply*, never in the actor approving unconditionally.
+
+## Options considered
+
+| | **Option A — GitHub App** *(recommended)* | **Option B — dedicated bot user** |
+|---|---|---|
+| Distinct actor for the gate | ✅ Approvals post as `app-slug[bot]`, a different actor than `omerzamir`. App reviews count toward `required_approving_review_count`. | ✅ A second user account is a different actor; its approval counts. |
+| Can be a CODEOWNER | ❌ CODEOWNERS only accepts users/teams, not apps. (Our ruleset has `require_code_owner_review: false`, so this is not needed for the gate.) | ✅ Can be listed in CODEOWNERS and required via `require_code_owner_review`. |
+| Seats / cost | ✅ Apps consume **no seat**. Free. | ⚠️ Free on this **public** repo, but a paid org seat per private repo; account lifecycle (email, 2FA, recovery) to own forever. |
+| Secret handling | ⚠️ One long-lived **App private key** (PEM), stored as a repo/org Actions secret, scoped to `pull_requests: write` + `contents/metadata: read`. Rotatable; never touches release signing (which stays keyless/OIDC). | ❌ A full second login: password + 2FA + a long-lived PAT with `repo` scope. Larger, human-shaped attack surface. |
+| Audit story | ✅ Reviews are clearly machine-posted by a named bot; fine-grained, least-privilege permissions; one auditable installation. | ⚠️ Looks like a human; easy to over-grant; harder to reason about least privilege. |
+| Automatable now | ✅ Manifest + workflow scaffolded in this repo; only App creation/install needs a human. | ⚠️ Account creation needs a human inbox + 2FA; collaborator invite + CODEOWNERS automatable after. |
+| GitHub guidance | ✅ Apps are GitHub's recommended automation primitive. | ⚠️ Machine user accounts are allowed but discouraged when an App fits. |
+
+### Recommendation: **Option A — a dedicated GitHub App.**
+
+It gives a distinct reviewer actor that satisfies the *existing* ruleset with
+**no branch-protection change**, consumes no seat, carries the smallest,
+fine-grained permission set, and produces the cleanest audit trail. Its only
+cost is a single long-lived CI credential (the App private key) — a scoped,
+rotatable Actions secret that never participates in release signing, so the
+keyless/OIDC signing posture is unchanged.
+
+CODEOWNERS (which an App cannot satisfy) is kept as a **ready-to-activate**
+artifact for the Option-B fallback and for documenting ownership; it stays
+advisory while `require_code_owner_review` is `false`.
+
+## How the gate is satisfied (Option A flow)
+
+```
+agent opens PR as omerzamir ──► CI: build + CodeQL go green
+                                      │
+                  human/board review of record recorded in Paperclip
+                                      │
+        repo admin dispatches reviewer-approve.yml with { pr, review_of_record }
+                                      │
+   workflow: admin-actor check ─► mint App installation token ─► POST APPROVE
+                                      │
+       branch protection sees 1 approval from ironclaw-reviewer[bot] ≠ author
+                                      │
+                              PR is mergeable — no admin bypass
+```
+
+The mechanics live in
+[`.github/workflows/reviewer-approve.yml`](https://github.com/IronSecCo/ironclaw/blob/main/.github/workflows/reviewer-approve.yml):
+
+- **Trigger:** `workflow_dispatch` only — never runs on push/PR, so it cannot
+  rubber-stamp anything automatically and adds no required-check surface.
+- **Inputs:** `pr` (number) and `review_of_record` (the Paperclip approval id or
+  URL). The approval body embeds `review_of_record` so the GitHub approval links
+  back to the recorded decision.
+- **Authorization:** the workflow re-checks that the dispatching actor has
+  **admin** permission on the repo before approving (dispatch already requires
+  write; the explicit admin check tightens it to repo admins, e.g. the CEO).
+- **Least privilege:** the job's `GITHUB_TOKEN` is `contents: read` +
+  `pull-requests: read`; the approving review is posted with the **App
+  installation token** (`pull_requests: write`), minted at run time via
+  [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token)
+  (SHA-pinned). The App private key is read from `secrets.REVIEWER_APP_PRIVATE_KEY`
+  and masked by the action — it is never logged.
+- **Safety:** the workflow refuses to approve if the App secret is absent, if
+  the PR is not open, or if the PR author is the App itself.
+
+Until the App is installed and the two secrets exist, the workflow is **inert**
+(a manual dispatch fails fast with a clear message). Nothing in CI or the
+release path depends on it, so landing the scaffold changes no current behaviour.
+
+## Branch protection: no change required
+
+The recommended path needs **no edit** to
+[`.github/rulesets/main.json`](https://github.com/IronSecCo/ironclaw/blob/main/.github/rulesets/main.json).
+The App's approving review satisfies the existing
+`pull_request.required_approving_review_count: 1`. The admin `bypass_actors`
+entry stays as the break-glass path of last resort, but with a working machine
+reviewer it should no longer be the *routine* way security PRs merge.
+
+If we ever adopt Option B instead, the only ruleset change would be flipping
+`require_code_owner_review` to `true` after the reviewer account/team is a
+CODEOWNER — tracked in [CODEOWNERS](https://github.com/IronSecCo/ironclaw/blob/main/.github/CODEOWNERS).
+
+## Human handoff (one-time setup)
+
+Everything an agent can do is already in this repo (manifest, workflow,
+CODEOWNERS, docs). The **only** step that genuinely needs a human is creating and
+installing the App and storing its credentials — GitHub App creation requires an
+interactive browser session and yields a private key an agent must never handle.
+**Escalated to the CEO.**
+
+Click-by-click (≈5 minutes, repo admin):
+
+1. **Create the App.** Go to
+   `https://github.com/organizations/IronSecCo/settings/apps/new`.
+   - **GitHub App name:** `ironclaw-reviewer`
+   - **Homepage URL:** `https://github.com/IronSecCo/ironclaw`
+   - **Webhook:** uncheck **Active** (no webhook needed).
+   - **Repository permissions:** **Pull requests → Read and write**,
+     **Contents → Read-only**, **Metadata → Read-only** (mandatory). Leave
+     everything else **No access**.
+   - **Where can this App be installed?** *Only on this account.*
+   - Click **Create GitHub App**.
+   *(The values above match [`.github/reviewer-app-manifest.yml`](https://github.com/IronSecCo/ironclaw/blob/main/.github/reviewer-app-manifest.yml).)*
+2. **Note the App ID** shown on the App's settings page.
+3. **Generate a private key:** on the App page → **Private keys** →
+   **Generate a private key**. A `.pem` downloads. Treat it as a secret.
+4. **Install the App:** App page → **Install App** → install on **IronSecCo**,
+   scoped to **only the `ironclaw` repository**.
+5. **Store the credentials as repo secrets** (Settings → Secrets and variables →
+   Actions → New repository secret), or via CLI:
+   ```bash
+   gh secret set REVIEWER_APP_ID --repo IronSecCo/ironclaw --body "<the App ID>"
+   gh secret set REVIEWER_APP_PRIVATE_KEY --repo IronSecCo/ironclaw < path/to/ironclaw-reviewer.*.private-key.pem
+   ```
+   Then delete the local `.pem`.
+6. *(Optional, only if adopting Option B / CODEOWNERS enforcement)* create the
+   `@IronSecCo/reviewers` team and add the reviewer as a member so the
+   [CODEOWNERS](https://github.com/IronSecCo/ironclaw/blob/main/.github/CODEOWNERS)
+   owner resolves.
+
+### Verification (run once the App exists)
+
+This proves the acceptance criterion — *a non-author reviewer approval satisfies
+the `main` required-review gate*:
+
+1. Open a throwaway PR against `main` (e.g. a no-op docs edit) as `omerzamir`.
+2. Let `build` + `CodeQL` go green.
+3. Run the reviewer workflow:
+   ```bash
+   gh workflow run reviewer-approve.yml -f pr=<PR_NUMBER> -f review_of_record="verification: IRO-148"
+   ```
+4. Confirm `ironclaw-reviewer[bot]` posted an **Approved** review and that the PR
+   page shows **"1 approving review"** with the required-review check satisfied
+   and the merge button enabled **without** admin bypass.
+5. Close the throwaway PR.
+
+Record the result on
+[IRO-148](https://github.com/IronSecCo/ironclaw) and remove the admin-bypass
+reliance for security PRs going forward.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,4 +130,5 @@ nav:
   - Reference:
       - API (OpenAPI): reference/api.md
       - Release runbook: release-runbook.md
+      - PR review & reviewer identity: pr-review-process.md
       - Roadmap: roadmap.md


### PR DESCRIPTION
## What & why

Permanent fix for the single-identity self-approval bottleneck (IRO-148). Every agent drives GitHub as the single `omerzamir` identity, and GitHub forbids approving your own PR — so `main`'s required-review gate cannot be satisfied by any agent, and the only escape is admin bypass. This lands the automatable parts of a durable replacement: a **distinct machine reviewer of record**.

## Decision

Recommend **Option A — a dedicated GitHub App** (`ironclaw-reviewer[bot]`) over a bot user account. It is a distinct actor whose approval counts toward the existing `required_approving_review_count: 1` (no ruleset change), consumes no seat, carries a minimal fine-grained permission set, and gives the cleanest audit trail. Full comparison + rationale in `docs/pr-review-process.md`.

## What's in this PR (everything an agent can do now)

- `docs/pr-review-process.md` — decision doc (App vs bot), flow, security/audit story, **click-by-click human-handoff** + verification checklist.
- `.github/workflows/reviewer-approve.yml` — gated, **manual-dispatch-only** workflow: mints an App installation token (SHA-pinned `create-github-app-token@v3.2.0`), re-checks the dispatcher is a repo **admin**, refuses if PR closed / App is the author / secrets absent, posts the APPROVE review referencing the Paperclip review of record. **Not an auto-approver.** Inert until the App secrets exist; never runs on push/PR so it adds no required-check surface.
- `.github/reviewer-app-manifest.yml` — least-privilege App settings (`pull_requests: write`, `contents`/`metadata: read`).
- `.github/CODEOWNERS` — advisory ownership of the supply-chain/release surface; ready-to-activate path for the Option-B fallback.
- `mkdocs.yml` — nav entry under Reference.

## Supply-chain lenses

- **Least-privilege CI** — top-level `permissions: {}`; job token is `contents: read` + `pull-requests: read`; the approve uses the separate App token (`pull_requests: write`).
- **Pinned, auditable actions** — `create-github-app-token` pinned to `bcd2ba4` (v3.2.0).
- **Signing integrity** — unchanged: the one new long-lived secret is the App private key (a scoped CI credential, rotatable), which never touches the keyless/OIDC release signing path.
- **Required-checks gating** — ratchets *up* (makes the existing required review honestly satisfiable; removes routine reliance on admin bypass).

## Irreducible human step (escalated to CEO)

Creating + installing the GitHub App and storing its private key as Actions secrets needs an interactive browser session and yields a key an agent must never handle. Exact click-by-click steps are in `docs/pr-review-process.md` → *Human handoff*.

## Verification

- `actionlint` (incl. shellcheck on `run:` blocks): **OK**
- Workflow + manifest YAML parse: **OK**
- End-to-end gate verification (App posts approval → required-review satisfied without bypass) is the post-install step in the handoff checklist — it requires the App to exist.

Trust-model change (how the required-review gate is satisfied) → **CEO review** before merge; do not self-merge.