### PR TITLE
Add a landing page to the website (IRO-154)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,78 +1,28 @@
 ---
-title: IronClaw
-description: Security-first, self-hosted AI agents — isolation you can prove, not just claim.
+title: IronClaw — security-first, self-hosted AI agents
+description: Security-first, self-hosted AI agents — isolation you can prove, not just promise. Run autonomous agents sealed off from the network, with a human-approval gateway no agent can bypass.
+template: home.html
+hide:
+  - navigation
+  - toc
 ---
 
-# IronClaw
+<!--
+  The homepage is rendered by overrides/home.html (set via `template:` above),
+  which replaces the standard content area with the landing page. This Markdown
+  body is intentionally a short text mirror of that page so the page still has
+  meaningful `page.content` for tooling; the rich layout lives in the template
+  and stylesheets/landing.css.
+-->
 
-**Security-hardened, self-hosted AI agents — isolation you can prove, not just claim.**
+# Security-first AI agents you actually run yourself.
 
-IronClaw runs autonomous agents the way a security team would want them run: every
-agent lives in a per-session **sandbox**, every capability change passes through a
-deterministic **human-approval gateway**, and every action lands in an append-only
-**audit log**. There is no path that bypasses the gateway.
+IronClaw runs autonomous AI assistants on infrastructure you control — reachable from the chat
+apps you already use. Every agent runs sealed off from the network (`network=none` in a gVisor
+sandbox) and cannot change its own configuration without a human approving it. Isolation you can
+prove, not just promise.
 
-<figure markdown="span">
-  ![Zero-credential chat demo: one command starts the offline mock-agent control-plane with no API key; a chat message engages the agent, which launches a real per-session sandbox container; the reply flows back through the encrypted per-session queue.](assets/demo.svg){ width="800" }
-  <figcaption><b>Zero credentials, one command.</b> The offline <code>mock-agent</code> runs the full chat → per-session sandbox → reply path with no API key — production seals each sandbox with gVisor and <code>network=none</code>. See the <a href="quickstart.md">Quickstart</a>.</figcaption>
-</figure>
-
-<div class="grid cards" markdown>
-
--   :material-rocket-launch: **[Quickstart](quickstart.md)**
-
-    From a clean clone to submitting, approving, and auditing your first agent
-    action — in about five minutes, on your machine.
-
--   :material-scale-balance: **[Why IronClaw / vs. alternatives](comparison.md)**
-
-    Evaluating your options? How IronClaw compares to hosted agent platforms,
-    raw container + LLM glue, and other self-hosted runtimes — honestly.
-
--   :material-school: **[Tutorials](tutorials/index.md)**
-
-    Hands-on, copy-pasteable walkthroughs: your first sandboxed agent, connecting
-    Slack, and writing a custom channel adapter.
-
--   :material-shield-lock: **[Security & trust](security.md)**
-
-    The trust story: the threat model, the sealed-runtime invariants, and how a
-    user verifies what they install.
-
--   :material-sitemap: **[Architecture](architecture.md)**
-
-    The control-plane / sandbox split, the frozen contract between them, and the
-    encrypted queues they speak over.
-
--   :material-api: **[API reference](reference/api.md)**
-
-    The control-plane HTTP API (OpenAPI 3.1) consumed by `ironctl` and the web
-    console.
-
-</div>
-
-## What makes IronClaw different
-
-- **Assume the agent is hostile.** The [threat model](threat-model.md) treats the
-  agent inside the sandbox as potentially compromised — by prompt injection, a
-  poisoned tool result, or a hostile model output — and designs the blast radius
-  around that assumption.
-- **Every mutation is gated.** Persona, enabled tools, packages, wiring,
-  permissions, and mounts are *held* at the gateway until a human approves them.
-  See the [Quickstart](quickstart.md) for a hands-on demonstration.
-- **Verifiable supply chain.** Every release is checksummed, keyless-signed
-  (cosign), and carries build-provenance attestations. See the
-  [Release runbook](release-runbook.md) for how to verify a download.
-
-## Where to go next
-
-| If you want to… | Read |
-| --- | --- |
-| See how IronClaw compares to the alternatives | [Why IronClaw](comparison.md) |
-| Run IronClaw locally | [Quickstart](quickstart.md) |
-| Follow a hands-on walkthrough | [Tutorials](tutorials/index.md) |
-| Understand the design | [IronClaw, Explained](ironclaw-explained.md) → [Architecture](architecture.md) |
-| Evaluate the security posture | [Security & trust](security.md) → [Threat model](threat-model.md) |
-| Wire an agent to Slack / Discord / … | [Channel adapters](channels.md) |
-| Extend an agent with curated capabilities | [Skills](skills.md) |
-| Drive the control-plane API | [API reference](reference/api.md) |
+- **[Run the zero-credential demo](quickstart.md)** — one command, no model key, no account.
+- **[Why IronClaw / vs. alternatives](comparison.md)** — how it compares, honestly.
+- **[Security posture](security.md)** and **[threat model](threat-model.md)** — the trust story.
+- **[Star it on GitHub](https://github.com/IronSecCo/ironclaw)**.

--- a/docs/stylesheets/landing.css
+++ b/docs/stylesheets/landing.css
@@ -1,0 +1,574 @@
+/* =============================================================================
+   IronClaw landing page (home) — IRO-154.
+
+   A conversion-focused homepage rendered through the MkDocs Material
+   `overrides/home.html` template (set via `template: home.html` in index.md).
+   It reuses the steel-blue brand scale from brand.css and the Material theme
+   surface variables so the page flips cleanly with the light/dark toggle.
+
+   Design system
+   -------------
+   - Steel-blue brand (#3b82f6 / #2563eb), navy hero (#0b1124 -> #16224a).
+   - One spacing scale, one type scale (clamp()-driven, fluid + mobile-first).
+   - Full-bleed coloured sections, 1100px centred content column.
+   - Contrast targets (WCAG 2.1 AA): body >= 4.5:1, large/CTA text >= 3:1.
+     Primary CTA = white on #2563eb (5.17:1). Hero body = white on #0b1124.
+
+   Only loaded on the home template, but scoped under `.iro-landing` so it
+   cannot leak into the docs body.
+   ========================================================================== */
+
+.iro-landing {
+  /* spacing scale */
+  --s-1: 0.25rem;
+  --s-2: 0.5rem;
+  --s-3: 0.75rem;
+  --s-4: 1rem;
+  --s-5: 1.5rem;
+  --s-6: 2rem;
+  --s-7: 3rem;
+  --s-8: 4.5rem;
+
+  --iro-radius: 0.6rem;
+  --iro-maxw: 1100px;
+
+  /* brand (mirrors brand.css; redeclared so the landing is self-contained) */
+  --iro-steel-500: #3b82f6;
+  --iro-steel-600: #2563eb;
+  --iro-steel-700: #1d4ed8;
+  --iro-navy-900: #16224a;
+  --iro-navy-950: #0b1124;
+
+  font-feature-settings: "kern" 1, "liga" 1;
+}
+
+/* Material wraps content in a constrained grid; the home template renders the
+   landing directly in <main>, so reset any inherited width/padding. */
+.iro-landing {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* The landing replaces `.md-content` inside `.md-main__inner.md-grid`, which is
+   capped at ~61rem and centred. On the home route only, break out of that cap so
+   the full-bleed coloured sections span the viewport. `hide: [navigation, toc]`
+   in index.md already removes both sidebars; this reclaims their grid width. */
+.md-main__inner:has(> .iro-landing) {
+  max-width: none;
+  margin: 0;
+}
+.md-main:has(.iro-landing),
+.md-main__inner:has(> .iro-landing) {
+  margin-top: 0;
+}
+/* The themed header already provides a top landmark + nav; no breadcrumbs. */
+.md-content__inner:has(.iro-landing) { margin: 0; padding: 0; }
+
+/* ----- layout primitives -------------------------------------------------- */
+.iro-section {
+  padding: clamp(3rem, 7vw, 5rem) 1.25rem;
+}
+.iro-wrap {
+  max-width: var(--iro-maxw);
+  margin-inline: auto;
+}
+.iro-section--tint {
+  background: var(--md-default-fg-color--lightest);
+}
+
+/* ----- type -------------------------------------------------------------- */
+.iro-eyebrow {
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  /* Scheme-aware accent: AA on both white (#1d4ed8 6.7:1) and dark slate
+     (#63a0ff 6.08:1). A fixed steel-500 would fail AA on light backgrounds. */
+  color: var(--md-accent-fg-color);
+  margin: 0 0 var(--s-4);
+}
+.iro-h2 {
+  font-size: clamp(1.6rem, 3.5vw, 2.35rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  margin: 0 0 var(--s-3);
+}
+.iro-lead {
+  font-size: clamp(1rem, 1.6vw, 1.15rem);
+  line-height: 1.65;
+  max-width: 60ch;
+  margin: 0 0 var(--s-6);
+  color: var(--md-default-fg-color);
+}
+
+/* =============================================================================
+   1. HERO  — always-dark navy, high contrast
+   ========================================================================== */
+.iro-hero {
+  position: relative;
+  background:
+    radial-gradient(120% 120% at 80% -10%, rgba(59, 130, 246, 0.28) 0%, rgba(59, 130, 246, 0) 55%),
+    linear-gradient(160deg, var(--iro-navy-900) 0%, var(--iro-navy-950) 70%);
+  color: #f4f8ff;
+  border-bottom: 1px solid rgba(99, 160, 255, 0.18);
+  overflow: hidden;
+}
+.iro-hero .iro-eyebrow {
+  color: #8fb4ff;
+}
+.iro-hero__title {
+  font-size: clamp(2.1rem, 5.2vw, 3.4rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1.07;
+  margin: 0 0 var(--s-5);
+  max-width: 18ch;
+}
+.iro-hero__sub {
+  font-size: clamp(1.02rem, 1.7vw, 1.22rem);
+  line-height: 1.6;
+  color: #c7d6f0;
+  max-width: 56ch;
+  margin: 0 0 var(--s-6);
+}
+.iro-hero__sub strong {
+  color: #ffffff;
+  font-weight: 700;
+}
+
+/* ----- CTA buttons ------------------------------------------------------- */
+.iro-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s-3);
+  margin-bottom: var(--s-6);
+}
+.iro-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  min-height: 2.9rem;
+  padding: 0.7rem 1.4rem;
+  border-radius: var(--iro-radius);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none;
+  border: 1.5px solid transparent;
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease, transform 120ms ease, box-shadow 120ms ease;
+}
+.iro-btn--primary {
+  background: var(--iro-steel-600);
+  color: #ffffff;
+  box-shadow: 0 0.3rem 1rem rgba(37, 99, 235, 0.35);
+}
+.iro-btn--primary:hover {
+  background: var(--iro-steel-700);
+  transform: translateY(-1px);
+}
+.iro-btn--ghost {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(143, 180, 255, 0.55);
+  color: #eaf2ff;
+}
+.iro-btn--ghost:hover {
+  background: rgba(143, 180, 255, 0.12);
+  border-color: #8fb4ff;
+  transform: translateY(-1px);
+}
+/* On light sections, ghost buttons use the steel outline */
+.iro-section .iro-btn--ghost {
+  background: transparent;
+  border-color: var(--iro-steel-600);
+  color: var(--iro-steel-700);
+}
+.iro-section .iro-btn--ghost:hover {
+  background: var(--md-accent-fg-color--transparent);
+}
+.iro-btn:focus-visible {
+  outline: 3px solid #8fb4ff;
+  outline-offset: 2px;
+}
+
+/* ----- copyable demo block ----------------------------------------------- */
+.iro-code {
+  position: relative;
+  margin: 0 0 var(--s-4);
+  max-width: 760px;
+}
+.iro-code pre {
+  margin: 0;
+  background: #0a1126;
+  border: 1px solid rgba(99, 160, 255, 0.28);
+  border-radius: var(--iro-radius);
+  padding: 1rem 3.2rem 1rem 1.1rem;
+  overflow-x: auto;
+  font-size: 0.86rem;
+  line-height: 1.6;
+  color: #d7e3fb;
+  -moz-tab-size: 2;
+  tab-size: 2;
+}
+.iro-code code {
+  font-family: var(--md-code-font-family, ui-monospace, SFMono-Regular, Menlo, monospace);
+  background: none;
+  padding: 0;
+  color: inherit;
+  white-space: pre;
+}
+.iro-code__prompt { color: #6f86b8; user-select: none; }
+.iro-code__cmt { color: #6f86b8; }
+.iro-copy {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  height: 2rem;
+  padding: 0 0.65rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #c7d6f0;
+  background: rgba(99, 160, 255, 0.12);
+  border: 1px solid rgba(99, 160, 255, 0.3);
+  border-radius: 0.4rem;
+  cursor: pointer;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+.iro-copy:hover { background: rgba(99, 160, 255, 0.24); color: #fff; }
+.iro-copy:focus-visible { outline: 3px solid #8fb4ff; outline-offset: 2px; }
+.iro-copy[data-copied="true"] { color: #7ef0c0; border-color: rgba(126, 240, 192, 0.5); }
+.iro-caption {
+  font-size: 0.92rem;
+  line-height: 1.55;
+  color: #aebfe0;
+  max-width: 70ch;
+  margin: 0;
+}
+.iro-caption strong { color: #eaf2ff; }
+.iro-caption code,
+.iro-section code {
+  background: rgba(99, 160, 255, 0.14);
+  border-radius: 0.25rem;
+  padding: 0.05em 0.4em;
+  font-size: 0.88em;
+}
+.iro-section code { background: var(--md-accent-fg-color--transparent); }
+
+/* ----- trust badge row --------------------------------------------------- */
+.iro-badges {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem;
+  margin-top: var(--s-6);
+  padding-top: var(--s-5);
+  border-top: 1px solid rgba(143, 180, 255, 0.18);
+}
+.iro-badges img { height: 22px; display: block; }
+.iro-badges a:focus-visible { outline: 3px solid #8fb4ff; outline-offset: 3px; border-radius: 3px; }
+.iro-badges__note {
+  flex-basis: 100%;
+  margin: var(--s-2) 0 0;
+  font-size: 0.82rem;
+  color: #9fb2d8;
+}
+.iro-badges__note a { color: #8fb4ff; }
+
+/* =============================================================================
+   2. DIFFERENTIATORS
+   ========================================================================== */
+.iro-grid-3 {
+  display: grid;
+  gap: var(--s-5);
+  grid-template-columns: 1fr;
+  margin-top: var(--s-6);
+}
+.iro-card {
+  background: var(--md-default-bg-color);
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: var(--iro-radius);
+  padding: var(--s-5);
+  transition: border-color 125ms ease, box-shadow 125ms ease, transform 125ms ease;
+}
+.iro-card:hover {
+  border-color: var(--iro-steel-500);
+  box-shadow: 0 0.3rem 0.9rem rgba(37, 99, 235, 0.16);
+  transform: translateY(-2px);
+}
+.iro-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.6rem;
+  height: 2.6rem;
+  margin-bottom: var(--s-3);
+  border-radius: 0.55rem;
+  background: var(--md-accent-fg-color--transparent);
+  color: var(--iro-steel-600);
+}
+.iro-card__icon svg { width: 1.4rem; height: 1.4rem; }
+.iro-card h3 {
+  font-size: 1.12rem;
+  font-weight: 700;
+  margin: 0 0 var(--s-2);
+}
+.iro-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--md-default-fg-color);
+}
+.iro-card code { word-break: break-word; }
+.iro-aside {
+  margin-top: var(--s-5);
+  font-size: 0.98rem;
+  color: var(--md-default-fg-color--light);
+}
+.iro-aside strong { color: var(--md-default-fg-color); }
+
+/* =============================================================================
+   3. HOW IT WORKS
+   ========================================================================== */
+.iro-steps {
+  display: grid;
+  gap: var(--s-5);
+  grid-template-columns: 1fr;
+  margin-top: var(--s-6);
+  counter-reset: step;
+}
+.iro-step {
+  position: relative;
+  padding-left: 3.4rem;
+}
+.iro-step__num {
+  position: absolute;
+  left: 0;
+  top: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background: var(--iro-steel-600);
+  color: #fff;
+  font-weight: 800;
+  font-size: 1.05rem;
+}
+.iro-step h3 { font-size: 1.1rem; font-weight: 700; margin: 0.2rem 0 var(--s-2); }
+.iro-step p { margin: 0; line-height: 1.6; color: var(--md-default-fg-color); font-size: 0.95rem; }
+.iro-flow {
+  margin-top: var(--s-6);
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--md-default-fg-color--light);
+}
+.iro-flow code {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* =============================================================================
+   4. PROOF STRIP
+   ========================================================================== */
+.iro-proof {
+  display: grid;
+  gap: var(--s-6);
+  grid-template-columns: 1fr;
+  margin-top: var(--s-6);
+}
+.iro-proof h3 {
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--md-accent-fg-color);
+  margin: 0 0 var(--s-4);
+  padding-bottom: var(--s-2);
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+.iro-checklist { list-style: none; margin: 0; padding: 0; }
+.iro-checklist li {
+  position: relative;
+  padding-left: 1.9rem;
+  margin-bottom: var(--s-3);
+  line-height: 1.55;
+  font-size: 0.95rem;
+  color: var(--md-default-fg-color);
+}
+.iro-checklist li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.15rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  background-color: var(--iro-steel-600);
+  -webkit-mask: var(--iro-check) center / contain no-repeat;
+  mask: var(--iro-check) center / contain no-repeat;
+}
+.iro-landing {
+  --iro-check: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="black" d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>');
+}
+.iro-checklist li strong { color: var(--md-default-fg-color); }
+.iro-pullquote {
+  margin: var(--s-7) auto 0;
+  max-width: 46ch;
+  text-align: center;
+  font-size: clamp(1.1rem, 2.2vw, 1.4rem);
+  font-weight: 600;
+  line-height: 1.45;
+  color: var(--md-default-fg-color);
+  border: none;
+}
+.iro-pullquote cite {
+  display: block;
+  margin-top: var(--s-3);
+  font-size: 0.85rem;
+  font-weight: 500;
+  font-style: normal;
+  color: var(--md-default-fg-color--light);
+}
+.iro-center-cta { text-align: center; margin-top: var(--s-6); }
+
+/* =============================================================================
+   5. DEMO BLOCK (light section)  — code panel reads on light bg
+   ========================================================================== */
+.iro-demo .iro-code pre {
+  background: var(--iro-navy-950);
+}
+.iro-demo .iro-caption,
+.iro-demo .iro-footnote {
+  color: var(--md-default-fg-color--light);
+}
+.iro-demo .iro-caption strong { color: var(--md-default-fg-color); }
+.iro-footnote {
+  margin: var(--s-4) 0 0;
+  font-size: 0.86rem;
+  line-height: 1.55;
+  max-width: 70ch;
+  padding-left: var(--s-4);
+  border-left: 3px solid var(--md-default-fg-color--lightest);
+}
+
+/* =============================================================================
+   6. FAQ  — native <details>, zero JS
+   ========================================================================== */
+.iro-faq { margin-top: var(--s-6); max-width: 820px; }
+.iro-faq details {
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+.iro-faq summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--s-4);
+  padding: var(--s-4) 0;
+  font-weight: 600;
+  font-size: 1.02rem;
+  cursor: pointer;
+  list-style: none;
+}
+.iro-faq summary::-webkit-details-marker { display: none; }
+.iro-faq summary::after {
+  content: "+";
+  font-size: 1.4rem;
+  font-weight: 400;
+  color: var(--iro-steel-600);
+  transition: transform 150ms ease;
+  flex: none;
+}
+.iro-faq details[open] summary::after { content: "\2212"; }
+.iro-faq summary:focus-visible { outline: 3px solid var(--iro-steel-500); outline-offset: 3px; border-radius: 4px; }
+.iro-faq p {
+  margin: 0 0 var(--s-4);
+  line-height: 1.65;
+  color: var(--md-default-fg-color);
+  max-width: 75ch;
+}
+
+/* =============================================================================
+   7. FINAL CTA  — dark band, repeats the primary action
+   ========================================================================== */
+.iro-final {
+  background: linear-gradient(160deg, var(--iro-navy-900) 0%, var(--iro-navy-950) 100%);
+  color: #f4f8ff;
+  text-align: center;
+}
+.iro-final .iro-h2 { color: #fff; }
+.iro-final p { color: #c7d6f0; max-width: 52ch; margin: 0 auto var(--s-6); line-height: 1.6; }
+.iro-final .iro-cta-row { justify-content: center; margin-bottom: var(--s-4); }
+.iro-final .iro-btn--ghost {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(143, 180, 255, 0.55);
+  color: #eaf2ff;
+}
+.iro-final .iro-btn--ghost:hover { background: rgba(143, 180, 255, 0.12); }
+.iro-final__link { display: inline-block; margin-top: var(--s-2); color: #8fb4ff; font-weight: 600; }
+
+/* =============================================================================
+   8. FOOTER  (overrides the theme footer on the home template)
+   ========================================================================== */
+.iro-footer {
+  background: var(--iro-navy-950);
+  color: #aebfe0;
+  padding: clamp(2.5rem, 5vw, 3.5rem) 1.25rem 2rem;
+  border-top: 1px solid rgba(99, 160, 255, 0.18);
+}
+.iro-footer__cols {
+  max-width: var(--iro-maxw);
+  margin: 0 auto;
+  display: grid;
+  gap: var(--s-6);
+  grid-template-columns: 1fr;
+}
+.iro-footer h4 {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #8fb4ff;
+  margin: 0 0 var(--s-3);
+}
+.iro-footer ul { list-style: none; margin: 0; padding: 0; }
+.iro-footer li { margin-bottom: var(--s-2); }
+.iro-footer a { color: #cdd9f0; text-decoration: none; font-size: 0.92rem; }
+.iro-footer a:hover { color: #fff; text-decoration: underline; }
+.iro-footer a:focus-visible { outline: 2px solid #8fb4ff; outline-offset: 2px; border-radius: 2px; }
+.iro-footer__base {
+  max-width: var(--iro-maxw);
+  margin: var(--s-6) auto 0;
+  padding-top: var(--s-5);
+  border-top: 1px solid rgba(143, 180, 255, 0.16);
+  font-size: 0.85rem;
+  color: #8295bd;
+}
+
+/* =============================================================================
+   Responsive — widen grids on larger viewports
+   ========================================================================== */
+@media (min-width: 720px) {
+  .iro-grid-3 { grid-template-columns: repeat(3, 1fr); }
+  .iro-steps { grid-template-columns: repeat(3, 1fr); }
+  .iro-proof { grid-template-columns: 1fr 1fr; gap: var(--s-7); }
+  .iro-footer__cols { grid-template-columns: repeat(3, 1fr); }
+}
+@media (min-width: 960px) {
+  .iro-section { padding-inline: 2rem; }
+}
+
+/* =============================================================================
+   Reduced motion
+   ========================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .iro-landing * { transition: none !important; }
+  .iro-card:hover,
+  .iro-btn:hover { transform: none; }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,8 @@ theme:
 
 extra_css:
   - stylesheets/brand.css
+  # Landing-page styles, scoped under `.iro-landing` (home template only).
+  - stylesheets/landing.css
 
 extra_javascript:
   # Render the bare <div class="mermaid"> blocks (see superfences config below).

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -1,0 +1,382 @@
+{#-
+  IronClaw landing page (home) — IRO-154.
+
+  Rendered when a page sets `template: home.html` (docs/index.md). Extends
+  main.html so the static OG/Twitter card meta in main.html's `extrahead` and
+  the themed steel-blue header are preserved. We override `container` to render
+  the full-bleed marketing sections in a single <main> (no left nav / right TOC
+  on the home route), and `footer` to render the landing's three-column footer
+  in place of the default theme footer. Styles live in stylesheets/landing.css
+  (wired through extra_css), so this template is markup + one tiny copy script.
+
+  Every factual claim mirrors the IRO-153 copy spec, which footnotes each line
+  to a shipped doc or live badge — no invented metrics or competitor claims.
+-#}
+{% extends "main.html" %}
+
+{% block container %}
+<div class="iro-landing">
+
+  {# ===== 1. HERO ===== #}
+  <section class="iro-section iro-hero" aria-labelledby="hero-title">
+    <div class="iro-wrap">
+      <span class="iro-eyebrow">Open source · AGPLv3 + commercial · self-hosted</span>
+      <h1 class="iro-hero__title" id="hero-title">Security-first AI agents you actually run yourself.</h1>
+      <p class="iro-hero__sub">
+        IronClaw runs autonomous AI assistants on infrastructure you control — reachable from the
+        chat apps you already use. The difference is the threat model: every agent runs sealed off
+        from the network and <strong>cannot change its own configuration without a human approving
+        it.</strong> Isolation you can prove, not just promise.
+      </p>
+
+      <div class="iro-cta-row">
+        <a class="iro-btn iro-btn--primary" href="#demo">Run the demo
+          <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        </a>
+        <a class="iro-btn iro-btn--ghost" href="https://github.com/IronSecCo/ironclaw" rel="noopener">
+          <svg width="18" height="18" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          Star on GitHub ★
+        </a>
+      </div>
+
+      {# Above-the-fold copyable, zero-credential demo line #}
+      <div class="iro-code">
+        <pre id="hero-cmd"><code><span class="iro-code__prompt">$ </span>git clone https://github.com/IronSecCo/ironclaw.git &amp;&amp; cd ironclaw &amp;&amp; \
+  bash container/build.sh &amp;&amp; docker compose -f docker-compose.demo.yml up --build -d</code></pre>
+        <button type="button" class="iro-copy" data-copy-target="hero-cmd" aria-label="Copy command to clipboard">
+          <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+          <span class="iro-copy__label">Copy</span>
+        </button>
+      </div>
+      <p class="iro-caption">
+        <strong>Zero credentials. No model key.</strong> Then open <code>http://127.0.0.1:8787/ui/</code>
+        and say hi — a real per-session sandbox launches and replies. Requires only Docker.
+      </p>
+
+      {# Live trust badges — Best Practices "passing" gets first / priority slot #}
+      <div class="iro-badges">
+        <a href="https://www.bestpractices.dev/projects/13348" rel="noopener" title="OpenSSF Best Practices (passing)"><img src="https://www.bestpractices.dev/projects/13348/badge" alt="OpenSSF Best Practices: passing" loading="lazy"></a>
+        <a href="https://scorecard.dev/viewer/?uri=github.com/IronSecCo/ironclaw" rel="noopener" title="OpenSSF Scorecard"><img src="https://api.securityscorecards.dev/projects/github.com/IronSecCo/ironclaw/badge" alt="OpenSSF Scorecard score" loading="lazy"></a>
+        <a href="https://github.com/IronSecCo/ironclaw/actions/workflows/codeql.yml" rel="noopener" title="CodeQL analysis"><img src="https://github.com/IronSecCo/ironclaw/actions/workflows/codeql.yml/badge.svg" alt="CodeQL workflow status" loading="lazy"></a>
+        <a href="https://ironsecco.github.io/ironclaw/security/" title="cosign-signed releases"><img src="https://img.shields.io/badge/releases-cosign%20signed-2563eb.svg" alt="Releases: cosign signed" loading="lazy"></a>
+        <a href="https://ironsecco.github.io/ironclaw/security/" title="SBOMs published"><img src="https://img.shields.io/badge/SBOM-SPDX%20%2B%20CycloneDX-44883e.svg" alt="SBOM: SPDX and CycloneDX" loading="lazy"></a>
+        <a href="https://ironsecco.github.io/ironclaw/security/" title="SLSA build provenance"><img src="https://img.shields.io/badge/SLSA-build%20provenance-44883e.svg" alt="SLSA build provenance" loading="lazy"></a>
+        <a href="https://github.com/IronSecCo/ironclaw/blob/main/LICENSE" rel="noopener" title="AGPLv3 license"><img src="https://img.shields.io/badge/License-AGPLv3-2563eb.svg" alt="License: AGPLv3" loading="lazy"></a>
+        <p class="iro-badges__note">
+          Alpha software — the gVisor seal is Linux-only.
+          <a href="https://ironsecco.github.io/ironclaw/roadmap/">See project status →</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  {# ===== 2. WHAT IT IS + DIFFERENTIATORS ===== #}
+  <section class="iro-section" aria-labelledby="what-title">
+    <div class="iro-wrap">
+      <span class="iro-eyebrow">What it is</span>
+      <h2 class="iro-h2" id="what-title">A secured alternative to running agents wide-open</h2>
+      <p class="iro-lead">
+        Most ways to run an AI agent assume the agent is trustworthy. IronClaw assumes the
+        opposite — that the agent, and the box it runs on, could be compromised at any moment — and
+        builds hard, provable walls anyway. You get the same "talk to it in Slack, it gets work
+        done" experience, without handing an LLM a shell on your machine.
+      </p>
+
+      <div class="iro-grid-3">
+        <article class="iro-card">
+          <span class="iro-card__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 4 5v6c0 5 3.4 8.5 8 11 4.6-2.5 8-6 8-11V5z"/><path d="m9 12 2 2 4-4"/></svg>
+          </span>
+          <h3>Sealed sandboxes, not trust</h3>
+          <p>
+            Each agent runs with <code>network=none</code> in a gVisor (<code>runsc</code>)
+            sandbox — read-only rootfs, dropped capabilities, no host network. It reaches the model
+            only through a host-side proxy it never holds the key to.
+          </p>
+        </article>
+        <article class="iro-card">
+          <span class="iro-card__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+          </span>
+          <h3>A human approval gateway with no bypass</h3>
+          <p>
+            An agent cannot change its own persona, tools, packages, wiring, permissions, or
+            mounts. Every capability change is <em>held</em> at a deterministic gateway until a
+            human approves it, and every decision lands in an append-only audit log.
+          </p>
+        </article>
+        <article class="iro-card">
+          <span class="iro-card__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+          </span>
+          <h3>A release you can verify, end to end</h3>
+          <p>
+            Every release is re-derivable from a known commit and ships cosign signatures, SBOMs
+            (SPDX + CycloneDX), and build-provenance attestations. Installers verify the
+            <code>SHA256SUMS</code> manifest <em>before</em> executing anything.
+          </p>
+        </article>
+      </div>
+      <p class="iro-aside">
+        <strong>Talk to it where you already work</strong> — 11 channel adapters
+        (<a href="https://ironsecco.github.io/ironclaw/channels/">Slack, Discord, Telegram, and more</a>).
+      </p>
+    </div>
+  </section>
+
+  {# ===== 3. HOW IT WORKS ===== #}
+  <section class="iro-section iro-section--tint" aria-labelledby="how-title">
+    <div class="iro-wrap">
+      <span class="iro-eyebrow">How it works</span>
+      <h2 class="iro-h2" id="how-title">Three steps, one choke point</h2>
+      <div class="iro-steps">
+        <div class="iro-step">
+          <span class="iro-step__num" aria-hidden="true">1</span>
+          <h3>You message your agent</h3>
+          <p>
+            A message arrives over a channel you connected (Slack, Discord, Telegram, …). The
+            control-plane spins up a fresh, per-conversation sandbox to handle it.
+          </p>
+        </div>
+        <div class="iro-step">
+          <span class="iro-step__num" aria-hidden="true">2</span>
+          <h3>The agent works — sealed off</h3>
+          <p>
+            Inside a <code>network=none</code> gVisor sandbox, the agent reads, writes, schedules,
+            and drafts a reply. It reaches the model only through the host proxy, and the outside
+            world only through an audited, broker-mediated egress allowlist.
+          </p>
+        </div>
+        <div class="iro-step">
+          <span class="iro-step__num" aria-hidden="true">3</span>
+          <h3>Sensitive changes wait for you</h3>
+          <p>
+            Anything that would change what the agent <em>can do</em> is parked at the approval
+            gateway. You approve or reject; the result is applied and written to the audit log.
+            Nothing bypasses that choke point.
+          </p>
+        </div>
+      </div>
+      <p class="iro-flow">
+        <code>message → gateway (HELD) → approve → applied → audit log</code>
+      </p>
+    </div>
+  </section>
+
+  {# ===== 4. PROOF STRIP ===== #}
+  <section class="iro-section" aria-labelledby="trust-title">
+    <div class="iro-wrap">
+      <span class="iro-eyebrow">Why you can trust it</span>
+      <h2 class="iro-h2" id="trust-title">Built to be checked, not taken on faith</h2>
+      <div class="iro-proof">
+        <div>
+          <h3>Runtime trust</h3>
+          <ul class="iro-checklist">
+            <li><code>network=none</code> per-session sandboxes; model access via host proxy only.</li>
+            <li>gVisor (<code>runsc</code>) seal in production — read-only rootfs, dropped caps, <code>nosuid,nodev,noexec</code>.</li>
+            <li>Mandatory human-approval gateway, deny-by-default; agents can't reconfigure themselves.</li>
+            <li>Append-only audit log of every gateway decision.</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Supply-chain trust</h3>
+          <ul class="iro-checklist">
+            <li><strong>OpenSSF Best Practices: passing</strong> (live badge).</li>
+            <li><strong>OpenSSF Scorecard</strong> + <strong>CodeQL</strong> run continuously in CI.</li>
+            <li><strong>Reproducible builds</strong> — every release re-derivable from a known commit.</li>
+            <li><strong>cosign-signed</strong> <code>SHA256SUMS</code>, <strong>SBOMs</strong> (SPDX + CycloneDX), and <strong>SLSA</strong> build-provenance; installers verify before executing.</li>
+          </ul>
+        </div>
+      </div>
+      <blockquote class="iro-pullquote">
+        "A release a user cannot verify is not a secured release."
+        <cite>— the bar IronClaw holds itself to</cite>
+      </blockquote>
+      <div class="iro-center-cta">
+        <a class="iro-btn iro-btn--ghost" href="https://ironsecco.github.io/ironclaw/security/">Read the security posture →</a>
+      </div>
+    </div>
+  </section>
+
+  {# ===== 5. ZERO-CREDENTIAL DEMO ===== #}
+  <section class="iro-section iro-section--tint iro-demo" id="demo" aria-labelledby="demo-title">
+    <div class="iro-wrap">
+      <span class="iro-eyebrow">See it work</span>
+      <h2 class="iro-h2" id="demo-title">See it actually work — no key, no signup</h2>
+      <p class="iro-lead">
+        The fastest way to believe any of this is to watch an agent reply on your own machine. The
+        offline <code>mock-agent</code> runs the full <strong>engage → sandbox → reply</strong> path
+        with no model key and no account — it launches a real per-conversation sandbox container and
+        routes the reply back through the encrypted per-session queue.
+      </p>
+
+      <div class="iro-code">
+        <pre id="demo-cmd"><code>git clone https://github.com/IronSecCo/ironclaw.git &amp;&amp; cd ironclaw
+bash container/build.sh                                  <span class="iro-code__cmt"># build the sandbox image once (~1–2 min)</span>
+docker compose -f docker-compose.demo.yml up --build -d  <span class="iro-code__cmt"># start the demo control-plane</span></code></pre>
+        <button type="button" class="iro-copy" data-copy-target="demo-cmd" aria-label="Copy demo commands to clipboard">
+          <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+          <span class="iro-copy__label">Copy</span>
+        </button>
+      </div>
+      <p class="iro-caption">
+        Then open <code>http://127.0.0.1:8787/ui/</code> → Chat tab → "Mock Agent (offline)" → say
+        hi. If prompted for a token, paste <code>ironclaw-demo</code>. Tear down with
+        <code>docker compose -f docker-compose.demo.yml down</code>.
+      </p>
+      <p class="iro-footnote">
+        The demo relaxes the seal for convenience — it uses runc (shared host kernel), not gVisor,
+        and a well-known token. The approval gateway, encrypted per-session queues, and host-side
+        credential custody are unchanged. The production <code>docker compose up</code> is the
+        hardened, gVisor posture.
+      </p>
+      <div class="iro-center-cta">
+        <a class="iro-btn iro-btn--primary" href="https://ironsecco.github.io/ironclaw/quickstart/">Full quickstart &amp; your first approved action →</a>
+      </div>
+    </div>
+  </section>
+
+  {# ===== 6. FAQ ===== #}
+  <section class="iro-section" aria-labelledby="faq-title">
+    <div class="iro-wrap">
+      <span class="iro-eyebrow">FAQ</span>
+      <h2 class="iro-h2" id="faq-title">Straight answers</h2>
+      <div class="iro-faq">
+        <details>
+          <summary>Is it really free / open source?</summary>
+          <p>
+            Yes — IronClaw is open source under <strong>AGPLv3</strong>, with a
+            <strong>commercial license</strong> available for teams that can't meet AGPL's terms.
+            Self-hosting needs no account and no payment.
+          </p>
+        </details>
+        <details>
+          <summary>Do I have to hand over my API keys?</summary>
+          <p>
+            Model credentials are held <strong>host-side only</strong> and never enter a sandbox.
+            The demo needs <strong>no key at all</strong>; a real agent reaches a provider through
+            the host proxy.
+          </p>
+        </details>
+        <details>
+          <summary>Does the security actually hold on my OS?</summary>
+          <p>
+            The full gVisor (<code>runsc</code>) seal is <strong>Linux-only</strong>. The whole host
+            side runs natively on macOS, but a real agent sandbox there falls back to runc inside
+            Docker Desktop's Linux VM — a weaker, kernel-shared boundary. Run production on Linux.
+          </p>
+        </details>
+        <details>
+          <summary>Is it production-ready?</summary>
+          <p>
+            It's <strong>alpha</strong>. The control-plane, gateway, and encrypted-queue core have
+            real coverage (800+ Go tests plus a black-box parity suite); channel adapters, some
+            tools, and a live sandbox launch are exercised more lightly. Don't point it at anything
+            you can't afford to lose yet.
+          </p>
+        </details>
+        <details>
+          <summary>How do I know the binary I download is the one you built?</summary>
+          <p>
+            Every release ships cosign signatures, SBOMs, and build-provenance attestations, and the
+            installers verify the <code>SHA256SUMS</code> manifest before running anything. The
+            release runbook walks through verifying it yourself.
+          </p>
+        </details>
+        <details>
+          <summary>How is this different from running an agent framework directly?</summary>
+          <p>
+            Most frameworks trust the agent. IronClaw seals it off from the network and makes every
+            capability change pass a human approval gateway. See the
+            <a href="https://ironsecco.github.io/ironclaw/comparison/">comparison page</a>.
+          </p>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  {# ===== 7. FINAL CTA ===== #}
+  <section class="iro-section iro-final" aria-labelledby="final-title">
+    <div class="iro-wrap">
+      <h2 class="iro-h2" id="final-title">Run a sealed agent in the next five minutes.</h2>
+      <p>
+        One command, no credentials. If you like what you see, the production path is Linux +
+        gVisor — and every step of it is documented.
+      </p>
+      <div class="iro-cta-row">
+        <a class="iro-btn iro-btn--primary" href="#demo">Run the demo →</a>
+        <a class="iro-btn iro-btn--ghost" href="https://github.com/IronSecCo/ironclaw" rel="noopener">Star on GitHub ★</a>
+      </div>
+      <a class="iro-final__link" href="https://ironsecco.github.io/ironclaw/comparison/">Read the comparison →</a>
+    </div>
+  </section>
+
+</div>
+{% endblock %}
+
+{% block footer %}
+<footer class="iro-footer" aria-label="Site footer">
+  <div class="iro-footer__cols">
+    <div>
+      <h4>Start</h4>
+      <ul>
+        <li><a href="https://ironsecco.github.io/ironclaw/quickstart/">Quickstart</a></li>
+        <li><a href="#demo">Demo</a></li>
+        <li><a href="https://ironsecco.github.io/ironclaw/deployment/">Deployment</a></li>
+        <li><a href="https://ironsecco.github.io/ironclaw/troubleshooting/">Troubleshooting</a></li>
+        <li><a href="https://ironsecco.github.io/ironclaw/faq/">FAQ</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4>Understand</h4>
+      <ul>
+        <li><a href="https://ironsecco.github.io/ironclaw/architecture/">Architecture</a></li>
+        <li><a href="https://ironsecco.github.io/ironclaw/threat-model/">Threat model</a></li>
+        <li><a href="https://ironsecco.github.io/ironclaw/security/">Security posture</a></li>
+        <li><a href="https://ironsecco.github.io/ironclaw/comparison/">Comparison</a></li>
+        <li><a href="https://ironsecco.github.io/ironclaw/roadmap/">Roadmap</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4>Project</h4>
+      <ul>
+        <li><a href="https://github.com/IronSecCo/ironclaw" rel="noopener">GitHub repo</a></li>
+        <li><a href="https://github.com/IronSecCo/ironclaw/releases" rel="noopener">Releases</a></li>
+        <li><a href="https://github.com/IronSecCo/ironclaw/blob/main/LICENSE" rel="noopener">License (AGPLv3)</a></li>
+        <li><a href="https://github.com/IronSecCo/ironclaw/blob/main/LICENSING.md" rel="noopener">Commercial license</a></li>
+        <li><a href="https://github.com/IronSecCo/ironclaw/security/policy" rel="noopener">Security policy</a></li>
+      </ul>
+    </div>
+  </div>
+  <p class="iro-footer__base">
+    IronClaw is open source (AGPLv3) by IronSecCo. Alpha software — verify before you rely on it.
+  </p>
+</footer>
+
+{#- Progressive-enhancement copy button. The <pre> is selectable without JS. -#}
+<script>
+  (function () {
+    var btns = document.querySelectorAll(".iro-copy");
+    btns.forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var pre = document.getElementById(btn.getAttribute("data-copy-target"));
+        if (!pre) return;
+        var text = pre.innerText.replace(/^\$ /gm, "");
+        var done = function () {
+          var label = btn.querySelector(".iro-copy__label");
+          var prev = label ? label.textContent : "";
+          if (label) label.textContent = "Copied";
+          btn.setAttribute("data-copied", "true");
+          setTimeout(function () {
+            if (label) label.textContent = prev || "Copy";
+            btn.removeAttribute("data-copied");
+          }, 1800);
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(done, function () {});
+        }
+      });
+    });
+  })();
+</script>
+{% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -11,7 +11,10 @@
 {% block extrahead %}
   {#- `page` is None on theme-rendered pages such as 404.html, so guard every
       page.* access (default(..., true) also replaces empty strings). -#}
-  {% set _title = (page.title if page else none) | default(config.site_name, true) %}
+  {#- Prefer an explicit front-matter `title:` over the nav-derived page.title
+      (the homepage's nav label is just "Home", a poor social-share title). -#}
+  {% set _meta_title = (page.meta.title if page and page.meta else none) %}
+  {% set _title = _meta_title | default((page.title if page else none), true) | default(config.site_name, true) %}
   {% set _descr = (page.meta.description if page and page.meta else none) | default(config.site_description, true) %}
   {% set _url = (page.canonical_url if page else none) | default(config.site_url, true) %}
   {% set _image = config.site_url ~ "assets/social-preview.png" %}


### PR DESCRIPTION
## What

Adds a conversion-focused **landing page** for the docs site at
`https://ironsecco.github.io/ironclaw/`, built from the copy/structure spec on
[IRO-153](https://github.com/IronSecCo/ironclaw/issues) (stage 2 of the landing-page work).

## Integration approach (no docs URLs change)

Rendered as a **Material custom homepage override** — the cleanest path that leaves every
existing docs URL intact:

- `overrides/home.html` — `index.md` sets `template: home.html`; the template renders the
  full-bleed landing in place of the default content area. Sidebars are hidden with
  `hide: [navigation, toc]`; the themed header and the static OG/Twitter card meta are kept.
- `docs/stylesheets/landing.css` — page styles, scoped under `.iro-landing`, reusing the
  steel-blue brand scale and Material surface variables so the page follows the light/dark toggle.
- `docs/index.md` — keeps a short text mirror for search/SEO; the layout lives in the template.
- `overrides/main.html` — now prefers an explicit front-matter `title:` for the OG/Twitter title
  so the homepage shares as its real title rather than the nav label "Home".

## The page

Hero with dual CTA (**Run the demo** / **Star on GitHub**) and the copyable zero-credential demo
above the fold · three differentiators · how-it-works · a runtime + supply-chain proof strip with
live trust badges · the expanded demo block · a short FAQ (native `<details>`, no JS) · a final CTA ·
a three-column footer.

## Quality

- **Responsive / mobile-first** — verified at 1440×900 and 390×844.
- **Accessible** — single `<main>`, semantic landmarks, keyboard focus styles, image alt text,
  reduced-motion guard. **WCAG AA contrast verified in both light and dark schemes** (body ≥ 12:1,
  accent labels ≥ 6.1:1, primary CTA 5.17:1).
- **Fast** — no framework, no heavy JS; only a tiny progressive-enhancement copy-button script
  (the command blocks are selectable without it).
- Correct `og:`/`twitter:` meta + canonical; `mkdocs build --strict` is clean.

Every factual claim maps to a shipped doc or live badge, per the spec's source table — no invented
metrics or competitor claims.