### PR TITLE
feat(provider): Google Gemini support (AI Studio + Gemini CLI) (IRO-157)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -206,6 +206,16 @@ func main() {
 	if apiKey := os.Getenv("OPENROUTER_API_KEY"); apiKey != "" {
 		addProvider("openrouter.ai", modelproxy.OpenRouterInjector(apiKey), apiKey)
 	}
+	// Google Gemini (Google AI Studio). GOOGLE_API_KEY is preferred; GEMINI_API_KEY
+	// is honored as the Gemini-CLI-conventional fallback. Either enables the
+	// generativelanguage.googleapis.com host and injects the key host-side. The
+	// Gemini CLI's OAuth credential is instead fronted by the credential gateway
+	// (IRONCLAW_MODEL_GATEWAY_URL) — the same `gemini` provider serves both.
+	if apiKey := os.Getenv("GOOGLE_API_KEY"); apiKey != "" {
+		addProvider("generativelanguage.googleapis.com", modelproxy.GeminiInjector(apiKey), apiKey)
+	} else if apiKey := os.Getenv("GEMINI_API_KEY"); apiKey != "" {
+		addProvider("generativelanguage.googleapis.com", modelproxy.GeminiInjector(apiKey), apiKey)
+	}
 	credInjected := len(injectors) > 0
 	if credInjected {
 		proxyOpts = append(proxyOpts,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -55,7 +55,7 @@ reply flowed back through the encrypted queues. Tear it down with
 > gVisor isolation see [deployment](https://github.com/IronSecCo/ironclaw/blob/main/README.md#deployment).
 
 **Chat with a real model:** set a provider key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
-`OPENROUTER_API_KEY`, …) host-side and point an agent group at that provider. The production deployment
+`OPENROUTER_API_KEY`, `GOOGLE_API_KEY`, …) host-side and point an agent group at that provider. The production deployment
 (gVisor sandboxes + the host model-proxy) is the supported path — see [deployment](https://github.com/IronSecCo/ironclaw/blob/main/README.md#deployment).
 Run `ironctl doctor` any time to diagnose a stuck setup, and `ironctl onboard` for a guided first-run check.
 

--- a/docs/site/configuration.mdx
+++ b/docs/site/configuration.mdx
@@ -18,6 +18,7 @@ least one.
 | `ANTHROPIC_API_KEY` | Default/primary provider (`api.anthropic.com`). |
 | `OPENAI_API_KEY` | Allowlists `api.openai.com` when present. |
 | `OPENROUTER_API_KEY` | Allowlists `openrouter.ai` when present. |
+| `GOOGLE_API_KEY` / `GEMINI_API_KEY` | Google Gemini (Google AI Studio). Allowlists `generativelanguage.googleapis.com` and injects the key as `x-goog-api-key`. Select with provider `gemini`. The Gemini CLI's OAuth credential is fronted by the credential gateway (`IRONCLAW_MODEL_GATEWAY_URL`) instead — the same `gemini` provider serves both. |
 
 ### Admin API token
 

--- a/internal/host/modelproxy/modelproxy.go
+++ b/internal/host/modelproxy/modelproxy.go
@@ -145,6 +145,21 @@ func OpenRouterInjector(apiKey string) Injector {
 	}
 }
 
+// GeminiInjector returns an Injector that authenticates requests to the Google
+// Generative Language API (Google AI Studio / Gemini) with a host-held API key via
+// the x-goog-api-key header (e.g. from GOOGLE_API_KEY or GEMINI_API_KEY). Like the
+// others the key lives only on the host and never enters the sandbox. It self-guards
+// on the upstream host so it no-ops for any other provider — safe to compose through
+// MultiInjector.
+func GeminiInjector(apiKey string) Injector {
+	return func(upstreamHost string, req *http.Request) {
+		if !strings.Contains(strings.ToLower(upstreamHost), "generativelanguage.googleapis.com") {
+			return
+		}
+		req.Header.Set("x-goog-api-key", apiKey)
+	}
+}
+
 // MultiInjector composes several provider injectors into one. Each injector
 // self-guards on the upstream host, so for any given request exactly the matching
 // provider's credential is stamped and the rest no-op. This is how the proxy
@@ -229,6 +244,7 @@ func (p *Proxy) Handler() http.Handler {
 				// host-held credential for this upstream.
 				req.Header.Del("Authorization")
 				req.Header.Del("X-Api-Key")
+				req.Header.Del("X-Goog-Api-Key")
 				if p.inject != nil {
 					p.inject(target.Host, req)
 				}

--- a/internal/host/onboard/onboard.go
+++ b/internal/host/onboard/onboard.go
@@ -126,6 +126,8 @@ var modelCredentialEnv = [][2]string{
 	{"ANTHROPIC_API_KEY", "Anthropic"},
 	{"OPENAI_API_KEY", "OpenAI"},
 	{"OPENROUTER_API_KEY", "OpenRouter"},
+	{"GOOGLE_API_KEY", "Google Gemini"},
+	{"GEMINI_API_KEY", "Google Gemini"},
 	{"IRONCLAW_MODEL_GATEWAY_URL", "credential gateway"},
 }
 

--- a/internal/sandbox/provider/gemini.go
+++ b/internal/sandbox/provider/gemini.go
@@ -1,0 +1,391 @@
+// This file adds a Google Gemini backend behind the same Provider/ToolConverser
+// abstraction as AnthropicProvider and OpenAIProvider. It speaks the Google
+// Generative Language API (POST /v1beta/models/{model}:streamGenerateContent) —
+// the wire format served by Google AI Studio and, through the credential gateway,
+// by the Gemini CLI's OAuth credentials. Like the other backends it dials only the
+// host model-proxy unix socket, never the public internet; the sandbox holds no
+// credential. The host proxy injects the host-held API key (x-goog-api-key) and
+// enforces the egress allowlist.
+//
+// The wire history is the Anthropic-shaped provider.Message/Block; this file
+// translates it to Gemini "contents" on the way out and the Gemini response back
+// to a provider.Turn, so the agent loop stays provider-agnostic. Two shape
+// differences from Anthropic are bridged here: Gemini names the assistant role
+// "model" (not "assistant"), and it keys a function result by the function *name*
+// (not a call id), so the translator threads each tool_use id → name as it walks
+// the history.
+
+package provider
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const (
+	geminiUpstreamHost = "generativelanguage.googleapis.com"
+	defaultGeminiModel = "gemini-2.5-pro"
+)
+
+// GeminiProvider talks to the Google Generative Language API via the host
+// model-proxy socket. The same implementation serves Google AI Studio (direct API
+// key) and the Gemini CLI (host credential gateway injecting an OAuth token) — only
+// the host-side credential differs; the wire format is identical.
+type GeminiProvider struct {
+	cfg    Config
+	client *http.Client
+	url    string
+}
+
+// NewGemini constructs a GeminiProvider from cfg, applying defaults for any
+// zero-valued field. The model id rides in the request path (not the body), so the
+// URL is fixed at construction from cfg.Model. Callers usually go through New.
+func NewGemini(cfg Config) *GeminiProvider {
+	if cfg.SocketPath == "" {
+		cfg.SocketPath = DefaultSocketPath
+	}
+	if cfg.UpstreamHost == "" {
+		cfg.UpstreamHost = geminiUpstreamHost
+	}
+	if cfg.Model == "" {
+		cfg.Model = defaultGeminiModel
+	}
+	if cfg.MaxTokens == 0 {
+		cfg.MaxTokens = defaultMaxTokens
+	}
+	if cfg.HTTPTimeout == 0 {
+		cfg.HTTPTimeout = defaultHTTPTimeout
+	}
+
+	// Gemini puts the model id in the path and streams via Server-Sent Events when
+	// asked with alt=sse (the default streamGenerateContent framing is a JSON array).
+	url := "http://" + cfg.UpstreamHost + "/v1beta/models/" + cfg.Model + ":streamGenerateContent?alt=sse"
+	return &GeminiProvider{
+		cfg:    cfg,
+		client: newSocketClient(cfg.SocketPath, cfg.HTTPTimeout),
+		url:    url,
+	}
+}
+
+// --- wire types ---
+
+type gemFunctionCall struct {
+	Name string          `json:"name"`
+	Args json.RawMessage `json:"args,omitempty"`
+}
+
+type gemFunctionResponse struct {
+	Name     string          `json:"name"`
+	Response json.RawMessage `json:"response"`
+}
+
+type gemPart struct {
+	Text             string               `json:"text,omitempty"`
+	FunctionCall     *gemFunctionCall     `json:"functionCall,omitempty"`
+	FunctionResponse *gemFunctionResponse `json:"functionResponse,omitempty"`
+}
+
+type gemContent struct {
+	Role  string    `json:"role,omitempty"`
+	Parts []gemPart `json:"parts"`
+}
+
+type gemFunctionDecl struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+type gemTool struct {
+	FunctionDeclarations []gemFunctionDecl `json:"functionDeclarations"`
+}
+
+type gemGenerationConfig struct {
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty"`
+}
+
+type gemRequest struct {
+	Contents          []gemContent         `json:"contents"`
+	SystemInstruction *gemContent          `json:"systemInstruction,omitempty"`
+	Tools             []gemTool            `json:"tools,omitempty"`
+	GenerationConfig  *gemGenerationConfig `json:"generationConfig,omitempty"`
+}
+
+// gemStreamChunk is the subset of a streamed GenerateContentResponse we consume.
+// Each SSE data line is one complete chunk; unlike OpenAI, a functionCall arrives
+// whole (its args are not fragmented across deltas).
+type gemStreamChunk struct {
+	Candidates []struct {
+		Content      gemContent `json:"content"`
+		FinishReason string     `json:"finishReason"`
+	} `json:"candidates"`
+	Error *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+	} `json:"error"`
+}
+
+// gemErr is the Generative Language API error envelope for non-200 responses.
+type gemErr struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+	} `json:"error"`
+}
+
+// Query sends a single-turn prompt and returns the assistant's text.
+func (p *GeminiProvider) Query(ctx context.Context, prompt string) (string, error) {
+	req := p.baseRequest()
+	req.Contents = []gemContent{{Role: "user", Parts: []gemPart{{Text: prompt}}}}
+	res, err := p.do(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	return res.text, nil
+}
+
+// Converse runs one model turn over the Anthropic-shaped history with the given
+// tools and returns the resulting Turn (text + any tool calls + the assistant
+// Message to append to history). The Message it returns is Anthropic-shaped so the
+// loop and a later replay round-trip identically.
+func (p *GeminiProvider) Converse(ctx context.Context, history []Message, tools []ToolSpec) (Turn, error) {
+	req := p.baseRequest()
+	req.Contents = toGeminiContents(history)
+	if len(tools) > 0 {
+		decls := make([]gemFunctionDecl, 0, len(tools))
+		for _, ts := range tools {
+			decls = append(decls, gemFunctionDecl{Name: ts.Name, Description: ts.Description, Parameters: ts.InputSchema})
+		}
+		req.Tools = []gemTool{{FunctionDeclarations: decls}}
+	}
+
+	res, err := p.do(ctx, req)
+	if err != nil {
+		return Turn{}, err
+	}
+
+	turn := Turn{Text: res.text, StopReason: normalizeGeminiStop(res.finishReason), Assistant: Message{Role: "assistant"}}
+	if res.text != "" {
+		turn.Assistant.Content = append(turn.Assistant.Content, Block{Type: "text", Text: res.text})
+	}
+	// Gemini does not assign ids to function calls; synthesize a stable per-turn id.
+	// toGeminiContents recovers the function name from the assistant block on replay,
+	// so the id only has to round-trip the tool_use/tool_result pairing in the loop.
+	for i, fc := range res.functionCalls {
+		input := fc.args
+		if len(input) == 0 {
+			input = json.RawMessage("{}")
+		}
+		id := fmt.Sprintf("call_%d", i)
+		turn.ToolCalls = append(turn.ToolCalls, ToolCall{ID: id, Name: fc.name, Input: input})
+		turn.Assistant.Content = append(turn.Assistant.Content, Block{Type: "tool_use", ID: id, Name: fc.name, Input: input})
+	}
+	// Gemini reports finishReason "STOP" even when it emits function calls; the loop
+	// keys on tool-call presence, so reflect that in the (informational) stop reason.
+	if len(turn.ToolCalls) > 0 {
+		turn.StopReason = "tool_use"
+	}
+	return turn, nil
+}
+
+// baseRequest builds a request carrying the system instruction and token cap; the
+// caller fills in Contents and Tools.
+func (p *GeminiProvider) baseRequest() gemRequest {
+	var req gemRequest
+	if p.cfg.System != "" {
+		req.SystemInstruction = &gemContent{Parts: []gemPart{{Text: p.cfg.System}}}
+	}
+	if p.cfg.MaxTokens > 0 {
+		req.GenerationConfig = &gemGenerationConfig{MaxOutputTokens: p.cfg.MaxTokens}
+	}
+	return req
+}
+
+// toGeminiContents translates Anthropic-shaped history into Gemini contents. An
+// assistant message becomes a role:"model" content whose tool_use blocks become
+// functionCall parts; a user message's tool_result blocks become functionResponse
+// parts keyed by the function *name*. Because Gemini omits call ids, the name is
+// recovered from the tool_use id seen earlier in the same history — a single
+// in-order pass keeps this correct even if synthesized ids repeat across turns,
+// since a tool_result always follows its tool_use.
+func toGeminiContents(history []Message) []gemContent {
+	var out []gemContent
+	names := map[string]string{} // tool_use id -> function name
+	for _, m := range history {
+		switch m.Role {
+		case "assistant":
+			c := gemContent{Role: "model"}
+			for _, b := range m.Content {
+				switch b.Type {
+				case "text":
+					if b.Text != "" {
+						c.Parts = append(c.Parts, gemPart{Text: b.Text})
+					}
+				case "tool_use":
+					names[b.ID] = b.Name
+					args := b.Input
+					if len(args) == 0 {
+						args = json.RawMessage("{}")
+					}
+					c.Parts = append(c.Parts, gemPart{FunctionCall: &gemFunctionCall{Name: b.Name, Args: args}})
+				}
+			}
+			if len(c.Parts) > 0 {
+				out = append(out, c)
+			}
+		default: // "user" (and any other) — text and/or tool_result blocks
+			c := gemContent{Role: "user"}
+			for _, b := range m.Content {
+				switch b.Type {
+				case "text":
+					if b.Text != "" {
+						c.Parts = append(c.Parts, gemPart{Text: b.Text})
+					}
+				case "tool_result":
+					c.Parts = append(c.Parts, gemPart{FunctionResponse: &gemFunctionResponse{
+						Name:     names[b.ToolUseID],
+						Response: geminiResultResponse(b.Content, b.IsError),
+					}})
+				}
+			}
+			if len(c.Parts) > 0 {
+				out = append(out, c)
+			}
+		}
+	}
+	return out
+}
+
+// geminiResultResponse wraps a tool result string in the JSON object Gemini's
+// functionResponse.response field requires (a google.protobuf.Struct), keyed
+// "output" for success and "error" for a failed tool call.
+func geminiResultResponse(content string, isError bool) json.RawMessage {
+	key := "output"
+	if isError {
+		key = "error"
+	}
+	b, err := json.Marshal(map[string]string{key: content})
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return b
+}
+
+// normalizeGeminiStop maps a Gemini finishReason to the Anthropic-style stop reason
+// the rest of the codebase expects. The loop keys only on tool-call presence, so
+// this is informational, but keeping it consistent avoids surprises for audit/logging.
+func normalizeGeminiStop(reason string) string {
+	switch reason {
+	case "STOP":
+		return "end_turn"
+	case "MAX_TOKENS":
+		return "max_tokens"
+	case "":
+		return ""
+	default:
+		return strings.ToLower(reason)
+	}
+}
+
+// gemResult is the accumulated outcome of a streamed generateContent response.
+type gemResult struct {
+	text          string
+	functionCalls []gemAccumCall
+	finishReason  string
+}
+
+type gemAccumCall struct {
+	name string
+	args json.RawMessage
+}
+
+// do sends one streaming generateContent request and accumulates the SSE stream.
+func (p *GeminiProvider) do(ctx context.Context, reqBody gemRequest) (gemResult, error) {
+	buf, err := json.Marshal(reqBody)
+	if err != nil {
+		return gemResult{}, fmt.Errorf("sandbox/provider: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.url, bytes.NewReader(buf))
+	if err != nil {
+		return gemResult{}, fmt.Errorf("sandbox/provider: build request: %w", err)
+	}
+	req.Header.Set("content-type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return gemResult{}, fmt.Errorf("sandbox/provider: model-proxy request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return gemResult{}, parseGeminiError(resp.StatusCode, body)
+	}
+	return accumulateGeminiSSE(resp.Body)
+}
+
+// accumulateGeminiSSE reduces a generateContent text/event-stream to a gemResult:
+// text parts are concatenated, functionCall parts are collected whole (Gemini does
+// not fragment a call's args), and the finishReason is captured. A stream error
+// object aborts with an error.
+func accumulateGeminiSSE(body io.Reader) (gemResult, error) {
+	var res gemResult
+	sc := bufio.NewScanner(body)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(line[len("data:"):])
+		if data == "" {
+			continue
+		}
+		var chunk gemStreamChunk
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			return gemResult{}, fmt.Errorf("sandbox/provider: decode stream event: %w", err)
+		}
+		if chunk.Error != nil {
+			return gemResult{}, fmt.Errorf("sandbox/provider: stream error (%s): %s", chunk.Error.Status, chunk.Error.Message)
+		}
+		for _, cand := range chunk.Candidates {
+			for _, part := range cand.Content.Parts {
+				if part.Text != "" {
+					res.text += part.Text
+				}
+				if part.FunctionCall != nil {
+					res.functionCalls = append(res.functionCalls, gemAccumCall{name: part.FunctionCall.Name, args: part.FunctionCall.Args})
+				}
+			}
+			if cand.FinishReason != "" {
+				res.finishReason = cand.FinishReason
+			}
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return gemResult{}, fmt.Errorf("sandbox/provider: read stream: %w", err)
+	}
+	return res, nil
+}
+
+// parseGeminiError turns a non-200 generateContent response into an error,
+// preferring the structured error envelope and falling back to the raw body.
+func parseGeminiError(status int, body []byte) error {
+	var e gemErr
+	if err := json.Unmarshal(body, &e); err == nil && e.Error.Message != "" {
+		return fmt.Errorf("sandbox/provider: model-proxy returned %d (%s): %s", status, e.Error.Status, e.Error.Message)
+	}
+	if len(body) == 0 {
+		return fmt.Errorf("sandbox/provider: model-proxy returned %d", status)
+	}
+	return fmt.Errorf("sandbox/provider: model-proxy returned %d: %s", status, string(body))
+}

--- a/internal/sandbox/provider/gemini_test.go
+++ b/internal/sandbox/provider/gemini_test.go
@@ -1,0 +1,186 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// geminiHelloStream produces "hello world" across two content parts, then stops.
+var geminiHelloStream = sse(
+	`{"candidates":[{"content":{"role":"model","parts":[{"text":"hello "}]}}]}`,
+	`{"candidates":[{"content":{"role":"model","parts":[{"text":"world"}]},"finishReason":"STOP"}]}`,
+)
+
+func TestGeminiQuerySuccess(t *testing.T) {
+	var gotBody []byte
+	var gotPath, gotHost string
+	sock := serveUnix(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotHost = r.Host
+		gotBody, _ = io.ReadAll(r.Body)
+		writeSSE(w, geminiHelloStream)
+	}))
+
+	p := NewGemini(Config{SocketPath: sock})
+	out, err := p.Query(context.Background(), "hi there")
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if out != "hello world" {
+		t.Fatalf("Query output = %q, want %q", out, "hello world")
+	}
+	// The model id rides in the path; the proxy allowlists on Host.
+	if !strings.Contains(gotPath, defaultGeminiModel) || !strings.Contains(gotPath, ":streamGenerateContent") {
+		t.Fatalf("path = %q, want it to carry the model and :streamGenerateContent", gotPath)
+	}
+	if gotHost != geminiUpstreamHost {
+		t.Fatalf("Host = %q, want %q (proxy allowlists on Host)", gotHost, geminiUpstreamHost)
+	}
+
+	var req gemRequest
+	if err := json.Unmarshal(gotBody, &req); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if len(req.Contents) != 1 || req.Contents[0].Role != "user" ||
+		len(req.Contents[0].Parts) != 1 || req.Contents[0].Parts[0].Text != "hi there" {
+		t.Fatalf("contents = %+v, want one user text part %q", req.Contents, "hi there")
+	}
+}
+
+func TestGeminiSystem(t *testing.T) {
+	var gotBody []byte
+	sock := serveUnix(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		writeSSE(w, geminiHelloStream)
+	}))
+	p := NewGemini(Config{SocketPath: sock, System: "be terse"})
+	if _, err := p.Query(context.Background(), "x"); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	var req gemRequest
+	if err := json.Unmarshal(gotBody, &req); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if req.SystemInstruction == nil || len(req.SystemInstruction.Parts) != 1 ||
+		req.SystemInstruction.Parts[0].Text != "be terse" {
+		t.Fatalf("systemInstruction = %+v, want a single 'be terse' part", req.SystemInstruction)
+	}
+}
+
+func TestGeminiTools(t *testing.T) {
+	var gotBody []byte
+	sock := serveUnix(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		writeSSE(w, sse(
+			`{"candidates":[{"content":{"role":"model","parts":[{"text":"let me check"}]}}]}`,
+			`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"a.txt"}}}]},"finishReason":"STOP"}]}`,
+		))
+	}))
+
+	p := NewGemini(Config{SocketPath: sock})
+	turn, err := p.Converse(context.Background(),
+		[]Message{UserTextMessage("read a.txt")},
+		[]ToolSpec{{Name: "read_file", Description: "read a file", InputSchema: json.RawMessage(`{"type":"object"}`)}})
+	if err != nil {
+		t.Fatalf("Converse: %v", err)
+	}
+	if turn.Text != "let me check" {
+		t.Fatalf("text = %q", turn.Text)
+	}
+	if turn.StopReason != "tool_use" {
+		t.Fatalf("stop reason = %q, want tool_use (function call present)", turn.StopReason)
+	}
+	if len(turn.ToolCalls) != 1 || turn.ToolCalls[0].Name != "read_file" {
+		t.Fatalf("tool calls = %+v", turn.ToolCalls)
+	}
+	var input struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(turn.ToolCalls[0].Input, &input); err != nil || input.Path != "a.txt" {
+		t.Fatalf("tool input = %s (err %v)", turn.ToolCalls[0].Input, err)
+	}
+	// The assistant message must round-trip back as Anthropic-shaped blocks.
+	if len(turn.Assistant.Content) != 2 || turn.Assistant.Content[1].Type != "tool_use" {
+		t.Fatalf("assistant content = %+v", turn.Assistant.Content)
+	}
+
+	// The request must carry the tool in Gemini functionDeclarations shape.
+	var req gemRequest
+	if err := json.Unmarshal(gotBody, &req); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if len(req.Tools) != 1 || len(req.Tools[0].FunctionDeclarations) != 1 ||
+		req.Tools[0].FunctionDeclarations[0].Name != "read_file" {
+		t.Fatalf("tools in request = %+v", req.Tools)
+	}
+}
+
+// TestToGeminiContents checks the translation of an Anthropic-shaped tool-use round
+// (assistant tool_use → user tool_result) into Gemini's role:"model" functionCall +
+// role:"user" functionResponse shape, with the function name recovered by id.
+func TestToGeminiContents(t *testing.T) {
+	history := []Message{
+		UserTextMessage("read a.txt"),
+		{Role: "assistant", Content: []Block{
+			{Type: "text", Text: "checking"},
+			{Type: "tool_use", ID: "call_0", Name: "read_file", Input: json.RawMessage(`{"path":"a.txt"}`)},
+		}},
+		ToolResultsMessage([]ToolResult{{ToolUseID: "call_0", Content: "file body"}}),
+	}
+	contents := toGeminiContents(history)
+	if len(contents) != 3 {
+		t.Fatalf("got %d contents, want 3: %+v", len(contents), contents)
+	}
+	if contents[0].Role != "user" || len(contents[0].Parts) != 1 || contents[0].Parts[0].Text != "read a.txt" {
+		t.Fatalf("contents[0] = %+v", contents[0])
+	}
+	if contents[1].Role != "model" || len(contents[1].Parts) != 2 ||
+		contents[1].Parts[1].FunctionCall == nil || contents[1].Parts[1].FunctionCall.Name != "read_file" {
+		t.Fatalf("contents[1] = %+v", contents[1])
+	}
+	fr := contents[2].Parts[0].FunctionResponse
+	if contents[2].Role != "user" || fr == nil || fr.Name != "read_file" {
+		t.Fatalf("contents[2] = %+v, want a functionResponse named read_file", contents[2])
+	}
+	// The result string must be wrapped in the required {output: ...} struct.
+	var resp struct {
+		Output string `json:"output"`
+	}
+	if err := json.Unmarshal(fr.Response, &resp); err != nil || resp.Output != "file body" {
+		t.Fatalf("functionResponse.response = %s (err %v)", fr.Response, err)
+	}
+}
+
+func TestGeminiError(t *testing.T) {
+	sock := serveUnix(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		io.WriteString(w, `{"error":{"code":400,"message":"API key not valid","status":"INVALID_ARGUMENT"}}`)
+	}))
+	p := NewGemini(Config{SocketPath: sock})
+	_, err := p.Query(context.Background(), "x")
+	if err == nil {
+		t.Fatal("Query: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "400") || !strings.Contains(err.Error(), "API key not valid") {
+		t.Fatalf("error = %q, want it to mention 400 and the API message", err)
+	}
+}
+
+func TestGeminiFactory(t *testing.T) {
+	pv, err := New(Config{Kind: "Gemini"}) // case-insensitive
+	if err != nil {
+		t.Fatalf("gemini: %v", err)
+	}
+	gp, ok := pv.(*GeminiProvider)
+	if !ok {
+		t.Fatalf("gemini kind = %T, want *GeminiProvider", pv)
+	}
+	if !strings.Contains(gp.url, geminiUpstreamHost) || !strings.Contains(gp.url, ":streamGenerateContent?alt=sse") {
+		t.Fatalf("gemini url = %q, want the AI Studio host and SSE streaming path", gp.url)
+	}
+}

--- a/internal/sandbox/provider/provider.go
+++ b/internal/sandbox/provider/provider.go
@@ -65,6 +65,10 @@ const (
 	// KindCodex routes to the ChatGPT Codex Responses API (chatgpt.com), powered
 	// by a ChatGPT/Codex OAuth credential injected host-side (e.g. via OneCLI).
 	KindCodex = "codex"
+	// KindGemini routes to the Google Generative Language API
+	// (generativelanguage.googleapis.com) — Google AI Studio with a host-held API
+	// key, or the Gemini CLI's OAuth credential injected via the credential gateway.
+	KindGemini = "gemini"
 	// KindMock is a deterministic, offline backend (no network, no credential)
 	// for local demos and end-to-end tests. See MockProvider.
 	KindMock = "mock"
@@ -106,6 +110,10 @@ func New(cfg Config) (Provider, error) {
 		// NewCodex applies the chatgpt.com upstream host and the default Codex
 		// model when cfg leaves them zero.
 		return NewCodex(cfg), nil
+	case KindGemini:
+		// NewGemini applies the generativelanguage.googleapis.com upstream host and
+		// the default Gemini model when cfg leaves them zero.
+		return NewGemini(cfg), nil
 	case KindMock:
 		// Deterministic offline backend; ignores host/model/socket entirely.
 		return NewMock(cfg), nil
@@ -117,8 +125,9 @@ func New(cfg Config) (Provider, error) {
 // Config configures a Provider. The same struct serves every backend; fields a
 // given backend ignores (e.g. DisableThinking for OpenAI) are simply unused.
 type Config struct {
-	// Kind selects the backend: "" / "anthropic" (default), "openai", or
-	// "openrouter". See New. The kind is chosen per agent group host-side.
+	// Kind selects the backend: "" / "anthropic" (default), "openai",
+	// "openrouter", "codex", or "gemini". See New. The kind is chosen per agent
+	// group host-side.
 	Kind string
 	// SocketPath is the host model-proxy unix socket. Defaults to DefaultSocketPath.
 	SocketPath string


### PR DESCRIPTION
## What

Adds **Google Gemini** as a first-class model backend (IRO-157), alongside Anthropic / OpenAI / OpenRouter / Codex. One provider implementation serves two of the three requested Google platforms:

- **Google AI Studio** — direct, host-held API key injected as `x-goog-api-key`.
- **Gemini CLI** — the CLI's OAuth credential, fronted by the existing credential gateway (`IRONCLAW_MODEL_GATEWAY_URL`). Same `gemini` provider, gateway injects the token instead of the API key — zero extra code.

Select per agent group with `--provider gemini`.

## How it fits the architecture

Mirrors the existing OpenAI backend exactly:
- The sandbox provider (`network=none`) dials **only** the host model-proxy unix socket; it holds no credential.
- The host model-proxy allowlists `generativelanguage.googleapis.com` only when a key is present, strips any sandbox-supplied auth (`Authorization`, `X-Api-Key`, and now `X-Goog-Api-Key`), and injects the host-held key.
- Wire history stays Anthropic-shaped; `gemini.go` translates to/from Gemini `contents` so the agent loop is provider-agnostic. Two Gemini-specific shape differences are bridged: assistant role is `model`, and function results key by function **name** (recovered from the `tool_use` id during an in-order history walk).

## Changes
- `internal/sandbox/provider/gemini.go` — `GeminiProvider` (`Query` + `Converse`, SSE streaming, function calling).
- `internal/sandbox/provider/provider.go` — `KindGemini` + factory case.
- `internal/host/modelproxy/modelproxy.go` — `GeminiInjector`; strip inbound `X-Goog-Api-Key` in the Director.
- `cmd/controlplane/main.go` — enable on `GOOGLE_API_KEY` (preferred) or `GEMINI_API_KEY` (fallback).
- `internal/host/onboard/onboard.go` — detect the Google key as a model credential.
- `docs/quickstart.md`, `docs/site/configuration.mdx` — provider table + env vars.
- `internal/sandbox/provider/gemini_test.go` — query, system instruction, tool use, history translation, error envelope, factory (6 tests).

## Verification
- `go build ./...` ✓
- `go test ./internal/sandbox/provider/ ./internal/host/modelproxy/ ./internal/host/onboard/` ✓ (all green; 6 new Gemini tests pass under `-v`)
- `go vet` ✓, `gofmt -l` clean

## Follow-up (not in this PR)
**Vertex AI** needs project/location threaded into the request path + an OAuth bearer injector — a larger change touching session/ModelSelection plumbing. Tracked as a child issue. The Gemini wire format is identical on Vertex, so the same `GeminiProvider` will be reused there.