### PR TITLE
chore: reviewer gate verification (IRO-148) — DO NOT MERGE

### DIFF
--- a/.github/.reviewer-gate-verify.md
+++ b/.github/.reviewer-gate-verify.md
@@ -1,0 +1,5 @@
+# Reviewer gate verification (IRO-148)
+
+Throwaway PR to prove the `ironclaw-reviewer[bot]` GitHub App can post an
+approving review that satisfies `main`'s required-review gate without admin
+bypass. Safe to close unmerged. See docs/pr-review-process.md.


### PR DESCRIPTION
Throwaway PR to verify the `ironclaw-reviewer[bot]` App can satisfy main's required-review gate without admin bypass (IRO-148 acceptance #4). Will be closed unmerged.