### PR TITLE
ci(deps): hold container golang base on the 1.23 line (IRO-156)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,14 @@ updates:
     groups:
       docker-bases:
         patterns: ["*"]
+    ignore:
+      # Hold the golang base on the 1.23 line so the container toolchain stays
+      # aligned with go.mod (go 1.23) and the exact setup-go pin (1.23.12) used by
+      # every CI/release build — one toolchain, one reproducible output. Patch
+      # digest refreshes within 1.23.x still flow; a move to a newer Go minor is a
+      # deliberate, coordinated bump (go.mod + setup-go + reproducibility re-verify),
+      # not a container-only drift.
+      - dependency-name: "golang"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
Resolves the disposition of Dependabot PR #156 (golang 1.23-bookworm -> 1.26-bookworm, container-only).

## Why decline #156
- `go.mod` declares `go 1.23`; every CI/release `setup-go` is exact-pinned to `1.23.12` ("every build uses one toolchain").
- PR #156 bumped **only** the two container Dockerfiles to Go 1.26, splitting the project across two Go toolchains.
- The container build path (`image.yml`) runs only on tags, so the 1.26 container build was **never exercised** by PR CI.
- Reproducibility is a shipped security property here; two toolchains weakens that story.

## This change
Adds a Dependabot `ignore` so the golang docker base only takes **1.23.x patch / digest** refreshes, not minor jumps. A real Go upgrade stays a deliberate, coordinated change (go.mod + all setup-go pins + cross-runner reproducibility re-verify).

PR #156 will be closed referencing this.