### PR TITLE
ci(release): cross-machine bit-reproducibility via digest-pinned Linux build container (IRO-127)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,14 @@ name: Release
 # amalgamation), so each target is built on a runner with a matching C toolchain
 # rather than cross-compiled blind. The only cross-build is linux/arm64, which is
 # pure C and links cleanly with the aarch64 GNU cross-compiler.
+#
+# The Linux legs build INSIDE a digest-pinned container (golang:1.23.12-bookworm,
+# see BUILDER_IMAGE below) so the cgo C toolchain (gcc + glibc) that compiles the
+# SQLCipher amalgamation is byte-identical for everyone — not whatever patch the
+# ubuntu-latest image happens to ship that day. That is what makes the published
+# linux/amd64 + linux/arm64 binaries reproducible by an INDEPENDENT third party,
+# not just twice on the same runner (IRO-127). macOS/Windows build natively on the
+# host. The exact rebuild procedure is documented in docs/release-runbook.md.
 
 on:
   push:
@@ -97,13 +105,25 @@ jobs:
           # Windows x86_64 — native mingw-w64 gcc (preinstalled on the runner).
           - { goos: windows, goarch: amd64, runner: windows-latest, name: windows_amd64 }
     runs-on: ${{ matrix.runner }}
+    # Pin the Linux build toolchain by container DIGEST so the published linux/amd64 +
+    # linux/arm64 artifacts are bit-for-bit reproducible by any independent rebuild, not
+    # just same-runner (IRO-127). golang:1.23.12-bookworm fixes the Go compiler/linker AND
+    # the gcc/glibc that compile the vendored SQLCipher C amalgamation — the cgo toolchain
+    # drift that made ubuntu-latest hashes vary across runners. macOS/Windows legs build
+    # natively on the host; '' = run directly on the runner (no container).
+    # KEEP IN SYNC with reproducibility.yml's BUILDER_IMAGE and docs/release-runbook.md.
+    container: ${{ matrix.goos == 'linux' && 'golang:1.23.12-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db' || '' }}
     permissions:
       contents: read # checkout
       id-token: write # OIDC token for keyless provenance signing (Sigstore)
       attestations: write # actions/attest-build-provenance over the raw binaries
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      # macOS/Windows build on the host and need Go installed; the Linux legs already get a
+      # digest-pinned Go 1.23.12 from the builder container, so installing a second Go there
+      # would defer reproducibility to setup-go's toolchain instead of the pinned image.
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        if: matrix.goos != 'linux'
         with:
           go-version: "1.23.12"
           # No build-cache restore: a cached archive can carry a symbol order frozen from
@@ -116,8 +136,11 @@ jobs:
         env:
           APT_PKG: ${{ matrix.apt }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y "${APT_PKG}"
+          # The Linux legs run in the builder container as root (no sudo); a host runner
+          # needs sudo. Detect and adapt so the linux/arm64 cross-gcc installs either way.
+          SUDO=""; command -v sudo >/dev/null 2>&1 && SUDO="sudo"
+          $SUDO apt-get update
+          $SUDO apt-get install -y "${APT_PKG}"
 
       - name: Build binaries
         shell: bash
@@ -189,11 +212,34 @@ jobs:
           set -euo pipefail
           base="ironclaw_${VERSION}_${MATRIX_NAME}"
           mkdir -p dist/out
-          if [ "${GOOS}" = "windows" ]; then
-            ( cd dist/pkg && 7z a -tzip "../out/${base}.zip" ./* >/dev/null )
-          else
-            tar -czf "dist/out/${base}.tar.gz" -C dist/pkg .
-          fi
+          case "${GOOS}" in
+            windows)
+              ( cd dist/pkg && 7z a -tzip "../out/${base}.zip" ./* >/dev/null )
+              ;;
+            linux)
+              # Deterministic archive so the linux rows of SHA256SUMS are reproducible by an
+              # INDEPENDENT rebuild, not just the binaries inside (IRO-127). A plain
+              # `tar -czf` embeds each file's mtime and gzip stamps its own timestamp+name,
+              # so two builds of the identical binaries still produce different archive
+              # hashes. We pin all of that:
+              #   SOURCE_DATE_EPOCH (the commit's committer date — recoverable by anyone who
+              #     checks out the tag) → every entry's mtime via --mtime
+              #   --sort=name                → stable entry order (no readdir-order seed)
+              #   --owner=0 --group=0 --numeric-owner → fixed ownership metadata
+              #   gzip -n                    → drop gzip's mtime + original-filename fields
+              # GNU tar (the bookworm builder container) supports all of these. macOS/Windows
+              # are not cross-machine reproducible (different SDK/zip) and keep their default
+              # packaging; only the Linux archives carry the reproducibility guarantee.
+              git config --global --add safe.directory "${GITHUB_WORKSPACE}" 2>/dev/null || true
+              SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)"
+              tar --sort=name --mtime="@${SOURCE_DATE_EPOCH}" \
+                  --owner=0 --group=0 --numeric-owner \
+                  -cf - -C dist/pkg . | gzip -n > "dist/out/${base}.tar.gz"
+              ;;
+            *)
+              tar -czf "dist/out/${base}.tar.gz" -C dist/pkg .
+              ;;
+          esac
           ls -l dist/out
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -1,24 +1,28 @@
-# Reproducible-build verification (IRO-32 A4).
+# Reproducible-build verification (IRO-32 A4; cross-machine IRO-127).
 #
-# Proves IronClaw's binaries are bit-for-bit deterministic: build every command twice
-# from a clean checkout with the SAME pinned toolchain and flags the release uses
-# (-trimpath, -buildid=, -extldflags=-Wl,--build-id=none, GOMAXPROCS=1, fixed module
-# versions via go.sum), then assert the two SHA256 sets are identical. A drift here means
-# something non-deterministic crept into the build (an unpinned tool, a timestamp, a
-# map-iteration order in codegen) and the "reproducible builds" guarantee is broken —
-# fail loud.
+# Proves IronClaw's Linux binaries are bit-for-bit deterministic at TWO levels:
+#
+#   1. Same-runner determinism — build every command twice from a clean checkout with
+#      the SAME pinned toolchain and flags the release uses (-trimpath, -buildid=,
+#      -extldflags=-Wl,--build-id=none, GOMAXPROCS=1, fixed module versions via go.sum),
+#      then assert the two SHA256 sets are identical. A drift here means a non-deterministic
+#      input crept in (an unpinned tool, a timestamp, a map-iteration order in codegen).
+#
+#   2. Cross-MACHINE determinism (IRO-127) — run that same double-build inside a
+#      DIGEST-PINNED builder container (golang:1.23.12-bookworm) on two DIFFERENT host
+#      runner images (ubuntu-22.04 and ubuntu-24.04), then assert the resulting hashes
+#      match across hosts. Without the container the cgo C toolchain (gcc/glibc) drifts
+#      between runner images and the absolute hashes diverge — an independent third party
+#      rebuilding from source would NOT reproduce the published SHA256SUMS. Pinning the
+#      toolchain by container digest removes that drift; this job is the test that it did.
+#      The build runs in the exact image release.yml ships, so the linux/amd64 hash this
+#      workflow produces is the one a third party reproduces by following docs/release-runbook.md.
 #
 # All three commands (controlplane, ironctl, sandbox) are hard-asserted reproducible.
-# The control-plane binary was previously a tracked exception (IRO-44). Two factors made
-# it — the largest binary, with the most generic [go.shape...] instantiations and ..stmp_
-# statics — non-deterministic on a multi-core runner, both now removed:
-#   1. The Go compiler/linker resolve ties in symbol ordering in the scheduling order of
-#      their GOMAXPROCS-many goroutines. GOMAXPROCS=1 makes that deterministic.
-#   2. The very first `go build` on a fresh runner races module download/extract (go clean
-#      -cache does not touch the module cache), so build #1 differed from build #2+. A
-#      `go mod download` before the builds removes that seed.
-# With both applied, all three commands build bit-for-bit identically, so the exception is
-# gone and controlplane is gated like the others.
+# The control-plane binary was previously a tracked exception (IRO-44): on a multi-core
+# runner the Go compiler/linker resolved symbol-ordering ties in GOMAXPROCS-goroutine
+# scheduling order, and the first cold `go build` raced module download/extract. GOMAXPROCS=1
+# plus a `go mod download` before the builds removed both seeds, so it is gated like the rest.
 #
 # Runs on PRs to main + weekly so a regression is caught before it ships, without
 # adding cost to the per-push release.
@@ -35,9 +39,24 @@ permissions:
   contents: read
 
 jobs:
+  # Build twice inside the pinned container on each host image. Asserts same-runner
+  # determinism per host and emits the linux/amd64 hash set as an artifact for the
+  # cross-machine compare below.
   verify:
     name: Verify deterministic build
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Two genuinely different host runner images. The build runs inside the pinned
+        # container, so a matching result across these proves the container — not the host
+        # — determines the toolchain (the whole point of IRO-127). If these ever diverge,
+        # host state is leaking into the build.
+        host: [ubuntu-22.04, ubuntu-24.04]
+    runs-on: ${{ matrix.host }}
+    # The digest-pinned builder image — identical Go compiler/linker AND gcc/glibc for
+    # everyone, regardless of which physical runner GitHub schedules this on.
+    # KEEP IN SYNC with release.yml's build-job container and docs/release-runbook.md.
+    container: golang:1.23.12-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db
     env:
       CGO_ENABLED: "1"
       # Single-threaded build so symbol-ordering ties resolve deterministically — half of
@@ -46,33 +65,29 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          # Must match the exact toolchain pin in ci.yml / release.yml — a different
-          # patch can change the emitted binary and is itself a reproducibility break.
-          go-version: "1.23.12"
-          # Don't restore a build cache: cached archives can carry a symbol order frozen
-          # from an earlier *parallel* build, which would contaminate the comparison.
-          cache: false
+      # No setup-go: the container already provides the digest-pinned Go 1.23.12. Installing
+      # a second Go here would defer reproducibility to setup-go's toolchain instead of the
+      # image release.yml actually ships, breaking the "rebuild in this image" guarantee.
 
       - name: Build twice and compare checksums
         shell: bash
+        env:
+          HOST: ${{ matrix.host }}
         run: |
           set -euo pipefail
           # Pre-fetch modules so neither build races a module download/extract on its first
           # run — the second half of the IRO-44 fix (otherwise build A != build B because
           # only A pays the download cost).
           go mod download all
-          # Mirror the release build flags. The version string is fixed (not derived
-          # from git state) so it can't be the source of a difference here. We also
-          # strip the two ELF identifiers that vary across cold rebuilds of a CGO
-          # (external-linked) binary:
-          #   -buildid=                  empties Go's build ID (a content hash that can
-          #                              shift when the action graph is recompiled cold)
-          #   -extldflags=-Wl,--build-id=none  drops the GNU .note.gnu.build-id the
-          #                              external linker (ld) stamps in. This is the
-          #                              standard reproducible-build fix for cgo binaries
-          #                              and is valid here because the runner is Linux.
+          # Mirror the release build flags exactly. The version string is fixed to a constant
+          # here (it is the one input the published build derives from the git tag); to
+          # reproduce a PUBLISHED binary, build with Version set to the release tag instead
+          # (see docs/release-runbook.md). We strip the two ELF identifiers that otherwise
+          # vary across cold rebuilds of a CGO (external-linked) binary:
+          #   -buildid=                        empties Go's content-hash build ID
+          #   -extldflags=-Wl,--build-id=none  drops the GNU .note.gnu.build-id ld stamps in
+          #                                    (the standard reproducible-build fix for cgo;
+          #                                    valid here because the builder is Linux).
           ldflags="-s -w -buildid= -X github.com/IronSecCo/ironclaw/internal/version.Version=repro-check -extldflags=-Wl,--build-id=none"
           build() {
             local dest="$1"
@@ -90,22 +105,73 @@ jobs:
           hashes() { ( cd "$1" && sha256sum controlplane ironctl sandbox ) | awk '{print $2, $1}'; }
           hashes out/a > a.sums
           hashes out/b > b.sums
-          echo "== build A =="; cat a.sums
-          echo "== build B =="; cat b.sums
+          echo "== build A (${HOST}) =="; cat a.sums
+          echo "== build B (${HOST}) =="; cat b.sums
 
-          # Every command MUST be bit-for-bit reproducible — a drift in any of them is a
-          # hard failure (a non-pinned input crept in). controlplane is no longer an
-          # exception: with GOMAXPROCS=1 + pre-fetched modules it builds deterministically
-          # (IRO-44 resolved).
+          # Same-runner determinism: a drift in any command is a hard failure (a non-pinned
+          # input crept in).
           rc=0
           for bin in controlplane ironctl sandbox; do
             a="$(grep "^${bin} " a.sums | awk '{print $2}')"
             b="$(grep "^${bin} " b.sums | awk '{print $2}')"
             if [ "${a}" != "${b}" ]; then
-              echo "::error title=Reproducibility::${bin} is not deterministic: two clean builds differ (${a} vs ${b}). A non-pinned input crept in — investigate before trusting the reproducible-build guarantee." >&2
+              echo "::error title=Reproducibility (${HOST})::${bin} is not deterministic: two clean builds differ (${a} vs ${b}). A non-pinned input crept in — investigate before trusting the reproducible-build guarantee." >&2
               rc=1
             else
-              echo "Reproducible: ${bin} is byte-identical across cold rebuilds (${a})."
+              echo "Reproducible: ${bin} is byte-identical across cold rebuilds on ${HOST} (${a})."
             fi
           done
-          exit "${rc}"
+          [ "${rc}" -eq 0 ] || exit "${rc}"
+
+          # Package out/a into a DETERMINISTIC archive exactly the way release.yml does, then
+          # hash it too. This extends the cross-machine guarantee from the raw binaries up to
+          # the .tar.gz whose digest lands in the published SHA256SUMS — a plain tar/gzip would
+          # bake in mtimes and a gzip timestamp and break that top-level reproducibility even
+          # when the binaries match (IRO-127). SOURCE_DATE_EPOCH is the checked-out commit's
+          # committer date: identical on both host images, recoverable by any rebuilder.
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}" 2>/dev/null || true
+          SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)"
+          cp LICENSE README.md out/a/
+          tar --sort=name --mtime="@${SOURCE_DATE_EPOCH}" \
+              --owner=0 --group=0 --numeric-owner \
+              -cf - -C out/a . | gzip -n > repro.tar.gz
+          sha256sum repro.tar.gz | awk '{print $2, $1}' >> a.sums
+
+          # Publish this host's hash set (binaries + deterministic archive; build A == build B
+          # already asserted) for the cross-machine compare. Named per host so the compare job
+          # can diff them.
+          cp a.sums "host.sums"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: repro-sums-${{ matrix.host }}
+          path: host.sums
+          if-no-files-found: error
+          retention-days: 7
+
+  # Cross-machine assertion (IRO-127): the hash sets from the two different host images,
+  # both built in the same pinned container, MUST be identical. If they differ, the
+  # container is NOT fully pinning the toolchain (host state is leaking in) and the
+  # published binaries are not reproducible by an independent rebuild — fail loud.
+  cross-machine:
+    name: Cross-machine bit-identity
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: dl
+
+      - name: Assert hashes identical across host images
+        shell: bash
+        run: |
+          set -euo pipefail
+          a="dl/repro-sums-ubuntu-22.04/host.sums"
+          b="dl/repro-sums-ubuntu-24.04/host.sums"
+          echo "== ubuntu-22.04 =="; cat "${a}"
+          echo "== ubuntu-24.04 =="; cat "${b}"
+          if ! diff -u "${a}" "${b}"; then
+            echo "::error title=Cross-machine reproducibility::linux/amd64 binaries built in the SAME pinned container differ across host images (ubuntu-22.04 vs ubuntu-24.04). The builder container is not fully pinning the toolchain — host state is leaking into the build, so an independent rebuild would not reproduce the published SHA256SUMS. Investigate before trusting the reproducible-build guarantee (IRO-127)." >&2
+            exit 1
+          fi
+          echo "Cross-machine reproducible: controlplane, ironctl and sandbox are byte-identical across ubuntu-22.04 and ubuntu-24.04 when built in the pinned container."

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -197,6 +197,70 @@ when you need full supply-chain assurance beyond the checksum.
 
 ---
 
+## 4a. Reproducing the published Linux binaries from source (IRO-127)
+
+The strongest guarantee a reproducible-builds reviewer wants is to **rebuild from the source
+commit and get bit-for-bit the same artifacts** the release published — proving the binaries
+contain nothing that isn't in the public source. IronClaw's `linux/amd64` and `linux/arm64`
+artifacts are reproducible this way because the release builds them inside a **digest-pinned
+container** (`golang:1.23.12-bookworm`), so the Go compiler/linker **and** the gcc/glibc that
+compile the vendored SQLCipher C amalgamation are byte-identical for every rebuilder — not
+whatever patch a given `ubuntu-latest` runner happened to ship. Same commit → same toolchain →
+same bytes.
+
+> **Scope.** Only the Linux targets carry this guarantee. macOS and Windows archives are built
+> natively on the host (different SDK / `zip` implementation) and are **not** bit-reproducible
+> across machines — verify those via the cosign signature and provenance attestation (Section 4)
+> instead.
+
+The builder image is pinned by digest in **one place each** in `release.yml` (the `build` job's
+`container:`) and `reproducibility.yml` (the `verify` job's `container:`). To roll the toolchain,
+bump both to the new `golang:<ver>-bookworm@sha256:<digest>` and update the command below.
+
+**To reproduce `linux/amd64` (use `linux/arm64` by swapping `GOARCH` + adding the cross-gcc):**
+
+```sh
+# 1. Check out the EXACT released commit (the tag points at it).
+git clone https://github.com/IronSecCo/ironclaw && cd ironclaw
+git checkout v0.1.<n>          # the release tag you are verifying
+TAG=v0.1.<n>
+
+# 2. Build the binaries inside the same digest-pinned container the release used.
+docker run --rm -v "$PWD":/src -w /src \
+  golang:1.23.12-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db \
+  bash -c '
+    set -euo pipefail
+    git config --global --add safe.directory /src   # root-in-container reads the mounted .git
+    export CGO_ENABLED=1 GOMAXPROCS=1 GOOS=linux GOARCH=amd64
+    go mod download all
+    ldflags="-s -w -buildid= -X github.com/IronSecCo/ironclaw/internal/version.Version='"$TAG"' -extldflags=-Wl,--build-id=none"
+    mkdir -p dist/pkg
+    for c in controlplane ironctl sandbox; do
+      out=ironctl; [ "$c" = controlplane ] && out=ironclaw-controlplane; [ "$c" = sandbox ] && out=ironclaw-sandbox
+      go build -trimpath -ldflags "$ldflags" -o "dist/pkg/$out" "./cmd/$c"
+    done
+    cp LICENSE README.md dist/pkg/
+    # Deterministic archive (fixed mtime from the commit, sorted, numeric-0 owner, gzip -n):
+    SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)"
+    tar --sort=name --mtime="@${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner \
+        -cf - -C dist/pkg . | gzip -n > "ironclaw_${TAG#v}_linux_amd64.tar.gz"
+    sha256sum "ironclaw_${TAG#v}_linux_amd64.tar.gz" dist/pkg/iron*'
+```
+
+**Compare to the release.** The printed archive hash must equal the `linux_amd64` row of the
+published `SHA256SUMS`, and each printed binary hash must equal what `gh attestation verify
+./<binary> --repo IronSecCo/ironclaw` attests. A match proves the published `linux/amd64` set is
+reproducible from source; a mismatch means either you built a different commit/tag or a
+non-pinned input crept into the release — investigate before trusting it.
+
+**This is enforced in CI.** `reproducibility.yml` builds all three commands twice inside the
+pinned container on **two different host runner images** (`ubuntu-22.04` + `ubuntu-24.04`) and
+fails the build unless the binaries **and** the deterministic archive are byte-identical across
+hosts — i.e. it tests cross-machine reproducibility on every PR and weekly, not just
+same-runner determinism.
+
+---
+
 ## 5. Partial-failure semantics (operator decision)
 
 The release job uploads the binaries + `SHA256SUMS` **first**, then attaches SBOMs, the cosign


### PR DESCRIPTION
## What & why

`reproducibility.yml` only proved **same-runner** reproducibility — build twice on one
runner, assert the hashes match. But the absolute hashes drift across runners (IRO-127):
the cgo C toolchain (gcc/glibc) that compiles the vendored SQLCipher amalgamation varies
by `ubuntu-latest` image patch, so an **independent third party rebuilding from source does
not reproduce the published `SHA256SUMS`** — the stronger guarantee reproducible-builds
reviewers and OpenSSF Scorecard actually want.

## Changes

- **`release.yml`** — the `linux/amd64` + `linux/arm64` build legs now run inside a
  **digest-pinned** `golang:1.23.12-bookworm` container, so the Go compiler/linker **and**
  gcc/glibc are byte-identical for everyone. macOS/Windows still build natively on the host.
- **`release.yml`** — Linux archives are packaged **deterministically**
  (`SOURCE_DATE_EPOCH` from the commit, `tar --sort=name --owner=0 --group=0
  --numeric-owner`, `gzip -n`) so the **linux rows of `SHA256SUMS`** — not just the binaries
  inside — reproduce. (A plain `tar -czf` bakes in mtimes + a gzip timestamp.)
- **`reproducibility.yml`** — builds twice in the pinned container on **two different host
  images** (`ubuntu-22.04` + `ubuntu-24.04`) and fails unless the binaries **and** the
  deterministic archive are byte-identical **across hosts**. Real cross-machine assertion.
- **`docs/release-runbook.md`** — documented independent-rebuild procedure (exact image
  digest + copy-pasteable build command) that reproduces the published `linux/amd64` set.

## Verification

Run locally under Docker (`--platform linux/amd64` in the pinned image):

- Two cold builds → byte-identical `controlplane`, `ironctl`, `sandbox`.
- Deterministic archive of each → byte-for-byte identical (`99be368c…`).
- `actionlint` clean on both workflows.

This PR's own `Reproducibility` run is the live cross-machine (two-host) proof in real CI.

## Supply-chain lenses

- **Reproducibility** — primary: published Linux artifacts re-derivable bit-for-bit from a
  known commit + documented container.
- **Pinned, auditable actions** — builder image pinned by `@sha256` digest, in sync across
  `release.yml` / `reproducibility.yml` / the runbook.
- **Build matrix fidelity** — matrix unchanged (macOS amd64+arm64, Linux amd64+arm64,
  Windows amd64; CGO, Go 1.23+); only the Linux build *environment* changed.
- **Least-privilege CI** — no token-scope changes.

No changes to signing, attestation, required-checks, or installer verification paths.

Closes IRO-127.