### PR TITLE
test(iro-162): verify reviewer-App approval gate [throwaway]

### DIFF
--- a/REVIEWER_GATE_VERIFY.md
+++ b/REVIEWER_GATE_VERIFY.md
@@ -1,0 +1,4 @@
+# Reviewer-gate verification (IRO-162)
+
+Throwaway PR to verify the ironclaw-reviewer App approving-review gate end-to-end.
+Not for merge. See docs/pr-review-process.md.


### PR DESCRIPTION
Throwaway PR to verify the `ironclaw-reviewer[bot]` approving-review gate end-to-end (IRO-162 / closes verification for IRO-148).

**Not for merge.** Will be closed once the gate is confirmed. See docs/pr-review-process.md.