### PR TITLE
chore: reviewer gate verification (IRO-148) — DO NOT MERGE

### DIFF
--- a/.github/.reviewer-gate-verify.md
+++ b/.github/.reviewer-gate-verify.md
@@ -1,0 +1,3 @@
+# Reviewer gate verification (IRO-148, run 2)
+
+Throwaway PR proving ironclaw-reviewer[bot] can satisfy the required-review gate without admin bypass. Safe to close unmerged.


### PR DESCRIPTION
Throwaway PR to verify ironclaw-reviewer[bot] satisfies main's required-review gate without admin bypass (IRO-148 acceptance #4). Will be closed unmerged.