### PR TITLE
docs(review): ironclaw-reviewer needs contents:write so its approval counts (IRO-148)

### DIFF
--- a/.github/reviewer-app-manifest.yml
+++ b/.github/reviewer-app-manifest.yml
@@ -24,10 +24,17 @@ hook_attributes:
 
 public: false
 
-# Least privilege. Only what is needed to post an approving review.
+# Least privilege. Only what is needed to post a *counting* approving review.
 default_permissions:
   pull_requests: write   # submit the APPROVE review
-  contents: read         # read PR head / repo metadata
+  # contents:write (not read) is REQUIRED: GitHub only counts an approving
+  # review toward required approvals if the reviewer has WRITE access to the
+  # repo. With contents:read the App's APPROVE is recorded but not counted
+  # (author_association=NONE, reviewDecision stays REVIEW_REQUIRED). main stays
+  # PR+checks protected, so write here only makes the approval count — it does
+  # not let the App bypass review.
+  # https://docs.github.com/articles/approving-a-pull-request-with-required-reviews
+  contents: write        # required for the App's approval to be counted
   metadata: read         # mandatory baseline
 
 # The App is event-driven by nothing; it subscribes to no events.

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -46,7 +46,7 @@ must supply*, never in the actor approving unconditionally.
 | Distinct actor for the gate | ✅ Approvals post as `app-slug[bot]`, a different actor than `omerzamir`. App reviews count toward `required_approving_review_count`. | ✅ A second user account is a different actor; its approval counts. |
 | Can be a CODEOWNER | ❌ CODEOWNERS only accepts users/teams, not apps. (Our ruleset has `require_code_owner_review: false`, so this is not needed for the gate.) | ✅ Can be listed in CODEOWNERS and required via `require_code_owner_review`. |
 | Seats / cost | ✅ Apps consume **no seat**. Free. | ⚠️ Free on this **public** repo, but a paid org seat per private repo; account lifecycle (email, 2FA, recovery) to own forever. |
-| Secret handling | ⚠️ One long-lived **App private key** (PEM), stored as a repo/org Actions secret, scoped to `pull_requests: write` + `contents/metadata: read`. Rotatable; never touches release signing (which stays keyless/OIDC). | ❌ A full second login: password + 2FA + a long-lived PAT with `repo` scope. Larger, human-shaped attack surface. |
+| Secret handling | ⚠️ One long-lived **App private key** (PEM), stored as a repo/org Actions secret, scoped to `pull_requests: write` + `contents: write` (required so the approval counts) + `metadata: read`. Rotatable; never touches release signing (which stays keyless/OIDC). | ❌ A full second login: password + 2FA + a long-lived PAT with `repo` scope. Larger, human-shaped attack surface. |
 | Audit story | ✅ Reviews are clearly machine-posted by a named bot; fine-grained, least-privilege permissions; one auditable installation. | ⚠️ Looks like a human; easy to over-grant; harder to reason about least privilege. |
 | Automatable now | ✅ Manifest + workflow scaffolded in this repo; only App creation/install needs a human. | ⚠️ Account creation needs a human inbox + 2FA; collaborator invite + CODEOWNERS automatable after. |
 | GitHub guidance | ✅ Apps are GitHub's recommended automation primitive. | ⚠️ Machine user accounts are allowed but discouraged when an App fits. |
@@ -133,8 +133,12 @@ Click-by-click (≈5 minutes, repo admin):
    - **Homepage URL:** `https://github.com/IronSecCo/ironclaw`
    - **Webhook:** uncheck **Active** (no webhook needed).
    - **Repository permissions:** **Pull requests → Read and write**,
-     **Contents → Read-only**, **Metadata → Read-only** (mandatory). Leave
-     everything else **No access**.
+     **Contents → Read and write**, **Metadata → Read-only** (mandatory). Leave
+     everything else **No access**. (Contents **write** is required: GitHub only
+     counts an approving review toward required approvals if the reviewer has
+     write access — with read-only the App's approval is recorded but not
+     counted. `main` stays PR+checks protected, so this only makes the approval
+     count, it does not let the App bypass review.)
    - **Where can this App be installed?** *Only on this account.*
    - Click **Create GitHub App**.
    *(The values above match [`.github/reviewer-app-manifest.yml`](https://github.com/IronSecCo/ironclaw/blob/main/.github/reviewer-app-manifest.yml).)*


### PR DESCRIPTION
Corrects the reviewer-App source-of-truth after live verification. The App posts an APPROVED review as a distinct actor (ironclaw-reviewer[bot] ≠ author), but GitHub does not count it because the App has contents:read (author_association=NONE → reviewDecision REVIEW_REQUIRED). Per [GitHub docs](https://docs.github.com/articles/approving-a-pull-request-with-required-reviews), an approving review only counts if the reviewer has write access. Updates manifest + human-handoff to Contents: Read & write. main stays PR+checks protected — this only makes the approval count, not bypass review. Docs/config only; bootstrap correction for the not-yet-functional reviewer.