### PR TITLE
feat(diag): surface early sandbox exit + doctor docker file-sharing check (IRO-171)

### DIFF
--- a/cmd/ironctl/doctor.go
+++ b/cmd/ironctl/doctor.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -52,6 +53,8 @@ func cmdDoctor(addr string, args []string) error {
 	// $IRONCLAW_RUNTIME, else gVisor's runsc. An explicit --runtime wins.
 	runtimeBin := fs.String("runtime", envOrDefault("IRONCLAW_RUNTIME", "runsc"),
 		"OCI runtime binary to check (gVisor's runsc by default; IRONCLAW_RUNTIME selects it)")
+	stateDir := fs.String("state-dir", defaultStateDir(),
+		"control-plane state dir (per-session queues/keys); used by the --runtime docker file-sharing check")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -66,6 +69,13 @@ func cmdDoctor(addr string, args []string) error {
 		checkChannels(os.Getenv),
 		checkConfig(),
 		checkModelProxy(*socket),
+	}
+	// The Docker fallback runtime (macOS dev) carries the per-session queues/keys
+	// into each sandbox via a bind mount; if the state dir is outside Docker
+	// Desktop's shared paths the bind mounts empty and the sandbox exits 1 on its
+	// session-key read (IRO-171). Only relevant when the Docker runtime is selected.
+	if strings.Contains(*runtimeBin, "docker") {
+		results = append(results, checkDockerFileSharing(*stateDir))
 	}
 	printChecks(os.Stdout, results)
 
@@ -347,6 +357,182 @@ func tryVersion(bin string) (string, bool) {
 		return "", false
 	}
 	return line, true
+}
+
+// defaultStateDir mirrors the control-plane's defaultStateDir (cmd/controlplane)
+// so the Docker file-sharing check probes the same dir the daemon binds into each
+// sandbox. Production passes --state-dir explicitly.
+func defaultStateDir() string {
+	if d, err := os.UserCacheDir(); err == nil {
+		return filepath.Join(d, "ironclaw", "state")
+	}
+	return filepath.Join(os.TempDir(), "ironclaw-state")
+}
+
+// checkDockerFileSharing verifies that, under the Docker fallback runtime, the host
+// state dir (per-session encrypted queues + keys) lands inside Docker Desktop's
+// shared paths — so the bind mount actually delivers it into each sandbox
+// container. A state dir outside the shared set mounts EMPTY in the container, and
+// the sandbox then exits 1 on its session-key read (the IRO-171 macOS failure). On
+// Linux there is no Docker Desktop VM boundary, so bind mounts always deliver.
+func checkDockerFileSharing(stateDir string) checkResult {
+	shared, ok := dockerDesktopSharedDirs()
+	return evalDockerFileSharing(stateDir, shared, ok, runtime.GOOS)
+}
+
+// evalDockerFileSharing is the pure decision core of checkDockerFileSharing,
+// separated from the OS/settings lookup so it is exhaustively unit-testable.
+func evalDockerFileSharing(stateDir string, shared []string, sharedOK bool, goos string) checkResult {
+	r := checkResult{Name: "docker file sharing", Doc: docBase + "/troubleshooting/#sandbox-exits-on-startup-macos-docker-file-sharing"}
+	if goos == "linux" {
+		r.Status = checkOK
+		r.Detail = "bind mounts deliver directly on Linux; Docker Desktop file sharing does not apply"
+		return r
+	}
+	// Resolve symlinks on both sides so the comparison is apples-to-apples (macOS
+	// /tmp -> /private/tmp, /var/folders -> /private/var/folders).
+	resolved := resolveExistingPath(stateDir)
+	probeHint := "verify it is delivered with: docker run --rm -v " + stateDir + ":/probe alpine ls -A /probe"
+	if sharedOK {
+		if pathUnderAny(resolved, resolveAll(shared)) {
+			r.Status = checkOK
+			r.Detail = stateDir + " is inside Docker Desktop's shared paths"
+			return r
+		}
+		r.Status = checkWarn
+		r.Detail = stateDir + " is NOT inside Docker Desktop's shared paths " + strings.Join(shared, ", ")
+		r.Fix = "add it under Docker Desktop → Settings → Resources → File sharing (or move --state-dir under a shared path); otherwise the per-session queues/keys bind mounts empty and the sandbox exits 1 on its session-key read. " + probeHint
+		return r
+	}
+	// Could not read Docker Desktop's settings — fall back to its default-shared roots.
+	if pathUnderAny(resolved, resolveAll(dockerDesktopDefaultRoots(goos))) {
+		r.Status = checkOK
+		r.Detail = stateDir + " is under a Docker Desktop default-shared root (Docker Desktop settings unreadable, so a custom config could not be confirmed)"
+		return r
+	}
+	r.Status = checkWarn
+	r.Detail = stateDir + " may be outside Docker Desktop's shared paths (could not read Docker Desktop settings to confirm)"
+	r.Fix = "ensure it is shared under Docker Desktop → Settings → Resources → File sharing; otherwise the per-session queues/keys bind mounts empty and the sandbox exits 1 on its session-key read. " + probeHint
+	return r
+}
+
+// dockerDesktopSharedDirs reads the host directories Docker Desktop is configured
+// to share into containers, from its settings file (macOS/Windows). ok is false
+// when no settings file is found or it has no file-sharing list, so the caller can
+// fall back to the default-shared roots heuristic.
+func dockerDesktopSharedDirs() (dirs []string, ok bool) {
+	for _, p := range dockerDesktopSettingsPaths() {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		if d := parseSharedDirs(data); len(d) > 0 {
+			return d, true
+		}
+	}
+	return nil, false
+}
+
+// dockerDesktopSettingsPaths returns the candidate Docker Desktop settings files,
+// newest layout first. Docker Desktop renamed settings.json to settings-store.json
+// in 4.34; both are tried.
+func dockerDesktopSettingsPaths() []string {
+	switch runtime.GOOS {
+	case "darwin":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil
+		}
+		base := filepath.Join(home, "Library", "Group Containers", "group.com.docker")
+		return []string{
+			filepath.Join(base, "settings-store.json"),
+			filepath.Join(base, "settings.json"),
+		}
+	case "windows":
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			return nil
+		}
+		base := filepath.Join(appData, "Docker")
+		return []string{
+			filepath.Join(base, "settings-store.json"),
+			filepath.Join(base, "settings.json"),
+		}
+	default:
+		return nil
+	}
+}
+
+// parseSharedDirs extracts the filesharingDirectories list from a Docker Desktop
+// settings blob. Tolerant of the surrounding schema — it only reads the one field.
+func parseSharedDirs(data []byte) []string {
+	var s struct {
+		FilesharingDirectories []string `json:"filesharingDirectories"`
+	}
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil
+	}
+	return s.FilesharingDirectories
+}
+
+// dockerDesktopDefaultRoots returns the directories Docker Desktop shares by
+// default when no custom file-sharing config can be read.
+func dockerDesktopDefaultRoots(goos string) []string {
+	if goos == "darwin" {
+		return []string{"/Users", "/Volumes", "/private", "/tmp", "/var/folders"}
+	}
+	return nil
+}
+
+// resolveExistingPath cleans path and resolves symlinks on its longest existing
+// ancestor (the state dir may not exist yet), so comparisons against shared roots
+// are apples-to-apples (e.g. macOS /tmp -> /private/tmp).
+func resolveExistingPath(path string) string {
+	path = filepath.Clean(path)
+	dir := path
+	for {
+		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+			if dir == path {
+				return resolved
+			}
+			// Re-attach the non-existent tail to the resolved existing prefix.
+			rel, rerr := filepath.Rel(dir, path)
+			if rerr != nil {
+				return resolved
+			}
+			return filepath.Join(resolved, rel)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return path // reached the root without resolving anything
+		}
+		dir = parent
+	}
+}
+
+// resolveAll resolves symlinks on each root (best-effort), so shared-path
+// comparisons survive macOS's /tmp and /var symlinks.
+func resolveAll(roots []string) []string {
+	out := make([]string, 0, len(roots))
+	for _, r := range roots {
+		out = append(out, resolveExistingPath(r))
+	}
+	return out
+}
+
+// pathUnderAny reports whether path equals or is nested under any of roots.
+func pathUnderAny(path string, roots []string) bool {
+	path = filepath.Clean(path)
+	for _, root := range roots {
+		root = filepath.Clean(root)
+		if path == root {
+			return true
+		}
+		if rel, err := filepath.Rel(root, path); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel) {
+			return true
+		}
+	}
+	return false
 }
 
 func printChecks(w io.Writer, results []checkResult) {

--- a/cmd/ironctl/doctor_test.go
+++ b/cmd/ironctl/doctor_test.go
@@ -238,3 +238,94 @@ func TestPrintChecks(t *testing.T) {
 		t.Error("failing check should print both the fix hint and the doc link")
 	}
 }
+
+// --- Docker file-sharing check (IRO-171) ---
+
+func TestEvalDockerFileSharing(t *testing.T) {
+	shared := []string{"/Users", "/private"}
+	cases := []struct {
+		name       string
+		stateDir   string
+		shared     []string
+		sharedOK   bool
+		goos       string
+		wantStatus checkStatus
+	}{
+		{"linux always ok", "/anywhere", nil, false, "linux", checkOK},
+		{"inside configured share", "/Users/me/Library/Caches/ironclaw/state", shared, true, "darwin", checkOK},
+		{"outside configured share", "/opt/ironclaw/state", shared, true, "darwin", checkWarn},
+		{"settings unreadable, under default root", "/Users/me/state", nil, false, "darwin", checkOK},
+		{"settings unreadable, outside default roots", "/opt/ironclaw/state", nil, false, "darwin", checkWarn},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := evalDockerFileSharing(c.stateDir, c.shared, c.sharedOK, c.goos)
+			if got.Status != c.wantStatus {
+				t.Errorf("status = %s, want %s (detail: %s)", got.Status, c.wantStatus, got.Detail)
+			}
+			if got.Status == checkWarn && got.Fix == "" {
+				t.Error("a WARN should carry an actionable fix")
+			}
+		})
+	}
+}
+
+func TestParseSharedDirs(t *testing.T) {
+	data := []byte(`{"filesharingDirectories":["/Users","/Volumes","/tmp"],"other":true}`)
+	got := parseSharedDirs(data)
+	if len(got) != 3 || got[0] != "/Users" {
+		t.Fatalf("parseSharedDirs = %v, want [/Users /Volumes /tmp]", got)
+	}
+	if d := parseSharedDirs([]byte("not json")); d != nil {
+		t.Errorf("malformed JSON should yield nil, got %v", d)
+	}
+	if d := parseSharedDirs([]byte(`{}`)); len(d) != 0 {
+		t.Errorf("missing field should yield empty, got %v", d)
+	}
+}
+
+func TestPathUnderAny(t *testing.T) {
+	roots := []string{"/Users", "/private"}
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/Users", true},
+		{"/Users/me/state", true},
+		{"/private/var/folders/x", true},
+		{"/opt/state", false},
+		{"/UsersOther/state", false}, // prefix collision must not match
+	}
+	for _, c := range cases {
+		if got := pathUnderAny(c.path, roots); got != c.want {
+			t.Errorf("pathUnderAny(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+// TestCheckDockerFileSharingFromSettings exercises the end-to-end check against a
+// real on-disk Docker Desktop settings file (read via dockerDesktopSharedDirs).
+func TestCheckDockerFileSharingFromSettings(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("settings path layout is exercised on darwin")
+	}
+	dir := t.TempDir()
+	settings := filepath.Join(dir, "Library", "Group Containers", "group.com.docker")
+	if err := os.MkdirAll(settings, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(settings, "settings-store.json"),
+		[]byte(`{"filesharingDirectories":["`+dir+`/shared"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", dir)
+
+	in := checkDockerFileSharing(filepath.Join(dir, "shared", "ironclaw", "state"))
+	if in.Status != checkOK {
+		t.Errorf("state under shared dir: status = %s, want OK (%s)", in.Status, in.Detail)
+	}
+	out := checkDockerFileSharing(filepath.Join(dir, "elsewhere", "state"))
+	if out.Status != checkWarn {
+		t.Errorf("state outside shared dir: status = %s, want WARN (%s)", out.Status, out.Detail)
+	}
+}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,6 +43,7 @@ ironctl doctor — diagnostics
 | **channel adapters** | At least one adapter armed from the environment. | None armed — channels are optional; set e.g. `SLACK_BOT_TOKEN` / `TELEGRAM_BOT_TOKEN` or wire one with `ironctl registry wiring …`. | [Channel adapter not arming](#channel-adapter-not-arming-env-mismatch) |
 | **onboard config** | The `0600` token env-file is present and owner-only. | Absent (run `ironctl onboard`), a directory, or readable beyond the owner (`chmod 600`). | [onboard config](#onboard-config-missing-or-too-permissive) |
 | **model-proxy socket** | The host model-proxy unix socket accepts a connection. | Socket missing (daemon not started) or present but not accepting connections (restart the control-plane). | [Daemon unreachable](#daemon-unreachable-connection-refused) |
+| **docker file sharing** *(only with `--runtime docker`)* | The state dir is inside Docker Desktop's shared paths, so the per-session queues/key bind mount delivers into each sandbox. | State dir outside the shared set — the bind mounts empty and the sandbox exits `1` on its session-key read. | [Sandbox exits on startup](#sandbox-exits-on-startup-macos-docker-file-sharing) |
 
 The credential and channel checks read **exactly** the same environment variables
 the control-plane consumes on boot (the detectors are shared with `ironctl
@@ -127,6 +128,34 @@ Common causes: Docker isn't started; the sandbox image wasn't built yet (run
 the sandbox as a **runc** container — a relaxed, laptop-only posture, *not* the
 sealed production seal. Tear it down with
 `docker compose -f docker-compose.demo.yml down`.
+
+### Sandbox exits on startup (macOS Docker file sharing)
+
+```
+host/session: sandbox for ses_… exited early with code 1; first log line: ironclaw sandbox: read session key ".../keys/ses_…/session.key": … no such file or directory
+```
+
+Under the **`--runtime docker`** fallback (macOS dev), the control-plane carries
+the per-session encrypted queues and key into each sandbox via a **bind mount**.
+If the host **state dir** sits outside Docker Desktop's *shared paths*, the mount
+arrives **empty** inside the container — the sandbox can't read the session key
+the host just wrote (it's present at `0600` on the host), so it exits `1` right
+away. Symptom from the outside: the chat just returns `[]` and never replies.
+
+Diagnose it:
+
+```sh
+ironctl doctor --runtime docker            # the "docker file sharing" check flags an unshared state dir
+# or probe the bind directly — the listing should NOT be empty:
+docker run --rm -v "$HOME/Library/Caches/ironclaw/state:/probe" alpine ls -A /probe
+```
+
+Fix: add the state dir (and, for the Compose demo, the project's
+`.ironclaw-demo-state` dir) under **Docker Desktop → Settings → Resources → File
+sharing**, then restart Docker Desktop and the daemon. Docker Desktop shares
+`/Users`, `/Volumes`, `/private`, `/tmp`, and `/var/folders` by default, so the
+default state dir under `~/Library/Caches` is normally covered — this bites custom
+`--state-dir` locations or a trimmed file-sharing list.
 
 ### Sandbox runtime: `runsc` not found (gVisor)
 

--- a/internal/host/isolation/docker.go
+++ b/internal/host/isolation/docker.go
@@ -15,6 +15,7 @@ package isolation
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -107,6 +108,9 @@ type dockerHandle struct {
 	id  string
 }
 
+// The Docker handle surfaces early container exits to the Manager (IRO-171).
+var _ EarlyExitReporter = (*dockerHandle)(nil)
+
 // Stop force-removes the sandbox container. Idempotent.
 func (h *dockerHandle) Stop(ctx context.Context) error {
 	if err := h.iso.do(ctx, http.MethodDelete, "/containers/"+h.id+"?force=true", nil, nil); err != nil {
@@ -127,6 +131,133 @@ func (h *dockerHandle) Alive(ctx context.Context) bool {
 		return true
 	}
 	return exists && running
+}
+
+// ExitInfo implements EarlyExitReporter: it reports whether the sandbox container
+// has already exited and, if so, with what code and its first log line. The
+// Manager calls it shortly after launch so a container that dies on startup — the
+// macOS Docker file-sharing case where the in-container session-key read misses a
+// host file (IRO-171) — is surfaced to the control-plane log instead of being
+// hidden behind "launched sandbox".
+//
+// A still-running container, or one that is already gone (HTTP 404 — a prior crash
+// auto-removed or a relaunch reclaimed the name), reports exited=false so the
+// caller logs nothing misleading. AutoRemove is off for sandbox containers, so an
+// exited-but-not-yet-removed container can still be inspected and its logs read.
+func (h *dockerHandle) ExitInfo(ctx context.Context) (exited bool, code int, logLine string, err error) {
+	running, exitCode, exists, ierr := h.iso.inspectExit(ctx, h.id)
+	if ierr != nil {
+		return false, 0, "", ierr
+	}
+	if !exists || running {
+		// Gone (can't tell) or still running: nothing to report.
+		return false, 0, "", nil
+	}
+	// Exited: best-effort fetch of the first log line for a one-line diagnostic. A
+	// log-fetch failure is non-fatal — the exit code alone is still worth surfacing.
+	line, _ := h.iso.firstLogLine(ctx, h.id)
+	return true, exitCode, line, nil
+}
+
+// inspectExit inspects a container's running state and exit code. Mirrors
+// inspectState but also returns State.ExitCode for the early-exit diagnostic.
+func (d *DockerIsolator) inspectExit(ctx context.Context, id string) (running bool, exitCode int, exists bool, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://docker/containers/"+id+"/json", nil)
+	if err != nil {
+		return false, 0, false, err
+	}
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return false, 0, false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return false, 0, false, nil // container is gone
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return false, 0, true, fmt.Errorf("docker api inspect %s: %s: %s", id, resp.Status, strings.TrimSpace(string(b)))
+	}
+	var out struct {
+		State struct {
+			Running  bool `json:"Running"`
+			ExitCode int  `json:"ExitCode"`
+		} `json:"State"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return false, 0, true, err
+	}
+	return out.State.Running, out.State.ExitCode, true, nil
+}
+
+// firstLogLine fetches the container's combined stdout+stderr and returns its
+// first non-empty line, truncated for a one-line log diagnostic. The Engine API
+// multiplexes stdout/stderr into a framed stream (an 8-byte header per frame) when
+// the container has no TTY (the sandbox case), so the payload is demultiplexed
+// before scanning for the first line.
+func (d *DockerIsolator) firstLogLine(ctx context.Context, id string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"http://docker/containers/"+id+"/logs?stdout=1&stderr=1&tail=20", nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("docker api logs %s: %s", id, resp.Status)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return "", err
+	}
+	return firstNonEmptyLine(demuxDockerStream(raw)), nil
+}
+
+// demuxDockerStream decodes Docker's multiplexed log framing (8-byte header:
+// [stream_type, 0,0,0, size:uint32be] then size payload bytes) into the raw
+// payload text. A stream that does not match the framing (a TTY container, or a
+// short/garbled buffer) is returned as-is, so the caller still gets usable text.
+func demuxDockerStream(b []byte) string {
+	var out bytes.Buffer
+	rest := b
+	framed := false
+	for len(rest) >= 8 {
+		// A valid header has a known stream type (0,1,2) and three zero pad bytes.
+		if rest[0] > 2 || rest[1] != 0 || rest[2] != 0 || rest[3] != 0 {
+			break
+		}
+		size := int(binary.BigEndian.Uint32(rest[4:8]))
+		if size < 0 || 8+size > len(rest) {
+			break
+		}
+		out.Write(rest[8 : 8+size])
+		rest = rest[8+size:]
+		framed = true
+	}
+	if framed {
+		return out.String()
+	}
+	return string(b)
+}
+
+// firstNonEmptyLine returns the first non-blank line of s, trimmed and truncated
+// to a sane length for a single log line.
+func firstNonEmptyLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimRight(strings.TrimSpace(line), "\r")
+		if line == "" {
+			continue
+		}
+		const max = 300
+		if len(line) > max {
+			line = line[:max] + "…"
+		}
+		return line
+	}
+	return ""
 }
 
 // inspectState inspects a container's running state. exists is false when the

--- a/internal/host/isolation/docker_test.go
+++ b/internal/host/isolation/docker_test.go
@@ -2,6 +2,7 @@ package isolation
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"io"
 	"net"
@@ -158,5 +159,95 @@ func TestDockerHandleAlive(t *testing.T) {
 		if got := h.Alive(context.Background()); got != c.want {
 			t.Errorf("Alive(%s) = %v, want %v", c.id, got, c.want)
 		}
+	}
+}
+
+// dockerLogFrame encodes one byte slice in Docker's multiplexed log framing
+// (8-byte header: [stream, 0,0,0, size:uint32be] then the payload).
+func dockerLogFrame(stream byte, payload string) []byte {
+	hdr := make([]byte, 8)
+	hdr[0] = stream
+	binary.BigEndian.PutUint32(hdr[4:8], uint32(len(payload)))
+	return append(hdr, []byte(payload)...)
+}
+
+// TestDockerHandleExitInfo drives dockerHandle.ExitInfo against a fake Engine API:
+// an exited container reports its code + first log line; a running container and a
+// vanished (404) one both report exited=false (nothing to surface). This is the
+// IRO-171 early-exit diagnostic the Manager logs after launch.
+func TestDockerHandleExitInfo(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "docker.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	const keyErr = `ironclaw sandbox: read session key "/var/lib/ironclaw/state/keys/ses_x/session.key": open ...: no such file or directory`
+	mux := http.NewServeMux()
+	mux.HandleFunc("/containers/exited/json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"State":{"Running":false,"ExitCode":1}}`))
+	})
+	mux.HandleFunc("/containers/exited/logs", func(w http.ResponseWriter, r *http.Request) {
+		// Two frames: a blank stderr line then the real error — the first NON-EMPTY
+		// line should be returned.
+		_, _ = w.Write(dockerLogFrame(2, "\n"))
+		_, _ = w.Write(dockerLogFrame(2, keyErr+"\n"))
+	})
+	mux.HandleFunc("/containers/running/json", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"State":{"Running":true,"ExitCode":0}}`))
+	})
+	mux.HandleFunc("/containers/gone/json", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"No such container: gone"}`, http.StatusNotFound)
+	})
+	srv := &http.Server{Handler: mux}
+	go srv.Serve(ln)
+	t.Cleanup(func() { srv.Close() })
+
+	d := NewDocker(sock, "none", nil, "0:0")
+
+	t.Run("exited non-zero surfaces code and first log line", func(t *testing.T) {
+		h := &dockerHandle{iso: d, id: "exited"}
+		exited, code, line, err := h.ExitInfo(context.Background())
+		if err != nil {
+			t.Fatalf("ExitInfo: %v", err)
+		}
+		if !exited || code != 1 {
+			t.Fatalf("got exited=%v code=%d, want true/1", exited, code)
+		}
+		if line != keyErr {
+			t.Errorf("logLine = %q, want %q", line, keyErr)
+		}
+	})
+
+	t.Run("running reports not exited", func(t *testing.T) {
+		h := &dockerHandle{iso: d, id: "running"}
+		exited, _, _, err := h.ExitInfo(context.Background())
+		if err != nil || exited {
+			t.Fatalf("got exited=%v err=%v, want false/nil", exited, err)
+		}
+	})
+
+	t.Run("gone container reports not exited", func(t *testing.T) {
+		h := &dockerHandle{iso: d, id: "gone"}
+		exited, _, _, err := h.ExitInfo(context.Background())
+		if err != nil || exited {
+			t.Fatalf("got exited=%v err=%v, want false/nil", exited, err)
+		}
+	})
+}
+
+// TestDemuxDockerStream checks the log-framing decoder handles both multiplexed
+// frames and a raw (un-framed) buffer.
+func TestDemuxDockerStream(t *testing.T) {
+	framed := append(dockerLogFrame(1, "hello\n"), dockerLogFrame(2, "world\n")...)
+	if got := demuxDockerStream(framed); got != "hello\nworld\n" {
+		t.Errorf("framed demux = %q, want %q", got, "hello\nworld\n")
+	}
+	// A buffer that does not look like framing is returned verbatim.
+	raw := "plain text line\n"
+	if got := demuxDockerStream([]byte(raw)); got != raw {
+		t.Errorf("raw demux = %q, want %q", got, raw)
+	}
+	if got := firstNonEmptyLine("\n\n  second\nthird\n"); got != "second" {
+		t.Errorf("firstNonEmptyLine = %q, want %q", got, "second")
 	}
 }

--- a/internal/host/isolation/isolation.go
+++ b/internal/host/isolation/isolation.go
@@ -182,6 +182,31 @@ type Handle interface {
 	Alive(ctx context.Context) bool
 }
 
+// EarlyExitReporter is an OPTIONAL capability a Handle may implement: report
+// whether the sandbox has ALREADY exited and, if so, with what status and its
+// first log line. The Manager probes it shortly after launch so a sandbox that
+// dies on startup surfaces in the control-plane log instead of being hidden
+// behind "launched sandbox" while the chat silently returns []. The motivating
+// case (IRO-171) is the macOS Docker fallback: when Docker Desktop file-sharing
+// is not delivering the host state/keys dir into the container, the in-container
+// session-key read misses a file the host wrote at 0600 and the container exits 1
+// immediately — undiagnosable from the host without this.
+//
+// Handles whose runtime cannot cheaply report an exit code + log line need not
+// implement it; the Manager simply skips the probe (the sweep's heartbeat ceiling
+// remains the backstop). The Docker isolator implements it; the gVisor (runsc)
+// path, which reaps the container on exit and keeps no stdout, does not.
+type EarlyExitReporter interface {
+	// ExitInfo reports the sandbox's terminal state. exited is true ONLY when the
+	// sandbox has stopped running; code is its exit status and logLine the first
+	// non-empty line of its combined output (truncated), for a one-line diagnostic.
+	// A still-running or indeterminate sandbox (e.g. the container is gone and the
+	// exit can no longer be read) returns exited=false so the caller logs nothing
+	// misleading. err is non-nil only on a transient/unexpected runtime-query
+	// failure.
+	ExitInfo(ctx context.Context) (exited bool, code int, logLine string, err error)
+}
+
 // Isolator launches sandboxes. Implementations: RunscIsolator (gVisor); Kata is a
 // future backend behind this same interface.
 type Isolator interface {

--- a/internal/host/session/manager.go
+++ b/internal/host/session/manager.go
@@ -107,7 +107,21 @@ type Config struct {
 	Clock func() time.Time
 	// Logger receives lifecycle diagnostics. Defaults to log.Default().
 	Logger *log.Logger
+
+	// EarlyExitGrace is how long after a launch the Manager waits before probing a
+	// sandbox for an immediate non-zero exit (only for isolators whose Handle
+	// implements isolation.EarlyExitReporter — the Docker fallback). It surfaces a
+	// container that died on startup (e.g. the macOS Docker file-sharing case where
+	// the in-container session-key read misses a host file, IRO-171) instead of
+	// hiding it behind "launched sandbox". Zero applies a small default; a negative
+	// value disables the probe.
+	EarlyExitGrace time.Duration
 }
+
+// defaultEarlyExitGrace is the post-launch wait before probing for an early exit.
+// Long enough for a container that fails its session-key read to exit and be
+// inspectable, short enough to surface the diagnostic promptly.
+const defaultEarlyExitGrace = 2 * time.Second
 
 // MCPProvisioner provisions a per-session MCP broker socket for a group with
 // gateway-approved MCP grants and tears it down when the session stops. Satisfied
@@ -195,6 +209,9 @@ func New(cfg Config) (*Manager, error) {
 	}
 	if cfg.Logger == nil {
 		cfg.Logger = log.Default()
+	}
+	if cfg.EarlyExitGrace == 0 {
+		cfg.EarlyExitGrace = defaultEarlyExitGrace
 	}
 	return &Manager{
 		cfg:     cfg,
@@ -444,7 +461,54 @@ func (m *Manager) Wake(id contract.SessionID) error {
 	m.running[id] = &tracked{handle: handle, launchedAt: m.cfg.Clock().UTC()}
 	m.mu.Unlock()
 	m.cfg.Logger.Printf("host/session: launched sandbox for %s", id)
+	// If the isolator can report an early exit (the Docker fallback), watch for a
+	// container that dies on startup so a silent failure surfaces in the host log
+	// rather than only as an empty chat. Best-effort and out-of-band: it never
+	// blocks the launch path.
+	if r, ok := handle.(isolation.EarlyExitReporter); ok && m.cfg.EarlyExitGrace >= 0 {
+		go m.watchEarlyExit(id, r)
+	}
 	return nil
+}
+
+// watchEarlyExit waits the configured grace period, then reports an early sandbox
+// exit (see reportEarlyExit). Run in its own goroutine off the launch path.
+func (m *Manager) watchEarlyExit(id contract.SessionID, r isolation.EarlyExitReporter) {
+	if m.cfg.EarlyExitGrace > 0 {
+		time.Sleep(m.cfg.EarlyExitGrace)
+	}
+	m.reportEarlyExit(id, r)
+}
+
+// reportEarlyExit probes a freshly-launched sandbox for an immediate exit and logs
+// a diagnostic when it has died. A non-zero exit gets an actionable hint pointing
+// at the most common cause on the macOS Docker fallback — Docker Desktop file
+// sharing not delivering the host state/keys dir into the container (IRO-171) —
+// and `ironctl doctor`, which checks exactly that. A still-running or already-gone
+// sandbox logs nothing.
+func (m *Manager) reportEarlyExit(id contract.SessionID, r isolation.EarlyExitReporter) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	exited, code, logLine, err := r.ExitInfo(ctx)
+	if err != nil {
+		m.cfg.Logger.Printf("host/session: could not probe early exit for %s: %v", id, err)
+		return
+	}
+	if !exited {
+		return
+	}
+	msg := fmt.Sprintf("host/session: sandbox for %s exited early with code %d", id, code)
+	if logLine != "" {
+		msg += fmt.Sprintf("; first log line: %s", logLine)
+	}
+	if code != 0 {
+		msg += " — the sandbox container failed to start. On the macOS Docker fallback this is" +
+			" most often a Docker Desktop file-sharing gap (the host state/keys dir is not" +
+			" delivered into the container, so the in-container session-key read misses a file" +
+			" the host wrote); run `ironctl doctor --runtime docker` to check. The triggering" +
+			" message stays queued and retries on the next wake."
+	}
+	m.cfg.Logger.Printf("%s", msg)
 }
 
 // Probe reports the liveness signals the sweep uses to decide whether a sandbox is

--- a/internal/host/session/manager_test.go
+++ b/internal/host/session/manager_test.go
@@ -1,9 +1,12 @@
 package session
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -303,4 +306,113 @@ func TestManagerInboundWriterEnsuresSession(t *testing.T) {
 		t.Fatalf("OutboundReader: %v", err)
 	}
 	r.Close()
+}
+
+// --- early-exit diagnostic (IRO-171) ---
+
+// exitHandle is a fakeHandle that also implements isolation.EarlyExitReporter, so
+// the Manager's post-launch early-exit watcher engages.
+type exitHandle struct {
+	fakeHandle
+	exited  bool
+	code    int
+	logLine string
+	err     error
+}
+
+func (h *exitHandle) ExitInfo(context.Context) (bool, int, string, error) {
+	return h.exited, h.code, h.logLine, h.err
+}
+
+func TestReportEarlyExit(t *testing.T) {
+	cases := []struct {
+		name        string
+		h           *exitHandle
+		wantLog     bool
+		wantSubstrs []string
+	}{
+		{
+			name:        "non-zero exit logs code, log line, and the file-sharing hint",
+			h:           &exitHandle{exited: true, code: 1, logLine: `read session key "...": no such file or directory`},
+			wantLog:     true,
+			wantSubstrs: []string{"exited early with code 1", "no such file or directory", "ironctl doctor", "file-sharing"},
+		},
+		{
+			name:        "probe error is reported, not swallowed",
+			h:           &exitHandle{err: errors.New("docker api down")},
+			wantLog:     true,
+			wantSubstrs: []string{"could not probe early exit", "docker api down"},
+		},
+		{
+			name:    "still running logs nothing",
+			h:       &exitHandle{exited: false},
+			wantLog: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := newTestManager(t, &fakeIsolator{})
+			var buf bytes.Buffer
+			m.cfg.Logger = log.New(&buf, "", 0)
+			m.reportEarlyExit("ses_x", c.h)
+			out := buf.String()
+			if c.wantLog && out == "" {
+				t.Fatalf("expected a log line, got none")
+			}
+			if !c.wantLog && out != "" {
+				t.Fatalf("expected no log, got %q", out)
+			}
+			for _, s := range c.wantSubstrs {
+				if !strings.Contains(out, s) {
+					t.Errorf("log %q missing %q", out, s)
+				}
+			}
+		})
+	}
+}
+
+// TestWakeWatchesEarlyExit asserts Wake spawns the early-exit watcher for an
+// isolator whose handle reports exits, and that the diagnostic eventually lands.
+func TestWakeWatchesEarlyExit(t *testing.T) {
+	iso := &exitIsolator{h: &exitHandle{exited: true, code: 1, logLine: "boom"}}
+	m := newTestManager(t, iso)
+	var buf syncBuffer
+	m.cfg.Logger = log.New(&buf, "", 0)
+	m.cfg.EarlyExitGrace = time.Millisecond // tiny but non-zero
+
+	if err := m.Wake("ses_e"); err != nil {
+		t.Fatalf("Wake: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(buf.String(), "exited early with code 1") {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("early-exit diagnostic never logged; got %q", buf.String())
+}
+
+type exitIsolator struct{ h *exitHandle }
+
+func (e *exitIsolator) Launch(context.Context, isolation.SandboxSpec) (isolation.Handle, error) {
+	return e.h, nil
+}
+
+// syncBuffer is a goroutine-safe bytes.Buffer for asserting on async log output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }


### PR DESCRIPTION
## Summary

Closes the silent-failure gap QA hit during IRO-31 live verification on a macOS Docker-runc host (IRO-171). Under `--runtime docker`, when Docker Desktop file-sharing didn't deliver the host state/keys dir into the sandbox container, the in-container session-key read missed a file the host wrote at `0600`, the container exited `1` immediately, and the host logged only `launched sandbox` while chat returned `[]` — undiagnosable from the control-plane (same class as IRO-128).

## What changed

**1. Surface non-zero sandbox exit + first log line (engineering ask #1)**
- New optional `isolation.EarlyExitReporter` capability, implemented by the Docker handle: inspects the container's `State.ExitCode` and demultiplexes Docker's framed log stream to extract the first log line.
- `session.Manager`, after a launch, probes it best-effort off the launch path (configurable `EarlyExitGrace`, default 2s) and logs a clear diagnostic — for a non-zero exit it adds an actionable hint pointing at Docker Desktop file sharing and `ironctl doctor`. A still-running or already-gone container logs nothing.
- The hardened **runsc/gVisor path does NOT implement this** (it reaps on exit and keeps no stdout), so the production posture never logs sandbox stdout — the diagnostic is the Docker dev-fallback only.

**2. `ironctl doctor` docker file-sharing check (engineering ask #2)**
- Only added when `--runtime docker` is selected. Verifies the state dir is inside Docker Desktop's shared paths — read from Docker Desktop's settings file (`settings-store.json`/`settings.json`), with a default-shared-roots fallback when settings can't be read. Warns with the fix + a `docker run -v <state-dir>:/probe` probe command otherwise. Linux is a no-op (bind mounts always deliver).
- New `--state-dir` flag (mirrors the control-plane default) so the probe targets the real bind source.

**Docs:** new Troubleshooting section *“Sandbox exits on startup (macOS Docker file sharing)”* + a doctor-table row, anchored to the `doctor` `see:` link.

## Security review

- **Trust boundary integrity:** unchanged — the watcher only *reads* container state/logs via the Docker Engine API; it never widens what the sandbox can do.
- **Isolation / egress / gateway / encryption at rest:** untouched — no new network paths, no control-plane mutation, no key handling. Keys are never read or logged (the failure log line is the sandbox's own error string, truncated to 300 chars, and only on the Docker dev fallback; production runsc never triggers it).

## Verification
- `CGO_ENABLED=1 go build ./...` ✅
- `go vet` on the touched packages ✅ clean
- `go test ./internal/host/isolation/ ./internal/host/session/ ./cmd/ironctl/ ./cmd/controlplane/` → **170 passed**
- New tests: Docker `ExitInfo` (exited/running/gone) + stream demux; Manager early-exit watcher (non-zero / probe-error / running, plus Wake-wiring); doctor file-sharing eval + settings parse + path containment + on-disk settings round-trip.

Built in a clean worktree off `origin/main` (the `forge/iro-27` checkout is far behind).