### PR TITLE
fix(landing): WCAG AA contrast on live home page (IRO-166)

### DIFF
--- a/docs/stylesheets/landing.css
+++ b/docs/stylesheets/landing.css
@@ -572,3 +572,47 @@
   .iro-card:hover,
   .iro-btn:hover { transform: none; }
 }
+
+/* =============================================================================
+   WCAG AA contrast fixes (IRO-166)
+
+   Live-rendered audit of both schemes (composited contrast, gradient/always-dark
+   hero+final excluded as known-good white-on-navy) surfaced four sub-AA cases.
+   Each fix was verified on the live site to clear its threshold in both schemes.
+   ========================================================================== */
+
+/* Secondary/caption text used `--md-default-fg-color--light`, which composited to
+   3.6:1 (slate) / 4.3:1 (light) on the tinted sections — below the 4.5:1 body
+   minimum, and these carry real content (the demo "Then open …" run path, the
+   gateway flow caption). Promote to the full-strength foreground token. */
+.iro-flow,
+.iro-aside,
+.iro-demo .iro-caption,
+.iro-demo .iro-footnote {
+  color: var(--md-default-fg-color);
+}
+
+/* Code-panel prompt/comment tokens sat at 4.33:1 on the always-dark navy panel
+   (scheme-independent). Lighten to clear 4.5:1. */
+.iro-code__cmt,
+.iro-code__prompt {
+  color: #8ea4cf;
+}
+
+/* Slate only: the `.iro-section .iro-btn--ghost` and accent-eyebrow rules assume
+   a LIGHT section background (steel-700 text = 6.7:1 on white). In dark mode the
+   tinted sections are dark, so that ghost-button text fell to 2.38:1 and the
+   accent eyebrow to 4.40:1. Restore the dark-surface treatment for slate. */
+[data-md-color-scheme="slate"] .iro-section .iro-btn--ghost {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(143, 180, 255, 0.55);
+  color: #eaf2ff;
+}
+[data-md-color-scheme="slate"] .iro-section .iro-btn--ghost:hover {
+  background: rgba(143, 180, 255, 0.12);
+  border-color: #8fb4ff;
+}
+[data-md-color-scheme="slate"] .iro-eyebrow,
+[data-md-color-scheme="slate"] .iro-proof h3 {
+  color: #8fb4ff;
+}


### PR DESCRIPTION
## Summary

Independent UX/a11y verification pass of the **live** landing + docs site at
`ironsecco.github.io/ironclaw` (IRO-166). Audited the rendered site (not source)
in both color schemes at 390 / 768 / 1440. Most of the site already passes; this
PR fixes the four sub-AA contrast cases found, all on the landing page.

Each fix was validated **on the live page** (CSS injected, contrast re-measured
with proper alpha compositing) to clear its WCAG 2.1 AA threshold in both schemes.

## Defects fixed (all CSS-only, `docs/stylesheets/landing.css`)

| # | Element | Before | Threshold | Scheme |
|---|---------|--------|-----------|--------|
| 1 | Ghost CTA on tinted sections ("Read the security posture →") | **2.38:1** | 3:1 (large) | slate only |
| 2 | Accent eyebrow / proof headings on tinted sections | **4.40:1** | 4.5:1 | slate only |
| 3 | Secondary caption text (demo run path, gateway flow) | **3.6 / 4.3:1** | 4.5:1 | both |
| 4 | Code-panel prompt/comment tokens | **4.33:1** | 4.5:1 | both |

Root cause for #1/#2: the light-section ghost-button + accent rules were not
scheme-scoped, so steel-700/steel-500 (tuned for white backgrounds) bled onto
dark slate tinted sections. Fix scopes the dark treatment under
`[data-md-color-scheme="slate"]`; light mode is untouched.

## Verified PASS (no change needed)

- Heading order (h1→h2→h3 logical), skip-to-content link present
- All images have alt text; no unnamed links/buttons
- Focus-visible: 3px solid outlines on every interactive element (CTAs, copy, FAQ, badges, footer)
- Reflow 390/768/1440: no horizontal page scroll; code blocks scroll within their own panel; content wraps
- Zero-credential demo CTA path ("Run the demo →" + copyable commands + run instructions) reachable and unambiguous
- Hero / final CTA bands: always-dark white-on-navy, already pass

Full checklist + screenshots posted to the IRO-166 issue thread.

Ungated; self-merge on green CI per task scope.