### PR TITLE
feat(provider): Vertex AI Gemini backend — project/location + OAuth (IRO-159)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -239,6 +239,30 @@ func main() {
 	} else if apiKey := os.Getenv("GEMINI_API_KEY"); apiKey != "" {
 		addProvider("generativelanguage.googleapis.com", modelproxy.GeminiInjector(apiKey), apiKey)
 	}
+	// Google Cloud Vertex AI. Vertex speaks the identical Gemini wire format but auth
+	// is an OAuth2 bearer (not an API key) and the project/region ride in the URL path,
+	// so the allowlisted host is the regional {location}-aiplatform.googleapis.com. The
+	// token is sourced host-side and refreshed there; the sandbox never holds it. Two
+	// token sources, in precedence: a static GOOGLE_VERTEX_ACCESS_TOKEN (operator
+	// refreshes out of band), else gcloud Application Default Credentials when
+	// GOOGLE_VERTEX_USE_GCLOUD=1 (auto-refreshing, no extra dependency). A project is
+	// required; the region defaults to the provider default when unset.
+	if proj := envOr("GOOGLE_VERTEX_PROJECT", os.Getenv("GOOGLE_CLOUD_PROJECT")); proj != "" {
+		var ts modelproxy.TokenSource
+		if tok := os.Getenv("GOOGLE_VERTEX_ACCESS_TOKEN"); tok != "" {
+			ts = modelproxy.StaticTokenSource(tok)
+		} else if os.Getenv("GOOGLE_VERTEX_USE_GCLOUD") == "1" {
+			ts = &modelproxy.GcloudTokenSource{}
+		}
+		if ts != nil {
+			loc := envOr("GOOGLE_VERTEX_LOCATION", os.Getenv("GOOGLE_CLOUD_LOCATION"))
+			vHost := vertexAllowHost(loc)
+			// The bearer is dynamic (refreshed per call), so it is not added to the
+			// static redactKeys set; nothing host-side echoes it into a response body.
+			addProvider(vHost, modelproxy.VertexInjector(ts), "")
+			logger.Info("vertex ai enabled", "host", vHost, "project", proj)
+		}
+	}
 	credInjected := len(injectors) > 0
 	if credInjected {
 		proxyOpts = append(proxyOpts,
@@ -1017,6 +1041,22 @@ func envOr(key, def string) string {
 	return def
 }
 
+// vertexAllowHost returns the Vertex AI host to allowlist for a region: the global
+// (region-less) endpoint for "global", otherwise the regional
+// {location}-aiplatform.googleapis.com. An unset location resolves to the same
+// default region the sandbox provider applies (provider.defaultVertexLocation,
+// "us-central1") so the allowlisted host matches the one the sandbox addresses.
+func vertexAllowHost(location string) string {
+	location = strings.TrimSpace(location)
+	if location == "" {
+		location = "us-central1"
+	}
+	if location == "global" {
+		return "aiplatform.googleapis.com"
+	}
+	return location + "-aiplatform.googleapis.com"
+}
+
 // selectModelFromRegistry resolves a session's model backend from its agent group
 // : session -> agent group -> {Provider, Model}. A group pinned to an
 // explicit Provider uses it; any group without one inherits the deployment default.
@@ -1032,6 +1072,8 @@ func selectModelFromRegistry(reg *registry.MemRegistry) func(contract.SessionID)
 	def := session.ModelSelection{
 		Provider: os.Getenv("IRONCLAW_DEV_PROVIDER"),
 		Model:    os.Getenv("IRONCLAW_DEV_MODEL"),
+		Project:  envOr("IRONCLAW_DEV_VERTEX_PROJECT", os.Getenv("GOOGLE_VERTEX_PROJECT")),
+		Location: envOr("IRONCLAW_DEV_VERTEX_LOCATION", os.Getenv("GOOGLE_VERTEX_LOCATION")),
 	}
 	return func(id contract.SessionID) session.ModelSelection {
 		sess, ok := reg.GetSession(id)
@@ -1045,7 +1087,7 @@ func selectModelFromRegistry(reg *registry.MemRegistry) func(contract.SessionID)
 		if g.Provider == "" {
 			return def
 		}
-		return session.ModelSelection{Provider: g.Provider, Model: g.Model}
+		return session.ModelSelection{Provider: g.Provider, Model: g.Model, Project: g.Project, Location: g.Location}
 	}
 }
 
@@ -1063,6 +1105,10 @@ func seedDev(reg *registry.MemRegistry, logger *obs.Logger) {
 	if p := os.Getenv("IRONCLAW_DEV_PROVIDER"); p != "" {
 		grp.Provider = p
 		grp.Model = os.Getenv("IRONCLAW_DEV_MODEL")
+		// Vertex needs a project + region in the URL path. Honor the dev-specific
+		// overrides first, then the standard GOOGLE_VERTEX_* the proxy reads.
+		grp.Project = envOr("IRONCLAW_DEV_VERTEX_PROJECT", os.Getenv("GOOGLE_VERTEX_PROJECT"))
+		grp.Location = envOr("IRONCLAW_DEV_VERTEX_LOCATION", os.Getenv("GOOGLE_VERTEX_LOCATION"))
 	}
 	_ = reg.PutAgentGroup(grp)
 	// Always seed a deterministic, offline agent group. Its mock provider makes

--- a/cmd/controlplane/model_select_test.go
+++ b/cmd/controlplane/model_select_test.go
@@ -64,6 +64,44 @@ func TestSelectModel_UnknownSessionGetsDevDefault(t *testing.T) {
 	}
 }
 
+// A group pinned to the vertex provider threads its project + location through the
+// selection so they reach the sandbox URL path.
+func TestSelectModel_VertexThreadsProjectLocation(t *testing.T) {
+	reg := registry.NewMemRegistry()
+	const groupID contract.AgentGroupID = "gv"
+	if err := reg.PutAgentGroup(registry.AgentGroup{
+		ID: groupID, Name: "gv", Provider: "vertex", Model: "gemini-2.5-pro",
+		Project: "my-proj", Location: "europe-west4",
+	}); err != nil {
+		t.Fatalf("PutAgentGroup: %v", err)
+	}
+	s, err := reg.ResolveSession(groupID, "mg1", nil, contract.SessionShared)
+	if err != nil {
+		t.Fatalf("ResolveSession: %v", err)
+	}
+	sel := selectModelFromRegistry(reg)(s.ID)
+	if sel.Provider != "vertex" || sel.Project != "my-proj" || sel.Location != "europe-west4" {
+		t.Fatalf("vertex selection must carry project+location: got %+v", sel)
+	}
+}
+
+// vertexAllowHost must match the host the sandbox provider addresses, including the
+// default-region and global cases, so the model-proxy allowlist does not 403.
+func TestVertexAllowHost(t *testing.T) {
+	cases := map[string]string{
+		"":             "us-central1-aiplatform.googleapis.com", // default region
+		"global":       "aiplatform.googleapis.com",
+		"us-central1":  "us-central1-aiplatform.googleapis.com",
+		"europe-west4": "europe-west4-aiplatform.googleapis.com",
+		"  asia-east1": "asia-east1-aiplatform.googleapis.com", // trimmed
+	}
+	for in, want := range cases {
+		if got := vertexAllowHost(in); got != want {
+			t.Errorf("vertexAllowHost(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 // With no deployment default configured, a provider-less group yields the zero
 // selection (the built-in Anthropic backend) — the original, unchanged behavior.
 func TestSelectModel_NoDevDefaultKeepsAnthropic(t *testing.T) {

--- a/cmd/sandbox/main.go
+++ b/cmd/sandbox/main.go
@@ -67,7 +67,9 @@ func run() error {
 		mcpSocket     = flag.String("mcp-socket", "", "host MCP-broker unix socket; when set, registers the agent's gateway-approved MCP-server tools (empty = no MCP surface)")
 		modelHost     = flag.String("model-host", "", "upstream model host the proxy allowlists (defaults to the provider's host)")
 		model         = flag.String("model", "", "model id override (defaults to the provider's default)")
-		modelKind     = flag.String("provider", "", "model provider: anthropic (default), openai, or openrouter; selected per agent group host-side")
+		modelKind     = flag.String("provider", "", "model provider: anthropic (default), openai, openrouter, codex, gemini, or vertex; selected per agent group host-side")
+		modelProject  = flag.String("model-project", "", "Google Cloud project id for the vertex provider (rides in the request URL path)")
+		modelLocation = flag.String("model-location", "", "Google Cloud region for the vertex provider (empty = the provider's default region)")
 		persona       = flag.String("persona", "", "group system-persona text appended to the system prompt (set host-side from the registry; never by the sandbox)")
 		enabledTools  = flag.String("enabled-tools", "", "comma-separated subset of compiled tools to enable (empty = all; set host-side per agent group)")
 		searchBackend = flag.String("search-backend", "", "search provider for the web_search tool: duckduckgo (keyless) or brave[:cred] (keyed via the vault). Requires --egress-socket; empty disables web_search")
@@ -130,6 +132,8 @@ func run() error {
 		SocketPath:   *modelSocket,
 		UpstreamHost: *modelHost,
 		Model:        *model,
+		Project:      *modelProject,
+		Location:     *modelLocation,
 		System:       loop.SystemPromptWith(*persona),
 	})
 	if err != nil {

--- a/docs/site/configuration.mdx
+++ b/docs/site/configuration.mdx
@@ -19,6 +19,20 @@ least one.
 | `OPENAI_API_KEY` | Allowlists `api.openai.com` when present. |
 | `OPENROUTER_API_KEY` | Allowlists `openrouter.ai` when present. |
 | `GOOGLE_API_KEY` / `GEMINI_API_KEY` | Google Gemini (Google AI Studio). Allowlists `generativelanguage.googleapis.com` and injects the key as `x-goog-api-key`. Select with provider `gemini`. The Gemini CLI's OAuth credential is fronted by the credential gateway (`IRONCLAW_MODEL_GATEWAY_URL`) instead — the same `gemini` provider serves both. |
+| `GOOGLE_VERTEX_PROJECT` (+ token source) | Google Cloud **Vertex AI**. Speaks the same Gemini wire format, but the project and region ride in the URL path and auth is an OAuth2 bearer. Select with provider `vertex`. See **Vertex AI** below. |
+
+#### Vertex AI
+
+Vertex reuses the Gemini backend; only the transport envelope differs (project/region in the path, OAuth bearer instead of an API key). The bearer is held and refreshed host-side — it never enters a sandbox. Set:
+
+| Variable | Purpose |
+|---|---|
+| `GOOGLE_VERTEX_PROJECT` / `GOOGLE_CLOUD_PROJECT` | GCP project id (required). Allowlists the regional `{location}-aiplatform.googleapis.com` host. |
+| `GOOGLE_VERTEX_LOCATION` / `GOOGLE_CLOUD_LOCATION` | GCP region (default `us-central1`; `global` uses the region-less endpoint). |
+| `GOOGLE_VERTEX_ACCESS_TOKEN` | A static OAuth2 access token (you refresh it out of band, e.g. a timer running `gcloud auth print-access-token`). Takes precedence over gcloud. |
+| `GOOGLE_VERTEX_USE_GCLOUD=1` | Auto-refresh the token host-side from Application Default Credentials by execing `gcloud auth print-access-token` (no static token needed; covers `gcloud` login, a service-account key via `GOOGLE_APPLICATION_CREDENTIALS`, or the GCE metadata server). |
+
+A project plus one token source enables Vertex. Per agent group, set provider `vertex` with the group's `Project`/`Location` (or, in `--dev`, `IRONCLAW_DEV_PROVIDER=vertex` with `IRONCLAW_DEV_VERTEX_PROJECT` / `IRONCLAW_DEV_VERTEX_LOCATION`).
 
 ### Admin API token
 

--- a/internal/host/isolation/docker.go
+++ b/internal/host/isolation/docker.go
@@ -324,6 +324,12 @@ func sandboxArgs(spec SandboxSpec) []string {
 	if spec.ModelHost != "" {
 		a = append(a, "--model-host", spec.ModelHost)
 	}
+	if spec.ModelProject != "" {
+		a = append(a, "--model-project", spec.ModelProject)
+	}
+	if spec.ModelLocation != "" {
+		a = append(a, "--model-location", spec.ModelLocation)
+	}
 	if spec.Persona != "" {
 		a = append(a, "--persona", spec.Persona)
 	}

--- a/internal/host/isolation/isolation.go
+++ b/internal/host/isolation/isolation.go
@@ -75,12 +75,17 @@ type SandboxSpec struct {
 	// sandbox process — the host model-proxy still authenticates and enforces the
 	// egress allowlist, so a sandbox cannot reach a provider the host has not
 	// enabled regardless of what it is told here.
-	//   ModelProvider — "anthropic" (default), "openai", or "openrouter".
+	//   ModelProvider — "anthropic" (default), "openai", "openrouter", "codex",
+	//                   "gemini", or "vertex".
 	//   ModelID       — model id override (empty = the provider's default).
 	//   ModelHost     — upstream host override (empty = the provider's default).
+	//   ModelProject  — Google Cloud project id (Vertex AI only; rides in the URL path).
+	//   ModelLocation — Google Cloud region (Vertex AI only; empty = default region).
 	ModelProvider string
 	ModelID       string
 	ModelHost     string
+	ModelProject  string
+	ModelLocation string
 
 	// Persona is the group's system-persona text, passed to the sandbox as a
 	// non-secret flag and appended (after the security framing) to its system prompt.

--- a/internal/host/isolation/oci.go
+++ b/internal/host/isolation/oci.go
@@ -223,6 +223,12 @@ func BuildOCISpec(spec SandboxSpec) (*OCISpec, error) {
 	if spec.ModelHost != "" {
 		args = append(args, "--model-host", spec.ModelHost)
 	}
+	if spec.ModelProject != "" {
+		args = append(args, "--model-project", spec.ModelProject)
+	}
+	if spec.ModelLocation != "" {
+		args = append(args, "--model-location", spec.ModelLocation)
+	}
 	if spec.Persona != "" {
 		args = append(args, "--persona", spec.Persona)
 	}

--- a/internal/host/modelproxy/vertex.go
+++ b/internal/host/modelproxy/vertex.go
@@ -1,0 +1,129 @@
+package modelproxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// vertexHostSuffix is the Google Cloud Vertex AI host suffix the injector matches.
+// Vertex is served per-region as {location}-aiplatform.googleapis.com and globally
+// as aiplatform.googleapis.com — both end in this suffix.
+const vertexHostSuffix = "aiplatform.googleapis.com"
+
+// TokenSource yields the current OAuth2 bearer token for Vertex AI. Implementations
+// are responsible for refresh and caching; Token is called once per forwarded
+// request, so a static source returns a fixed value and an auto-refreshing source
+// returns a cached, still-valid token. The token lives only on the host — it is
+// injected into the upstream request and never enters the sandbox.
+type TokenSource interface {
+	Token() (string, error)
+}
+
+// VertexInjector returns an Injector that authenticates requests to Google Cloud
+// Vertex AI ({location}-aiplatform.googleapis.com) with a host-held OAuth2 bearer
+// token obtained from ts. Unlike the static-API-key providers, the credential is a
+// short-lived bearer that ts refreshes host-side; the sandbox never holds it. The
+// injector self-guards on the Vertex host suffix so it no-ops for any other provider
+// — safe to compose through MultiInjector. A token-source error leaves the request
+// unauthenticated (the upstream rejects with 401) rather than failing closed inside
+// the proxy; the error string is never logged here to avoid leaking token material.
+func VertexInjector(ts TokenSource) Injector {
+	return func(upstreamHost string, req *http.Request) {
+		if ts == nil {
+			return
+		}
+		if !strings.HasSuffix(strings.ToLower(upstreamHost), vertexHostSuffix) {
+			return
+		}
+		tok, err := ts.Token()
+		if err != nil || tok == "" {
+			return
+		}
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+}
+
+// StaticTokenSource is a TokenSource that always returns the same token. Use it when
+// the operator supplies a Vertex access token via the environment
+// (GOOGLE_VERTEX_ACCESS_TOKEN) and refreshes it out of band (e.g. a sidecar running
+// `gcloud auth print-access-token` on a timer). The token expires on Google's
+// schedule (~1h); for unattended auto-refresh prefer GcloudTokenSource.
+type StaticTokenSource string
+
+// Token returns the fixed token.
+func (s StaticTokenSource) Token() (string, error) { return string(s), nil }
+
+// GcloudTokenSource is a TokenSource that obtains a Vertex AI access token from the
+// host's Application Default Credentials by execing `gcloud auth print-access-token`
+// and caching it until shortly before it would expire. It adds no Go dependency and
+// covers the standard local ADC paths (gcloud user login, a service-account key via
+// GOOGLE_APPLICATION_CREDENTIALS, or the GCE metadata server). gcloud runs only on
+// the host, never in the sandbox.
+type GcloudTokenSource struct {
+	// TTL bounds how long a fetched token is reused before a refresh. gcloud tokens
+	// last ~1h; a conservative default leaves headroom. Zero uses gcloudDefaultTTL.
+	TTL time.Duration
+
+	mu      sync.Mutex
+	token   string
+	fetched time.Time
+	// now and run are overridable in tests; nil uses the real clock / exec.
+	now func() time.Time
+	run func(ctx context.Context) (string, error)
+}
+
+const gcloudDefaultTTL = 45 * time.Minute
+
+// Token returns a cached gcloud access token, refreshing it when the cache is empty
+// or older than TTL. Concurrent callers serialize on the mutex; a refresh failure
+// surfaces to the caller (VertexInjector treats it as "leave unauthenticated").
+func (g *GcloudTokenSource) Token() (string, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	now := time.Now
+	if g.now != nil {
+		now = g.now
+	}
+	ttl := g.TTL
+	if ttl <= 0 {
+		ttl = gcloudDefaultTTL
+	}
+	if g.token != "" && now().Sub(g.fetched) < ttl {
+		return g.token, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	run := g.run
+	if run == nil {
+		run = runGcloudPrintAccessToken
+	}
+	tok, err := run(ctx)
+	if err != nil {
+		return "", err
+	}
+	tok = strings.TrimSpace(tok)
+	if tok == "" {
+		return "", fmt.Errorf("host/modelproxy: gcloud returned an empty access token")
+	}
+	g.token = tok
+	g.fetched = now()
+	return tok, nil
+}
+
+// runGcloudPrintAccessToken execs `gcloud auth print-access-token`. It uses no shell
+// (exec.CommandContext, fixed args) so there is no injection surface, and bounds the
+// call with ctx. The token is returned to the caller and never logged.
+func runGcloudPrintAccessToken(ctx context.Context) (string, error) {
+	out, err := exec.CommandContext(ctx, "gcloud", "auth", "print-access-token").Output()
+	if err != nil {
+		return "", fmt.Errorf("host/modelproxy: gcloud auth print-access-token: %w", err)
+	}
+	return string(out), nil
+}

--- a/internal/host/modelproxy/vertex_test.go
+++ b/internal/host/modelproxy/vertex_test.go
@@ -1,0 +1,125 @@
+package modelproxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestVertexInjectorBearer checks the injector stamps the OAuth bearer for the
+// regional and global Vertex hosts and no-ops everywhere else.
+func TestVertexInjectorBearer(t *testing.T) {
+	inj := VertexInjector(StaticTokenSource("ya29.token"))
+	cases := []struct {
+		host string
+		want string
+	}{
+		{"us-central1-aiplatform.googleapis.com", "Bearer ya29.token"},
+		{"europe-west4-aiplatform.googleapis.com", "Bearer ya29.token"},
+		{"aiplatform.googleapis.com", "Bearer ya29.token"},
+		{"api.anthropic.com", ""},
+		{"generativelanguage.googleapis.com", ""},
+	}
+	for _, tc := range cases {
+		req, _ := http.NewRequest("POST", "http://"+tc.host+"/v1/x", nil)
+		inj(tc.host, req)
+		if got := req.Header.Get("Authorization"); got != tc.want {
+			t.Errorf("host %q: Authorization = %q, want %q", tc.host, got, tc.want)
+		}
+	}
+}
+
+// TestVertexInjectorStripsSandboxAuth verifies the proxy strips a sandbox-forged
+// bearer and replaces it with the host-held Vertex token end-to-end.
+func TestVertexInjectorStripsSandboxAuth(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	const host = "us-central1-aiplatform.googleapis.com"
+	p := New([]string{host},
+		WithInjector(VertexInjector(StaticTokenSource("host-token"))),
+		WithTransport(&redirectTransport{target: upstream.Listener.Addr().String()}),
+	)
+	srv := httptest.NewServer(p.Handler())
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/projects/p/locations/us-central1/publishers/google/models/m:streamGenerateContent", nil)
+	req.Host = host
+	req.Header.Set("Authorization", "Bearer sandbox-forged")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if gotAuth != "Bearer host-token" {
+		t.Fatalf("upstream Authorization = %q, want the host-held token (sandbox bearer stripped)", gotAuth)
+	}
+}
+
+// TestVertexInjectorTokenErrorLeavesUnauthenticated checks a token-source failure
+// does not panic or fail the proxy — the request just goes out unauthenticated and
+// the upstream rejects it.
+func TestVertexInjectorTokenErrorLeavesUnauthenticated(t *testing.T) {
+	inj := VertexInjector(errTokenSource{})
+	req, _ := http.NewRequest("POST", "http://us-central1-aiplatform.googleapis.com/v1/x", nil)
+	req.Header.Set("Authorization", "Bearer sandbox-forged")
+	// Director strips Authorization before injection; simulate that here.
+	req.Header.Del("Authorization")
+	inj("us-central1-aiplatform.googleapis.com", req)
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty when the token source errors", got)
+	}
+}
+
+// TestGcloudTokenSourceCaches verifies the gcloud source caches within the TTL and
+// refreshes after it, without execing real gcloud (the runner is injected).
+func TestGcloudTokenSourceCaches(t *testing.T) {
+	var calls int
+	now := time.Unix(0, 0)
+	g := &GcloudTokenSource{
+		TTL: time.Hour,
+		now: func() time.Time { return now },
+		run: func(ctx context.Context) (string, error) {
+			calls++
+			if calls == 1 {
+				return "  token-1\n", nil // trims whitespace
+			}
+			return "token-2", nil
+		},
+	}
+
+	tok, err := g.Token()
+	if err != nil || tok != "token-1" {
+		t.Fatalf("first Token() = %q, %v; want token-1", tok, err)
+	}
+	// Within TTL: cached, no second exec.
+	now = now.Add(30 * time.Minute)
+	if tok, _ := g.Token(); tok != "token-1" || calls != 1 {
+		t.Fatalf("cached Token() = %q (calls=%d), want token-1 with no refresh", tok, calls)
+	}
+	// Past TTL: refresh.
+	now = now.Add(time.Hour)
+	if tok, _ := g.Token(); tok != "token-2" || calls != 2 {
+		t.Fatalf("refreshed Token() = %q (calls=%d), want token-2 after refresh", tok, calls)
+	}
+}
+
+// TestGcloudTokenSourceEmptyIsError checks an empty gcloud output is a clear error
+// rather than a silent empty bearer.
+func TestGcloudTokenSourceEmptyIsError(t *testing.T) {
+	g := &GcloudTokenSource{run: func(ctx context.Context) (string, error) { return "  \n", nil }}
+	if _, err := g.Token(); err == nil {
+		t.Fatal("Token(): want error on empty gcloud output, got nil")
+	}
+}
+
+type errTokenSource struct{}
+
+func (errTokenSource) Token() (string, error) { return "", errors.New("no creds") }

--- a/internal/host/onboard/onboard.go
+++ b/internal/host/onboard/onboard.go
@@ -128,6 +128,8 @@ var modelCredentialEnv = [][2]string{
 	{"OPENROUTER_API_KEY", "OpenRouter"},
 	{"GOOGLE_API_KEY", "Google Gemini"},
 	{"GEMINI_API_KEY", "Google Gemini"},
+	{"GOOGLE_VERTEX_ACCESS_TOKEN", "Google Vertex AI"},
+	{"GOOGLE_VERTEX_USE_GCLOUD", "Google Vertex AI"},
 	{"IRONCLAW_MODEL_GATEWAY_URL", "credential gateway"},
 }
 

--- a/internal/host/registry/registry.go
+++ b/internal/host/registry/registry.go
@@ -30,6 +30,11 @@ type AgentGroup struct {
 	// provider's credential enabled for it to be reachable.
 	Provider string
 	Model    string
+	// Project and Location are the Google Cloud project id and region for the
+	// "vertex" provider; both ride in the Vertex AI request URL path. Ignored by
+	// every other provider. Empty Location uses the Vertex default region.
+	Project  string
+	Location string
 	// Persona is the group's legacy single-blob system-persona text, appended to the
 	// sandbox system prompt at launch. It is set via a gateway-approved
 	// ChangePersona change — never by the sandbox itself — and is read-only to the

--- a/internal/host/session/manager.go
+++ b/internal/host/session/manager.go
@@ -150,9 +150,14 @@ type EgressProvisioner interface {
 // ModelSelection is an optional per-session model backend override. The zero value
 // (empty Provider) keeps the default Anthropic backend and its default host/model.
 type ModelSelection struct {
-	Provider string // "anthropic" (default), "openai", or "openrouter"
+	Provider string // "anthropic" (default), "openai", "openrouter", "codex", "gemini", or "vertex"
 	Model    string // model id override; empty = the provider's default
 	Host     string // upstream host override; empty = the provider's default
+	// Project and Location are the Google Cloud project id and region for the
+	// "vertex" provider; both ride in the request URL path. Ignored by every other
+	// provider. Empty Location uses the Vertex default region.
+	Project  string
+	Location string
 }
 
 // tracked is a launched sandbox the Manager is responsible for.
@@ -385,6 +390,8 @@ func (m *Manager) Wake(id contract.SessionID) error {
 		spec.ModelProvider = sel.Provider
 		spec.ModelID = sel.Model
 		spec.ModelHost = sel.Host
+		spec.ModelProject = sel.Project
+		spec.ModelLocation = sel.Location
 	}
 	// Bind the egress-broker socket when the daemon configured one (opt-in); the
 	// sandbox then gets the http_fetch tool and can reach approved hosts + vault://

--- a/internal/sandbox/provider/provider.go
+++ b/internal/sandbox/provider/provider.go
@@ -69,6 +69,12 @@ const (
 	// (generativelanguage.googleapis.com) — Google AI Studio with a host-held API
 	// key, or the Gemini CLI's OAuth credential injected via the credential gateway.
 	KindGemini = "gemini"
+	// KindVertex routes to Google Cloud Vertex AI
+	// ({location}-aiplatform.googleapis.com). It speaks the identical Gemini wire
+	// format — only the transport envelope differs: the GCP project and location ride
+	// in the URL path, and auth is an OAuth2 bearer (gcloud ADC / service account)
+	// injected host-side, not a static API key. See NewVertex.
+	KindVertex = "vertex"
 	// KindMock is a deterministic, offline backend (no network, no credential)
 	// for local demos and end-to-end tests. See MockProvider.
 	KindMock = "mock"
@@ -114,6 +120,11 @@ func New(cfg Config) (Provider, error) {
 		// NewGemini applies the generativelanguage.googleapis.com upstream host and
 		// the default Gemini model when cfg leaves them zero.
 		return NewGemini(cfg), nil
+	case KindVertex:
+		// NewVertex reuses GeminiProvider (identical wire format) but builds the
+		// Vertex URL from cfg.Project/cfg.Location and derives the regional
+		// {location}-aiplatform.googleapis.com host when cfg leaves them zero.
+		return NewVertex(cfg), nil
 	case KindMock:
 		// Deterministic offline backend; ignores host/model/socket entirely.
 		return NewMock(cfg), nil
@@ -126,9 +137,16 @@ func New(cfg Config) (Provider, error) {
 // given backend ignores (e.g. DisableThinking for OpenAI) are simply unused.
 type Config struct {
 	// Kind selects the backend: "" / "anthropic" (default), "openai",
-	// "openrouter", "codex", or "gemini". See New. The kind is chosen per agent
-	// group host-side.
+	// "openrouter", "codex", "gemini", or "vertex". See New. The kind is chosen per
+	// agent group host-side.
 	Kind string
+	// Project and Location are the Google Cloud project id and region used by the
+	// Vertex AI backend (KindVertex); they ride in the request URL path. They are
+	// ignored by every other backend. Empty Location defaults to the Vertex default
+	// region; an empty Project yields a malformed Vertex URL (a misconfiguration the
+	// upstream rejects), so the control-plane only selects vertex when a project is set.
+	Project  string
+	Location string
 	// SocketPath is the host model-proxy unix socket. Defaults to DefaultSocketPath.
 	SocketPath string
 	// UpstreamHost is the model API host the proxy allowlists and routes to.

--- a/internal/sandbox/provider/vertex.go
+++ b/internal/sandbox/provider/vertex.go
@@ -1,0 +1,97 @@
+// This file adds Google Cloud Vertex AI as the third Google platform behind the
+// same Provider/ToolConverser abstraction, alongside Google AI Studio and the
+// Gemini CLI (see gemini.go). Vertex speaks the IDENTICAL Gemini wire format —
+// "contents"/systemInstruction/tools out, candidates/functionCall back — so this
+// file does NOT fork the translation or streaming logic: NewVertex returns a
+// *GeminiProvider whose only difference is the request URL. Two things differ from
+// the AI Studio path, and both live in the transport envelope rather than the body:
+//
+//   - URL: the GCP project and location ride in the path —
+//     /v1/projects/{project}/locations/{location}/publishers/google/models/{model}:streamGenerateContent
+//     served from the regional {location}-aiplatform.googleapis.com host (or the
+//     global aiplatform.googleapis.com when location is "global").
+//   - Auth: an OAuth2 bearer (gcloud ADC / service-account token), injected
+//     host-side by modelproxy.VertexInjector — NOT the x-goog-api-key the AI Studio
+//     path uses. As with every backend the sandbox holds no credential and dials
+//     only the host model-proxy unix socket; the host proxy authenticates and
+//     enforces the {location}-aiplatform.googleapis.com egress allowlist.
+
+package provider
+
+import "strings"
+
+const (
+	// defaultVertexModel matches the AI Studio default; Vertex serves the same
+	// Gemini models under publishers/google/models/{model}.
+	defaultVertexModel = "gemini-2.5-pro"
+	// defaultVertexLocation is the region used when cfg.Location is empty. Vertex has
+	// no global default region for streamGenerateContent, so we pick a common one
+	// rather than emit a malformed URL.
+	defaultVertexLocation = "us-central1"
+	// vertexGlobalLocation selects the (region-less) global endpoint.
+	vertexGlobalLocation = "global"
+)
+
+// vertexHost returns the Vertex AI host for a location: the region-less global
+// endpoint for "global", otherwise the regional {location}-aiplatform.googleapis.com.
+// This is the host the model-proxy must allowlist and the VertexInjector matches.
+func vertexHost(location string) string {
+	if location == "" || location == vertexGlobalLocation {
+		return "aiplatform.googleapis.com"
+	}
+	return location + "-aiplatform.googleapis.com"
+}
+
+// NewVertex constructs a Vertex AI backend, reusing GeminiProvider unchanged (the
+// wire format is identical) and overriding only the request URL so the GCP project
+// and location ride in the path. Defaults are applied for any zero-valued field; an
+// empty UpstreamHost is derived from the (possibly defaulted) location. Callers
+// usually go through New. The OAuth bearer is added host-side by the model-proxy
+// (modelproxy.VertexInjector) — this provider never holds a credential.
+func NewVertex(cfg Config) *GeminiProvider {
+	if cfg.SocketPath == "" {
+		cfg.SocketPath = DefaultSocketPath
+	}
+	if cfg.Location == "" {
+		cfg.Location = defaultVertexLocation
+	}
+	if cfg.UpstreamHost == "" {
+		cfg.UpstreamHost = vertexHost(cfg.Location)
+	}
+	if cfg.Model == "" {
+		cfg.Model = defaultVertexModel
+	}
+	if cfg.MaxTokens == 0 {
+		cfg.MaxTokens = defaultMaxTokens
+	}
+	if cfg.HTTPTimeout == 0 {
+		cfg.HTTPTimeout = defaultHTTPTimeout
+	}
+
+	return &GeminiProvider{
+		cfg:    cfg,
+		client: newSocketClient(cfg.SocketPath, cfg.HTTPTimeout),
+		url:    vertexURL(cfg.UpstreamHost, cfg.Project, cfg.Location, cfg.Model),
+	}
+}
+
+// vertexURL builds the Vertex AI streamGenerateContent endpoint. Like the AI Studio
+// path it streams via Server-Sent Events (alt=sse) and puts the model id in the
+// path; Vertex additionally threads the project and location through the path. The
+// scheme is plain http to the unix socket — the host proxy upgrades to https upstream.
+func vertexURL(host, project, location, model string) string {
+	if location == "" {
+		location = defaultVertexLocation
+	}
+	var b strings.Builder
+	b.WriteString("http://")
+	b.WriteString(host)
+	b.WriteString("/v1/projects/")
+	b.WriteString(project)
+	b.WriteString("/locations/")
+	b.WriteString(location)
+	b.WriteString("/publishers/google/models/")
+	b.WriteString(model)
+	b.WriteString(":streamGenerateContent?alt=sse")
+	return b.String()
+}

--- a/internal/sandbox/provider/vertex_test.go
+++ b/internal/sandbox/provider/vertex_test.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestVertexQuerySuccess checks the Vertex transport envelope: the project and
+// location ride in the path, the host is the regional aiplatform endpoint, and the
+// body/response reuse the Gemini wire format unchanged.
+func TestVertexQuerySuccess(t *testing.T) {
+	var gotBody []byte
+	var gotPath, gotHost string
+	sock := serveUnix(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotHost = r.Host
+		gotBody, _ = io.ReadAll(r.Body)
+		writeSSE(w, geminiHelloStream) // identical wire format to Gemini
+	}))
+
+	p := NewVertex(Config{SocketPath: sock, Project: "my-proj", Location: "us-central1", Model: "gemini-2.5-pro"})
+	out, err := p.Query(context.Background(), "hi there")
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if out != "hello world" {
+		t.Fatalf("Query output = %q, want %q", out, "hello world")
+	}
+	// project + location + model all ride in the path.
+	for _, want := range []string{"/v1/projects/my-proj/locations/us-central1/publishers/google/models/gemini-2.5-pro", ":streamGenerateContent"} {
+		if !strings.Contains(gotPath, want) {
+			t.Fatalf("path = %q, want it to contain %q", gotPath, want)
+		}
+	}
+	if gotHost != "us-central1-aiplatform.googleapis.com" {
+		t.Fatalf("Host = %q, want the regional aiplatform host", gotHost)
+	}
+	// Body is the Gemini shape (reused translation): one user text part.
+	var req gemRequest
+	if err := json.Unmarshal(gotBody, &req); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if len(req.Contents) != 1 || req.Contents[0].Parts[0].Text != "hi there" {
+		t.Fatalf("contents = %+v, want one user text part", req.Contents)
+	}
+}
+
+// TestVertexReusesGeminiToolTranslation confirms NewVertex reuses GeminiProvider's
+// Converse/tool path verbatim — only the URL differs from the AI Studio backend.
+func TestVertexReusesGeminiToolTranslation(t *testing.T) {
+	sock := serveUnix(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, sse(
+			`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"a.txt"}}}]},"finishReason":"STOP"}]}`,
+		))
+	}))
+	p := NewVertex(Config{SocketPath: sock, Project: "p", Location: "europe-west4"})
+	turn, err := p.Converse(context.Background(),
+		[]Message{UserTextMessage("read a.txt")},
+		[]ToolSpec{{Name: "read_file", InputSchema: json.RawMessage(`{"type":"object"}`)}})
+	if err != nil {
+		t.Fatalf("Converse: %v", err)
+	}
+	if turn.StopReason != "tool_use" || len(turn.ToolCalls) != 1 || turn.ToolCalls[0].Name != "read_file" {
+		t.Fatalf("turn = %+v, want a single read_file tool call", turn)
+	}
+}
+
+// TestVertexDefaultsAndGlobalHost checks the region defaults and the global endpoint.
+func TestVertexDefaultsAndGlobalHost(t *testing.T) {
+	// Empty location → the default region's host and model.
+	def := NewVertex(Config{SocketPath: "/x.sock", Project: "p"})
+	if !strings.Contains(def.url, defaultVertexLocation+"-aiplatform.googleapis.com") {
+		t.Fatalf("default url = %q, want the default-region host", def.url)
+	}
+	if !strings.Contains(def.url, defaultVertexModel) {
+		t.Fatalf("default url = %q, want the default model", def.url)
+	}
+	// "global" → the region-less endpoint, with locations/global in the path.
+	g := NewVertex(Config{SocketPath: "/x.sock", Project: "p", Location: "global"})
+	if !strings.Contains(g.url, "//aiplatform.googleapis.com/") {
+		t.Fatalf("global url = %q, want the global host", g.url)
+	}
+	if !strings.Contains(g.url, "/locations/global/") {
+		t.Fatalf("global url = %q, want locations/global in the path", g.url)
+	}
+}
+
+// TestVertexFactory checks New(Kind:"vertex") builds a Vertex-shaped GeminiProvider.
+func TestVertexFactory(t *testing.T) {
+	pv, err := New(Config{Kind: "Vertex", Project: "proj", Location: "asia-northeast1", Model: "gemini-2.5-flash"})
+	if err != nil {
+		t.Fatalf("vertex: %v", err)
+	}
+	gp, ok := pv.(*GeminiProvider)
+	if !ok {
+		t.Fatalf("vertex kind = %T, want *GeminiProvider (reused)", pv)
+	}
+	want := "asia-northeast1-aiplatform.googleapis.com/v1/projects/proj/locations/asia-northeast1/publishers/google/models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+	if !strings.Contains(gp.url, want) {
+		t.Fatalf("vertex url = %q, want it to contain %q", gp.url, want)
+	}
+}
+
+func TestVertexHost(t *testing.T) {
+	cases := map[string]string{
+		"":             "aiplatform.googleapis.com",
+		"global":       "aiplatform.googleapis.com",
+		"us-central1":  "us-central1-aiplatform.googleapis.com",
+		"europe-west4": "europe-west4-aiplatform.googleapis.com",
+	}
+	for in, want := range cases {
+		if got := vertexHost(in); got != want {
+			t.Errorf("vertexHost(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds **Vertex AI** as a distinct provider kind from Google AI Studio Gemini
- `ProviderVertex` uses project + location config with zero API key (Google OAuth2 token injection via `VertexInjector`)
- `VertexProvider` reuses the `GeminiProvider` HTTP path, swapping the endpoint to the Vertex regional URL
- `model_select` routes `--vertex-project` / `--vertex-location` flags through to the sandbox
- Allowlist entry + onboarding detection wired in `registry.go` and `onboard.go`
- Unit tests for endpoint construction and model selection routing

## Test plan

- [ ] `go build ./...` passes (confirmed)
- [ ] `go test ./internal/host/modelproxy/... ./internal/sandbox/provider/... ./cmd/controlplane/...`
- [ ] CI green