### PR TITLE
feat(vault): credential-secret rotation via the injector (IRO-144)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -89,6 +89,8 @@ func main() {
 		"OPT-IN: host-local credential-injector URL; enables vault://<cred>/<path> routing through the egress broker. Requires --egress-socket")
 	vaultInjectorConfig := flag.String("vault-injector-config", "",
 		"path to the JSON injector config (cred -> {upstream, secretEnv}); supplies the cred->upstream-host map the broker enforces vault policy against. Required with --vault-endpoint")
+	vaultControlEndpoint := flag.String("vault-control-endpoint", "",
+		"OPT-IN: the injector's rotation CONTROL surface (http://host:port or unix:/path), SEPARATE from --vault-endpoint; enables gateway-approved `ironctl vault rotate` to signal the injector to re-resolve a credential's held secret. No secret travels this channel")
 	searchBackend := flag.String("search-backend", "",
 		"web_search provider given to each sandbox: duckduckgo (keyless) or brave[:cred] (keyed via the vault). Requires --egress-socket; its host is auto-added to the egress allowlist. Empty disables web_search (--dev defaults it to duckduckgo)")
 	skillsDir := flag.String("skills-dir", "",
@@ -313,6 +315,21 @@ func main() {
 		vaultCredHosts = cfg.CredHosts()
 		logger.Info("vault enforcement enabled", "credentials", len(vaultCredHosts))
 	}
+	// OPT-IN credential-secret rotation (IRO-144): with --vault-control-endpoint set,
+	// an approved `vault rotate` change signals the injector's control surface to
+	// re-resolve a credential's held secret from the host environment. The signaller is
+	// the gateway's RotateCredentialFunc seam; nil leaves rotation unconfigured, so an
+	// approved rotation fails loudly ("no rotation signaller wired") rather than silently
+	// no-opping. No secret ever crosses this channel.
+	var vaultRotateSignaller func(contract.AgentGroupID, string) error
+	if *vaultControlEndpoint != "" {
+		vaultRotateSignaller, err = newVaultRotateSignaller(*vaultControlEndpoint)
+		if err != nil {
+			logger.Error("vault control endpoint", "error", err)
+			os.Exit(1)
+		}
+		logger.Info("vault credential rotation enabled")
+	}
 	// When a search backend is configured, approve its egress host so web_search is not
 	// present-but-403 (selecting a backend IS the operator opting into reaching it). A
 	// vault-routed backend returns "" here — its injector endpoint is allowlisted via
@@ -474,6 +491,10 @@ func main() {
 		}
 		return vaultPolicies.Set(registry.VaultPolicy{AgentGroupID: id, Rules: rr})
 	}, capApplier)
+	// An approved vault-rotate change signals the injector to re-resolve the named
+	// credential's held secret. It carries no secret and mutates no control-plane state;
+	// the side effect is entirely host-side in the injector.
+	capApplier = gateway.NewVaultRotateApplier(vaultRotateSignaller, capApplier)
 	// An approved ChangeMCPRegister lands the proposed server in the host catalog and
 	// drops any cached broker connection so the next use reconnects with it. It grants
 	// the proposing agent NOTHING — access stays the separate ChangeMCPAccess approval.
@@ -504,6 +525,7 @@ func main() {
 			gateway.NewCreateAgentVerifier(agentExists),
 			gateway.NewMCPServerVerifier(mcpServerKnown),
 			gateway.VaultPolicyVerifier{},
+			gateway.VaultRotateVerifier{},
 			gateway.NewMCPRegisterVerifier(func() bool { return mcpCatalogStore != nil }),
 			gateway.AlwaysRequireHuman{},
 		},

--- a/cmd/controlplane/vault_rotate.go
+++ b/cmd/controlplane/vault_rotate.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+	"github.com/IronSecCo/ironclaw/internal/host/vaultinjector"
+)
+
+// newVaultRotateSignaller builds the gateway.RotateCredentialFunc seam used to
+// materialize an approved credential-secret rotation (IRO-144). It POSTs to the
+// injector's rotation CONTROL surface (its --control-addr/--control-socket), which is
+// SEPARATE from the broker's --vault-endpoint so only the control plane can trigger a
+// rotation. The request carries only the credential NAME (vaultinjector.CredHeader) —
+// never a secret, in either direction — and any non-2xx is treated as a failed
+// rotation so an approved-but-unapplied rotation surfaces loudly rather than silently
+// no-opping. endpoint forms: "http://127.0.0.1:8201" or
+// "unix:/run/ironclaw/vault-control.sock".
+func newVaultRotateSignaller(endpoint string) (func(contract.AgentGroupID, string) error, error) {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return nil, fmt.Errorf("empty vault control endpoint")
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	var base string
+	if strings.HasPrefix(endpoint, "unix:") {
+		sock := strings.TrimPrefix(endpoint, "unix:")
+		if sock == "" {
+			return nil, fmt.Errorf("vault control endpoint %q names no socket path", endpoint)
+		}
+		client.Transport = &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", sock)
+			},
+		}
+		base = "http://unix"
+	} else {
+		if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+			return nil, fmt.Errorf("vault control endpoint must be http(s):// or unix: (got %q)", endpoint)
+		}
+		base = strings.TrimRight(endpoint, "/")
+	}
+	return func(_ contract.AgentGroupID, credential string) error {
+		req, err := http.NewRequest(http.MethodPost, base+"/rotate", nil)
+		if err != nil {
+			return err
+		}
+		// The credential NAME only — the injector re-resolves the secret host-side.
+		req.Header.Set(vaultinjector.CredHeader, credential)
+		resp, err := client.Do(req)
+		if err != nil {
+			return fmt.Errorf("signal injector rotate: %w", err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("injector rotate %q: HTTP %d: %s", credential, resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		return nil
+	}, nil
+}

--- a/cmd/controlplane/vault_rotate_test.go
+++ b/cmd/controlplane/vault_rotate_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/host/vaultinjector"
+)
+
+func TestVaultRotateSignaller_PostsCredNameToControlEndpoint(t *testing.T) {
+	var gotPath, gotCred, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotCred = r.Header.Get(vaultinjector.CredHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	signal, err := newVaultRotateSignaller(srv.URL)
+	if err != nil {
+		t.Fatalf("newVaultRotateSignaller: %v", err)
+	}
+	if err := signal("grp-1", "github"); err != nil {
+		t.Fatalf("signal: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/rotate" {
+		t.Fatalf("got %s %s, want POST /rotate", gotMethod, gotPath)
+	}
+	if gotCred != "github" {
+		t.Fatalf("cred header = %q, want github", gotCred)
+	}
+}
+
+func TestVaultRotateSignaller_NonTwoXXIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unknown credential", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	signal, err := newVaultRotateSignaller(srv.URL)
+	if err != nil {
+		t.Fatalf("newVaultRotateSignaller: %v", err)
+	}
+	if err := signal("grp-1", "stripe"); err == nil {
+		t.Fatal("a 403 from the injector must surface as an error, not a silent success")
+	}
+}
+
+func TestVaultRotateSignaller_RejectsBadEndpoint(t *testing.T) {
+	if _, err := newVaultRotateSignaller(""); err == nil {
+		t.Error("empty endpoint should error")
+	}
+	if _, err := newVaultRotateSignaller("127.0.0.1:8201"); err == nil {
+		t.Error("a scheme-less endpoint should error (must be http(s):// or unix:)")
+	}
+	if _, err := newVaultRotateSignaller("unix:"); err == nil {
+		t.Error("unix: with no socket path should error")
+	}
+}

--- a/cmd/ironclaw-vault-injector/main.go
+++ b/cmd/ironclaw-vault-injector/main.go
@@ -37,6 +37,8 @@ func main() {
 	cfgPath := flag.String("config", "", "path to the JSON injector config (cred -> {upstream, secretEnv})")
 	addr := flag.String("addr", "127.0.0.1:8200", "TCP address to listen on (use a loopback port the broker allowlists)")
 	socket := flag.String("socket", "", "unix socket to listen on instead of --addr (bound into the broker's reach)")
+	controlSocket := flag.String("control-socket", "", "OPT-IN: unix socket for the rotation CONTROL surface, reachable ONLY by the control plane (never the broker). Enables gateway-approved `ironctl vault rotate`")
+	controlAddr := flag.String("control-addr", "", "OPT-IN: TCP address for the rotation CONTROL surface (alternative to --control-socket). Bind to loopback the control plane reaches")
 	flag.Parse()
 
 	if *cfgPath == "" {
@@ -48,8 +50,12 @@ func main() {
 	}
 	inj, err := vaultinjector.New(cfg, os.LookupEnv, vaultinjector.WithAudit(func(rec vaultinjector.AuditRecord) {
 		// Audit carries the credential NAME + correlation id — never the secret value.
-		log.Printf("inject cred=%q upstream=%q path=%q status=%d allowed=%v corr=%q dur_ms=%d",
-			rec.Credential, rec.Upstream, rec.Path, rec.Status, rec.Allowed, rec.CorrelationID, rec.Duration.Milliseconds())
+		action := rec.Action
+		if action == "" {
+			action = "inject"
+		}
+		log.Printf("%s cred=%q upstream=%q path=%q status=%d allowed=%v corr=%q dur_ms=%d",
+			action, rec.Credential, rec.Upstream, rec.Path, rec.Status, rec.Allowed, rec.CorrelationID, rec.Duration.Milliseconds())
 	}))
 	if err != nil {
 		log.Fatalf("ironclaw-vault-injector: %v", err)
@@ -73,13 +79,40 @@ func main() {
 	}
 	log.Printf("ironclaw-vault-injector: listening on %s", where)
 
+	// OPT-IN rotation CONTROL surface on its OWN listener, separate from the
+	// broker-facing proxy above, so only the control plane can trigger a rotation.
+	var ctrlSrv *http.Server
+	if *controlSocket != "" || *controlAddr != "" {
+		ctrlLn, lerr := listen(*controlSocket, *controlAddr)
+		if lerr != nil {
+			log.Fatalf("ironclaw-vault-injector: control listen: %v", lerr)
+		}
+		ctrlSrv = &http.Server{Handler: inj.RotateHandler()}
+		go func() {
+			if serr := ctrlSrv.Serve(ctrlLn); serr != nil && !errors.Is(serr, http.ErrServerClosed) {
+				errCh <- serr
+			}
+		}()
+		cwhere := *controlAddr
+		if *controlSocket != "" {
+			cwhere = "unix:" + *controlSocket
+		}
+		log.Printf("ironclaw-vault-injector: rotation control listening on %s", cwhere)
+	}
+
 	select {
 	case <-ctx.Done():
 		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_ = srv.Shutdown(shutCtx)
+		if ctrlSrv != nil {
+			_ = ctrlSrv.Shutdown(shutCtx)
+		}
 		if *socket != "" {
 			_ = os.Remove(*socket)
+		}
+		if *controlSocket != "" {
+			_ = os.Remove(*controlSocket)
 		}
 	case err := <-errCh:
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/cmd/ironctl/vault.go
+++ b/cmd/ironctl/vault.go
@@ -19,12 +19,13 @@ import (
 // approves it. ironctl is a thin client; the daemon owns the verifier + applier +
 // store.
 //
-// The actual credential (the key) is never held or rotated here: it lives only in
-// the host-side injector (see internal/host/egress/vault.go). Rotating the
-// injector's held secret is an injector operation, not a control-plane one.
+// The actual credential (the key) is never held here: it lives only in the host-side
+// injector (see internal/host/egress/vault.go). `rotate` does not carry or display a
+// secret either — it PROPOSES a gateway-gated rotation that, once a human approves it,
+// signals the injector to re-resolve its held secret from the host environment.
 func cmdVault(addr string, args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("expected: vault <list|grant|revoke|set>")
+		return fmt.Errorf("expected: vault <list|grant|revoke|set|rotate>")
 	}
 	switch args[0] {
 	case "list", "ls", "show":
@@ -35,8 +36,10 @@ func cmdVault(addr string, args []string) error {
 		return cmdVaultRevoke(addr, args[1:])
 	case "set":
 		return cmdVaultSet(addr, args[1:])
+	case "rotate":
+		return cmdVaultRotate(addr, args[1:])
 	default:
-		return fmt.Errorf("unknown vault subcommand %q (want list|grant|revoke|set)", args[0])
+		return fmt.Errorf("unknown vault subcommand %q (want list|grant|revoke|set|rotate)", args[0])
 	}
 }
 
@@ -159,6 +162,35 @@ func cmdVaultSet(addr string, args []string) error {
 		return err
 	}
 	return submitVaultPolicy(addr, *group, *by, rules)
+}
+
+// cmdVaultRotate proposes rotating the SECRET a logical credential maps to. The
+// control plane never holds the secret, so this carries none: it submits a
+// gateway-gated rotation request (kind permissions, a `vaultRotate` body naming the
+// credential) that, once a human approves it, signals the host-side injector to
+// re-resolve its held secret from the host environment. No key is ever entered,
+// printed, or logged — rotate the underlying secret in the injector's secret source
+// (env / secret manager) first, then run this to make the injector pick it up.
+//
+//	ironctl vault rotate --group <id> --credential github [--by <user>]
+func cmdVaultRotate(addr string, args []string) error {
+	fs := flag.NewFlagSet("vault rotate", flag.ContinueOnError)
+	group := fs.String("group", "", "target agent group id")
+	cred := fs.String("credential", "", "logical credential name to rotate (e.g. github) — never a key")
+	by := fs.String("by", "", "requesting user id (channel:handle)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *group == "" || *cred == "" {
+		return fmt.Errorf("vault rotate requires --group and --credential")
+	}
+	credential := strings.ToLower(strings.TrimSpace(*cred))
+	return postJSON(addr+"/v1/ui/config/change", map[string]any{
+		"kind":         "permissions",
+		"agentGroupID": *group,
+		"requestedBy":  *by,
+		"after":        map[string]any{"vaultRotate": map[string]any{"credential": credential}},
+	})
 }
 
 // fetchVaultPolicy GETs a group's current policy and returns it parsed + raw.

--- a/cmd/ironctl/vault_rotate_test.go
+++ b/cmd/ironctl/vault_rotate_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCmdVaultRotate_RequiresGroupAndCredential(t *testing.T) {
+	if err := cmdVaultRotate("http://127.0.0.1:0", []string{"--credential", "github"}); err == nil {
+		t.Error("rotate without --group should error")
+	}
+	if err := cmdVaultRotate("http://127.0.0.1:0", []string{"--group", "grp-1"}); err == nil {
+		t.Error("rotate without --credential should error")
+	}
+}
+
+func TestCmdVaultRotate_ProposesGatewayChangeNoSecret(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"chg-1"}`))
+	}))
+	defer srv.Close()
+
+	err := cmdVaultRotate(srv.URL, []string{"--group", "grp-1", "--credential", "GitHub", "--by", "slack:alice"})
+	if err != nil {
+		t.Fatalf("cmdVaultRotate: %v", err)
+	}
+	if gotPath != "/v1/ui/config/change" {
+		t.Fatalf("posted to %q, want /v1/ui/config/change (the gateway approval path)", gotPath)
+	}
+	if gotBody["kind"] != "permissions" {
+		t.Fatalf("kind = %v, want permissions", gotBody["kind"])
+	}
+	if gotBody["agentGroupID"] != "grp-1" {
+		t.Fatalf("agentGroupID = %v, want grp-1", gotBody["agentGroupID"])
+	}
+	after, ok := gotBody["after"].(map[string]any)
+	if !ok {
+		t.Fatalf("after missing/not an object: %v", gotBody["after"])
+	}
+	vr, ok := after["vaultRotate"].(map[string]any)
+	if !ok {
+		t.Fatalf("after.vaultRotate missing: %v", after)
+	}
+	if vr["credential"] != "github" {
+		t.Fatalf("credential = %v, want normalized github", vr["credential"])
+	}
+	// The change body must carry the credential NAME only — never a secret field.
+	raw, _ := json.Marshal(gotBody)
+	for _, banned := range []string{"secret", "token", "value", "password"} {
+		if strings.Contains(strings.ToLower(string(raw)), banned) {
+			t.Fatalf("rotation change body contains a secret-like field %q: %s", banned, raw)
+		}
+	}
+}

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -75,22 +75,54 @@ secretEnv}`). Secrets live in the **environment**, never in the file:
 Run the injector as its own OS user, then start the control-plane pointing at it:
 
 ```sh
-# 1) the injector (separate principal; holds the secrets)
+# 1) the injector (separate principal; holds the secrets). --control-socket is the
+#    OPT-IN rotation channel, SEPARATE from the broker-facing --addr; the broker never
+#    reaches it, only the control plane does.
 VAULT_GITHUB_TOKEN=ghp_… ironclaw-vault-injector \
-  --config vault-injector.json --addr 127.0.0.1:8200
+  --config vault-injector.json --addr 127.0.0.1:8200 \
+  --control-addr 127.0.0.1:8201
 
 # 2) the control-plane (enforces policy; holds no secret)
 controlplane \
   --egress-socket /run/ironclaw/egress.sock \
   --vault-endpoint http://127.0.0.1:8200 \
-  --vault-injector-config vault-injector.json
+  --vault-injector-config vault-injector.json \
+  --vault-control-endpoint http://127.0.0.1:8201
 ```
 
 `--vault-endpoint` requires `--vault-injector-config`: without the cred→upstream-host
 map the broker cannot enforce vault policy, so the daemon refuses to enable vault rather
-than run it unenforced.
+than run it unenforced. `--vault-control-endpoint` is optional and only enables
+credential-secret **rotation** (below); omit it and rotation is simply unavailable.
 
 A group is granted a credential through the gateway's human-approval path (a vault-policy
 change is a capability change like any other); see
 [`ironctl vault`](channels.md) for the management commands. With no grant, vault stays
 deny-by-default.
+
+## Rotating a credential's secret
+
+The control plane **never holds the secret**, so rotating it is an **injector**
+operation: the injector re-resolves the secret from its `secretEnv` and swaps the held
+value. `ironctl vault rotate` drives that through the **same human-approval + audit
+path** as the policy commands — it carries no secret and prints no secret.
+
+```sh
+# 1) Put the NEW secret where the injector reads it (its secret source) and reload it
+#    into the injector's environment — e.g. update the secret manager / env var
+#    VAULT_GITHUB_TOKEN. (How the new value reaches the injector's environment is your
+#    deployment's concern; IronClaw never sees it.)
+
+# 2) Propose the rotation. This submits a gateway-gated change naming only the
+#    credential — never a key. It takes effect after a human approves it.
+ironctl vault rotate --group <agent-group-id> --credential github --by slack:alice
+```
+
+On approval the control plane signals the injector's control endpoint
+(`--vault-control-endpoint`), which re-reads `secretEnv` and atomically swaps the held
+secret for in-flight and future requests. The signal carries only the credential
+**name**; the new secret never travels through the control plane, the change body, the
+CLI, or the audit log. A rotation whose new secret is missing/empty **fails closed** —
+the injector keeps the previous secret rather than blanking a live credential — and the
+failure surfaces on the approving change. Every rotation is audited
+(`action=rotate cred=… status=…`), secret-free, like every injection.

--- a/internal/host/gateway/vault_rotate_applier.go
+++ b/internal/host/gateway/vault_rotate_applier.go
@@ -1,0 +1,107 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+)
+
+// Vault credential-secret ROTATION gateway integration (IRO-144). Rotating the secret
+// a logical credential maps to is an INJECTOR operation — the control plane never
+// holds the secret (threat-model §11) — so a rotation change carries NO secret: only
+// the credential NAME and the (trusted) target group taken from the ChangeRequest.
+// Like a vault-policy change it rides the gateway's mandatory human-approval floor; on
+// approval the applier SIGNALS the host-side injector to re-resolve its held secret
+// from the host environment. The secret value never touches the control plane, the
+// change body, or the audit log.
+
+// RotateCredentialFunc signals the host-side injector to rotate the held secret for a
+// logical credential. Satisfied by a small injector-control client in
+// cmd/controlplane; a seam so the gateway stays decoupled from the injector wiring (the
+// VaultPolicyApplier/SetVaultPolicyFunc pattern). A nil setter makes an approved
+// rotation fail loudly rather than silently no-op.
+type RotateCredentialFunc func(id contract.AgentGroupID, credential string) error
+
+// vaultRotatePayload is the rotation portion of a change's After body. A change with no
+// vaultRotate field is not a rotation change and passes through untouched.
+type vaultRotatePayload struct {
+	VaultRotate *struct {
+		Credential string `json:"credential"`
+	} `json:"vaultRotate"`
+}
+
+// VaultRotateApplier materializes an approved credential-rotation change by signalling
+// the injector to re-resolve its held secret for the named credential. It is
+// kind-agnostic (it keys off the payload, like VaultPolicyApplier): any approved change
+// carrying a vaultRotate body triggers a rotation; every other payload and kind passes
+// through to next unchanged.
+type VaultRotateApplier struct {
+	rotate RotateCredentialFunc
+	next   contract.Applier
+}
+
+// NewVaultRotateApplier wraps next. rotate may be nil (a recognized rotation change
+// then errors rather than silently dropping it); next may be nil.
+func NewVaultRotateApplier(rotate RotateCredentialFunc, next contract.Applier) *VaultRotateApplier {
+	return &VaultRotateApplier{rotate: rotate, next: next}
+}
+
+// Apply signals an approved rotation, then delegates. The gateway only invokes Apply
+// for approved changes, so reaching here means a human approved the rotation.
+func (a *VaultRotateApplier) Apply(ctx context.Context, req contract.ChangeRequest, d contract.Decision) error {
+	if len(req.After) > 0 {
+		var p vaultRotatePayload
+		// Best-effort: a payload with no "vaultRotate" field simply yields none.
+		if err := json.Unmarshal(req.After, &p); err == nil && p.VaultRotate != nil {
+			if a.rotate == nil {
+				return fmt.Errorf("vault rotate apply: no rotation signaller wired")
+			}
+			if strings.TrimSpace(string(req.AgentGroupID)) == "" {
+				return fmt.Errorf("vault rotate apply: change has no agent group id")
+			}
+			cred := strings.ToLower(strings.TrimSpace(p.VaultRotate.Credential))
+			if !validVaultCredName(cred) {
+				return fmt.Errorf("vault rotate apply: invalid credential name %q", p.VaultRotate.Credential)
+			}
+			if err := a.rotate(req.AgentGroupID, cred); err != nil {
+				return fmt.Errorf("vault rotate apply: %w", err)
+			}
+		}
+	}
+	if a.next != nil {
+		return a.next.Apply(ctx, req, d)
+	}
+	return nil
+}
+
+// VaultRotateVerifier rejects a malformed rotation change before it ever reaches a
+// human, and marks a well-formed one as requiring human approval (rotating a
+// credential is privileged — it is never auto-approved). It is deterministic (a pure
+// shape check, no I/O) and additive: a change with no vaultRotate body passes through
+// untouched.
+type VaultRotateVerifier struct{}
+
+// Name identifies the verifier.
+func (VaultRotateVerifier) Name() string { return "vault-rotate" }
+
+// Verify checks a rotation change's shape. Non-rotation changes pass through.
+func (VaultRotateVerifier) Verify(ctx context.Context, req contract.ChangeRequest) (contract.Verdict, string, error) {
+	if len(req.After) == 0 {
+		return contract.VerdictPass, "", nil
+	}
+	var p vaultRotatePayload
+	if err := json.Unmarshal(req.After, &p); err != nil || p.VaultRotate == nil {
+		// Not a rotation change (or an unrelated payload); nothing to say.
+		return contract.VerdictPass, "", nil
+	}
+	if strings.TrimSpace(string(req.AgentGroupID)) == "" {
+		return contract.VerdictReject, "vault rotate change must target an agent group", nil
+	}
+	if !validVaultCredName(p.VaultRotate.Credential) {
+		return contract.VerdictReject, fmt.Sprintf("invalid vault credential name %q", p.VaultRotate.Credential), nil
+	}
+	return contract.VerdictRequireHuman, "vault credential rotation requires human approval", nil
+}

--- a/internal/host/gateway/vault_rotate_applier_test.go
+++ b/internal/host/gateway/vault_rotate_applier_test.go
@@ -1,0 +1,125 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+)
+
+func rotateAfter(t *testing.T, credential string) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{"vaultRotate": map[string]any{"credential": credential}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+func TestVaultRotateApplierSignalsApprovedRotation(t *testing.T) {
+	var gotID contract.AgentGroupID
+	var gotCred string
+	called := 0
+	rotate := func(id contract.AgentGroupID, cred string) error {
+		called++
+		gotID = id
+		gotCred = cred
+		return nil
+	}
+	a := NewVaultRotateApplier(rotate, nil)
+	req := contract.ChangeRequest{
+		Kind:         contract.ChangePermissions,
+		AgentGroupID: "grp-1",
+		After:        rotateAfter(t, "GitHub"),
+	}
+	if err := a.Apply(context.Background(), req, contract.Decision{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("rotate called %d times, want 1", called)
+	}
+	if gotID != "grp-1" {
+		t.Fatalf("group id = %q, want grp-1 (must come from req, not payload)", gotID)
+	}
+	if gotCred != "github" {
+		t.Fatalf("credential = %q, want normalized github", gotCred)
+	}
+}
+
+func TestVaultRotateApplierPassesThroughNonRotatePayload(t *testing.T) {
+	called := 0
+	rotate := func(contract.AgentGroupID, string) error { called++; return nil }
+	a := NewVaultRotateApplier(rotate, nil)
+	req := contract.ChangeRequest{
+		Kind:         contract.ChangePermissions,
+		AgentGroupID: "grp-1",
+		After:        json.RawMessage(`{"vaultPolicy":{"rules":[]}}`),
+	}
+	if err := a.Apply(context.Background(), req, contract.Decision{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if called != 0 {
+		t.Fatalf("rotate called %d times for a non-rotate payload, want 0", called)
+	}
+}
+
+func TestVaultRotateApplierErrorsWhenSignallerMissing(t *testing.T) {
+	a := NewVaultRotateApplier(nil, nil)
+	req := contract.ChangeRequest{
+		Kind:         contract.ChangePermissions,
+		AgentGroupID: "grp-1",
+		After:        rotateAfter(t, "github"),
+	}
+	if err := a.Apply(context.Background(), req, contract.Decision{}); err == nil {
+		t.Fatal("Apply with a recognized rotation but no signaller should error, not silently drop it")
+	}
+}
+
+func TestVaultRotateVerifierRequiresHuman(t *testing.T) {
+	v := VaultRotateVerifier{}
+	req := contract.ChangeRequest{AgentGroupID: "grp-1", After: rotateAfter(t, "github")}
+	verdict, _, err := v.Verify(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if verdict != contract.VerdictRequireHuman {
+		t.Fatalf("verdict = %v, want RequireHuman (rotation is privileged)", verdict)
+	}
+}
+
+func TestVaultRotateVerifierRejectsBadName(t *testing.T) {
+	v := VaultRotateVerifier{}
+	req := contract.ChangeRequest{AgentGroupID: "grp-1", After: rotateAfter(t, "../etc/passwd")}
+	verdict, _, err := v.Verify(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if verdict != contract.VerdictReject {
+		t.Fatalf("verdict = %v, want Reject for a path-traversal credential name", verdict)
+	}
+}
+
+func TestVaultRotateVerifierRejectsMissingGroup(t *testing.T) {
+	v := VaultRotateVerifier{}
+	req := contract.ChangeRequest{After: rotateAfter(t, "github")}
+	verdict, _, err := v.Verify(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if verdict != contract.VerdictReject {
+		t.Fatalf("verdict = %v, want Reject when no agent group is targeted", verdict)
+	}
+}
+
+func TestVaultRotateVerifierPassesThroughNonRotate(t *testing.T) {
+	v := VaultRotateVerifier{}
+	req := contract.ChangeRequest{AgentGroupID: "grp-1", After: json.RawMessage(`{"vaultPolicy":{"rules":[]}}`)}
+	verdict, _, err := v.Verify(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if verdict != contract.VerdictPass {
+		t.Fatalf("verdict = %v, want Pass for a non-rotate payload", verdict)
+	}
+}

--- a/internal/host/vaultinjector/injector.go
+++ b/internal/host/vaultinjector/injector.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -119,10 +120,11 @@ func (c *Config) CredHosts() map[string]string {
 	return out
 }
 
-// AuditRecord is one injection decision, emitted to an AuditSink. It carries the
-// credential NAME and correlation id — never the secret value.
+// AuditRecord is one injection or rotation decision, emitted to an AuditSink. It
+// carries the credential NAME and correlation id — never the secret value.
 type AuditRecord struct {
 	Time          time.Time     `json:"time"`
+	Action        string        `json:"action,omitempty"` // "inject" (default) or "rotate"
 	Credential    string        `json:"credential"`
 	CorrelationID string        `json:"correlationId,omitempty"`
 	Upstream      string        `json:"upstream,omitempty"`
@@ -136,18 +138,23 @@ type AuditRecord struct {
 type AuditSink func(AuditRecord)
 
 // resolved is one credential ready to attach: upstream + the secret value pulled from
-// the environment at construction.
+// the environment at construction. secretEnv is retained so Rotate can re-resolve the
+// secret from the same host env var the credential was configured against.
 type resolved struct {
-	upstream *url.URL
-	secret   string
-	header   string
-	scheme   string
+	upstream  *url.URL
+	secret    string
+	secretEnv string
+	header    string
+	scheme    string
 }
 
 // Injector attaches host-held credentials to broker-forwarded requests. It holds the
-// secret values resolved from the environment; the config file never does.
+// secret values resolved from the environment; the config file never does. The held
+// secrets are guarded by mu so a Rotate can swap one atomically while Handler reads it.
 type Injector struct {
-	creds     map[string]resolved
+	mu        sync.RWMutex
+	creds     map[string]*resolved
+	lookupEnv func(string) (string, bool)
 	transport http.RoundTripper
 	audit     AuditSink
 }
@@ -176,7 +183,7 @@ func New(cfg *Config, lookupEnv func(string) (string, bool), opts ...Option) (*I
 	if lookupEnv == nil {
 		lookupEnv = os.LookupEnv
 	}
-	i := &Injector{creds: make(map[string]resolved, len(cfg.Creds)), transport: http.DefaultTransport}
+	i := &Injector{creds: make(map[string]*resolved, len(cfg.Creds)), lookupEnv: lookupEnv, transport: http.DefaultTransport}
 	for name, spec := range cfg.Creds {
 		u, err := url.Parse(strings.TrimSpace(spec.Upstream))
 		if err != nil {
@@ -194,7 +201,7 @@ func New(cfg *Config, lookupEnv func(string) (string, bool), opts ...Option) (*I
 		if scheme == "" {
 			scheme = "Bearer "
 		}
-		i.creds[strings.ToLower(name)] = resolved{upstream: u, secret: secret, header: header, scheme: scheme}
+		i.creds[strings.ToLower(name)] = &resolved{upstream: u, secret: secret, secretEnv: spec.SecretEnv, header: header, scheme: scheme}
 	}
 	for _, o := range opts {
 		o(i)
@@ -213,6 +220,68 @@ func (i *Injector) Creds() []string {
 	return out
 }
 
+// Rotate re-resolves a credential's secret from its configured secretEnv via the
+// injector's env lookup and atomically swaps the held value. This is the injector's
+// half of the rotation contract (IRO-144): the control plane signals a rotation only
+// AFTER a human approves it, and the new secret is read from the host environment
+// here — it NEVER travels through the control plane, the change body, or this call.
+// An unknown credential, or a secret env that is now unset/empty, returns an error
+// and KEEPS the old secret, so a botched rotation fails closed rather than blanking a
+// live credential. The secret value is never returned or logged.
+func (i *Injector) Rotate(cred string) error {
+	cred = strings.ToLower(strings.TrimSpace(cred))
+	i.mu.RLock()
+	res, ok := i.creds[cred]
+	env := ""
+	if ok {
+		env = res.secretEnv
+	}
+	i.mu.RUnlock()
+	if cred == "" || !ok {
+		return fmt.Errorf("vaultinjector: unknown credential %q", cred)
+	}
+	secret, found := i.lookupEnv(env)
+	if !found || secret == "" {
+		return fmt.Errorf("vaultinjector: credential %q secret env %q is unset", cred, env)
+	}
+	i.mu.Lock()
+	i.creds[cred].secret = secret
+	i.mu.Unlock()
+	return nil
+}
+
+// RotateHandler serves the injector's CONTROL surface: a request that re-resolves a
+// credential's held secret from the host environment. It is SEPARATE from Handler
+// (the broker-facing proxy) and MUST be bound to a channel only the control plane can
+// reach — its own loopback addr / unix socket, never the broker's — so the sandbox can
+// never trigger a rotation. The request carries the credential NAME in CredHeader
+// (never a secret) and returns no secret: 200 on a successful rotation, 403 for an
+// unknown credential, 502 when the new secret cannot be resolved. Every outcome is
+// audited (name + correlation only).
+func (i *Injector) RotateHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		cred := strings.ToLower(strings.TrimSpace(r.Header.Get(CredHeader)))
+		corr := r.Header.Get(CorrelationHeader)
+		err := i.Rotate(cred)
+		status := http.StatusOK
+		switch {
+		case err == nil:
+		case strings.Contains(err.Error(), "unknown credential"):
+			status = http.StatusForbidden
+		default:
+			status = http.StatusBadGateway
+		}
+		i.emit(AuditRecord{Time: start, Action: "rotate", Credential: cred, CorrelationID: corr, Path: "/rotate", Status: status, Allowed: err == nil, Duration: time.Since(start)})
+		if err != nil {
+			http.Error(w, "vaultinjector: rotate failed", status)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("rotated\n"))
+	})
+}
+
 // Handler serves the injector: it reads the credential name, attaches the host-held
 // secret, and reverse-proxies to the real upstream. Deny-by-default: an unknown or
 // missing credential is refused 403. The secret is attached only on the upstream hop
@@ -226,17 +295,24 @@ func (i *Injector) Handler() http.Handler {
 		if r.URL != nil {
 			path = r.URL.Path
 		}
+		// Snapshot the credential under the read lock so a concurrent Rotate cannot
+		// swap the secret mid-request; the proxy below uses these copies.
+		i.mu.RLock()
 		res, ok := i.creds[cred]
+		var target url.URL
+		var secret, header, scheme string
+		if ok {
+			target = *res.upstream
+			secret = res.secret
+			header = res.header
+			scheme = res.scheme
+		}
+		i.mu.RUnlock()
 		if cred == "" || !ok {
 			http.Error(w, "vaultinjector: unknown credential", http.StatusForbidden)
-			i.emit(AuditRecord{Time: start, Credential: cred, CorrelationID: corr, Path: path, Status: http.StatusForbidden, Allowed: false, Duration: time.Since(start)})
+			i.emit(AuditRecord{Time: start, Action: "inject", Credential: cred, CorrelationID: corr, Path: path, Status: http.StatusForbidden, Allowed: false, Duration: time.Since(start)})
 			return
 		}
-
-		target := *res.upstream
-		secret := res.secret
-		header := res.header
-		scheme := res.scheme
 		rp := &httputil.ReverseProxy{
 			Director: func(req *http.Request) {
 				req.URL.Scheme = target.Scheme
@@ -255,7 +331,7 @@ func (i *Injector) Handler() http.Handler {
 		}
 		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		rp.ServeHTTP(rec, r)
-		i.emit(AuditRecord{Time: start, Credential: cred, CorrelationID: corr, Upstream: target.Host, Path: path, Status: rec.status, Allowed: true, Duration: time.Since(start)})
+		i.emit(AuditRecord{Time: start, Action: "inject", Credential: cred, CorrelationID: corr, Upstream: target.Host, Path: path, Status: rec.status, Allowed: true, Duration: time.Since(start)})
 	})
 }
 

--- a/internal/host/vaultinjector/injector_rotate_test.go
+++ b/internal/host/vaultinjector/injector_rotate_test.go
@@ -1,0 +1,162 @@
+package vaultinjector
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestRotateSwapsHeldSecret: after Rotate re-reads the env, subsequent injections
+// attach the NEW secret. The new value never travels through Rotate — it is read from
+// the (mutated) host env, mirroring an operator rotating the secret in its source.
+func TestRotateSwapsHeldSecret(t *testing.T) {
+	var seen string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+
+	env := map[string]string{"TOK": "old-secret"}
+	cfg := &Config{Creds: map[string]CredSpec{"github": {Upstream: upstream.URL, SecretEnv: "TOK"}}}
+	inj, err := New(cfg, fakeEnv(env))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	srv := httptest.NewServer(inj.Handler())
+	defer srv.Close()
+	do := func() {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/", nil)
+		req.Header.Set(CredHeader, "github")
+		resp, derr := (&http.Client{}).Do(req)
+		if derr != nil {
+			t.Fatalf("do: %v", derr)
+		}
+		resp.Body.Close()
+	}
+
+	do()
+	if seen != "Bearer old-secret" {
+		t.Fatalf("before rotate: upstream saw %q, want Bearer old-secret", seen)
+	}
+
+	// Operator rotates the secret at its source, then signals the injector.
+	env["TOK"] = "new-secret"
+	if err := inj.Rotate("github"); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+	do()
+	if seen != "Bearer new-secret" {
+		t.Fatalf("after rotate: upstream saw %q, want Bearer new-secret", seen)
+	}
+}
+
+// TestRotateUnknownCredential: an unknown credential is refused (deny-by-default) and
+// the control handler reports 403, never touching any held secret.
+func TestRotateUnknownCredential(t *testing.T) {
+	env := map[string]string{"TOK": "s"}
+	cfg := &Config{Creds: map[string]CredSpec{"github": {Upstream: "https://api.github.com", SecretEnv: "TOK"}}}
+	inj, err := New(cfg, fakeEnv(env))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := inj.Rotate("stripe"); err == nil {
+		t.Fatal("Rotate of unknown credential should error")
+	}
+
+	srv := httptest.NewServer(inj.RotateHandler())
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/rotate", nil)
+	req.Header.Set(CredHeader, "stripe")
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+// TestRotateFailsClosedOnUnsetSecret: if the secret env is now unset/empty, Rotate
+// errors and KEEPS the previous secret rather than blanking a live credential.
+func TestRotateFailsClosedOnUnsetSecret(t *testing.T) {
+	var seen string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("Authorization")
+	}))
+	defer upstream.Close()
+
+	env := map[string]string{"TOK": "live-secret"}
+	cfg := &Config{Creds: map[string]CredSpec{"github": {Upstream: upstream.URL, SecretEnv: "TOK"}}}
+	inj, err := New(cfg, fakeEnv(env))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	delete(env, "TOK") // secret source went away
+	if err := inj.Rotate("github"); err == nil {
+		t.Fatal("Rotate with unset secret env should error (fail closed)")
+	}
+
+	// The old secret must still be served.
+	srv := httptest.NewServer(inj.Handler())
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/", nil)
+	req.Header.Set(CredHeader, "github")
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	resp.Body.Close()
+	if seen != "Bearer live-secret" {
+		t.Fatalf("after failed rotate: upstream saw %q, want the unchanged Bearer live-secret", seen)
+	}
+}
+
+// TestRotateHandlerAuditNoSecret: a successful rotation audits with Action=="rotate"
+// and the credential NAME, and the response body carries no secret.
+func TestRotateHandlerAuditNoSecret(t *testing.T) {
+	env := map[string]string{"TOK": "first"}
+	cfg := &Config{Creds: map[string]CredSpec{"github": {Upstream: "https://api.github.com", SecretEnv: "TOK"}}}
+	var mu sync.Mutex
+	var recs []AuditRecord
+	inj, err := New(cfg, fakeEnv(env), WithAudit(func(r AuditRecord) {
+		mu.Lock()
+		recs = append(recs, r)
+		mu.Unlock()
+	}))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	env["TOK"] = "second"
+
+	srv := httptest.NewServer(inj.RotateHandler())
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/rotate", nil)
+	req.Header.Set(CredHeader, "github")
+	req.Header.Set(CorrelationHeader, "corr-rot")
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if strings.Contains(string(body), "second") || strings.Contains(string(body), "first") {
+		t.Fatalf("rotate response leaked a secret: %q", body)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(recs) != 1 {
+		t.Fatalf("audit records = %d, want 1", len(recs))
+	}
+	got := recs[0]
+	if got.Action != "rotate" || got.Credential != "github" || !got.Allowed || got.CorrelationID != "corr-rot" {
+		t.Fatalf("audit = %+v, want rotate/github/allowed/corr-rot", got)
+	}
+}


### PR DESCRIPTION
## What

Adds gateway-gated, audited **credential-secret rotation** (`ironctl vault rotate`), the last open item of the credential vault (IRO-144, follow-up to IRO-140). The blocker IRO-138 (reference injector) shipped to main, so rotation now has a concrete injector contract to drive.

## Why this shape

The control plane **never holds the credential's secret** — the host-side injector does (threat-model §11). So rotation is fundamentally an *injector* operation: the injector re-resolves the secret from its configured `secretEnv` and swaps the held value. **No secret travels through the control plane, the CLI, the change body, or the audit log** — in either direction. The operator updates the secret at its source (env / secret manager), then `vault rotate` signals the injector to pick it up.

It rides the **exact same human-approval + audit path** as the `vaultPolicy` CRUD shipped in IRO-140: a `permissions`-class change carrying a `vaultRotate` body that names only the credential, marked `RequireHuman`, applied by a payload-keyed applier.

## Changes

- **`internal/host/vaultinjector`**: `Rotate(cred)` re-reads `secretEnv` and atomically swaps the held secret under a lock; **fails closed** (keeps the old secret) on an unset/empty env. New `RotateHandler()` is a control-only surface (`POST /rotate`, credential **name** header, no secret in or out), audited as `action=rotate`.
- **`cmd/ironclaw-vault-injector`**: opt-in `--control-socket` / `--control-addr` second listener for the rotation surface, **separate** from the broker-facing proxy — only the control plane reaches it.
- **`internal/host/gateway`**: `VaultRotateVerifier` (RequireHuman; rejects malformed/path-traversal names) + `VaultRotateApplier` signalling a `RotateCredentialFunc` seam — mirrors `VaultPolicyApplier`.
- **`cmd/controlplane`**: `--vault-control-endpoint` wires the seam to the injector control surface (`http(s)://` or `unix:`). Absent ⇒ rotation unconfigured; an approved rotation then fails loudly rather than silently no-opping.
- **`cmd/ironctl`**: `vault rotate --group --credential [--by]` proposes the gateway-gated change.
- **`docs/vault.md`**: rotation section + updated run example.

## Acceptance

> Credential secret rotation usable (CLI or console), gateway-gated + audited, with no plaintext secret surfaced. ✅

- Usable: `ironctl vault rotate …` (console can POST the same change).
- Gateway-gated: `permissions` change, `VaultRotateVerifier` → `RequireHuman`.
- Audited: injector emits `action=rotate` records (name + correlation only).
- No plaintext secret: nothing carries a key; CLI test asserts the change body has no secret-like field.

## Tests

Injector swap / unknown-cred 403 / fail-closed / audit-no-leak; gateway verify + apply (incl. setter-missing, non-rotate passthrough, bad-name reject); CLI payload shape (no secret field, normalized name); control-plane signaller (POST /rotate, non-2xx ⇒ error, bad-endpoint reject). `go vet` clean; **204 tests pass** across the 5 touched packages.

Closes IRO-144.