### PR TITLE
docs(seo): technical SEO hardening for the docs/landing site (IRO-164)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,8 @@
+---
+title: "Architecture: control-plane, gVisor sandboxes & encrypted queues"
+description: How IronClaw fits together — a host control-plane orchestrates per-session gVisor sandboxes that talk only through a pair of encrypted SQLCipher queues.
+---
+
 # Architecture
 
 IronClaw is a security-hardened, open-source assistant platform written entirely

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,3 +1,8 @@
+---
+title: "Channels: connect your AI agent to Slack, Discord & more"
+description: Connect your self-hosted AI agent to Slack, Discord, Telegram and 8 more channels. Credentials stay host-side and never enter the gVisor sandbox.
+---
+
 # Channel adapters & their credentials
 
 IronClaw delivers an agent's replies through **channel adapters** in

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,3 +1,8 @@
+---
+title: "FAQ: self-hosted, sandboxed AI agents"
+description: Straight answers on running self-hosted, sandboxed AI agents — gVisor isolation, the zero-credential demo, host-side API-key custody, and production readiness.
+---
+
 # FAQ
 
 Short, straight answers to the questions people ask before (and right after) their

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,3 +1,8 @@
+---
+title: "MCP servers: gated, audited tools outside the sandbox"
+description: Add MCP server tools to a self-hosted AI agent without weakening the gVisor sandbox — a human approves named servers and tools, and every call is gated and audited.
+---
+
 # MCP servers
 
 IronClaw can extend an agent with the tools of a **Model Context Protocol (MCP)**

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,3 +1,8 @@
+---
+title: "Quickstart: zero-credential AI agent in 5 minutes"
+description: Run a self-hosted AI agent gateway in about five minutes — zero credentials, no model key. One Docker command launches a real per-session gVisor sandbox that replies.
+---
+
 # Quickstart
 
 Two short paths, pick one:

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,8 @@
+# robots.txt for the IronClaw documentation site.
+# Copied verbatim into the site root by MkDocs (non-Markdown files in docs/ are
+# treated as static assets). Allows all well-behaved crawlers and advertises the
+# MkDocs-generated sitemap so search engines can discover every page.
+User-agent: *
+Allow: /
+
+Sitemap: https://ironsecco.github.io/ironclaw/sitemap.xml

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,3 +1,8 @@
+---
+title: "Security & trust: gVisor sandbox + approval gateway"
+description: How IronClaw's security holds — per-session gVisor sandboxes with network=none, a no-bypass human approval gateway, and cosign-signed, reproducible releases you can verify.
+---
+
 # Security & trust
 
 IronClaw's value is not "AI agents" — it is **AI agents you can run without

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,3 +1,8 @@
+---
+title: "Skills: declarative capability bundles, no in-sandbox code"
+description: Skills are declarative capability bundles for IronClaw agents — persona, tool subset, egress allowlist — composed through the human-approval gateway, never new code in the sandbox.
+---
+
 # Skills
 
 A **skill** is a declarative, host-curated **capability bundle** — a persona

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,3 +1,8 @@
+---
+title: "Threat model: a compromised AI agent that can't escalate"
+description: IronClaw's threat model assumes the agent is compromised. A zero-credential, network-sealed gVisor sandbox and a no-bypass approval gateway keep it from escalating.
+---
+
 # Threat model
 
 > Versioned with the code. Linked from the [README](https://github.com/IronSecCo/ironclaw/blob/main/README.md) and

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -32,4 +32,58 @@
   <meta name="twitter:title" content="{{ _title }}">
   <meta name="twitter:description" content="{{ _descr }}">
   <meta name="twitter:image" content="{{ _image }}">
+  {#- Structured data (schema.org JSON-LD) on the homepage only. Two linked
+      nodes in one @graph: the product (SoftwareApplication) and its source
+      (SoftwareSourceCode). Keeps every URL absolute so validators resolve them.
+      Validate with https://validator.schema.org/ against the rendered home. -#}
+  {% if page and page.is_homepage %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "SoftwareApplication",
+        "@id": "{{ config.site_url }}#software",
+        "name": "IronClaw",
+        "alternateName": "IronClaw self-hosted AI agent gateway",
+        "applicationCategory": "DeveloperApplication",
+        "applicationSubCategory": "AI agent gateway",
+        "operatingSystem": "Linux, macOS",
+        "url": "{{ config.site_url }}",
+        "downloadUrl": "https://github.com/IronSecCo/ironclaw/releases",
+        "description": "Security-first, self-hosted AI agent gateway. Every agent runs in a per-session gVisor sandbox with network=none, reaches the model only through a host-side proxy, and cannot change its own configuration without a human approving it at a no-bypass gateway.",
+        "keywords": "self-hosted AI agent gateway, gVisor sandbox, zero-credential, AI agent security, human approval gateway, sandboxed AI agents",
+        "license": "https://github.com/IronSecCo/ironclaw/blob/main/LICENSE",
+        "isAccessibleForFree": true,
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "author": {
+          "@type": "Organization",
+          "name": "IronSec Co.",
+          "url": "https://github.com/IronSecCo"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "IronSec Co.",
+          "url": "https://github.com/IronSecCo"
+        }
+      },
+      {
+        "@type": "SoftwareSourceCode",
+        "@id": "https://github.com/IronSecCo/ironclaw#source",
+        "name": "IronClaw",
+        "description": "Open-source (AGPLv3) source for IronClaw, a self-hosted AI agent gateway that seals each agent in a gVisor sandbox and gates every capability change behind human approval.",
+        "codeRepository": "https://github.com/IronSecCo/ironclaw",
+        "programmingLanguage": "Go",
+        "license": "https://github.com/IronSecCo/ironclaw/blob/main/LICENSE",
+        "url": "{{ config.site_url }}",
+        "about": { "@id": "{{ config.site_url }}#software" }
+      }
+    ]
+  }
+  </script>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary

Technical SEO + organic-discoverability hardening for the live docs site (`ironsecco.github.io/ironclaw`) ahead of public launch. Ungated docs work per IRO-164 — ships via the existing `docs.yml` push-to-main deploy.

### What changed
- **robots.txt** — new `docs/robots.txt` (copied to site root) that allows all crawlers and advertises the sitemap.
- **JSON-LD structured data** — `SoftwareApplication` + `SoftwareSourceCode` (`@graph`) added to the homepage only, via `overrides/main.html` `extrahead` with an `is_homepage` guard. All URLs absolute.
- **Per-page `<title>` + meta description** — unique, keyword-aligned front-matter on `quickstart`, `security`, `channels`, `architecture`, `threat-model`, `skills`, `mcp`, `faq` (target keywords: *self-hosted AI agent gateway*, *gVisor sandbox*, *zero-credential*). `index` + `comparison` already had theirs.

### Already correct (verified, no change needed)
- `sitemap.xml` (+ `.gz`) is auto-emitted by MkDocs core — 27 URLs.
- Canonical URLs emitted per page by Material.
- `og:image` / `twitter:card` are absolute (IRO-135); the asset resolves **HTTP 200** on the live site.
- Every rendered page already links to **quickstart** + **comparison** via the global nav.

### Verification
`mkdocs build --strict` — clean build. Then against the built `_site`:
- `robots.txt` present at root with `Sitemap:` line ✅
- `sitemap.xml` (27 urls) + `sitemap.xml.gz` ✅
- JSON-LD parses as valid JSON; present on `index.html` only (0 on subpages) ✅
- All 10 audited pages have **unique** meta descriptions ✅
- Canonical URLs correct per page ✅
- og/twitter image absolute; live asset HTTP 200 ✅
- 0 pages missing a quickstart or comparison link ✅

Self-merge on green CI per the established ungated-trunk docs policy (no board approval required).