### PR TITLE
fix(brew): qualify install name — homebrew-core owns bare `ironclaw` (IRO-175)

### DIFF
--- a/Formula/ironclaw.rb
+++ b/Formula/ironclaw.rb
@@ -8,7 +8,11 @@
 # newer release, re-run that script and commit the result.
 #
 # Install:  brew tap IronSecCo/ironclaw https://github.com/IronSecCo/ironclaw
-#           brew install ironclaw
+#           brew install ironsecco/ironclaw/ironclaw
+#
+# NOTE: homebrew-core ships an UNRELATED formula also named "ironclaw", and core
+# wins the bare name. Always install the fully-qualified tap formula above; a bare
+# "brew install ironclaw" would fetch the core package, not this one.
 class Ironclaw < Formula
   desc "Security-hardened, self-hosted AI assistant platform (secured Go port)"
   homepage "https://github.com/IronSecCo/ironclaw"

--- a/README.md
+++ b/README.md
@@ -308,12 +308,16 @@ intentionally **not vendored**. See [`deploy/README.md`](deploy/README.md) for h
 
 ```sh
 brew tap IronSecCo/ironclaw https://github.com/IronSecCo/ironclaw
-brew install ironclaw
+brew install ironsecco/ironclaw/ironclaw
 ```
 
 This installs `ironctl`, `ironclaw-controlplane`, and `ironclaw-sandbox` from the latest release. The
 formula pins each archive to the SHA-256 recorded in the release's signed `SHA256SUMS`, so Homebrew
 verifies the download before installing. Confirm it with `ironctl version`.
+
+> **Use the fully-qualified name.** homebrew-core ships an *unrelated* formula also called `ironclaw`,
+> and core wins the bare name — so install `ironsecco/ironclaw/ironclaw`, not bare `ironclaw`. The
+> explicit tap URL is required too: our tap lives in this repo, not a `homebrew-ironclaw` repo.
 
 > In production the control plane usually runs as the GHCR container image (see the
 > [deployment guide](https://ironsecco.github.io/ironclaw/deployment/)); the native

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -109,9 +109,10 @@ If the build fails with an SQLite/cgo error, your C toolchain isn't set up — s
     On macOS or Linux you can install the latest checksum-verified release instead of building:
 
     ```sh
-    # Homebrew (macOS / Linux)
+    # Homebrew (macOS / Linux) — use the fully-qualified name (homebrew-core has an
+    # unrelated formula also called `ironclaw`).
     brew tap IronSecCo/ironclaw https://github.com/IronSecCo/ironclaw
-    brew install ironclaw
+    brew install ironsecco/ironclaw/ironclaw
 
     # …or the one-line installer (verifies SHA256SUMS before installing)
     curl -fsSL https://raw.githubusercontent.com/IronSecCo/ironclaw/main/scripts/install.sh | sh

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -152,10 +152,15 @@ that point). This gate lands with IRO-15.
 
 ### 3.6 Bump the Homebrew formula (after a release you want `brew install` to track)
 
-`brew install ironclaw` is served by `Formula/ironclaw.rb` in this repo, tapped with
-`brew tap IronSecCo/ironclaw https://github.com/IronSecCo/ironclaw`. The formula pins each
+`brew install ironsecco/ironclaw/ironclaw` is served by `Formula/ironclaw.rb` in this repo, tapped
+with `brew tap IronSecCo/ironclaw https://github.com/IronSecCo/ironclaw`. The formula pins each
 platform archive to the SHA-256 recorded in that release's **signed `SHA256SUMS`** — the same
 trust anchor `install.sh` uses — so a `brew` user gets the same checksum-verified bytes.
+
+> **Name collision (important).** homebrew-core ships an *unrelated* formula also named `ironclaw`,
+> and core wins the bare name. Always install/verify the **fully-qualified** `ironsecco/ironclaw/ironclaw`
+> — a bare `brew install ironclaw` fetches the core package, not ours. The explicit tap URL above is
+> also required (the tap is this repo, not a `homebrew-ironclaw` repo).
 
 Because a new release is cut on every push to `main`, the formula is intentionally **pinned, not
 auto-tracking**: it points at one specific tag and is bumped deliberately. There is **no CI job

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -55,6 +55,9 @@ LINUX_AMD64="$(sum "ironclaw_${VERSION}_linux_amd64.tar.gz")"
 base="https://github.com/${REPO}/releases/download/${TAG}"
 
 mkdir -p "${ROOT}/Formula"
+# NOTE: this is an UNQUOTED heredoc so ${VERSION}/${TAG}/${base}/${sha} expand. Do
+# NOT put backticks or $(...) in the template below — the shell would execute them.
+# Ruby string interpolation (#{version}, #{bin}) is safe (no leading $).
 cat > "$OUT" <<EOF
 # typed: false
 # frozen_string_literal: true
@@ -66,7 +69,11 @@ cat > "$OUT" <<EOF
 # newer release, re-run that script and commit the result.
 #
 # Install:  brew tap IronSecCo/ironclaw https://github.com/IronSecCo/ironclaw
-#           brew install ironclaw
+#           brew install ironsecco/ironclaw/ironclaw
+#
+# NOTE: homebrew-core ships an UNRELATED formula also named "ironclaw", and core
+# wins the bare name. Always install the fully-qualified tap formula above; a bare
+# "brew install ironclaw" would fetch the core package, not this one.
 class Ironclaw < Formula
   desc "Security-hardened, self-hosted AI assistant platform (secured Go port)"
   homepage "https://github.com/IronSecCo/ironclaw"


### PR DESCRIPTION
## Why

Follow-up to #196. While verifying the real `brew tap` flow end-to-end I hit a name collision: **homebrew-core already ships an unrelated formula named `ironclaw`** (v0.29.1, an unrelated "WASM sandbox" assistant). Core wins the bare name, so a bare `brew install ironclaw` installs the **wrong** package — a trust footgun. #196's docs showed the bare command.

## Fix — use the fully-qualified name everywhere

```sh
brew tap IronSecCo/ironclaw https://github.com/IronSecCo/ironclaw
brew install ironsecco/ironclaw/ironclaw
```

- README / quickstart / runbook: qualified install command + explicit collision note (also: the tap needs the explicit URL since our tap is this repo, not a `homebrew-ironclaw` repo).
- `Formula/ironclaw.rb` header + generator: same note.
- **Generator bug fixed:** the `cat <<EOF` template is an *unquoted* heredoc, so backticks I added in the note executed as a command substitution and corrupted the formula. Removed the backticks and added a guard comment so it can't recur. (The formula merged in #196 had no backticks, so `main` was never broken.)

## Verification (macOS, local tap)
- `bash -n` on the generator → OK
- `brew style Formula/ironclaw.rb` → no offenses
- `brew install ironsecco/ironclaw/ironclaw` → builds 0.1.80 (25.3MB, 7 files)
- `ironctl version` → `ironctl v0.1.80`
- `brew test ironclaw` → exit 0

Ungated / self-merge on green CI (IRO-175).