### PR TITLE
feat(console): accessibility & keyboard-nav hardening pass (IRO-176)

### DIFF
--- a/web/static/agents.js
+++ b/web/static/agents.js
@@ -44,7 +44,7 @@ const Agents = (() => {
     box.replaceChildren();
     if (!personaSections.length) {
       // Fallback: a single textarea so persona is still editable if the schema fails.
-      box.append(el("textarea", { id: "ab-persona", rows: "3", placeholder: "How it should behave (optional)" }));
+      box.append(el("textarea", { id: "ab-persona", rows: "3", "aria-label": "Persona", placeholder: "How it should behave (optional)" }));
       return;
     }
     for (const sec of personaSections) {
@@ -53,7 +53,7 @@ const Agents = (() => {
           el("span", { class: "pd-title", text: sec.title }),
           el("span", { class: "pd-file mono", text: sec.filename }),
           el("span", { class: "pd-help", text: sec.help })),
-        el("textarea", { rows: "2", "data-doc": sec.key, placeholder: sec.placeholder })));
+        el("textarea", { id: "ab-doc-" + sec.key, rows: "2", "data-doc": sec.key, "aria-label": sec.title, placeholder: sec.placeholder })));
     }
   }
 

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -96,6 +96,37 @@ function emptyState(title, sub, ctaLabel, ctaPanel, icon) {
   return box;
 }
 
+// linkFieldLabels associates each single-control field label with its control so
+// assistive tech announces the field name when the control is focused (WCAG 1.3.1 /
+// 4.1.2). The console builds forms as `<div class="field"><label>…</label><control>`
+// with no `for`; wiring it once here keeps the markup clean and is idempotent, so it
+// can re-run safely when panels render their forms lazily (Setup, MCP grants).
+let _labelSeq = 0;
+function linkFieldLabels(root) {
+  for (const label of (root || document).querySelectorAll(".field > label")) {
+    if (label.htmlFor) continue;                                   // already linked
+    if (label.querySelector("input, select, textarea")) continue; // wrapping label
+    const control = label.parentElement.querySelector("input, select, textarea");
+    if (!control) continue;
+    if (!control.id) control.id = "fld-" + ++_labelSeq;
+    label.htmlFor = control.id;
+  }
+}
+
+// watchDynamicLabels re-links labels for forms built after first paint (e.g. the
+// Setup change-form, MCP tool grants). Scoped to the content area and gated on a
+// `.field` actually being added, so chat/list churn doesn't trigger needless work.
+function watchDynamicLabels() {
+  const target = document.querySelector(".content");
+  if (!target || typeof MutationObserver === "undefined") return;
+  new MutationObserver((muts) => {
+    if (muts.some((m) => [...m.addedNodes].some((n) =>
+      n.nodeType === 1 && (n.matches?.(".field") || n.querySelector?.(".field"))))) {
+      linkFieldLabels();
+    }
+  }).observe(target, { childList: true, subtree: true });
+}
+
 // ---- Agent pickers ---------------------------------------------------------
 // Any <select data-agents> is filled from /v1/ui/agents so an operator picks an
 // agent from a list instead of typing an id. Cached so panel switches are instant.
@@ -301,7 +332,12 @@ function refreshPanel(name) {
 
 function showPanel(name) {
   for (const tab of document.querySelectorAll(".nav-item")) {
-    tab.classList.toggle("active", tab.dataset.panel === name);
+    const on = tab.dataset.panel === name;
+    tab.classList.toggle("active", on);
+    // Convey the active section programmatically — the .active class alone is a
+    // visual-only signal a screen reader can't perceive (WCAG 4.1.2).
+    if (on) tab.setAttribute("aria-current", "page");
+    else tab.removeAttribute("aria-current");
   }
   for (const panel of document.querySelectorAll(".panel")) {
     const on = panel.id === name;
@@ -354,10 +390,22 @@ function init() {
 
   for (const tab of document.querySelectorAll(".nav-item")) {
     tab.addEventListener("click", () => showPanel(tab.dataset.panel));
+    // Mark the section that loads active on first paint so the state is exposed
+    // before the first navigation, not only after a click.
+    if (tab.classList.contains("active")) tab.setAttribute("aria-current", "page");
+    // Give every nav item a stable accessible name. On mobile the text span is
+    // display:none (icon-only), which would otherwise leave the button nameless
+    // to assistive tech (WCAG 4.1.2). textContent survives the CSS hide.
+    const lbl = tab.querySelector("span:not(.nav-badge)");
+    if (lbl && !tab.getAttribute("aria-label")) tab.setAttribute("aria-label", lbl.textContent.trim());
   }
   for (const b of document.querySelectorAll("[data-go]")) {
     b.addEventListener("click", () => goPanel(b.dataset.go));
   }
+
+  // Associate static field labels now and keep lazily-rendered forms covered.
+  linkFieldLabels();
+  watchDynamicLabels();
 
   // Prefill any token already held in this tab so connect() preserves it, then
   // load the visible panel immediately (works on an open loopback; a gated

--- a/web/static/channels.js
+++ b/web/static/channels.js
@@ -159,7 +159,7 @@ const Channels = (() => {
     if (!host || host.dataset.rendered) return;
     host.dataset.rendered = "1";
     host.replaceChildren(...ADAPTERS.map((a) => {
-      const input = el("input", { type: "password", placeholder: a.env + " (masked; not sent)", autocomplete: "off" });
+      const input = el("input", { type: "password", "aria-label": a.env + " value", placeholder: a.env + " (masked; not sent)", autocomplete: "off" });
       const cmd = el("pre", { class: "payload", text: "export " + a.env + "=<token>" });
       const reveal = el("button", { class: "ghost", type: "button", text: "Show export line" });
       reveal.addEventListener("click", () => {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -9,6 +9,9 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <!-- Bypass block: lets keyboard and screen-reader users jump past the 11-item
+       sidebar straight to the page content (WCAG 2.4.1). Hidden until focused. -->
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <div class="app">
     <!-- ============ Sidebar ============ -->
     <aside class="sidebar">
@@ -82,7 +85,8 @@
         <details class="conn-token">
           <summary>API token</summary>
           <div class="token-row">
-            <input id="token" type="password" placeholder="bearer token (optional on loopback)"
+            <input id="token" type="password" aria-label="API bearer token"
+                   placeholder="bearer token (optional on loopback)"
                    autocomplete="off" spellcheck="false" />
             <button id="connect" class="btn-primary btn-sm" type="button">Connect</button>
           </div>
@@ -93,7 +97,7 @@
 
     <!-- ============ Content ============ -->
     <div class="content">
-      <main>
+      <main id="main-content" tabindex="-1">
         <!-- ---- Dashboard ---- -->
         <section id="dashboard" class="panel active" aria-label="Dashboard">
           <div class="page-head">
@@ -114,7 +118,8 @@
                 your agents, approvals, and sessions. The token stays in this browser tab only
                 (<code>sessionStorage</code>) and is sent as <code>Authorization: Bearer</code>.</p>
               <div class="token-row">
-                <input id="token-fr" type="password" placeholder="bearer token (IRONCLAW_API_TOKEN)"
+                <input id="token-fr" type="password" aria-label="API bearer token"
+                       placeholder="bearer token (IRONCLAW_API_TOKEN)"
                        autocomplete="off" spellcheck="false" />
                 <button id="connect-fr" class="btn-primary" type="button">Connect</button>
               </div>
@@ -174,14 +179,14 @@
           <div class="page-head"><h1>Chat playground</h1><p class="sub">Talk to an agent group through the real engage / delivery path.</p></div>
           <div class="chat-wrap">
             <div class="chat-bar">
-              <select id="chat-ag" title="agent group"><option value="">Select an agent…</option></select>
-              <button id="chat-refresh-agents" class="ghost btn-sm" type="button">↻</button>
+              <select id="chat-ag" aria-label="Agent group" title="agent group"><option value="">Select an agent…</option></select>
+              <button id="chat-refresh-agents" class="ghost btn-sm" type="button" aria-label="Refresh agent list">↻</button>
               <span class="spacer"></span>
-              <span id="chat-status" class="muted">pick an agent group</span>
+              <span id="chat-status" class="muted" role="status">pick an agent group</span>
             </div>
-            <div id="chat-transcript"></div>
+            <div id="chat-transcript" role="log" aria-live="polite" aria-label="Conversation"></div>
             <div class="chat-compose">
-              <input id="chat-input" placeholder="Message the agent…" autocomplete="off" />
+              <input id="chat-input" aria-label="Message the agent" placeholder="Message the agent…" autocomplete="off" />
               <button id="chat-send" class="btn-primary" type="button">Send</button>
             </div>
           </div>
@@ -219,7 +224,7 @@
               chat, etc. You'll wire it to an agent in step 2.</p>
             <div class="form-row">
               <div class="field">
-                <label>Platform</label>
+                <label for="ch-mg-channel">Platform</label>
                 <select id="ch-mg-channel">
                   <option value="">Choose a platform…</option>
                   <option value="slack">Slack</option>
@@ -235,12 +240,12 @@
                 </select>
               </div>
               <div class="field" style="flex:2 1 220px">
-                <label>Where on that platform</label>
+                <label for="ch-mg-platform">Where on that platform</label>
                 <input id="ch-mg-platform" placeholder="channel / chat id (e.g. Slack C0123…, Telegram 12345)" />
                 <p class="hint">The platform's own id for the channel or chat.</p>
               </div>
               <div class="field">
-                <label>Who can trigger it</label>
+                <label for="ch-mg-policy">Who can trigger it</label>
                 <select id="ch-mg-policy">
                   <option value="strict">Only people you've added</option>
                   <option value="request_approval">Anyone, with approval</option>
@@ -255,7 +260,7 @@
             </div>
             <input id="ch-mg-instance" type="hidden" />
             <div class="form-row" style="margin-top:6px">
-              <div class="field" style="flex:2"><label>Inspect an existing surface</label><select id="ch-mg-id" data-mgs><option value="">Pick a connected surface…</option></select></div>
+              <div class="field" style="flex:2"><label for="ch-mg-id">Inspect an existing surface</label><select id="ch-mg-id" data-mgs><option value="">Pick a connected surface…</option></select></div>
               <button id="ch-mg-load" class="ghost" type="button" style="align-self:end">View wirings</button>
             </div>
             <div id="ch-channel-view" class="list"></div>
@@ -267,28 +272,28 @@
               agent should jump in.</p>
             <div class="form-row">
               <div class="field">
-                <label>Agent</label>
+                <label for="ch-w-ag">Agent</label>
                 <select id="ch-w-ag" data-agents><option value="">Select an agent…</option></select>
               </div>
-              <div class="field"><label>Chat surface</label><select id="ch-w-mg" data-mgs><option value="">Connect a surface in step 1…</option></select></div>
+              <div class="field"><label for="ch-w-mg">Chat surface</label><select id="ch-w-mg" data-mgs><option value="">Connect a surface in step 1…</option></select></div>
               <div class="field">
-                <label>When to engage</label>
+                <label for="ch-w-engage">When to engage</label>
                 <select id="ch-w-engage">
                   <option value="mention">On @mention</option>
                   <option value="mention-sticky">On @mention, then stay in the thread</option>
                   <option value="pattern">When a message matches a pattern</option>
                 </select>
               </div>
-              <div class="field"><label>Pattern (for pattern mode)</label><input id="ch-w-pattern" placeholder="e.g. deploy|incident   ·   .* for everything" /></div>
+              <div class="field"><label for="ch-w-pattern">Pattern (for pattern mode)</label><input id="ch-w-pattern" placeholder="e.g. deploy|incident   ·   .* for everything" /></div>
               <div class="field">
-                <label>Conversation memory</label>
+                <label for="ch-w-session">Conversation memory</label>
                 <select id="ch-w-session">
                   <option value="per-thread">One per thread</option>
                   <option value="shared">One shared</option>
                   <option value="agent-shared">Shared across the agent</option>
                 </select>
               </div>
-              <div class="field" style="flex:0 0 90px"><label>Priority</label><input id="ch-w-priority" type="number" value="1" /></div>
+              <div class="field" style="flex:0 0 90px"><label for="ch-w-priority">Priority</label><input id="ch-w-priority" type="number" value="1" /></div>
               <button id="ch-w-create" class="btn-primary" type="button" style="align-self:end">Wire it up</button>
             </div>
           </details>
@@ -297,12 +302,12 @@
             <summary>3 · Allow the agent to reply somewhere</summary>
             <p class="hint">An agent can only send to places you approve. Add the destinations it's allowed to post back to.</p>
             <div class="form-row">
-              <div class="field"><label>Agent</label><select id="ch-d-ag" data-agents><option value="">Select an agent…</option></select></div>
+              <div class="field"><label for="ch-d-ag">Agent</label><select id="ch-d-ag" data-agents><option value="">Select an agent…</option></select></div>
               <button id="ch-d-load" class="ghost" type="button" style="align-self:end">List allowed</button>
             </div>
             <div class="form-row">
               <div class="field">
-                <label>Platform</label>
+                <label for="ch-d-channel">Platform</label>
                 <select id="ch-d-channel">
                   <option value="">Choose a platform…</option>
                   <option value="slack">Slack</option>
@@ -317,7 +322,7 @@
                   <option value="webhook">Webhook</option>
                 </select>
               </div>
-              <div class="field" style="flex:2"><label>Where</label><input id="ch-d-platform" placeholder="channel / chat id" /></div>
+              <div class="field" style="flex:2"><label for="ch-d-platform">Where</label><input id="ch-d-platform" placeholder="channel / chat id" /></div>
               <button id="ch-d-add" class="btn-primary" type="button" style="align-self:end">Allow</button>
             </div>
             <div id="ch-dest-view" class="list"></div>
@@ -347,9 +352,9 @@
               effect on the next launch (enabled tools, approved egress hosts, and assets mounted at
               <code>/skills/&lt;name&gt;</code>).</p>
             <div class="form-row">
-              <div class="field" style="flex:2"><label>Skill</label><input id="skill-ref" placeholder="name@version (e.g. incident-triage@1.4.0)" /></div>
-              <div class="field"><label>For which agent</label><select id="skill-group" data-agents><option value="">Select an agent…</option></select></div>
-              <div class="field"><label>Requested by</label><input id="skill-by" placeholder="you (e.g. slack:alice)" /></div>
+              <div class="field" style="flex:2"><label for="skill-ref">Skill</label><input id="skill-ref" placeholder="name@version (e.g. incident-triage@1.4.0)" /></div>
+              <div class="field"><label for="skill-group">For which agent</label><select id="skill-group" data-agents><option value="">Select an agent…</option></select></div>
+              <div class="field"><label for="skill-by">Requested by</label><input id="skill-by" placeholder="you (e.g. slack:alice)" /></div>
               <button id="skill-install" class="btn-primary" type="button" style="align-self:end">Install (needs approval)</button>
             </div>
           </div>
@@ -371,8 +376,8 @@
               reaches a per-session broker socket, every call is gated against the approved grant and audited.
               <strong>Granting an agent access needs human approval</strong> (it lands in Approvals).</p>
             <div class="form-row">
-              <div class="field"><label>Name</label><input id="mcp-name" placeholder="github" /></div>
-              <div class="field"><label>Type</label>
+              <div class="field"><label for="mcp-name">Name</label><input id="mcp-name" placeholder="github" /></div>
+              <div class="field"><label for="mcp-transport">Type</label>
                 <select id="mcp-transport">
                   <option value="stdio">Local (stdio subprocess)</option>
                   <option value="http">Remote (HTTP/SSE)</option>
@@ -380,16 +385,16 @@
               </div>
             </div>
             <div id="mcp-stdio-fields" class="form-row">
-              <div class="field"><label>Command</label><input id="mcp-command" placeholder="npx" /></div>
-              <div class="field" style="flex:2"><label>Arguments</label><input id="mcp-args" placeholder="-y @modelcontextprotocol/server-github" /></div>
+              <div class="field"><label for="mcp-command">Command</label><input id="mcp-command" placeholder="npx" /></div>
+              <div class="field" style="flex:2"><label for="mcp-args">Arguments</label><input id="mcp-args" placeholder="-y @modelcontextprotocol/server-github" /></div>
             </div>
             <div id="mcp-stdio-fields2" class="form-row">
-              <div class="field" style="flex:2"><label>Image <span class="muted">(isolation)</span></label><input id="mcp-image" placeholder="optional — default --mcp-image" /></div>
-              <div class="field" style="flex:2"><label>Environment <span class="muted">(optional)</span></label><input id="mcp-env" placeholder="GITHUB_TOKEN=${GITHUB_TOKEN}, REGION=eu" /></div>
+              <div class="field" style="flex:2"><label for="mcp-image">Image <span class="muted">(isolation)</span></label><input id="mcp-image" placeholder="optional — default --mcp-image" /></div>
+              <div class="field" style="flex:2"><label for="mcp-env">Environment <span class="muted">(optional)</span></label><input id="mcp-env" placeholder="GITHUB_TOKEN=${GITHUB_TOKEN}, REGION=eu" /></div>
             </div>
             <div id="mcp-http-fields" class="form-row" hidden>
-              <div class="field" style="flex:2"><label>URL</label><input id="mcp-url" placeholder="https://mcp.example.com/rpc" /></div>
-              <div class="field" style="flex:2"><label>Auth header <span class="muted">(optional)</span></label><input id="mcp-auth" placeholder="Bearer ${GITHUB_TOKEN}" /></div>
+              <div class="field" style="flex:2"><label for="mcp-url">URL</label><input id="mcp-url" placeholder="https://mcp.example.com/rpc" /></div>
+              <div class="field" style="flex:2"><label for="mcp-auth">Auth header <span class="muted">(optional)</span></label><input id="mcp-auth" placeholder="Bearer ${GITHUB_TOKEN}" /></div>
             </div>
             <p class="muted" style="margin-bottom:0">Secrets: write <code>${ENV_VAR}</code> to reference a host
               environment variable — the value is resolved host-side at connect time and is never stored, shown, or
@@ -418,7 +423,7 @@
           <details>
             <summary>Config editor</summary>
             <div class="form-row">
-              <div class="field" style="flex:2"><label>Agent</label><select id="setup-ag" data-agents><option value="">Select an agent…</option></select></div>
+              <div class="field" style="flex:2"><label for="setup-ag">Agent</label><select id="setup-ag" data-agents><option value="">Select an agent…</option></select></div>
               <button id="setup-ag-load" class="ghost" type="button" style="align-self:end">Load</button>
             </div>
             <div id="setup-config-view" class="list"></div>
@@ -463,7 +468,7 @@
       </div>
       <div class="modal-body builder-form">
         <div class="field">
-          <label>What's your agent called?</label>
+          <label for="ab-name">What's your agent called?</label>
           <input id="ab-name" placeholder="e.g. Research Bot" autocomplete="off" />
           <p class="hint" id="ab-id-preview">Pick a name to get started.</p>
         </div>
@@ -479,8 +484,8 @@
         </div>
 
         <div class="form-row" style="margin:0">
-          <div class="field"><label>Model <span class="muted">— optional</span></label><input id="ab-model" placeholder="control-plane default" autocomplete="off" /></div>
-          <div class="field"><label>Provider <span class="muted">— optional, advanced</span></label><input id="ab-provider" placeholder="default backend" autocomplete="off" /></div>
+          <div class="field"><label for="ab-model">Model <span class="muted">— optional</span></label><input id="ab-model" placeholder="control-plane default" autocomplete="off" /></div>
+          <div class="field"><label for="ab-provider">Provider <span class="muted">— optional, advanced</span></label><input id="ab-provider" placeholder="default backend" autocomplete="off" /></div>
         </div>
 
         <div class="field">

--- a/web/static/mcp.js
+++ b/web/static/mcp.js
@@ -100,8 +100,8 @@ const MCP = (() => {
       checks.append(el("label", { class: "muted", style: "display:flex;align-items:center;gap:.3rem;margin-right:.6rem", title: t.description || "" },
         el("input", { type: "checkbox", value: t.name, id }), t.name));
     }
-    const agentSel = el("select", { "data-agents": "" }, el("option", { value: "", text: "Select an agent…" }));
-    const by = el("input", { placeholder: "requested by (e.g. slack:alice)" });
+    const agentSel = el("select", { "data-agents": "", "aria-label": "Grant tools to agent" }, el("option", { value: "", text: "Select an agent…" }));
+    const by = el("input", { "aria-label": "Requested by", placeholder: "requested by (e.g. slack:alice)" });
     const btn = el("button", { class: "btn-primary", type: "button" }, "Request grant (needs approval)");
     btn.addEventListener("click", () => {
       const picked = [...checks.querySelectorAll("input:checked")].map((c) => c.value);

--- a/web/static/setup.js
+++ b/web/static/setup.js
@@ -277,7 +277,7 @@ const Setup = (() => {
 
   function renderForm() {
     const host = $("setup-change-form");
-    const select = el("select", { id: "setup-kind" });
+    const select = el("select", { id: "setup-kind", "aria-label": "Change type" });
     for (const [k, spec] of Object.entries(KINDS)) select.append(el("option", { value: k, text: spec.label }));
     const help = el("p", { class: "hint", id: "setup-kind-help" });
     const fieldsBox = el("div", { id: "setup-kind-fields", class: "form-row" });

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -28,7 +28,10 @@
   --radius-xs: 6px;
   --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.28);
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.35);
-  --ring: 0 0 0 3px var(--accent-soft);
+  /* Keyboard focus ring: a dark gap then a solid steel-400 band so the indicator
+     stays clearly visible on any surface — inputs, cards, or the light primary
+     button (WCAG 2.4.11 focus appearance). A translucent fill alone read too faint. */
+  --ring: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent-2);
   --sidebar-w: 248px;
 }
 
@@ -65,8 +68,25 @@ code {
   font-size: 0.9em;
 }
 
+/* ---- Skip link --------------------------------------------------------- */
+/* Bypass-block (WCAG 2.4.1): off-screen until focused, then anchored top-left
+   above everything so keyboard users see it land. */
+.skip-link {
+  position: fixed; top: 10px; left: 10px; z-index: 100;
+  transform: translateY(-150%); transition: transform 0.16s ease;
+  background: var(--accent); color: var(--accent-ink);
+  padding: 9px 16px; border-radius: var(--radius-sm); font-weight: 650; font-size: 13px;
+  box-shadow: var(--shadow);
+}
+.skip-link:focus-visible { transform: translateY(0); outline: none; box-shadow: var(--ring), var(--shadow); }
+@media (prefers-reduced-motion: reduce) { .skip-link { transition: none; } }
+
 /* ---- App shell --------------------------------------------------------- */
 .app { display: flex; min-height: 100vh; }
+
+/* main is a focus target for the skip link; never show a focus ring on the
+   container itself (it receives focus only programmatically). */
+#main-content:focus { outline: none; }
 
 .sidebar {
   width: var(--sidebar-w);


### PR DESCRIPTION
## Web-console accessibility & keyboard-nav hardening (IRO-176)

Console-only WCAG hardening for `web/static` (served at `/ui/`). Net-new and **not** gated on the WS-G findings that block IRO-39 — done proactively to shorten IRO-39 later. No behavior change; additive semantics + a stronger focus indicator.

### Keyboard navigation
- **Skip link** (WCAG 2.4.1 Bypass Blocks) — first tab stop, hidden until focused, jumps past the 11-item sidebar to `<main id="main-content" tabindex="-1">`. Verified: activating it moves focus to main.
- **Visible focus ring** (WCAG 2.4.11) — replaced the 0.15-alpha fill (too faint on the dark theme) with a dark-gap + solid steel-400 band that reads clearly on inputs, cards, and the light primary button.
- No keyboard traps: native `<dialog>.showModal()` already traps focus and closes on Escape.

### Semantics / ARIA
- **Form labels** — every single-control field label now associates with its control via static `for=` (28 labels) so the name is exposed even before JS (WCAG 1.3.1 / 4.1.2). `linkFieldLabels()` keeps lazily-rendered forms (Setup change-form, MCP grants) covered and is idempotent.
- **Named controls** — nav items get `aria-label` (critical on mobile, where the text span is `display:none`), plus the chat refresh button, chat agent select, message + token inputs, MCP grant select/input, channel-credential inputs, and agent-builder persona textareas.
- **Active section** — sidebar nav marks the current section with `aria-current="page"` (was visual-only via a class).
- **Live regions** — chat status is `role="status"`; transcript is `role="log" aria-live="polite"` so working/reply updates are announced.

### Verification (chrome-devtools, `controlplane --dev`, 1440×900 + 390×844)
- **0 controls with an empty accessible name** — 55 audited, confirmed three independent ways (orphan-input scan, strict no-title computation, accessible-name computation).
- Skip link reachable + functional; focus ring renders as `dark-gap + steel-400` (`:focus-visible`).
- All 11 nav buttons keep an accessible name on mobile despite hidden labels.
- **AA text contrast holds** on the dark steel-blue theme: field labels 5.36:1, hints 5.12:1. The console is **dark-only by design** (security-grade); a light theme is out of scope for this pass.

> Note: Chrome's Issues panel re-emits a transient "No label associated (count:3)" at parse time that maps to no field in the loaded accessibility tree (clipboard-fallback nodes that flash in/out); the live tree is fully labeled per the three checks above.

Before/after screenshots attached to IRO-176.

Closes IRO-176.