### PR TITLE
feat(ironctl): friendly first-run banner instead of error on no args (IRO-39 F10)

### DIFF
--- a/cmd/ironctl/main.go
+++ b/cmd/ironctl/main.go
@@ -50,6 +50,14 @@ func run(args []string) error {
 		return nil
 	}
 
+	// `ironctl help` / `--help` / `-h` is an explicit, friendly first-run banner
+	// (not an error). It points newcomers at onboard/doctor/status before the
+	// dense `usage` reference, and exits 0.
+	if len(args) >= 1 && (args[0] == "help" || args[0] == "--help" || args[0] == "-h") {
+		firstRunHelp()
+		return nil
+	}
+
 	// Global --addr / --token / -v can appear (in any order) before the subcommand.
 	addr := defaultAddr
 	token = os.Getenv("IRONCLAW_API_TOKEN")
@@ -76,8 +84,11 @@ parse:
 		}
 	}
 	if len(args) < 1 {
-		usage()
-		return fmt.Errorf("expected: change <...> or audit")
+		// Bare `ironctl` (or only global flags) is a first-run user discovering the
+		// tool, not a misuse — greet them and exit 0 instead of dumping the full
+		// reference and failing.
+		firstRunHelp()
+		return nil
 	}
 
 	// Top-level "audit" command.
@@ -282,6 +293,28 @@ func printBody(resp *http.Response) error {
 func mustReadAll(r io.Reader) []byte {
 	b, _ := io.ReadAll(r)
 	return b
+}
+
+// firstRunHelp prints a short, friendly banner for `ironctl` with no command and
+// for `ironctl help`. It curates a first-run path (onboard → doctor → status)
+// ahead of the full reference so newcomers are not met with the dense `usage`
+// block (Hick's Law), and it writes to stdout because it is requested output,
+// not an error diagnostic.
+func firstRunHelp() {
+	fmt.Println(`ironctl ` + version.String() + ` — IronClaw control-plane admin CLI
+
+New here? Start with:
+  ironctl onboard      Guided first-run setup (checks deps, writes config)
+  ironctl doctor       Diagnose your install (runtime, model creds, channels)
+  ironctl status       Control-plane health at a glance
+
+Everyday commands:
+  ironctl agent create | list             Create and inspect agents
+  ironctl change pending | approve <id>   Review gated capability changes
+  ironctl audit                           Tail the append-only audit log
+
+Run ` + "`ironctl usage`" + ` for the full command reference.
+  --addr  defaults to ` + defaultAddr + `   ·   --token defaults to $IRONCLAW_API_TOKEN`)
 }
 
 func usage() {

--- a/cmd/ironctl/main_test.go
+++ b/cmd/ironctl/main_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+// TestRunFirstRunHelp covers the F10 first-run UX fix (IRO-39): bare `ironctl`
+// and explicit `help` greet the user and succeed (exit 0), while genuine misuse
+// still fails (exit non-zero). None of these paths touch the network.
+func TestRunFirstRunHelp(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"no args", nil, false},
+		{"only global flags", []string{"--addr", "http://127.0.0.1:9"}, false},
+		{"help", []string{"help"}, false},
+		{"--help", []string{"--help"}, false},
+		{"-h", []string{"-h"}, false},
+		{"unknown command is misuse", []string{"frobnicate"}, true},
+		{"change without verb is misuse", []string{"change"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := run(tc.args)
+			if tc.wantErr && err == nil {
+				t.Fatalf("run(%v): want error, got nil", tc.args)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("run(%v): want nil, got %v", tc.args, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Closes **F10**, the last open WS-G first-run UX finding, for **WS-H** ([IRO-39](https://github.com/IronSecCo/ironclaw/issues)).

Bare `ironctl` (and `ironctl --addr X` with no command) previously dumped the dense 25-line `usage` reference to **stderr** and exited **non-zero**. The WS-G audit flagged this: a first-time user typing the binary name is met with an *error* and a wall of options (Hick's Law), with no scent toward the guided path.

## Change (CLI-only, `cmd/ironctl/main.go`)

- `ironctl` with no command → short, friendly banner on **stdout**, exit **0**.
- New explicit `ironctl help` / `--help` / `-h` → same banner, exit 0.
- Banner curates the first-run path **onboard → doctor → status** ahead of everyday commands, then defers the full reference to `ironctl usage`.
- **Genuine misuse unchanged**: unknown command / malformed `change` still prints `usage` to stderr and exits 1.

## Verification

- `go build ./cmd/ironctl` ✓
- `go test ./cmd/ironctl/` → **74 pass** (incl. new `TestRunFirstRunHelp` covering no-args, `help`/`--help`/`-h`, and misuse exit codes).
- Manual: confirmed banner→exit 0 for no-args / `help` / `--addr X`; `usage`→exit 1 for bogus command and bare `change`; `version` unaffected.

## Context

F1–F9 from the WS-G audit already shipped (IRO-107 retheme/AA, IRO-130 empty states + reduced-motion, IRO-132 wizard affordances + posture chip, IRO-108 doctor). This is the final P3 item, completing the WS-G → WS-H fix list.

No Paperclip co-author trailer per repo `CLAUDE.md`.