### PR TITLE
fix(ironctl): `usage` is the command reference; metrics → `ironctl metrics` (IRO-179)

### DIFF
--- a/cmd/ironctl/main.go
+++ b/cmd/ironctl/main.go
@@ -113,7 +113,14 @@ parse:
 	if args[0] == "doctor" {
 		return cmdDoctor(addr, args[1:])
 	}
-	if args[0] == "usage" {
+	// `usage` / `commands` print the full command reference to stdout and exit 0:
+	// a help request is requested output, not an error. The model-call metrics
+	// report (which queries /metrics) now lives under `metrics`.
+	if args[0] == "usage" || args[0] == "commands" {
+		printReference(os.Stdout)
+		return nil
+	}
+	if args[0] == "metrics" {
 		return cmdUsage(addr, args[1:])
 	}
 
@@ -317,8 +324,16 @@ Run ` + "`ironctl usage`" + ` for the full command reference.
   --addr  defaults to ` + defaultAddr + `   ·   --token defaults to $IRONCLAW_API_TOKEN`)
 }
 
-func usage() {
-	fmt.Fprintln(os.Stderr, `usage:
+// usage writes the full command reference to stderr. It is the error-path
+// diagnostic shown when a command is missing or malformed.
+func usage() { printReference(os.Stderr) }
+
+// printReference writes the full command reference to w. `ironctl usage`
+// (and `ironctl commands`) call it with os.Stdout and exit 0, because asking
+// for the reference is requested output — not an error.
+func printReference(w io.Writer) {
+	fmt.Fprintln(w, `usage:
+  ironctl help | usage | commands                                          (this reference; help is the short first-run banner)
   ironctl [--addr URL] [--token T] agent create [--name N] [--template T] [--tool X ...]   (guided in a terminal)
   ironctl [--addr URL] [--token T] agent list | show <id> | templates
   ironctl [--addr URL] [--token T] tools [list]
@@ -332,7 +347,7 @@ func usage() {
   ironctl [--addr URL] onboard [--yes] [--dry-run] [--force] [--config PATH]
   ironctl [--addr URL] [--token T] status [--json]
   ironctl [--addr URL] [--token T] doctor [--runtime BIN] [--model-proxy-socket PATH]
-  ironctl [--addr URL] [--token T] usage [--json]
+  ironctl [--addr URL] [--token T] metrics [--json]
   ironctl [--addr URL] [--token T] skill add <name>@<version> --group <id> [--by <user>]
   ironctl [--addr URL] [--token T] skill list
   ironctl [--addr URL] [--token T] skill remove <name>[@<version>]

--- a/cmd/ironctl/status.go
+++ b/cmd/ironctl/status.go
@@ -168,10 +168,11 @@ type modelUsage struct {
 	AvgMillis float64 `json:"avgMillis"`
 }
 
-// cmdUsage implements `ironctl usage [--json]` — a model-call usage report from
-// the model-proxy audit counters exposed at /metrics.
+// cmdUsage implements `ironctl metrics [--json]` — a model-call usage report
+// from the model-proxy audit counters exposed at /metrics. (Named `metrics`
+// because `usage` prints the command reference, per CLI convention.)
 func cmdUsage(addr string, args []string) error {
-	fs := flag.NewFlagSet("usage", flag.ContinueOnError)
+	fs := flag.NewFlagSet("metrics", flag.ContinueOnError)
 	asJSON := fs.Bool("json", false, "emit the usage report as JSON")
 	if err := fs.Parse(args); err != nil {
 		return err

--- a/cmd/ironctl/status_test.go
+++ b/cmd/ironctl/status_test.go
@@ -105,10 +105,21 @@ ironclaw_model_call_duration_seconds_count 42
 	}
 }
 
-func TestUsageCommandSmoke(t *testing.T) {
+func TestMetricsCommandSmoke(t *testing.T) {
 	token = ""
 	srv, _, _ := newStatusServer(t)
-	if err := run([]string{"--addr", srv.URL, "usage", "--json"}); err != nil {
-		t.Fatalf("ironctl usage: %v", err)
+	if err := run([]string{"--addr", srv.URL, "metrics", "--json"}); err != nil {
+		t.Fatalf("ironctl metrics: %v", err)
+	}
+}
+
+// `ironctl usage` / `commands` print the full command reference to stdout and
+// exit 0 — they must not hit the network (no daemon on a fresh machine).
+func TestUsageCommandPrintsReference(t *testing.T) {
+	token = ""
+	for _, name := range []string{"usage", "commands"} {
+		if err := run([]string{name}); err != nil {
+			t.Fatalf("ironctl %s: unexpected error %v", name, err)
+		}
 	}
 }

--- a/docs/site/reference/cli.mdx
+++ b/docs/site/reference/cli.mdx
@@ -61,9 +61,16 @@ model credential, point at the sandbox image build, and verify the API is reacha
 ## Observability
 
 ```sh
-ironctl status [--json]       # control-plane status summary
-ironctl doctor [--runtime BIN] [--model-proxy-socket PATH]   # environment + readiness checks
-ironctl usage  [--json]       # model-call usage / metrics
+ironctl status  [--json]       # control-plane status summary
+ironctl doctor  [--runtime BIN] [--model-proxy-socket PATH]   # environment + readiness checks
+ironctl metrics [--json]       # model-call usage / metrics (queries /metrics)
+```
+
+## Help
+
+```sh
+ironctl help                   # short, friendly first-run banner (also: ironctl, --help, -h)
+ironctl usage                  # full command reference to stdout (also: ironctl commands)
 ```
 
 ## Skills


### PR DESCRIPTION
## WS-H F10 — fix the first-run banner's broken promise

Fixes IRO-179 (the one blocker on the IRO-178 UX launch re-rate).

### Problem
The F10 first-run banner ends with "Run `ironctl usage` for the full command reference", but `usage` was a model-call **metrics** report hitting `/metrics`. On a fresh machine (no daemon — the first-run audience) it errored with `connection refused`; with a daemon it printed a metrics summary. Either way the banner's promise was unsatisfiable.

### Fix (design call: Option 1 / Proper)
Repair the naming to CLI convention (Jakob's Law / Norman's mapping — `usage` means *command usage*):
- `ironctl usage` (+ synonym `ironctl commands`) → prints the **full command reference to stdout, exit 0**. A help request is requested output, not an error — so it no longer touches the network.
- The metrics report moves to **`ironctl metrics`** (matches the `/metrics` endpoint it queries).
- Banner copy is **unchanged** — it is now true.
- Docs (`reference/cli.mdx`) + tests updated; added a test asserting `usage`/`commands` exit 0 without a daemon.

The minimal alternative (just reword the banner) was rejected: it would leave newcomers with *no* command that prints the full reference (the friendly banner is a curated subset), trading one gap for another.

### Verified (CLI visual-truth gate)
```
$ ironctl usage        # follow the banner's advice — was: connection refused
usage:
  ironctl help | usage | commands  ...
exit=0                 # no network
$ ironctl metrics      # relocated report (errors w/o daemon, as before)
```
`go test ./cmd/ironctl/` → 75 passed; `go build` clean.

When this lands on `main`, IRO-178 auto-resumes for the final re-rate (CLI banner only — all other surfaces already PASS).