### PR TITLE
fix(ironctl): make `ironctl usage` the command reference; move metrics to `ironctl metrics` (IRO-179)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ dist/
 *.dll
 *.so
 *.dylib
+# Top-level dev build artifacts (`go build ./cmd/...` drops these at the repo root)
+/ironctl
+/controlplane
 
 # Go
 *.test

--- a/cmd/ironctl/main.go
+++ b/cmd/ironctl/main.go
@@ -113,7 +113,14 @@ parse:
 	if args[0] == "doctor" {
 		return cmdDoctor(addr, args[1:])
 	}
-	if args[0] == "usage" {
+	// `usage` / `commands` print the full command reference to stdout and exit 0:
+	// a help request is requested output, not an error. The model-call metrics
+	// report (which queries /metrics) now lives under `metrics`.
+	if args[0] == "usage" || args[0] == "commands" {
+		printReference(os.Stdout)
+		return nil
+	}
+	if args[0] == "metrics" {
 		return cmdUsage(addr, args[1:])
 	}
 
@@ -317,8 +324,16 @@ Run ` + "`ironctl usage`" + ` for the full command reference.
   --addr  defaults to ` + defaultAddr + `   ·   --token defaults to $IRONCLAW_API_TOKEN`)
 }
 
-func usage() {
-	fmt.Fprintln(os.Stderr, `usage:
+// usage writes the full command reference to stderr. It is the error-path
+// diagnostic shown when a command is missing or malformed.
+func usage() { printReference(os.Stderr) }
+
+// printReference writes the full command reference to w. `ironctl usage`
+// (and `ironctl commands`) call it with os.Stdout and exit 0, because asking
+// for the reference is requested output — not an error.
+func printReference(w io.Writer) {
+	fmt.Fprintln(w, `usage:
+  ironctl help | usage | commands                                          (this reference; help is the short first-run banner)
   ironctl [--addr URL] [--token T] agent create [--name N] [--template T] [--tool X ...]   (guided in a terminal)
   ironctl [--addr URL] [--token T] agent list | show <id> | templates
   ironctl [--addr URL] [--token T] tools [list]
@@ -332,7 +347,7 @@ func usage() {
   ironctl [--addr URL] onboard [--yes] [--dry-run] [--force] [--config PATH]
   ironctl [--addr URL] [--token T] status [--json]
   ironctl [--addr URL] [--token T] doctor [--runtime BIN] [--model-proxy-socket PATH]
-  ironctl [--addr URL] [--token T] usage [--json]
+  ironctl [--addr URL] [--token T] metrics [--json]
   ironctl [--addr URL] [--token T] skill add <name>@<version> --group <id> [--by <user>]
   ironctl [--addr URL] [--token T] skill list
   ironctl [--addr URL] [--token T] skill remove <name>[@<version>]

--- a/cmd/ironctl/status.go
+++ b/cmd/ironctl/status.go
@@ -168,10 +168,11 @@ type modelUsage struct {
 	AvgMillis float64 `json:"avgMillis"`
 }
 
-// cmdUsage implements `ironctl usage [--json]` — a model-call usage report from
-// the model-proxy audit counters exposed at /metrics.
+// cmdUsage implements `ironctl metrics [--json]` — a model-call usage report
+// from the model-proxy audit counters exposed at /metrics. (Named `metrics`
+// because `usage` prints the command reference, per CLI convention.)
 func cmdUsage(addr string, args []string) error {
-	fs := flag.NewFlagSet("usage", flag.ContinueOnError)
+	fs := flag.NewFlagSet("metrics", flag.ContinueOnError)
 	asJSON := fs.Bool("json", false, "emit the usage report as JSON")
 	if err := fs.Parse(args); err != nil {
 		return err

--- a/cmd/ironctl/status_test.go
+++ b/cmd/ironctl/status_test.go
@@ -105,10 +105,21 @@ ironclaw_model_call_duration_seconds_count 42
 	}
 }
 
-func TestUsageCommandSmoke(t *testing.T) {
+func TestMetricsCommandSmoke(t *testing.T) {
 	token = ""
 	srv, _, _ := newStatusServer(t)
-	if err := run([]string{"--addr", srv.URL, "usage", "--json"}); err != nil {
-		t.Fatalf("ironctl usage: %v", err)
+	if err := run([]string{"--addr", srv.URL, "metrics", "--json"}); err != nil {
+		t.Fatalf("ironctl metrics: %v", err)
+	}
+}
+
+// `ironctl usage` / `commands` print the full command reference to stdout and
+// exit 0 — they must not hit the network (no daemon on a fresh machine).
+func TestUsageCommandPrintsReference(t *testing.T) {
+	token = ""
+	for _, name := range []string{"usage", "commands"} {
+		if err := run([]string{name}); err != nil {
+			t.Fatalf("ironctl %s: unexpected error %v", name, err)
+		}
 	}
 }

--- a/docs/site/reference/cli.mdx
+++ b/docs/site/reference/cli.mdx
@@ -61,9 +61,16 @@ model credential, point at the sandbox image build, and verify the API is reacha
 ## Observability
 
 ```sh
-ironctl status [--json]       # control-plane status summary
-ironctl doctor [--runtime BIN] [--model-proxy-socket PATH]   # environment + readiness checks
-ironctl usage  [--json]       # model-call usage / metrics
+ironctl status  [--json]       # control-plane status summary
+ironctl doctor  [--runtime BIN] [--model-proxy-socket PATH]   # environment + readiness checks
+ironctl metrics [--json]       # model-call usage / metrics (queries /metrics)
+```
+
+## Help
+
+```sh
+ironctl help                   # short, friendly first-run banner (also: ironctl, --help, -h)
+ironctl usage                  # full command reference to stdout (also: ironctl commands)
 ```
 
 ## Skills


### PR DESCRIPTION
## What

The F10 first-run banner (IRO-39, #200) ends with **"Run \`ironctl usage\` for the full command reference"**, but `ironctl usage` was a model-call **metrics** report that queries `/metrics`. On a fresh machine — no daemon, the exact first-run audience — it fails with `connection refused`. The banner's own advice was unsatisfiable by any command. QA caught this as the **one blocker** on the UX launch gate (IRO-178).

## Fix (the "proper" option from IRO-179)

Repair the naming to match CLI convention (Jakob's Law):

- `ironctl usage` (and synonym `ironctl commands`) now print the **full command reference to stdout** and **exit 0** — a help request is requested output, not an error.
- The model-call metrics report moves to **`ironctl metrics`**, matching the `/metrics` endpoint it queries.
- **Banner copy is unchanged — it is now true.** No wording change needed.
- Docs (`reference/cli.mdx`) + tests updated; added `TestUsageCommandPrintsReference` asserting `usage`/`commands` never hit the network.
- Also `.gitignore` the top-level `/ironctl` and `/controlplane` dev build artifacts.

## Verification (CGO_ENABLED=1)

- `go build ./cmd/ironctl/` ✅ · `go test ./cmd/ironctl/` ✅ (75 tests)
- Behavioral, no daemon running (fresh-machine sim):
  - `ironctl usage` → reference to stdout, **exit 0**, no network call
  - `ironctl commands` → exit 0
  - `ironctl` no-args banner still points to `ironctl usage` — now satisfiable
  - `ironctl metrics` → the model-call report (errors w/o daemon, as expected)

Implements the fix originally drafted by UXDesigner on `uxdesigner/iro-179-usage-reference`, with the accidentally-committed 13 MB `ironctl` binary dropped and the artifact gitignored.

Closes IRO-179. Unblocks IRO-178 (UX launch gate) → IRO-39 → IRO-40.