### PR TITLE
docs(readme): link Code of Conduct + SECURITY from contributor front-door (IRO-182)

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,6 +846,8 @@ home for Q&A, design discussion, and show-and-tell, and it's where maintainers a
 - **Want to contribute code?** Start with a
   [**good first issue**](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
   — these are small, self-contained, and mentored. See [Contributing](#contributing) for the workflow.
+- **First time here?** Everyone interacting with the project is expected to follow our
+  [**Code of Conduct**](CODE_OF_CONDUCT.md) — be excellent to each other.
 
 We keep the whole community on GitHub — no Discord or Matrix to sign up for.
 [**Discussions**](https://github.com/IronSecCo/ironclaw/discussions) is the live channel: subscribe
@@ -854,7 +856,8 @@ to a category to follow along, and watch the repo for **Announcements**.
 ## Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the contract-freeze rule, the code layout
-(the control-plane and sandbox trees build against the frozen seam), and how to open a pull request.
+(the control-plane and sandbox trees build against the frozen seam), how to report a vulnerability
+([`SECURITY.md`](SECURITY.md)), our [Code of Conduct](CODE_OF_CONDUCT.md), and how to open a pull request.
 New here? Pick up a [**good first issue**](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 ## License


### PR DESCRIPTION
## Why
IRO-182 — complete the GitHub OSS Community Standards set and the contributor front-door.

## Audit result: already 100% green
GitHub **Insights → Community Standards** shows all 8 items green for `IronSecCo/ironclaw`:
Description, README, Code of conduct, Contributing, License (AGPLv3), Security policy, Issue templates, Pull request template.

All health files already exist on `main` and are high quality: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant), `SECURITY.md` (coordinated disclosure + safe harbor + scope), `LICENSE` (AGPLv3), `LICENSING.md` (commercial), `CLA.md`, `.github/ISSUE_TEMPLATE/*` (YAML forms + chooser config), `.github/pull_request_template.md`, `.github/CODEOWNERS`, `.github/DISCUSSIONS.md`, `.github/dependabot.yml`.

> Note: the REST `/community/profile` API reports 87% / `issue_template:false` — a known GitHub limitation where the API does not count YAML **issue forms**, only legacy markdown templates. The canonical **Insights → Community Standards** web page counts the forms and shows green.

## What this PR changes
The only real gap was README linkage: the Code of Conduct was reachable only from `CONTRIBUTING.md`/`DISCUSSIONS.md`, not the README itself.

- README **Community** section: add a Code of Conduct bullet.
- README **Contributing** section: link `SECURITY.md` and the Code of Conduct alongside `CONTRIBUTING.md`.

Docs-only; no code paths, no trust-boundary surface touched.