### PR TITLE
feat(deploy): Helm chart for Kubernetes self-hosters (IRO-189)

### DIFF
--- a/deploy/helm/ironclaw/.helmignore
+++ b/deploy/helm/ironclaw/.helmignore
@@ -1,0 +1,10 @@
+# Patterns to ignore when packaging the chart.
+.DS_Store
+.git/
+.gitignore
+*.tmpl.bak
+*.swp
+*.bak
+*.tgz
+.idea/
+.vscode/

--- a/deploy/helm/ironclaw/Chart.yaml
+++ b/deploy/helm/ironclaw/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: ironclaw
+description: |
+  Hardened, self-hosted IronClaw control-plane for Kubernetes — the mandatory
+  approval gateway, encrypted (SQLCipher) per-session queues, host-side model
+  credential custody, web console and channel adapters. Mirrors the security
+  posture of the hardened Docker Compose (deploy/docker-compose.prod.yml):
+  non-root uid 65532, read-only rootfs, all capabilities dropped,
+  no-new-privileges, resource ceilings, and durable encrypted state on a PVC.
+type: application
+
+# Chart version — bump on chart changes (semver, independent of the app).
+version: 0.1.0
+
+# The IronClaw release this chart tracks. `helm install` pins this as the image
+# tag by default; override values.image.tag (ideally with a @sha256 digest) to
+# pin a verified, attested image in production.
+appVersion: "0.1.0"
+
+home: https://github.com/IronSecCo/ironclaw
+sources:
+  - https://github.com/IronSecCo/ironclaw
+keywords:
+  - ai
+  - agents
+  - self-hosted
+  - security
+  - gvisor
+  - sandbox
+maintainers:
+  - name: IronSec Co.
+    url: https://github.com/IronSecCo
+annotations:
+  # The control-plane is the trusted process; agent sandboxes are launched by it
+  # on a gVisor-capable host and are NOT Kubernetes workloads (see README.md).
+  category: Security

--- a/deploy/helm/ironclaw/README.md
+++ b/deploy/helm/ironclaw/README.md
@@ -1,0 +1,126 @@
+# IronClaw control-plane Helm chart
+
+Deploy the **hardened IronClaw control-plane** on Kubernetes. This chart mirrors the
+security posture of the [hardened Docker Compose](../../docker-compose.prod.yml):
+non-root uid `65532`, read-only rootfs, **all Linux capabilities dropped**,
+`no-new-privileges` (`allowPrivilegeEscalation: false`), `RuntimeDefault` seccomp,
+resource ceilings, and durable encrypted (SQLCipher) state on a PersistentVolume.
+
+> **Where the sandboxes run.** This chart deploys the **trusted control-plane only** —
+> the mandatory approval gateway, the encrypted per-session queues, host-side model
+> credential custody, the web console and channel adapters. IronClaw's agent sandboxes
+> run under **gVisor (`runsc`)**, launched by the control-plane directly on a
+> runsc-capable host; they are **not** Kubernetes Pods and never share this Pod's
+> network. For full sandbox isolation the control-plane must run on a gVisor-capable
+> node. See [docs/deployment.md](../../../docs/deployment.md).
+
+## Prerequisites
+
+- Kubernetes 1.25+ and Helm 3.8+ (validated with Helm 4).
+- A default StorageClass (or set `persistence.storageClass` / `persistence.existingClaim`).
+- An Ingress controller + cert-manager if you want TLS termination at the edge.
+
+## Install
+
+```sh
+# From a checkout of the repo:
+helm install ironclaw ./deploy/helm/ironclaw \
+  --namespace ironclaw --create-namespace \
+  --set secrets.apiToken="$(openssl rand -hex 32)" \
+  --set secrets.anthropicApiKey="sk-ant-…"
+```
+
+Then reach it (ClusterIP by default — not exposed outside the cluster):
+
+```sh
+kubectl -n ironclaw port-forward svc/ironclaw 8787:8787
+curl -fsS http://127.0.0.1:8787/healthz
+```
+
+### Production: pin a verified image digest
+
+Don't ship a floating tag. Resolve and **cosign-verify** the digest, then pin it:
+
+```sh
+docker buildx imagetools inspect ghcr.io/ironsecco/ironclaw-controlplane:v0.1.0
+cosign verify ghcr.io/ironsecco/ironclaw-controlplane@sha256:<digest> \
+  --certificate-identity-regexp '^https://github.com/IronSecCo/ironclaw' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+helm upgrade --install ironclaw ./deploy/helm/ironclaw -n ironclaw \
+  --set image.digest=sha256:<digest>
+```
+
+### Production: secrets from your own Secret
+
+Avoid putting secrets in Helm values. Create a Secret (or have your secrets operator
+sync one) whose keys are the daemon env names, then point the chart at it:
+
+```sh
+kubectl -n ironclaw create secret generic ironclaw-creds \
+  --from-literal=IRONCLAW_API_TOKEN="$(openssl rand -hex 32)" \
+  --from-literal=ANTHROPIC_API_KEY="sk-ant-…"
+
+helm upgrade --install ironclaw ./deploy/helm/ironclaw -n ironclaw \
+  --set secrets.existingSecret=ironclaw-creds
+```
+
+If you leave `IRONCLAW_API_TOKEN` unset, the control-plane **mints one on first run and
+prints it once** in the Pod logs (no recovery) — grab it from
+`kubectl logs deploy/ironclaw` and set it explicitly.
+
+### Expose with TLS at the Ingress
+
+The control-plane serves **plain HTTP** — terminate TLS at the Ingress.
+
+```sh
+helm upgrade --install ironclaw ./deploy/helm/ironclaw -n ironclaw \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set ingress.hosts[0].host=ironclaw.example.com \
+  --set 'ingress.annotations.cert-manager\.io/cluster-issuer=letsencrypt-prod' \
+  --set ingress.tls[0].secretName=ironclaw-tls \
+  --set ingress.tls[0].hosts[0]=ironclaw.example.com
+```
+
+## Key values
+
+| Key | Default | Notes |
+|---|---|---|
+| `image.repository` | `ghcr.io/ironsecco/ironclaw-controlplane` | |
+| `image.tag` | `""` → `.Chart.appVersion` | |
+| `image.digest` | `""` | Pin a cosign-verified `sha256:…` in production (wins over `tag`). |
+| `replicaCount` | `1` | Single-writer; do not scale active-active. |
+| `config.dev` | `"0"` | **MUST stay `0`** in production (`1` seeds an unauthenticated owner). |
+| `config.logFormat` | `"json"` | Logger redacts secrets regardless. |
+| `secrets.existingSecret` | `""` | Prefer this over inline `secrets.*`. |
+| `secrets.apiToken` | `""` | Admin bearer; minted+printed once if empty. |
+| `persistence.enabled` | `true` | Durable encrypted state; back it up **encrypted**. |
+| `persistence.size` | `1Gi` | |
+| `persistence.existingClaim` | `""` | Bring your own PVC. |
+| `resources.limits` | `cpu: 2, memory: 1Gi` | |
+| `ingress.enabled` | `false` | Terminate TLS here. |
+| `networkPolicy.enabled` | `false` | Restrict ingress to the Pod (needs an enforcing CNI). |
+| `service.type` / `service.port` | `ClusterIP` / `8787` | |
+
+The hardening `securityContext` / `podSecurityContext` blocks are intentionally locked
+down — **do not relax them**. They are part of IronClaw's security promise.
+
+## Persistence & backups
+
+All durable state — encrypted SQLCipher queues, gateway change store, append-only audit
+log, **sealed encryption keys**, and the minted admin token — lives on the `state` PVC.
+The volume holds the encryption keys, so **back it up encrypted** and test restore. See
+the Backups & restore section of [docs/deployment.md](../../../docs/deployment.md).
+
+## Pod PID limits
+
+Kubernetes has no per-container `pids` field (unlike the Compose `pids` limit). Enforce a
+PID ceiling at the node (kubelet `--pod-max-pids`) or with a namespace `LimitRange`.
+
+## Validate locally (no cluster needed)
+
+```sh
+helm lint deploy/helm/ironclaw
+helm template ironclaw deploy/helm/ironclaw | kubeconform -strict -summary -
+```

--- a/deploy/helm/ironclaw/templates/NOTES.txt
+++ b/deploy/helm/ironclaw/templates/NOTES.txt
@@ -1,0 +1,51 @@
+IronClaw control-plane installed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+Image: {{ include "ironclaw.image" . }}
+{{- if not .Values.image.digest }}
+
+  ⚠  You are running a tag, not a pinned digest. In production set
+     image.digest to a cosign-verified sha256 (see docs/deployment.md).
+{{- end }}
+
+1. Admin/API token
+{{- if .Values.secrets.existingSecret }}
+   Loaded from existing Secret "{{ .Values.secrets.existingSecret }}".
+{{- else if .Values.secrets.apiToken }}
+   Set from chart values into Secret "{{ include "ironclaw.fullname" . }}".
+{{- else }}
+   ⚠  No IRONCLAW_API_TOKEN provided. The control-plane MINTED one on first run
+      and printed it ONCE in the Pod logs (no recovery). Grab it now:
+
+        kubectl -n {{ .Release.Namespace }} logs deploy/{{ include "ironclaw.fullname" . }} | grep -A2 "token MINTED"
+
+      Then set secrets.apiToken (or secrets.existingSecret) and `helm upgrade`.
+{{- end }}
+
+2. Reach the control-plane
+{{- if .Values.ingress.enabled }}
+   Ingress is enabled. TLS is terminated at the Ingress; the control-plane serves
+   plain HTTP behind it. Hosts:
+   {{- range .Values.ingress.hosts }}
+     - https://{{ .host }}
+   {{- end }}
+{{- else }}
+   ClusterIP only (not exposed outside the cluster). Port-forward to try it:
+
+     kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "ironclaw.fullname" . }} 8787:{{ .Values.service.port }}
+     curl -fsS http://127.0.0.1:8787/healthz
+
+   For external access, enable ingress.* and terminate TLS there.
+{{- end }}
+
+3. State & backups
+{{- if .Values.persistence.enabled }}
+   Durable state (encrypted SQLCipher queues, keys, admin token) lives on PVC
+   "{{ include "ironclaw.pvcName" . }}". It holds the encryption keys — back it up
+   ENCRYPTED. Losing it loses the token and all session state.
+{{- else }}
+   ⚠  persistence.enabled=false — state is EPHEMERAL and lost on restart. Use only
+      for evaluation; enable persistence for any real deployment.
+{{- end }}
+
+Security posture: non-root uid 65532, read-only rootfs, all caps dropped,
+no-new-privileges, RuntimeDefault seccomp. See docs/deployment.md (Kubernetes).

--- a/deploy/helm/ironclaw/templates/_helpers.tpl
+++ b/deploy/helm/ironclaw/templates/_helpers.tpl
@@ -1,0 +1,94 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ironclaw.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified app name (truncated to 63 chars for k8s name limits).
+*/}}
+{{- define "ironclaw.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "ironclaw.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "ironclaw.labels" -}}
+helm.sh/chart: {{ include "ironclaw.chart" . }}
+{{ include "ironclaw.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: control-plane
+app.kubernetes.io/part-of: ironclaw
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "ironclaw.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ironclaw.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name to use.
+*/}}
+{{- define "ironclaw.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ironclaw.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the Secret holding credentials (existing or chart-created).
+*/}}
+{{- define "ironclaw.secretName" -}}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
+{{- else }}
+{{- include "ironclaw.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the PVC (existing or chart-created).
+*/}}
+{{- define "ironclaw.pvcName" -}}
+{{- if .Values.persistence.existingClaim }}
+{{- .Values.persistence.existingClaim }}
+{{- else }}
+{{- printf "%s-state" (include "ironclaw.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the image reference, preferring an immutable digest over a tag.
+*/}}
+{{- define "ironclaw.image" -}}
+{{- $repo := .Values.image.repository -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $repo .Values.image.digest -}}
+{{- else -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end }}

--- a/deploy/helm/ironclaw/templates/configmap.yaml
+++ b/deploy/helm/ironclaw/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ironclaw.fullname" . }}
+  labels:
+    {{- include "ironclaw.labels" . | nindent 4 }}
+data:
+  IRONCLAW_API_ADDR: {{ .Values.config.apiAddr | quote }}
+  IRONCLAW_LOG_FORMAT: {{ .Values.config.logFormat | quote }}
+  IRONCLAW_DEV: {{ .Values.config.dev | quote }}
+  IRONCLAW_STATE_DIR: {{ .Values.config.stateDir | quote }}
+  {{- range $k, $v := .Values.config.extraEnv }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}

--- a/deploy/helm/ironclaw/templates/deployment.yaml
+++ b/deploy/helm/ironclaw/templates/deployment.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ironclaw.fullname" . }}
+  labels:
+    {{- include "ironclaw.labels" . | nindent 4 }}
+spec:
+  # The control-plane owns durable SQLCipher state on a ReadWriteOnce volume and
+  # is single-writer; Recreate avoids two Pods racing for the same PVC on rollout.
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "ironclaw.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Roll the Pod when non-secret config changes.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "ironclaw.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ironclaw.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: controlplane
+          image: {{ include "ironclaw.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "ironclaw.fullname" . }}
+            - secretRef:
+                name: {{ include "ironclaw.secretName" . }}
+          ports:
+            - name: http
+              containerPort: 8787
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            # Durable encrypted state (SQLCipher queues, gateway store, audit log,
+            # sealed keys, minted admin token).
+            - name: state
+              mountPath: {{ .Values.config.stateDir | quote }}
+            # Writable scratch required by the read-only rootfs: the model-proxy
+            # unix socket lives under /run/ironclaw, plus a small /tmp.
+            - name: run
+              mountPath: /run/ironclaw
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: state
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "ironclaw.pvcName" . }}
+          {{- else }}
+          # No persistence: state is ephemeral and lost on Pod restart (the admin
+          # token is re-minted). Use only for evaluation.
+          emptyDir: {}
+          {{- end }}
+        - name: run
+          emptyDir:
+            medium: Memory
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/ironclaw/templates/ingress.yaml
+++ b/deploy/helm/ironclaw/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "ironclaw.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "ironclaw.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/ironclaw/templates/networkpolicy.yaml
+++ b/deploy/helm/ironclaw/templates/networkpolicy.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "ironclaw.fullname" . }}
+  labels:
+    {{- include "ironclaw.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "ironclaw.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        {{- if .Values.networkPolicy.ingressFrom }}
+        {{- toYaml .Values.networkPolicy.ingressFrom | nindent 8 }}
+        {{- else }}
+        # Default: same-namespace sources only (e.g. an in-namespace ingress proxy).
+        - podSelector: {}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 8787
+{{- end }}

--- a/deploy/helm/ironclaw/templates/pvc.yaml
+++ b/deploy/helm/ironclaw/templates/pvc.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ironclaw.pvcName" . }}
+  labels:
+    {{- include "ironclaw.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if eq .Values.persistence.storageClass "-" }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/ironclaw/templates/secret.yaml
+++ b/deploy/helm/ironclaw/templates/secret.yaml
@@ -1,0 +1,43 @@
+{{- if not .Values.secrets.existingSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ironclaw.fullname" . }}
+  labels:
+    {{- include "ironclaw.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- with .Values.secrets.apiToken }}
+  IRONCLAW_API_TOKEN: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secrets.anthropicApiKey }}
+  ANTHROPIC_API_KEY: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secrets.openaiApiKey }}
+  OPENAI_API_KEY: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secrets.openrouterApiKey }}
+  OPENROUTER_API_KEY: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secrets.slackBotToken }}
+  SLACK_BOT_TOKEN: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secrets.discordBotToken }}
+  DISCORD_BOT_TOKEN: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secrets.telegramBotToken }}
+  TELEGRAM_BOT_TOKEN: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secrets.teamsWebhookUrl }}
+  IRONCLAW_TEAMS_WEBHOOK_URL: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secrets.signalCliUrl }}
+  IRONCLAW_SIGNAL_CLI_URL: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secrets.signalNumber }}
+  IRONCLAW_SIGNAL_NUMBER: {{ . | quote }}
+  {{- end }}
+  {{- range $k, $v := .Values.secrets.extraEnv }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/ironclaw/templates/service.yaml
+++ b/deploy/helm/ironclaw/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ironclaw.fullname" . }}
+  labels:
+    {{- include "ironclaw.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "ironclaw.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/ironclaw/templates/serviceaccount.yaml
+++ b/deploy/helm/ironclaw/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ironclaw.serviceAccountName" . }}
+  labels:
+    {{- include "ironclaw.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+# The control-plane does not talk to the Kubernetes API; do not mount a token.
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/deploy/helm/ironclaw/values.yaml
+++ b/deploy/helm/ironclaw/values.yaml
@@ -1,0 +1,214 @@
+# Default values for the IronClaw control-plane chart.
+#
+# These defaults mirror the hardened Docker Compose posture
+# (deploy/docker-compose.prod.yml): non-root uid 65532, read-only rootfs, all
+# Linux capabilities dropped, no-new-privileges, resource ceilings, and durable
+# encrypted (SQLCipher) state on a PersistentVolume. Keep the securityContext
+# blocks locked down — they are part of the product's security promise, not
+# boilerplate.
+#
+# IMPORTANT — where the sandboxes run. This chart deploys the *trusted
+# control-plane only*. IronClaw's agent sandboxes run under gVisor (runsc),
+# launched by the control-plane directly on a runsc-capable host — they are NOT
+# Kubernetes Pods and never share this Pod's network. For full sandbox
+# isolation the control-plane must run on a gVisor-capable node; see
+# docs/deployment.md.
+
+# -- Number of control-plane replicas. Keep at 1: the control-plane owns durable
+# SQLCipher state on a ReadWriteOnce volume and is not designed to run active-active.
+replicaCount: 1
+
+image:
+  # ghcr.io/ironsecco/ironclaw-controlplane — published on every release, signed
+  # with cosign and attested on the index digest.
+  repository: ghcr.io/ironsecco/ironclaw-controlplane
+  # In production pin by DIGEST, not a floating tag, so deploys are reproducible
+  # and cosign-verifiable. Set `tag` to "" and use `digest` below, e.g.:
+  #   docker buildx imagetools inspect ghcr.io/ironsecco/ironclaw-controlplane:v0.1.0
+  #   cosign verify <repo>@sha256:<digest> \
+  #     --certificate-identity-regexp '^https://github.com/IronSecCo/ironclaw' \
+  #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+  # Leave tag empty to fall back to .Chart.appVersion.
+  tag: ""
+  # Pin by immutable digest (preferred in production). When set it takes
+  # precedence over `tag`. Example: "sha256:abc123...".
+  digest: ""
+  pullPolicy: IfNotPresent
+
+# Image pull secrets for a private registry (the GHCR image is public).
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  # The control-plane never talks to the Kubernetes API — do not mount a token
+  # into the Pod (least privilege).
+  automountServiceAccountToken: false
+
+# -- Non-secret daemon configuration, rendered into a ConfigMap and exposed as
+# env. Names mirror .env.example / the container entrypoint.
+config:
+  # Listen address INSIDE the Pod. Must be 0.0.0.0 so the Service can reach it;
+  # the Pod is never exposed except through the Service / Ingress.
+  apiAddr: "0.0.0.0:8787"
+  # text | json — json for log shippers. The logger redacts secrets regardless.
+  logFormat: "json"
+  # MUST stay "0" in production: "1" seeds an unauthenticated dev owner/agent-group.
+  dev: "0"
+  # Durable state directory (the PVC mounts here). Holds the encrypted SQLCipher
+  # queues, gateway change store, append-only audit log, sealed keys, and the
+  # minted admin token.
+  stateDir: "/var/lib/ironclaw/state"
+  # Extra non-secret env vars (e.g. IRONCLAW_DEV_PROVIDER for a mock demo). Never
+  # put secrets here — use `secrets` below or an existing Secret.
+  extraEnv: {}
+
+# -- Secrets (admin token, model credential, channel tokens). Names mirror
+# .env.example. Leave a value empty to omit it.
+#
+#   * If you set values here, the chart creates a Secret holding them. This is
+#     convenient but writes secrets into your Helm release/values — prefer an
+#     existing Secret (secrets.existingSecret) sourced from your secrets manager.
+#   * If you leave IRONCLAW_API_TOKEN empty, the control-plane MINTS one on first
+#     run and prints it ONCE in the Pod logs (no recovery). Set it explicitly in
+#     production.
+secrets:
+  # Reference an existing Secret instead of creating one from the values below.
+  # Its keys are mounted as env vars verbatim (IRONCLAW_API_TOKEN, ANTHROPIC_API_KEY, …).
+  existingSecret: ""
+
+  # Admin/API bearer token (ironctl + console + Prometheus scraper).
+  # Generate: openssl rand -hex 32
+  apiToken: ""
+
+  # Model credential — set at least one so agents can call a model. Held
+  # host-side by the model-proxy; NEVER enters a sandbox.
+  anthropicApiKey: ""
+  openaiApiKey: ""
+  openrouterApiKey: ""
+
+  # Channel adapters (each registers only when its token/URL is set).
+  slackBotToken: ""
+  discordBotToken: ""
+  telegramBotToken: ""
+  teamsWebhookUrl: ""
+  signalCliUrl: ""
+  signalNumber: ""
+
+  # Extra secret env vars merged into the created Secret (ignored when
+  # existingSecret is set).
+  extraEnv: {}
+
+service:
+  type: ClusterIP
+  port: 8787
+  annotations: {}
+
+# -- Ingress for TLS termination. The control-plane serves PLAIN HTTP — its
+# security boundary is the network plus the bearer token, not its own TLS.
+# Terminate TLS at the Ingress (cert-manager / your controller). Disabled by
+# default; enable and set a host.
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+    # nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+  hosts:
+    - host: ironclaw.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+    # - hosts:
+    #     - ironclaw.example.com
+    #   secretName: ironclaw-tls
+
+# -- Durable state. The state directory holds ALL durable state, including the
+# encryption keys and admin token — back the PVC up encrypted (see
+# docs/deployment.md). ReadWriteOnce: a single writer, matching replicaCount 1.
+persistence:
+  enabled: true
+  # Use an already-provisioned PVC instead of creating one.
+  existingClaim: ""
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi
+  annotations: {}
+
+# -- Resource ceilings. A runaway control-plane must not starve the node. These
+# mirror the Compose limits; tune to your cluster.
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: "2"
+    memory: 1Gi
+
+# -- Pod-level security context. uid/gid 65532 is the image's non-root account;
+# fsGroup makes the PVC and emptyDir scratch group-writable by it.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container security context. The control-plane needs NO Linux capabilities;
+# the read-only rootfs is backed by the emptyDir scratch mounts below. Do not
+# relax these — they are the chart's hardening contract.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  privileged: false
+  capabilities:
+    drop:
+      - ALL
+
+# -- Liveness/readiness probes. /healthz and /readyz are unauthenticated by
+# design (probes need no credential) and exempt from rate limiting.
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 5
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+# -- Graceful shutdown: the daemon stops its sandboxes (up to 10s) before exiting.
+terminationGracePeriodSeconds: 20
+
+# -- Optional NetworkPolicy restricting ingress to the control-plane Pod, mirroring
+# the Compose "private network, only the proxy reaches it" posture. Requires a CNI
+# that enforces NetworkPolicy. Disabled by default to avoid silently dropping
+# traffic on clusters without an enforcing CNI; enable it once you have one.
+networkPolicy:
+  enabled: false
+  # Selectors for sources allowed to reach the control-plane port (e.g. your
+  # ingress controller). Empty means "same namespace only".
+  ingressFrom: []
+    # - namespaceSelector:
+    #     matchLabels:
+    #       kubernetes.io/metadata.name: ingress-nginx
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+podLabels: {}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,15 +9,15 @@ exist. This page is the *how*.
 
 ## Pick a deployment path
 
-There are two supported ways to run the control-plane in production. They differ in
+There are three supported ways to run the control-plane in production. They differ in
 **how much sandbox isolation you get**, because that depends on the host kernel.
 
-| | Bare-host (systemd / launchd) | Hardened Docker Compose |
-|---|---|---|
-| Installer | [`deploy/install.sh`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/install.sh) | [`deploy/docker-compose.prod.yml`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/docker-compose.prod.yml) |
-| Sandbox isolation | **Full gVisor (`runsc`)** — `network=none`, all caps dropped, read-only rootfs, user-namespaced | Control-plane only; sandboxes need a runsc host |
-| Best for | The real production posture: agents executing tool calls under gVisor | Hardened control-plane, gateway, console, channels on any Docker host |
-| Host requirements | Linux + containerd + gVisor (or macOS/launchd for the control-plane) | Any host with Docker + Compose |
+| | Bare-host (systemd / launchd) | Hardened Docker Compose | Kubernetes (Helm) |
+|---|---|---|---|
+| Installer | [`deploy/install.sh`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/install.sh) | [`deploy/docker-compose.prod.yml`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/docker-compose.prod.yml) | [`deploy/helm/ironclaw`](https://github.com/IronSecCo/ironclaw/tree/main/deploy/helm/ironclaw) |
+| Sandbox isolation | **Full gVisor (`runsc`)** — `network=none`, all caps dropped, read-only rootfs, user-namespaced | Control-plane only; sandboxes need a runsc host | Control-plane only; full gVisor needs a runsc-capable node |
+| Best for | The real production posture: agents executing tool calls under gVisor | Hardened control-plane, gateway, console, channels on any Docker host | Self-hosters who run their infra on k8s |
+| Host requirements | Linux + containerd + gVisor (or macOS/launchd for the control-plane) | Any host with Docker + Compose | A Kubernetes cluster (1.25+) + Helm |
 
 !!! important "Where the sandboxes run"
     IronClaw's security value is that **agent code runs inside a gVisor sandbox** with
@@ -156,6 +156,83 @@ docker compose -f deploy/docker-compose.prod.yml logs -f controlplane
 The control-plane comes up `healthy` (the `/healthz` probe), locked down: read-only
 rootfs, `CapDrop=ALL`, `no-new-privileges`, non-root, with a tmpfs for the model-proxy
 socket. Caddy fronts it on `:443`/`:80`.
+
+---
+
+## Path C — Kubernetes (Helm)
+
+For self-hosters who already run on Kubernetes, the
+[`deploy/helm/ironclaw`](https://github.com/IronSecCo/ironclaw/tree/main/deploy/helm/ironclaw)
+chart deploys the control-plane with the **same hardening as the Compose path**:
+non-root uid `65532`, read-only rootfs, **all capabilities dropped**,
+`allowPrivilegeEscalation: false` (`no-new-privileges`), `RuntimeDefault` seccomp,
+resource ceilings, and durable encrypted (SQLCipher) state on a PersistentVolume. Like
+Compose, this runs and locks down the **trusted control-plane only** — agent sandboxes
+run under gVisor on the host and are never Kubernetes Pods (see the box above); for full
+sandbox isolation, schedule the control-plane onto a **runsc-capable node**.
+
+### 1. Install
+
+```sh
+helm install ironclaw ./deploy/helm/ironclaw \
+  --namespace ironclaw --create-namespace \
+  --set secrets.apiToken="$(openssl rand -hex 32)" \
+  --set secrets.anthropicApiKey="sk-ant-…"
+```
+
+The control-plane is `ClusterIP` only (not exposed outside the cluster). Try it with a
+port-forward:
+
+```sh
+kubectl -n ironclaw port-forward svc/ironclaw 8787:8787
+curl -fsS http://127.0.0.1:8787/healthz
+```
+
+!!! tip "Bring your own Secret"
+    Putting secrets in `--set` writes them into the Helm release. In production, create a
+    Secret (keys = daemon env names like `IRONCLAW_API_TOKEN`, `ANTHROPIC_API_KEY`) from
+    your secrets manager and pass `--set secrets.existingSecret=<name>`. If
+    `IRONCLAW_API_TOKEN` is unset the control-plane mints one and prints it **once** in
+    the Pod logs (`kubectl logs deploy/ironclaw`) — no recovery.
+
+### 2. Pin a verified image digest
+
+Mirror the Compose digest-pinning. Resolve and `cosign verify` the digest (as in Path B),
+then:
+
+```sh
+helm upgrade --install ironclaw ./deploy/helm/ironclaw -n ironclaw \
+  --set image.digest=sha256:<digest>
+```
+
+### 3. TLS termination via Ingress
+
+The control-plane serves **plain HTTP** — terminate TLS at the Ingress (cert-manager or
+your controller), exactly as Caddy/nginx do for the other paths:
+
+```sh
+helm upgrade --install ironclaw ./deploy/helm/ironclaw -n ironclaw \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set ingress.hosts[0].host=ironclaw.example.com \
+  --set ingress.tls[0].secretName=ironclaw-tls \
+  --set ingress.tls[0].hosts[0]=ironclaw.example.com
+```
+
+### Persistence, PID limits & network policy
+
+- **State** lives on the `state` PVC (`persistence.size`, default `1Gi`; or
+  `persistence.existingClaim`). It holds the encryption keys and admin token — back it up
+  **encrypted** (see [Backups & restore](#backups-restore)).
+- **PID ceiling:** Kubernetes has no per-container `pids` field (the Compose path sets
+  one), so enforce it at the node (`--pod-max-pids`) or with a namespace `LimitRange`.
+- **NetworkPolicy:** set `networkPolicy.enabled=true` (with an enforcing CNI) to restrict
+  ingress to the Pod, mirroring the Compose "private network" posture.
+
+Full value reference and validation commands are in the chart
+[README](https://github.com/IronSecCo/ironclaw/blob/main/deploy/helm/ironclaw/README.md).
+The chart is validated with `helm lint` and `helm template` rendering against the
+Kubernetes schema; a live-cluster apply is left to the operator.
 
 ---
 


### PR DESCRIPTION
## What

Adds `deploy/helm/ironclaw` — a maintained Helm chart to deploy the IronClaw
control-plane on Kubernetes, plus a **Path C — Kubernetes (Helm)** section in
`docs/deployment.md`. Closes IRO-189.

The chart mirrors the hardened Docker Compose posture (`deploy/docker-compose.prod.yml`):

- **Workloads:** Deployment + Service + ConfigMap + Secret + ServiceAccount + PVC, with optional **Ingress** and **NetworkPolicy**.
- **Security defaults (locked down):** non-root uid `65532`, `readOnlyRootFilesystem`, `capabilities.drop: [ALL]`, `allowPrivilegeEscalation: false` (no-new-privileges), `RuntimeDefault` seccomp, `automountServiceAccountToken: false`, CPU/memory ceilings. Read-only rootfs is backed by `emptyDir` scratch for `/run/ironclaw` (model-proxy socket) and `/tmp`.
- **Persistence:** durable encrypted (SQLCipher) state on a PVC at `/var/lib/ironclaw/state`; `Recreate` strategy + single replica (single-writer).
- **Values:** image tag/digest, resources, persistence (or `existingClaim`), secrets (inline **or** `existingSecret`), Ingress TLS, NetworkPolicy.
- **Honest scoping:** the chart runs the **trusted control-plane only**; agent gVisor sandboxes run on the host and are not Kubernetes Pods — documented in the chart README, `values.yaml`, and the docs section. Full sandbox isolation needs a runsc-capable node.

## Validation (render-only — no live cluster exercised)

- `helm lint --strict` — clean.
- `helm template` (defaults **and** overrides: digest, ingress, networkPolicy, existingSecret/existingClaim) renders valid manifests.
- `kubeconform -strict` against the **Kubernetes 1.29** schema — all resources valid (6/6 default, 8/8 with ingress+netpol).
- `mkdocs build --strict` — green (broken-anchor fixed).

A live-cluster `helm install` was **not** exercised, per the issue scope (render-only).

## Notes

- Kubernetes has no per-container `pids` limit (the Compose path sets one); documented to enforce it at the node (`--pod-max-pids`) or via a `LimitRange`.

Ungated per the issue; self-merge when CI is green.