### PR TITLE
ci(release): pin cosign to 2.6.3 to fix sign-blob crash (IRO-195)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,7 +292,16 @@ jobs:
             -o "cyclonedx-json=ironclaw_${VERSION}.cdx.json"
           gh release upload "${TAG}" "ironclaw_${VERSION}.spdx.json" "ironclaw_${VERSION}.cdx.json" --clobber
 
+      # Pin cosign to the 2.x line. cosign 3.x flips `sign-blob` to the new Sigstore
+      # bundle format by default, makes `--bundle` required, and deprecates/ignores
+      # `--output-signature`/`--output-certificate` — which broke this step (it tried
+      # to write a bundle to an empty path → "create bundle file: open :"). 2.6.3 keeps
+      # the detached `.sig`/`.pem` output that the verify smoke step, README "Verify the
+      # download", docs/security.md, and the release runbook all rely on. Pinning also
+      # makes the signing tool a deterministic, reproducible dependency. See IRO-195.
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v2.6.3
 
       - name: Sign the checksum file (cosign keyless) and attach it
         env:
@@ -346,7 +355,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # Pin to the same 2.x cosign the release job signed with, so verify-blob
+      # consumes the detached `.sig`/`.pem` it produced. See IRO-195.
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v2.6.3
 
       # Verify the keyless cosign signature over SHA256SUMS the way a real user does:
       # anonymously, from the published release, with no key to manage — the trusted


### PR DESCRIPTION
## Launch blocker fix — IRO-195

The **Release** workflow has failed on every recent tag (v0.1.88–v0.1.91) at the
cosign **"Sign the checksum file"** step:

```
Error: signing dist/SHA256SUMS: create bundle file: open : no such file or directory
```

### Root cause
`sigstore/cosign-installer` was used **without a `cosign-release` pin**, so it pulled
**cosign 3.x**. cosign 3.0.0 flipped `sign-blob` to default to the new Sigstore bundle
format, made `--bundle` **required**, and deprecated/ignored
`--output-signature`/`--output-certificate`. With no `--bundle` path, cosign tried to
write a bundle to an empty path and crashed. Because the step runs under
`set -euo pipefail`, the job aborted **before** the build-provenance attestation step →

- no `SHA256SUMS.sig` / `SHA256SUMS.pem` on any release,
- `gh attestation verify <tarball>` → **HTTP 404** (attest step never ran),
- post-release install **smoke jobs skipped** (they `need` the release job).

Regression of **IRO-46** (SLSA provenance) and **IRO-32** (WS-A supply-chain trust).

### Fix
Pin `cosign-release: v2.6.3` (latest 2.x) on **both** cosign-installer steps (the
release/sign job and the smoke/verify job). In 2.6.x the new bundle format is **opt-in**
(`--new-bundle-format=true`), so `sign-blob --output-signature/--output-certificate`
still emits the detached `.sig`/`.pem` that the anonymous `cosign verify-blob` smoke
step, the README "Verify the download", `docs/security.md`, and `docs/release-runbook.md`
all consume — **no command or doc churn**. Pinning also makes the signing tool a
deterministic, reproducible dependency (consistent with IRO-92 pinned-deps posture).

### Verification
- `release.yml` parses as valid YAML; diff is exactly the two `cosign-release: v2.6.3` pins.
- cosign 2.6.x release notes confirm new-bundle-format is opt-in there; the default flip
  to required-bundle landed in v3.0.0. `cosign-linux-amd64` asset exists for v2.6.3.
- **End-to-end validation happens on merge:** pushing to `main` cuts a fresh tag and runs
  the full Release workflow. Success criteria: green Release run, `.sig`/`.pem` attached,
  `gh attestation verify` passes, and the cosign-verify + install smoke jobs pass. Then
  re-run IRO-190 pre-launch smoke (checksum already PASS; need attestation + cosign verify).

Scope confined to `release.yml`; no other workflow uses cosign-installer.

Security lenses: supply-chain / release integrity (restores signing + provenance);
no trust boundary widened — strengthens determinism. Trust-model/release-gating → CEO review.