### PR TITLE
docs(readme): Homebrew version-pin pointer + WS-H copy review (IRO-197)

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,10 @@ This installs `ironctl`, `ironclaw-controlplane`, and `ironclaw-sandbox` from th
 formula pins each archive to the SHA-256 recorded in the release's signed `SHA256SUMS`, so Homebrew
 verifies the download before installing. Confirm it with `ironctl version`.
 
+Homebrew always installs the **latest** release. To pin an older version, use the installer
+script's `IRONCLAW_VERSION` ([below](#prebuilt-binaries-installer-script)) or grab the archive
+by hand — the tap carries only the current release.
+
 > **Use the fully-qualified name.** homebrew-core ships an *unrelated* formula also called `ironclaw`,
 > and core wins the bare name — so install `ironsecco/ironclaw/ironclaw`, not bare `ironclaw`. The
 > explicit tap URL is required too: our tap lives in this repo, not a `homebrew-ironclaw` repo.


### PR DESCRIPTION
## WS-H copy review — README + quickstart Homebrew install section

Follow-up to IRO-193 (functional brew defects) and IRO-175 (#198, which landed the qualified command + collision warning). This is the **non-blocking copy review** requested in IRO-197.

### Verdict on the three asks

**1. Collision caveat — trustworthy. No change.**
The blockquote explains *why* (homebrew-core wins the bare name), shows right vs. wrong form, and correctly justifies the explicit tap URL (our tap repo isn't `homebrew-ironclaw`). A first-time user has the *what* and the *why* to trust `ironsecco/ironclaw/ironclaw`.

**2. Ordering — correct. No change.**
README: Homebrew → installer script → from source → Docker is the conventional lowest-friction order (Jakob's Law; package manager first for macOS/Linux devs). Quickstart correctly keeps build-first with a "skip the build" tip box — adding pinning detail there would fight its purpose (Tesler's Law), so it's left alone.

**3. `--HEAD` / version-pin — the one real gap. Fixed here.**
- `--HEAD` is **intentionally not documented**: `Formula/ironclaw.rb` is a binary/bottle formula with **no `head do` block**, so `brew install --HEAD …` would error. Telling users to run a command that fails is a trust break for a security tool — so we must *not* surface it.
- Version-pinning *was* undiscoverable from the Homebrew block: the only pin path (`IRONCLAW_VERSION`) lived in a separate section with no pointer. This PR adds a one-line, in-context pointer that routes pinning to the correct path and states plainly that brew tracks only the latest release.

### Change
One paragraph added to the README Homebrew block (4 lines). No quickstart change.

### Notes / deliberate non-changes
- README uses `ironctl version` (Homebrew confirm) and `ironctl --version` (prebuilt confirm). Both are valid (`cmd/ironctl/main.go:43`). Left the `--version` flag form in the prebuilt code block — it's the conventional flag and chasing uniformity adds churn without UX gain.

### Visual-truth note
This is a copy/Markdown change verified against rendered source on `origin/main`; the added anchor `#prebuilt-binaries-installer-script` matches GitHub's slug for "Prebuilt binaries (installer script)". cc @QA if a rendered-Markdown spot-check is wanted.