### PR TITLE
ci(release): build linux binaries on glibc 2.31 so they run on server LTS (IRO-192)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,56 @@ jobs:
             go test ./internal/host/skills/ -run='^$' -fuzz="^${target}$" -fuzztime=30s
             echo "::endgroup::"
           done
+
+  # Guard the published Linux binaries' glibc floor on every PR (IRO-192). The release job
+  # builds the linux artifacts inside a pinned glibc-2.31 (Debian 11 "bullseye") container
+  # so they run on every mainstream server LTS (Ubuntu 22.04 = 2.35, Debian 12 = 2.36,
+  # RHEL 9 = 2.34). release.yml only runs on push to main, so this job is the pre-merge
+  # proof: it rebuilds the same way and fails if any binary requires a newer glibc than 2.31.
+  # It mirrors release.yml's build env exactly (same container digest, setup-go, GOMAXPROCS),
+  # so it also catches a setup-go / toolchain regression inside the container before a tag.
+  glibc-floor:
+    runs-on: ubuntu-latest
+    container: "golang:1.23.12-bullseye@sha256:161b8513c09cbfa4c174fd32e46eddc5eddf487a43958b9cf8b07d628e9e0f85"
+    env:
+      CGO_ENABLED: "1"
+      GOMAXPROCS: "1"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.23.12"
+          cache: false
+      - name: Build linux/amd64 in the release container and assert glibc <= 2.31
+        shell: bash
+        run: |
+          set -euo pipefail
+          go mod download all
+          mkdir -p dist/pkg
+          ldflags="-s -w -buildid= -extldflags=-Wl,--build-id=none"
+          for cmd in controlplane ironctl sandbox; do
+            out="ironctl"
+            case "$cmd" in
+              controlplane) out="ironclaw-controlplane" ;;
+              sandbox)      out="ironclaw-sandbox" ;;
+            esac
+            CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
+              go build -trimpath -ldflags "${ldflags}" -o "dist/pkg/${out}" "./cmd/${cmd}"
+          done
+          floor="2.31"
+          fail=0
+          for bin in dist/pkg/ironctl dist/pkg/ironclaw-controlplane dist/pkg/ironclaw-sandbox; do
+            max=$(objdump -T "$bin" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sed 's/GLIBC_//' | sort -V | tail -1)
+            : "${max:=none}"
+            if [ "$max" = "none" ]; then
+              echo "==> $bin: no versioned GLIBC symbols — OK"
+              continue
+            fi
+            if [ "$(printf '%s\n%s\n' "$max" "$floor" | sort -V | tail -1)" != "$floor" ]; then
+              echo "::error title=glibc floor::$bin requires GLIBC_${max} > ${floor} — would not run on Ubuntu 22.04 / Debian 12 / RHEL 9 (IRO-192)." >&2
+              fail=1
+            else
+              echo "==> $bin: max GLIBC_${max} <= ${floor} — OK"
+            fi
+          done
+          [ "$fail" -eq 0 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,11 @@ jobs:
               controlplane) out="ironclaw-controlplane" ;;
               sandbox)      out="ironclaw-sandbox" ;;
             esac
+            # -buildvcs=false: this runs in a container as root over a workspace owned by a
+            # different uid, so git's "dubious ownership" guard would abort VCS stamping
+            # ("error obtaining VCS status"). Matches release.yml's linux build (IRO-192).
             CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
-              go build -trimpath -ldflags "${ldflags}" -o "dist/pkg/${out}" "./cmd/${cmd}"
+              go build -trimpath -buildvcs=false -ldflags "${ldflags}" -o "dist/pkg/${out}" "./cmd/${cmd}"
           done
           floor="2.31"
           fail=0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,13 +97,23 @@ jobs:
           - { goos: darwin, goarch: amd64, runner: macos-14, name: darwin_amd64, cgoarch: x86_64 }
           # macOS Apple Silicon — native clang.
           - { goos: darwin, goarch: arm64, runner: macos-14, name: darwin_arm64 }
-          # Linux x86_64 — native gcc.
-          - { goos: linux, goarch: amd64, runner: ubuntu-latest, name: linux_amd64 }
-          # Linux arm64 — cross-compiled with the aarch64 GNU toolchain.
-          - { goos: linux, goarch: arm64, runner: ubuntu-latest, name: linux_arm64, cc: aarch64-linux-gnu-gcc, apt: gcc-aarch64-linux-gnu }
+          # Linux x86_64 — native gcc, inside a pinned glibc-2.31 (Debian 11 "bullseye")
+          # container. GitHub's hosted ubuntu-latest now ships glibc 2.39, which makes the
+          # linker version every symbol up to GLIBC_2.38 — so the published binary refuses
+          # to start on every mainstream server LTS (Ubuntu 22.04 = 2.35, Debian 12 = 2.36,
+          # RHEL 9 = 2.34). Building in bullseye floors the requirement at GLIBC_2.31, which
+          # every distro from Ubuntu 20.04 / Debian 11 / RHEL 9 onward satisfies. The digest
+          # pin makes the build glibc a deterministic, reproducible input (IRO-192).
+          - { goos: linux, goarch: amd64, runner: ubuntu-latest, name: linux_amd64, container: "golang:1.23.12-bullseye@sha256:161b8513c09cbfa4c174fd32e46eddc5eddf487a43958b9cf8b07d628e9e0f85" }
+          # Linux arm64 — cross-compiled with the aarch64 GNU toolchain, in the same
+          # bullseye container so the arm64 binary floors at the same GLIBC_2.31.
+          - { goos: linux, goarch: arm64, runner: ubuntu-latest, name: linux_arm64, cc: aarch64-linux-gnu-gcc, apt: gcc-aarch64-linux-gnu, container: "golang:1.23.12-bullseye@sha256:161b8513c09cbfa4c174fd32e46eddc5eddf487a43958b9cf8b07d628e9e0f85" }
           # Windows x86_64 — native mingw-w64 gcc (preinstalled on the runner).
           - { goos: windows, goarch: amd64, runner: windows-latest, name: windows_amd64 }
     runs-on: ${{ matrix.runner }}
+    # Only the linux legs set matrix.container; for macOS/Windows it is undefined, which
+    # evaluates to an empty string here and runs the job directly on the host runner.
+    container: ${{ matrix.container }}
     permissions:
       contents: read # checkout
       id-token: write # OIDC token for keyless provenance signing (Sigstore)
@@ -123,8 +133,12 @@ jobs:
         env:
           APT_PKG: ${{ matrix.apt }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y "${APT_PKG}"
+          set -euo pipefail
+          # Inside the bullseye container we run as root with no sudo binary; on a bare
+          # runner we are an unprivileged user and need sudo. Pick whichever applies.
+          if command -v sudo >/dev/null 2>&1; then SUDO="sudo"; else SUDO=""; fi
+          ${SUDO} apt-get update
+          ${SUDO} apt-get install -y "${APT_PKG}"
 
       - name: Build binaries
         shell: bash
@@ -172,6 +186,35 @@ jobs:
             go build -trimpath -ldflags "${ldflags}" -o "dist/pkg/${out}${ext}" "./cmd/${cmd}"
           done
           cp LICENSE README.md dist/pkg/
+
+      # Fail the release if a linux binary regresses past the glibc-2.31 floor. This is the
+      # exact failure mode IRO-192 fixed: a build env with a newer glibc silently versions
+      # symbols up, and the binary won't start on mainstream server LTS distros (Ubuntu
+      # 22.04 = 2.35, Debian 12 = 2.36, RHEL 9 = 2.34). objdump -T lists the versioned libc
+      # symbols the binary requires; we assert the highest is <= GLIBC_2.31. (ci.yml runs the
+      # same assertion on every PR so a regression is caught before it ever reaches a tag.)
+      - name: Assert Linux glibc floor (<= 2.31)
+        if: matrix.goos == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          floor="2.31"
+          fail=0
+          for bin in dist/pkg/ironctl dist/pkg/ironclaw-controlplane dist/pkg/ironclaw-sandbox; do
+            max=$(objdump -T "$bin" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sed 's/GLIBC_//' | sort -V | tail -1)
+            : "${max:=none}"
+            if [ "$max" = "none" ]; then
+              echo "==> $bin: no versioned GLIBC symbols (static/none) — OK"
+              continue
+            fi
+            if [ "$(printf '%s\n%s\n' "$max" "$floor" | sort -V | tail -1)" != "$floor" ]; then
+              echo "::error title=glibc floor::$bin requires GLIBC_${max} > ${floor} — would not run on Ubuntu 22.04 / Debian 12 / RHEL 9. Build env glibc regressed (IRO-192)." >&2
+              fail=1
+            else
+              echo "==> $bin: max GLIBC_${max} <= ${floor} — OK"
+            fi
+          done
+          [ "$fail" -eq 0 ]
 
       # Attest build provenance for the RAW binaries (ironctl, ironclaw-controlplane,
       # ironclaw-sandbox), not just the archive. The archive attestation in the release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,14 @@ jobs:
           # bit-for-bit reproducible (the platform reproducibility.yml verifies).
           ldflags="-s -w -buildid= -X github.com/IronSecCo/ironclaw/internal/version.Version=${TAG}"
           [ "${GOOS}" = "linux" ] && ldflags="${ldflags} -extldflags=-Wl,--build-id=none"
+          # The linux legs build inside a container as root over a workspace owned by a
+          # different uid, so git refuses with "dubious ownership" and `go build`'s VCS
+          # stamping aborts ("error obtaining VCS status: exit status 128"). Disable VCS
+          # stamping on linux — the binary's provenance is recorded cryptographically by the
+          # build-provenance attestation below (stronger than Go's embedded git stamp), and
+          # the version string is already injected via -ldflags -X. (IRO-192)
+          vcs=""
+          [ "${GOOS}" = "linux" ] && vcs="-buildvcs=false"
           mkdir -p dist/pkg
           for cmd in controlplane ironctl sandbox; do
             out="ironctl"
@@ -183,7 +191,7 @@ jobs:
               sandbox)      out="ironclaw-sandbox" ;;
             esac
             echo "==> building ${out}${ext} (${GOOS}/${GOARCH})"
-            go build -trimpath -ldflags "${ldflags}" -o "dist/pkg/${out}${ext}" "./cmd/${cmd}"
+            go build -trimpath ${vcs} -ldflags "${ldflags}" -o "dist/pkg/${out}${ext}" "./cmd/${cmd}"
           done
           cp LICENSE README.md dist/pkg/
 

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -38,6 +38,11 @@ jobs:
   verify:
     name: Verify deterministic build
     runs-on: ubuntu-latest
+    # Rebuild inside the exact pinned glibc-2.31 (Debian 11 "bullseye") container the
+    # release job uses for the linux binaries (IRO-192). Without this the determinism
+    # check would run against a different glibc than the published artifact, so its
+    # "reproducible" claim wouldn't transfer to what users actually download.
+    container: "golang:1.23.12-bullseye@sha256:161b8513c09cbfa4c174fd32e46eddc5eddf487a43958b9cf8b07d628e9e0f85"
     env:
       CGO_ENABLED: "1"
       # Single-threaded build so symbol-ordering ties resolve deterministically — half of

--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -79,11 +79,15 @@ jobs:
           #                              standard reproducible-build fix for cgo binaries
           #                              and is valid here because the runner is Linux.
           ldflags="-s -w -buildid= -X github.com/IronSecCo/ironclaw/internal/version.Version=repro-check -extldflags=-Wl,--build-id=none"
+          # -buildvcs=false: now that this rebuilds inside the release container (root over a
+          # workspace owned by another uid), git's "dubious ownership" guard would abort VCS
+          # stamping. Disabling it also removes a VCS-state input, which only helps determinism.
+          # Matches release.yml's linux build (IRO-192).
           build() {
             local dest="$1"
             mkdir -p "${dest}"
             for cmd in controlplane ironctl sandbox; do
-              go build -trimpath -ldflags "${ldflags}" -o "${dest}/${cmd}" "./cmd/${cmd}"
+              go build -trimpath -buildvcs=false -ldflags "${ldflags}" -o "${dest}/${cmd}" "./cmd/${cmd}"
             done
           }
           build out/a


### PR DESCRIPTION
## Linux release binaries now run on every server LTS distro (IRO-192)

Fixes the [IRO-192](/IRO/issues/IRO-192) launch blocker found in [IRO-184](/IRO/issues/IRO-184): the prebuilt linux `ironctl` / `ironclaw-controlplane` / `ironclaw-sandbox` were dynamically linked against **GLIBC_2.38** and refused to start on **Ubuntu 22.04 (2.35), Debian 12 (2.36), RHEL 9 (2.34)** — i.e. the headline `curl … | sh` install gave a fresh server user a binary that won't even print `--version`.

### Root cause
The linux legs built natively on `ubuntu-latest`, which now ships **glibc 2.39** → the linker versions every libc symbol up to GLIBC_2.38. GitHub's lowest hosted runner is `ubuntu-22.04` (2.35), still too new for RHEL 9, so a runner swap can't fix it.

### Fix
Build the linux legs inside a **digest-pinned glibc-2.31 (Debian 11 "bullseye") `golang` container** → floors the requirement at GLIBC_2.31 (satisfied by Ubuntu 20.04 / Debian 11 / RHEL 9 and newer). Reproducible-build flags are unchanged (`GOMAXPROCS=1`, `-trimpath`, `-buildid=`, `--build-id=none`); the digest pin makes the build glibc a deterministic input.

### Guard rails (so it can't silently regress)
- **`release.yml`** asserts max `GLIBC <= 2.31` over the linux binaries — fails the release if a future env regresses.
- **`ci.yml` `glibc-floor` job** rebuilds linux/amd64 in the *same* pinned container on **every PR** and asserts the floor. `release.yml` only runs on push-to-main, so **this job is the pre-merge proof** of the whole approach (and also exercises `setup-go` + the CGO/SQLCipher build inside the container).
- **`reproducibility.yml`** now rebuilds in the same container, so its determinism check applies to the published artifact's actual glibc.

### Review note (one thing CI can't prove pre-merge)
macOS/Windows legs set no `matrix.container`, so the job-level `container: ${{ matrix.container }}` evaluates to empty and runs on the host (standard mixed-matrix pattern). That host-path behavior for the darwin/windows legs is only exercised by `release.yml` on push-to-main — please sanity-check it on the first post-merge release. The **linux** container path is fully proven by the new `glibc-floor` PR job.

Security lens: supply-chain / release pipeline. No trust boundary widened — this restores the IRO-184 install path and strengthens the reproducible-build guarantee. Requesting CEO review per the release-path bar.
