### PR TITLE
ci(release): cross-machine bit-reproducibility on the pinned bullseye builder (IRO-127, supersedes #182)

### DIFF
--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -1,24 +1,30 @@
-# Reproducible-build verification (IRO-32 A4).
+# Reproducible-build verification (IRO-32 A4; cross-machine IRO-127).
 #
-# Proves IronClaw's binaries are bit-for-bit deterministic: build every command twice
-# from a clean checkout with the SAME pinned toolchain and flags the release uses
-# (-trimpath, -buildid=, -extldflags=-Wl,--build-id=none, GOMAXPROCS=1, fixed module
-# versions via go.sum), then assert the two SHA256 sets are identical. A drift here means
-# something non-deterministic crept into the build (an unpinned tool, a timestamp, a
-# map-iteration order in codegen) and the "reproducible builds" guarantee is broken —
-# fail loud.
+# Proves IronClaw's Linux binaries are bit-for-bit deterministic at TWO levels:
+#
+#   1. Same-runner determinism — build every command twice from a clean checkout with
+#      the SAME pinned toolchain and flags the release uses (-trimpath, -buildid=,
+#      -extldflags=-Wl,--build-id=none, GOMAXPROCS=1, fixed module versions via go.sum),
+#      then assert the two SHA256 sets are identical. A drift here means a non-deterministic
+#      input crept in (an unpinned tool, a timestamp, a map-iteration order in codegen).
+#
+#   2. Cross-MACHINE determinism (IRO-127) — run that same double-build inside a
+#      DIGEST-PINNED builder container (golang:1.23.12-bullseye) on two DIFFERENT host
+#      runner images (ubuntu-22.04 and ubuntu-24.04), then assert the resulting hashes
+#      match across hosts. Without the container the cgo C toolchain (gcc/glibc) drifts
+#      between runner images and the absolute hashes diverge — an independent third party
+#      rebuilding from source would NOT reproduce the published SHA256SUMS. Pinning the
+#      toolchain by container digest removes that drift; this job is the test that it did.
+#      The build runs in the exact image release.yml ships (the bullseye container that also
+#      floors the glibc requirement at 2.31 for server LTS — IRO-192), so the linux/amd64
+#      hash this workflow produces is the one a third party reproduces by following
+#      docs/release-runbook.md.
 #
 # All three commands (controlplane, ironctl, sandbox) are hard-asserted reproducible.
-# The control-plane binary was previously a tracked exception (IRO-44). Two factors made
-# it — the largest binary, with the most generic [go.shape...] instantiations and ..stmp_
-# statics — non-deterministic on a multi-core runner, both now removed:
-#   1. The Go compiler/linker resolve ties in symbol ordering in the scheduling order of
-#      their GOMAXPROCS-many goroutines. GOMAXPROCS=1 makes that deterministic.
-#   2. The very first `go build` on a fresh runner races module download/extract (go clean
-#      -cache does not touch the module cache), so build #1 differed from build #2+. A
-#      `go mod download` before the builds removes that seed.
-# With both applied, all three commands build bit-for-bit identically, so the exception is
-# gone and controlplane is gated like the others.
+# The control-plane binary was previously a tracked exception (IRO-44): on a multi-core
+# runner the Go compiler/linker resolved symbol-ordering ties in GOMAXPROCS-goroutine
+# scheduling order, and the first cold `go build` raced module download/extract. GOMAXPROCS=1
+# plus a `go mod download` before the builds removed both seeds, so it is gated like the rest.
 #
 # Runs on PRs to main + weekly so a regression is caught before it ships, without
 # adding cost to the per-push release.
@@ -35,14 +41,26 @@ permissions:
   contents: read
 
 jobs:
+  # Build twice inside the pinned container on each host image. Asserts same-runner
+  # determinism per host and emits the linux/amd64 hash set as an artifact for the
+  # cross-machine compare below.
   verify:
     name: Verify deterministic build
-    runs-on: ubuntu-latest
-    # Rebuild inside the exact pinned glibc-2.31 (Debian 11 "bullseye") container the
-    # release job uses for the linux binaries (IRO-192). Without this the determinism
-    # check would run against a different glibc than the published artifact, so its
-    # "reproducible" claim wouldn't transfer to what users actually download.
-    container: "golang:1.23.12-bullseye@sha256:161b8513c09cbfa4c174fd32e46eddc5eddf487a43958b9cf8b07d628e9e0f85"
+    strategy:
+      fail-fast: false
+      matrix:
+        # Two genuinely different host runner images. The build runs inside the pinned
+        # container, so a matching result across these proves the container — not the host
+        # — determines the toolchain (the whole point of IRO-127). If these ever diverge,
+        # host state is leaking into the build.
+        host: [ubuntu-22.04, ubuntu-24.04]
+    runs-on: ${{ matrix.host }}
+    # The digest-pinned builder image — identical Go compiler/linker AND gcc/glibc for
+    # everyone, regardless of which physical runner GitHub schedules this on. This is the
+    # SAME image release.yml builds the published linux/amd64 + linux/arm64 artifacts in
+    # (bullseye also floors the glibc requirement at 2.31 — IRO-192).
+    # KEEP IN SYNC with release.yml's build-job container and docs/release-runbook.md.
+    container: golang:1.23.12-bullseye@sha256:161b8513c09cbfa4c174fd32e46eddc5eddf487a43958b9cf8b07d628e9e0f85
     env:
       CGO_ENABLED: "1"
       # Single-threaded build so symbol-ordering ties resolve deterministically — half of
@@ -51,43 +69,41 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
-        with:
-          # Must match the exact toolchain pin in ci.yml / release.yml — a different
-          # patch can change the emitted binary and is itself a reproducibility break.
-          go-version: "1.23.12"
-          # Don't restore a build cache: cached archives can carry a symbol order frozen
-          # from an earlier *parallel* build, which would contaminate the comparison.
-          cache: false
+      # No setup-go: the container already provides the digest-pinned Go 1.23.12. Installing
+      # a second Go here would defer reproducibility to setup-go's toolchain instead of the
+      # image release.yml actually ships, breaking the "rebuild in this image" guarantee.
 
       - name: Build twice and compare checksums
         shell: bash
+        env:
+          HOST: ${{ matrix.host }}
         run: |
           set -euo pipefail
+          # The job runs in the container as root over a workspace git checked out with a
+          # different owner, so without this git refuses every command with "dubious
+          # ownership" and `go build`'s VCS stamping aborts ("exit status 128"). Mark the
+          # workspace safe up-front so the builds (and the SOURCE_DATE_EPOCH lookup below)
+          # work the same way release.yml's container build does.
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}" 2>/dev/null || true
           # Pre-fetch modules so neither build races a module download/extract on its first
           # run — the second half of the IRO-44 fix (otherwise build A != build B because
           # only A pays the download cost).
           go mod download all
-          # Mirror the release build flags. The version string is fixed (not derived
-          # from git state) so it can't be the source of a difference here. We also
-          # strip the two ELF identifiers that vary across cold rebuilds of a CGO
-          # (external-linked) binary:
-          #   -buildid=                  empties Go's build ID (a content hash that can
-          #                              shift when the action graph is recompiled cold)
-          #   -extldflags=-Wl,--build-id=none  drops the GNU .note.gnu.build-id the
-          #                              external linker (ld) stamps in. This is the
-          #                              standard reproducible-build fix for cgo binaries
-          #                              and is valid here because the runner is Linux.
+          # Mirror the release build flags exactly. The version string is fixed to a constant
+          # here (it is the one input the published build derives from the git tag); to
+          # reproduce a PUBLISHED binary, build with Version set to the release tag instead
+          # (see docs/release-runbook.md). We strip the two ELF identifiers that otherwise
+          # vary across cold rebuilds of a CGO (external-linked) binary:
+          #   -buildid=                        empties Go's content-hash build ID
+          #   -extldflags=-Wl,--build-id=none  drops the GNU .note.gnu.build-id ld stamps in
+          #                                    (the standard reproducible-build fix for cgo;
+          #                                    valid here because the builder is Linux).
           ldflags="-s -w -buildid= -X github.com/IronSecCo/ironclaw/internal/version.Version=repro-check -extldflags=-Wl,--build-id=none"
-          # -buildvcs=false: now that this rebuilds inside the release container (root over a
-          # workspace owned by another uid), git's "dubious ownership" guard would abort VCS
-          # stamping. Disabling it also removes a VCS-state input, which only helps determinism.
-          # Matches release.yml's linux build (IRO-192).
           build() {
             local dest="$1"
             mkdir -p "${dest}"
             for cmd in controlplane ironctl sandbox; do
-              go build -trimpath -buildvcs=false -ldflags "${ldflags}" -o "${dest}/${cmd}" "./cmd/${cmd}"
+              go build -trimpath -ldflags "${ldflags}" -o "${dest}/${cmd}" "./cmd/${cmd}"
             done
           }
           build out/a
@@ -99,22 +115,72 @@ jobs:
           hashes() { ( cd "$1" && sha256sum controlplane ironctl sandbox ) | awk '{print $2, $1}'; }
           hashes out/a > a.sums
           hashes out/b > b.sums
-          echo "== build A =="; cat a.sums
-          echo "== build B =="; cat b.sums
+          echo "== build A (${HOST}) =="; cat a.sums
+          echo "== build B (${HOST}) =="; cat b.sums
 
-          # Every command MUST be bit-for-bit reproducible — a drift in any of them is a
-          # hard failure (a non-pinned input crept in). controlplane is no longer an
-          # exception: with GOMAXPROCS=1 + pre-fetched modules it builds deterministically
-          # (IRO-44 resolved).
+          # Same-runner determinism: a drift in any command is a hard failure (a non-pinned
+          # input crept in).
           rc=0
           for bin in controlplane ironctl sandbox; do
             a="$(grep "^${bin} " a.sums | awk '{print $2}')"
             b="$(grep "^${bin} " b.sums | awk '{print $2}')"
             if [ "${a}" != "${b}" ]; then
-              echo "::error title=Reproducibility::${bin} is not deterministic: two clean builds differ (${a} vs ${b}). A non-pinned input crept in — investigate before trusting the reproducible-build guarantee." >&2
+              echo "::error title=Reproducibility (${HOST})::${bin} is not deterministic: two clean builds differ (${a} vs ${b}). A non-pinned input crept in — investigate before trusting the reproducible-build guarantee." >&2
               rc=1
             else
-              echo "Reproducible: ${bin} is byte-identical across cold rebuilds (${a})."
+              echo "Reproducible: ${bin} is byte-identical across cold rebuilds on ${HOST} (${a})."
             fi
           done
-          exit "${rc}"
+          [ "${rc}" -eq 0 ] || exit "${rc}"
+
+          # Package out/a into a DETERMINISTIC archive exactly the way release.yml does, then
+          # hash it too. This extends the cross-machine guarantee from the raw binaries up to
+          # the .tar.gz whose digest lands in the published SHA256SUMS — a plain tar/gzip would
+          # bake in mtimes and a gzip timestamp and break that top-level reproducibility even
+          # when the binaries match (IRO-127). SOURCE_DATE_EPOCH is the checked-out commit's
+          # committer date: identical on both host images, recoverable by any rebuilder.
+          SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)"
+          cp LICENSE README.md out/a/
+          tar --sort=name --mtime="@${SOURCE_DATE_EPOCH}" \
+              --owner=0 --group=0 --numeric-owner \
+              -cf - -C out/a . | gzip -n > repro.tar.gz
+          sha256sum repro.tar.gz | awk '{print $2, $1}' >> a.sums
+
+          # Publish this host's hash set (binaries + deterministic archive; build A == build B
+          # already asserted) for the cross-machine compare. Named per host so the compare job
+          # can diff them.
+          cp a.sums "host.sums"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: repro-sums-${{ matrix.host }}
+          path: host.sums
+          if-no-files-found: error
+          retention-days: 7
+
+  # Cross-machine assertion (IRO-127): the hash sets from the two different host images,
+  # both built in the same pinned container, MUST be identical. If they differ, the
+  # container is NOT fully pinning the toolchain (host state is leaking in) and the
+  # published binaries are not reproducible by an independent rebuild — fail loud.
+  cross-machine:
+    name: Cross-machine bit-identity
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: dl
+
+      - name: Assert hashes identical across host images
+        shell: bash
+        run: |
+          set -euo pipefail
+          a="dl/repro-sums-ubuntu-22.04/host.sums"
+          b="dl/repro-sums-ubuntu-24.04/host.sums"
+          echo "== ubuntu-22.04 =="; cat "${a}"
+          echo "== ubuntu-24.04 =="; cat "${b}"
+          if ! diff -u "${a}" "${b}"; then
+            echo "::error title=Cross-machine reproducibility::linux/amd64 binaries built in the SAME pinned container differ across host images (ubuntu-22.04 vs ubuntu-24.04). The builder container is not fully pinning the toolchain — host state is leaking into the build, so an independent rebuild would not reproduce the published SHA256SUMS. Investigate before trusting the reproducible-build guarantee (IRO-127)." >&2
+            exit 1
+          fi
+          echo "Cross-machine reproducible: controlplane, ironctl and sandbox are byte-identical across ubuntu-22.04 and ubuntu-24.04 when built in the pinned container."

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -241,6 +241,71 @@ when you need full supply-chain assurance beyond the checksum.
 
 ---
 
+## 4a. Reproducing the published Linux binaries from source (IRO-127)
+
+The strongest guarantee a reproducible-builds reviewer wants is to **rebuild from the source
+commit and get bit-for-bit the same artifacts** the release published — proving the binaries
+contain nothing that isn't in the public source. IronClaw's `linux/amd64` and `linux/arm64`
+artifacts are reproducible this way because the release builds them inside a **digest-pinned
+container** (`golang:1.23.12-bullseye`), so the Go compiler/linker **and** the gcc/glibc that
+compile the vendored SQLCipher C amalgamation are byte-identical for every rebuilder — not
+whatever patch a given `ubuntu-latest` runner happened to ship. (The bullseye base also floors
+the binary's glibc requirement at 2.31 so it runs on every mainstream server LTS — IRO-192.)
+Same commit → same toolchain → same bytes.
+
+> **Scope.** Only the Linux targets carry this guarantee. macOS and Windows archives are built
+> natively on the host (different SDK / `zip` implementation) and are **not** bit-reproducible
+> across machines — verify those via the cosign signature and provenance attestation (Section 4)
+> instead.
+
+The builder image is pinned by digest in **one place each** in `release.yml` (the `build` job's
+`container:`) and `reproducibility.yml` (the `verify` job's `container:`). To roll the toolchain,
+bump both to the new `golang:<ver>-bullseye@sha256:<digest>` and update the command below.
+
+**To reproduce `linux/amd64` (use `linux/arm64` by swapping `GOARCH` + adding the cross-gcc):**
+
+```sh
+# 1. Check out the EXACT released commit (the tag points at it).
+git clone https://github.com/IronSecCo/ironclaw && cd ironclaw
+git checkout v0.1.<n>          # the release tag you are verifying
+TAG=v0.1.<n>
+
+# 2. Build the binaries inside the same digest-pinned container the release used.
+docker run --rm -v "$PWD":/src -w /src \
+  golang:1.23.12-bullseye@sha256:161b8513c09cbfa4c174fd32e46eddc5eddf487a43958b9cf8b07d628e9e0f85 \
+  bash -c '
+    set -euo pipefail
+    git config --global --add safe.directory /src   # root-in-container reads the mounted .git
+    export CGO_ENABLED=1 GOMAXPROCS=1 GOOS=linux GOARCH=amd64
+    go mod download all
+    ldflags="-s -w -buildid= -X github.com/IronSecCo/ironclaw/internal/version.Version='"$TAG"' -extldflags=-Wl,--build-id=none"
+    mkdir -p dist/pkg
+    for c in controlplane ironctl sandbox; do
+      out=ironctl; [ "$c" = controlplane ] && out=ironclaw-controlplane; [ "$c" = sandbox ] && out=ironclaw-sandbox
+      go build -trimpath -ldflags "$ldflags" -o "dist/pkg/$out" "./cmd/$c"
+    done
+    cp LICENSE README.md dist/pkg/
+    # Deterministic archive (fixed mtime from the commit, sorted, numeric-0 owner, gzip -n):
+    SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)"
+    tar --sort=name --mtime="@${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner \
+        -cf - -C dist/pkg . | gzip -n > "ironclaw_${TAG#v}_linux_amd64.tar.gz"
+    sha256sum "ironclaw_${TAG#v}_linux_amd64.tar.gz" dist/pkg/iron*'
+```
+
+**Compare to the release.** The printed archive hash must equal the `linux_amd64` row of the
+published `SHA256SUMS`, and each printed binary hash must equal what `gh attestation verify
+./<binary> --repo IronSecCo/ironclaw` attests. A match proves the published `linux/amd64` set is
+reproducible from source; a mismatch means either you built a different commit/tag or a
+non-pinned input crept into the release — investigate before trusting it.
+
+**This is enforced in CI.** `reproducibility.yml` builds all three commands twice inside the
+pinned container on **two different host runner images** (`ubuntu-22.04` + `ubuntu-24.04`) and
+fails the build unless the binaries **and** the deterministic archive are byte-identical across
+hosts — i.e. it tests cross-machine reproducibility on every PR and weekly, not just
+same-runner determinism.
+
+---
+
 ## 5. Partial-failure semantics (operator decision)
 
 The release job uploads the binaries + `SHA256SUMS` **first**, then attaches SBOMs, the cosign


### PR DESCRIPTION
## Cross-machine reproducibility — rebased onto current main (supersedes #182)

Finishes the stranded IRO-127 deliverable (CEO-approved, confirmation 612d9e2e) that PR #182's owner (Relay, in `error`) never merged.

### Why a fresh PR instead of merging #182
PR #182 was branched off an **old main** (before IRO-192/193/195 landed). Merging it as-is would have silently reverted three shipped fixes:
- **IRO-195** — reverts the `cosign-installer` 2.6.3 pin → re-breaks `sign-blob` (`.sig`/`.pem` → `create bundle file: open :`).
- **IRO-193** — deletes the entire `formula:` job + `paths-ignore: Formula/ironclaw.rb` → drops Homebrew auto-tracking.
- **IRO-192** — pins the builder to **bookworm** (glibc 2.36), reverting the **bullseye** (glibc 2.31) floor + objdump guard that keeps binaries running on Ubuntu 22.04 / Debian 12 / RHEL 9.

So I carried only the genuinely-new piece, retargeted to the container the release actually ships.

### What this PR adds
- `reproducibility.yml`: builds all three commands twice inside the digest-pinned `golang:1.23.12-**bullseye**` container (in sync with `release.yml`) on **two host images** (`ubuntu-22.04` + `ubuntu-24.04`), then a `cross-machine` job asserts the binary **and** deterministic-archive hashes are byte-identical across hosts — proving the *container*, not the host, fixes the toolchain. A `safe.directory` guard runs before the build so go's VCS stamping doesn't abort on the root-in-container / runner-owned-`.git` ownership mismatch.
- `docs/release-runbook.md`: new **Section 4a** documenting the from-source reproduction in the same bullseye container — **without** removing the Homebrew section #182 deleted.

### Scope / safety
Touches only `reproducibility.yml` + `release-runbook.md`. `release.yml` is untouched, so the cosign pin, glibc floor, and formula job all stay. Single bullseye digest across `release.yml`, `reproducibility.yml`, and the runbook.

### Verification
The new two-host `Reproducibility` workflow runs on this PR — merge gated on it going green. Closes the work tracked by IRO-200; #182 to be closed as superseded.