### PR TITLE
ci(release): pin bash on container toolchain step so pipefail is valid (IRO-201)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,11 @@ jobs:
 
       - name: Install cross C toolchain
         if: matrix.apt != ''
+        # Runs inside the bullseye container (the linux/arm64 leg sets matrix.apt),
+        # whose default shell is sh (dash) — and dash rejects `set -o pipefail`. The
+        # sibling run-steps already pin bash; this one was missed in #211, which reds
+        # every Release run on the linux/arm64 leg. Pin bash so pipefail is valid. (IRO-201)
+        shell: bash
         env:
           APT_PKG: ${{ matrix.apt }}
         run: |


### PR DESCRIPTION
## What

Adds `shell: bash` to the **Install cross C toolchain** step in `release.yml`.

## Why

Since IRO-192 (#211, `e172c9d`) the linux build legs run inside the `golang:1.23.12-bullseye` container, whose default shell is `sh` (dash). The "Install cross C toolchain" step opens with `set -euo pipefail`, which dash rejects:

```
/__w/_temp/....sh: 1: set: Illegal option -o pipefail
##[error]Process completed with exit code 2
```

This reds the `build (linux, arm64, …)` leg (the `matrix.apt != ''` leg) and therefore the **entire Release run on every push to main** since the bullseye merge. The last green Release was `481aee7`, before the container landed.

The sibling `run` steps (Build binaries, Assert glibc floor, Package archive) already pin `shell: bash`; this one was missed in the #211 squash.

## Audit

The `build` job is the only job that sets `container:`. Within it, every other `run:` step already pins `shell: bash`. All other jobs (version, release, smoke, smoke_windows, formula) run on host runners where bash is the default. This step was the sole omission.

## VCS-stamping (already fixed)

The issue also flagged the `-buildvcs=false` fix as potentially unmerged. It is in fact **already on main** — it landed in #211 itself (`release.yml` lines 184–185). No change needed.

## Verification

`release.yml` only runs on push to `main` (not PRs), so this can't be proven on the PR. Success condition: a green `Release` run on the next `main` push after merge.

Closes IRO-201.