### PR TITLE
chore(brew): track v0.1.99 in the Homebrew formula (IRO-202)

### DIFF
--- a/Formula/ironclaw.rb
+++ b/Formula/ironclaw.rb
@@ -16,28 +16,28 @@
 class Ironclaw < Formula
   desc "Security-hardened, self-hosted AI assistant platform (secured Go port)"
   homepage "https://github.com/IronSecCo/ironclaw"
-  version "0.1.90"
+  version "0.1.99"
   license "AGPL-3.0-or-later"
 
   on_macos do
     on_arm do
-      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.90/ironclaw_0.1.90_darwin_arm64.tar.gz"
-      sha256 "e6ad74821e2fd85fa43b5019e55719002b5adf58ed2d6f3a01f433072213940f"
+      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.99/ironclaw_0.1.99_darwin_arm64.tar.gz"
+      sha256 "99f882ce1a1b0963b034be9239cd58676c3d7e01f765377a9e9210a3a91dac38"
     end
     on_intel do
-      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.90/ironclaw_0.1.90_darwin_amd64.tar.gz"
-      sha256 "30f8c89ab1b5aa6342a024c6ee7a0515a193b734661c6c01da22279b3232aefb"
+      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.99/ironclaw_0.1.99_darwin_amd64.tar.gz"
+      sha256 "a10003d9bd39291a6d22d78715159fd4b281d1199adf724f16f0907cf0fd2e5c"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.90/ironclaw_0.1.90_linux_arm64.tar.gz"
-      sha256 "ac165b79e54509c4086bbf86ca806240bfa0b8fa57b1f98d7acb01b0013fbf6f"
+      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.99/ironclaw_0.1.99_linux_arm64.tar.gz"
+      sha256 "7a4cc49bf3895810d38adf753474cc4b676ad770760c2f3d27a29934de66b8a0"
     end
     on_intel do
-      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.90/ironclaw_0.1.90_linux_amd64.tar.gz"
-      sha256 "111fb538482623244ae9ebedba13d4b1615dddd9f346cc9c5ff6784fb59ff839"
+      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.99/ironclaw_0.1.99_linux_amd64.tar.gz"
+      sha256 "901fc63f3df3ed906605774c210fdc6c4c5a2d9e0a6e4ffafd6a85f72da69c49"
     end
   end
 
@@ -56,7 +56,7 @@ class Ironclaw < Formula
         ironctl doctor      # preflight: model creds, toolchain, sockets
 
       For production the control plane usually runs as a container:
-        ghcr.io/ironsecco/ironclaw-controlplane:v0.1.90
+        ghcr.io/ironsecco/ironclaw-controlplane:v0.1.99
       See https://ironsecco.github.io/ironclaw/quickstart/ for the full first-run flow.
     EOS
   end


### PR DESCRIPTION
Bumps `Formula/ironclaw.rb` from v0.1.90 → **v0.1.99** so `brew install ironsecco/ironclaw/ironclaw` tracks the latest green, glibc-fixed release.

**Why this was stuck:** the Release `formula` job *did* run on the v0.1.99 green release and created this GitHub-signed branch `brew/track-v0.1.99` (commit ba112fc) — but its `gh pr create` step failed with `GraphQL: GitHub Actions is not permitted to create or approve pull requests`, swallowed by a `|| echo` fallback, so the job went green with no PR. Same failure left `brew/track-v0.1.94/95/96` dangling. Opening the PR manually from the already-signed branch (Forge creds). Follow-up to make the job self-bump tracked in IRO-202.

**Trust anchor:** every SHA-256 below is read from the v0.1.99 signed `SHA256SUMS` (the same anchor install.sh uses):
- linux_amd64  `901fc63f…`  / linux_arm64  `7a4cc49b…`
- darwin_amd64 `a10003d9…`  / darwin_arm64 `99f882ce…`

**glibc floor:** v0.1.90 predated the IRO-192 fix and required GLIBC_2.38 (broke Ubuntu 22.04/Debian 12/RHEL 9). v0.1.99 is built on `golang:1.23.12-bullseye` and cleared the release `objdump` glibc-2.31-floor guard (build leg green in run 28216033979) — so the brew Linux path now runs on server LTS.

Closes the launch gap from IRO-194 review. Relates to IRO-175 / IRO-193.