### PR TITLE
docs: contributor on-ramp — ROADMAP.md + CONTRIBUTING 5-min quickstart (IRO-209)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,37 @@ bug reports, fixes, new channel adapters, docs, and tests.
 New here? The [**documentation site**](https://ironsecco.github.io/ironclaw/) is the best
 starting point — architecture, threat model, quickstart, channels, and skills in one place.
 
+## Quickstart — your first PR in 5 minutes
+
+From a clean checkout (Go 1.23+, with `CGO_ENABLED=1` for the SQLCipher binding):
+
+```bash
+# 1. Fork on GitHub, then clone your fork
+git clone https://github.com/<you>/ironclaw && cd ironclaw
+
+# 2. Build and run the checks (this is exactly what CI runs)
+export CGO_ENABLED=1
+make build vet test      # or: go build ./... && go vet ./... && go test ./...
+
+# 3. Branch, make your change, and verify formatting
+git checkout -b my-change
+gofmt -l .               # must print nothing
+
+# 4. Commit and push to your fork, then open a PR against `main`
+git commit -am "docs: fix a typo"
+git push -u origin my-change
+```
+
+Then open the pull request, fill in the template, and link the issue it closes.
+The **CLA Assistant** bot comments on your first PR with a one-click signing link —
+that's all the setup there is. A maintainer reviews and merges.
+
+**Looking for something to work on?** Grab a
+[**good first issue**](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+(comment to claim it first), or ask in
+[**Discussions**](https://github.com/IronSecCo/ironclaw/discussions). The rest of this
+guide covers the ground rules, the frozen contract, and the code layout in detail.
+
 ## Ground rules
 
 - **Open an issue first** for anything non-trivial, so we can agree on the approach

--- a/README.md
+++ b/README.md
@@ -836,8 +836,10 @@ To report a vulnerability, please open a private security advisory rather than a
 > [Road to 1.0](https://ironsecco.github.io/ironclaw/roadmap/)** — the single source
 > of truth. It tracks the *product* road to 1.0 (public launch, web UI, channels, and
 > supply-chain trust) with a status-at-a-glance table and a comparison against the
-> category. The checklist below is the **engineering build-log** for the security
-> backend (Waves 0–5) and the hardening that followed.
+> category. For the short, contributor-facing view — direction, what 1.0 means, and
+> **help-wanted themes** — see [`ROADMAP.md`](ROADMAP.md). The checklist below is the
+> **engineering build-log** for the security backend (Waves 0–5) and the hardening
+> that followed.
 
 - [x] Architecture and threat model
 - [x] Compiling skeleton: frozen contract, control-plane and sandbox stubs, CI

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,60 @@
+# IronClaw roadmap
+
+This is the short, contributor-facing view: where IronClaw is, where it's headed,
+and **where we'd love your help**. For the full status-at-a-glance tables and the
+category comparison, the **living roadmap is on the docs site:
+[Road to 1.0](https://ironsecco.github.io/ironclaw/roadmap/)** — that page is the
+single source of truth and is kept in lockstep with what's actually shipped.
+
+> Legend: ✅ done · 🚧 in progress · ⬜ planned
+
+## Where IronClaw is today
+
+The **security backend is complete** — gVisor/Kata isolation with `network=none`,
+SQLCipher-encrypted per-session queues, a deterministic approval gateway with a
+mandatory-human floor, a host-brokered egress broker, a credential vault, and
+signed releases with an SBOM and build provenance. The remaining work to 1.0 is
+**product surface and ecosystem**, not the core.
+
+- ✅ Isolation (gVisor + Kata), encrypted queues, approval gateway, egress broker
+- ✅ 11 channel adapters + an in-product web chat playground (12 delivery surfaces)
+- ✅ Multi-provider models (Anthropic · OpenAI · OpenRouter · Codex · Gemini · Vertex · local OpenAI-compatible)
+- ✅ Embedded mesh-only web console (approvals inbox, sessions, logs, chat playground)
+- ✅ Signed releases + SBOM + provenance; threat model; OpenAPI spec; docs site
+- ✅ Credential vault with logical-name `vault://` injection behind the gateway
+
+## What "1.0" means
+
+- **Public-ready** — meets every GitHub community standard and the category's
+  onboarding bar.
+- **At parity** — a web UI, broad channels, and guided setup: the product
+  experience of the category, on IronClaw's stronger security base.
+- **Best-in-class trust** — signed and reproducible builds, an SBOM, a published
+  threat model, and a third-party security audit.
+
+See the [docs roadmap](https://ironsecco.github.io/ironclaw/roadmap/) for the
+wave-by-wave breakdown of what's done and what's left.
+
+## Where we'd love help (help-wanted themes)
+
+You don't need to touch the security core to make a real difference. These are the
+areas where outside contributions land best:
+
+- **Channel adapters** — they're small, uniform, and dependency-free. Adding or
+  improving one is a great first PR. See
+  [Writing a channel adapter](https://ironsecco.github.io/ironclaw/writing-a-channel-adapter/).
+- **Docs & examples** — tutorials, cookbook recipes, and clarifications. The
+  [examples gallery](https://ironsecco.github.io/ironclaw/examples/) always has room.
+- **Test coverage** — hermetic unit and integration tests for host and sandbox
+  packages; fuzz targets for parsers.
+- **Developer experience** — onboarding friction, `ironctl` ergonomics, build and
+  tooling polish.
+- **Reproducible builds** — help close the control-plane reproducibility gap (the
+  `ironctl` and `sandbox` binaries already reproduce).
+
+The fastest way in is a
+[**good first issue**](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+— small, self-contained, and mentored. Comment to claim one before you start, and
+see [`CONTRIBUTING.md`](CONTRIBUTING.md) for the 5-minute quickstart. Got an idea
+that isn't an issue yet? Open a thread in
+[**Discussions**](https://github.com/IronSecCo/ironclaw/discussions).


### PR DESCRIPTION
## What

Part of the contributor on-ramp (IRO-209). Pure docs/infrastructure — fully ungated, independent of the launch decision (IRO-40).

- **New root `ROADMAP.md`** — short, contributor-facing view: where IronClaw is, what "1.0" means, and **help-wanted themes** (channel adapters, docs/examples, test coverage, DX, reproducible builds). Points to the docs-site [Road to 1.0](https://ironsecco.github.io/ironclaw/roadmap/) as the single source of truth, so there's no drift.
- **README** roadmap section now links `ROADMAP.md`.
- **CONTRIBUTING** gains a top-of-file **5-minute quickstart** — fork → `make build vet test` → branch → PR, with the CLA one-click note.

## Claims accuracy

Every capability claim is tied to shipped reality — 11 channel adapters + the web chat playground = 12 delivery surfaces (matches README/docs and prior channel-count corrections). No overclaiming, no launch/announcement actions.

## Companion (non-PR) work under IRO-209
- Good-first-issue batch refreshed/expanded
- Discussions seed posts added (Q&A, Ideas)

Closes IRO-209 doc deliverables.