### PR TITLE
ci(fuzz): nightly extended fuzz campaign + docs (IRO-208)

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -1,0 +1,74 @@
+# Nightly extended fuzz campaign over IronClaw's trust-boundary parsers (IRO-208).
+#
+# The PR/push `fuzz` job in ci.yml runs each target for only 30s — enough to catch a
+# regression and to keep OpenSSF Scorecard's Fuzzing check satisfied, but far too short
+# to find deep bugs. This workflow is the long-running companion: each target runs for
+# several minutes on a nightly schedule (and on demand), giving the engine time to walk
+# past the seed corpus into novel inputs.
+#
+# It is deliberately ISOLATED from the release path:
+#   * It lives in its own workflow, never in release.yml, and triggers only on `schedule`
+#     and manual `workflow_dispatch` — never on push/tag — so it can never gate a release.
+#   * Its only write permission is `contents: read`; a failure here does not block merges.
+# A crash here produces a reproducer that `go test` writes under
+# internal/host/skills/testdata/fuzz/<Target>/; we upload that directory as an artifact so
+# the failure is triageable without re-running the campaign locally.
+name: fuzz-nightly
+
+on:
+  schedule:
+    # 03:17 UTC daily — off-peak, and offset from the Monday Scorecard run.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      fuzztime:
+        description: "Per-target fuzz duration (Go duration, e.g. 300s, 10m)"
+        required: false
+        default: "300s"
+
+# Least-privilege: this workflow only reads the repo (Scorecard Token-Permissions).
+permissions:
+  contents: read
+
+# A new nightly run supersedes an in-flight one rather than piling up.
+concurrency:
+  group: fuzz-nightly
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    # CGO is required: the skills package transitively pulls in the encrypted-SQLite
+    # binding via the host module graph, which builds through cgo.
+    env:
+      CGO_ENABLED: "1"
+      FUZZTIME: ${{ github.event.inputs.fuzztime || '300s' }}
+    strategy:
+      # One job per target so a crash in one does not cut the others short, and each
+      # target's artifact is uploaded independently.
+      fail-fast: false
+      matrix:
+        target:
+          - FuzzParse
+          - FuzzParseSignature
+          - FuzzParsePublicKey
+          - FuzzValidAssetPath
+          - FuzzValidIdentifiers
+    steps:
+      # Third-party actions pinned to commit SHA (human tag in trailing comment) so a
+      # moved tag can never change what runs (OpenSSF Scorecard Pinned-Dependencies).
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.23.12"
+      - name: "fuzz ${{ matrix.target }} (${{ env.FUZZTIME }})"
+        run: |
+          go test ./internal/host/skills/ -run='^$' \
+            -fuzz="^${{ matrix.target }}$" -fuzztime="${FUZZTIME}"
+      - name: Upload crash reproducer (only if the fuzzer found one)
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-crash-${{ matrix.target }}
+          path: internal/host/skills/testdata/fuzz/
+          if-no-files-found: ignore

--- a/docs/security.md
+++ b/docs/security.md
@@ -100,6 +100,38 @@ artifacts are:
 The [Release runbook](release-runbook.md) is the operational reference for cutting,
 verifying, and yanking a release.
 
+## Fuzzing the trust boundary
+
+The parsers that sit on the trust boundary — skill/MCP **manifest** YAML, the
+minisign **signature** and **public-key** blobs, and the name/version/asset-**path**
+validators that compose filesystem paths — all consume attacker-influenced bytes.
+Every one of them must *fail closed*: malformed input returns an error, never a
+panic (a crash in the host control-plane is an availability break), and a validator
+must never accept an identifier or path that could escape its mount root.
+
+These properties are enforced by Go [native fuzz](https://go.dev/doc/security/fuzz/)
+targets in `internal/host/skills/fuzz_test.go`. Each target ships an inline seed
+corpus (valid inputs plus hostile ones — traversal paths, NUL bytes, YAML
+pathologies, junk base64) so coverage starts meaningful. Run one locally with:
+
+```bash
+# 30s is enough for a quick regression check; raise -fuzztime for a deeper run.
+CGO_ENABLED=1 go test ./internal/host/skills/ -run='^$' -fuzz='^FuzzParse$' -fuzztime=30s
+```
+
+Available targets: `FuzzParse` (manifest), `FuzzParseSignature`,
+`FuzzParsePublicKey`, `FuzzValidAssetPath`, `FuzzValidIdentifiers`.
+
+Two CI jobs keep this honest, both isolated from the release path so a fuzz failure
+can never gate a release:
+
+- The `fuzz` job in **ci.yml** runs every target for 30s on each push and PR — a
+  fast regression smoke test (and what OpenSSF Scorecard's Fuzzing check detects).
+- **fuzz-nightly.yml** runs each target for several minutes on a nightly schedule
+  (and on demand via *Run workflow*), giving the engine time to walk past the seed
+  corpus. If a target crashes, the reproducer it writes under
+  `internal/host/skills/testdata/fuzz/` is uploaded as a build artifact for triage.
+
 ## Reporting a vulnerability
 
 Disclosure policy lives in


### PR DESCRIPTION
## What

Completes the remaining acceptance criteria for **IRO-208** (fuzz-testing harness for trust-boundary parsers). The fuzz targets and the short 30s PR/push `fuzz` job already landed in `main` (`internal/host/skills/fuzz_test.go`, `ci.yml`); this PR adds the two pieces that were still missing:

- **`.github/workflows/fuzz-nightly.yml`** — a per-target matrix that runs each fuzz target (`FuzzParse`, `FuzzParseSignature`, `FuzzParsePublicKey`, `FuzzValidAssetPath`, `FuzzValidIdentifiers`) for several minutes on a nightly `schedule` + manual `workflow_dispatch`. Crash reproducers under `testdata/fuzz/` upload as artifacts for triage.
- **`docs/security.md`** — a *Fuzzing the trust boundary* section: what is fuzzed, the fail-closed invariants, how to run a target locally, and the two CI jobs.

## Additive / release-safe

The nightly workflow triggers **only** on `schedule` and `workflow_dispatch` (never push/tag) and holds only `contents: read`. It is a separate workflow from `release.yml`, so a fuzz failure can never gate a release.

## Verification

- `go vet ./internal/host/skills/` clean.
- All 5 fuzz targets pass locally (`-fuzztime=15s` each, no crashes).
- `fuzz-nightly.yml` parses as valid YAML; dispatch input passed via `env:` (no workflow injection).

Security lenses touched: supply-chain / availability (strengthens trust-boundary parser robustness; widens no boundary).