### PR TITLE
fix(landing): wrap install commands on mobile + refresh stale README version pins (IRO-210)

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ The installer reads a few environment variables (pass them on the `sh` side of t
 
 ```sh
 # Pin a version instead of latest
-curl -fsSL https://raw.githubusercontent.com/IronSecCo/ironclaw/main/scripts/install.sh | IRONCLAW_VERSION=v0.1.66 sh
+curl -fsSL https://raw.githubusercontent.com/IronSecCo/ironclaw/main/scripts/install.sh | IRONCLAW_VERSION=v0.1.102 sh
 
 # Install system-wide (a normal user defaults to ~/.local/bin)
 curl -fsSL https://raw.githubusercontent.com/IronSecCo/ironclaw/main/scripts/install.sh | sudo sh
@@ -483,7 +483,7 @@ Prefer the published image? It is pushed to GitHub Container Registry on every r
 
 ```sh
 docker pull ghcr.io/ironsecco/ironclaw-controlplane:latest
-# or pin a release: docker pull ghcr.io/ironsecco/ironclaw-controlplane:v0.1.0
+# or pin a release: docker pull ghcr.io/ironsecco/ironclaw-controlplane:v0.1.102
 ```
 
 Set `IRONCLAW_IMAGE` in `.env` to pin that tag for `docker compose`. Every variable the

--- a/docs/stylesheets/landing.css
+++ b/docs/stylesheets/landing.css
@@ -206,8 +206,13 @@
   background: #0a1126;
   border: 1px solid rgba(99, 160, 255, 0.28);
   border-radius: var(--iro-radius);
-  padding: 1rem 3.2rem 1rem 1.1rem;
-  overflow-x: auto;
+  /* extra right pad keeps the first wrapped line clear of the Copy button */
+  padding: 1rem 4.5rem 1rem 1.1rem;
+  /* wrap the install one-liner so it stays inside the card at every width
+     (mobile included) instead of scrolling off-screen under the Copy button */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   font-size: 0.86rem;
   line-height: 1.6;
   color: #d7e3fb;
@@ -219,7 +224,7 @@
   background: none;
   padding: 0;
   color: inherit;
-  white-space: pre;
+  white-space: inherit;
 }
 .iro-code__prompt { color: #6f86b8; user-select: none; }
 .iro-code__cmt { color: #6f86b8; }

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -219,8 +219,8 @@
 
       <div class="iro-code">
         <pre id="demo-cmd"><code>git clone https://github.com/IronSecCo/ironclaw.git &amp;&amp; cd ironclaw
-bash container/build.sh                                  <span class="iro-code__cmt"># build the sandbox image once (~1–2 min)</span>
-docker compose -f docker-compose.demo.yml up --build -d  <span class="iro-code__cmt"># start the demo control-plane</span></code></pre>
+bash container/build.sh    <span class="iro-code__cmt"># build the sandbox image once (~1–2 min)</span>
+docker compose -f docker-compose.demo.yml up --build -d    <span class="iro-code__cmt"># start the demo control-plane</span></code></pre>
         <button type="button" class="iro-copy" data-copy-target="demo-cmd" aria-label="Copy demo commands to clipboard">
           <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
           <span class="iro-copy__label">Copy</span>


### PR DESCRIPTION
## Front-door conversion audit (IRO-210)

Fresh first-touch audit of the live docs landing (ironsecco.github.io/ironclaw) and README install path across mobile/desktop, light/dark, reduced-motion.

### Findings
- **Install command blocks overflow horizontally** (hero + demo). `white-space:pre` + `overflow-x:auto` made the long one-liner scroll off-screen and run **under the Copy button** on narrow viewports — the primary install CTA read as broken on mobile.
- **Stale version pins in README** install examples: `IRONCLAW_VERSION=v0.1.66` and `docker pull ...:v0.1.0` — a first-touch copy-paste would fetch an old/wrong release.
- ✓ Demo SVG renders & animates correctly in a foreground tab; reduced-motion guard intact.
- ✓ Header version string `v0.1.102` is current.
- ✓ Hero is intentionally a dark spotlight band in both schemes (by design) — not a defect.

### Fixes
- `.iro-code pre`: `pre-wrap` + `overflow-wrap:anywhere` + wider right padding so the full command stays inside the card at every width and clears the Copy button.
- Trim the demo block's column-alignment spaces so it wraps gracefully.
- Bump the two stale README version-pin examples to `v0.1.102`.

No color changes → WCAG AA contrast unaffected (regression-safe).

### Evidence
Verified live via chrome-devtools `resize_page` at 1440×900 and 390×844, light + dark, with the CSS applied to the real DOM:
- **Before (mobile):** command runs under the Copy button and off-screen.
- **After (mobile + desktop):** full command wraps inside the card, Copy button clear, no truncation.

Screenshots attached on [IRO-210](/IRO/issues/IRO-210).

Closes IRO-210.