### PR TITLE
docs(observability): document /metrics + ship Grafana dashboard (IRO-215)

### DIFF
--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -1,0 +1,18 @@
+# Grafana dashboards
+
+`ironclaw-overview.json` — control-plane overview built on the host `/metrics`
+endpoint (model-call volume, error rate, latency percentiles, sandbox kills).
+
+## Import
+
+1. Point Prometheus at the control-plane `/metrics` endpoint — see
+   [docs/observability.md](../../docs/observability.md) for the scrape config.
+2. In Grafana: **Dashboards → New → Import**, upload this JSON, and select your
+   Prometheus data source when prompted.
+
+The dashboard uses a `$job` template variable (defaults to `ironclaw`); set it to
+match the `job_name` in your scrape config.
+
+> Some panels (sandbox launches, gateway decisions, deliveries) chart series that
+> are registered but not yet emitted by the control plane — they read `0` until
+> that instrumentation lands. See `docs/observability.md` for the current status.

--- a/deploy/grafana/ironclaw-overview.json
+++ b/deploy/grafana/ironclaw-overview.json
@@ -1,0 +1,222 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source scraping the IronClaw control-plane /metrics endpoint.",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "IronClaw control-plane overview: model-call volume, error rate, latency percentiles, and sandbox lifecycle. Series come from the host /metrics endpoint (internal/host/metrics).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["ironclaw", "observability"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": { "selected": false, "text": "ironclaw", "value": "ironclaw" },
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(ironclaw_model_calls_total, job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Job",
+        "name": "job",
+        "options": [],
+        "query": { "query": "label_values(ironclaw_model_calls_total, job)", "refId": "JobVar" },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "IronClaw — Control Plane Overview",
+  "uid": "ironclaw-overview",
+  "version": 1,
+  "weekStart": "",
+  "panels": [
+    {
+      "type": "row",
+      "title": "Model egress (proxy audit)",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Model calls (total)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 1 },
+      "id": 1,
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "thresholds" }, "unit": "short", "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] } },
+        "overrides": []
+      },
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(ironclaw_model_calls_total{job=\"$job\"})", "legendFormat": "calls", "refId": "A" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Error rate (5m)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 1 },
+      "id": 2,
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "thresholds" }, "unit": "percent", "decimals": 2, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 } ] } },
+        "overrides": []
+      },
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "100 * sum(rate(ironclaw_model_call_errors_total{job=\"$job\"}[5m])) / clamp_min(sum(rate(ironclaw_model_calls_total{job=\"$job\"}[5m])), 1e-9)", "legendFormat": "error %", "refId": "A" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Avg latency (5m)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 1 },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "thresholds" }, "unit": "s", "decimals": 3, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 2 }, { "color": "red", "value": 5 } ] } },
+        "overrides": []
+      },
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(ironclaw_model_call_duration_seconds_sum{job=\"$job\"}[5m])) / clamp_min(sum(rate(ironclaw_model_call_duration_seconds_count{job=\"$job\"}[5m])), 1e-9)", "legendFormat": "avg", "refId": "A" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Sandbox kills (total)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "thresholds" }, "unit": "short", "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 } ] } },
+        "overrides": []
+      },
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(ironclaw_sandbox_kills_total{job=\"$job\"})", "legendFormat": "kills", "refId": "A" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Model-call rate (req/s)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never", "spanNulls": true } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(ironclaw_model_calls_total{job=\"$job\"}[5m]))", "legendFormat": "all calls", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "sum(rate(ironclaw_model_call_errors_total{job=\"$job\"}[5m]))", "legendFormat": "errors", "refId": "B" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Model-call latency (percentiles)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 0, "lineWidth": 2, "showPoints": "never", "spanNulls": true } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.50, sum(rate(ironclaw_model_call_duration_seconds_bucket{job=\"$job\"}[5m])) by (le))", "legendFormat": "p50", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.90, sum(rate(ironclaw_model_call_duration_seconds_bucket{job=\"$job\"}[5m])) by (le))", "legendFormat": "p90", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "histogram_quantile(0.99, sum(rate(ironclaw_model_call_duration_seconds_bucket{job=\"$job\"}[5m])) by (le))", "legendFormat": "p99", "refId": "C" }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Sandbox lifecycle",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 101,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Sandbox kills (per minute)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "id": 7,
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short", "custom": { "drawStyle": "bars", "fillOpacity": 40, "lineWidth": 1, "showPoints": "never", "spanNulls": false } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "60 * sum(rate(ironclaw_sandbox_kills_total{job=\"$job\"}[5m]))", "legendFormat": "kills/min", "refId": "A" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Sandbox launches (per minute) — instrumentation pending",
+      "description": "ironclaw_sandbox_launches_total is registered but not yet incremented; this panel reads 0 until that instrumentation lands.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "id": 8,
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short", "custom": { "drawStyle": "bars", "fillOpacity": 40, "lineWidth": 1, "showPoints": "never", "spanNulls": false } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" }, "expr": "60 * sum(rate(ironclaw_sandbox_launches_total{job=\"$job\"}[5m]))", "legendFormat": "launches/min", "refId": "A" }
+      ]
+    }
+  ]
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -332,10 +332,12 @@ or re-installing the previous tag, then restoring the pre-upgrade backup if stat
 - **Liveness / readiness:** `GET /healthz` and `GET /readyz` are **unauthenticated** by
   design (so probes need no credential) and exempt from rate limiting. The Compose
   healthcheck uses `/healthz`.
-- **Metrics:** `GET /metrics` exposes Prometheus counters and histograms (gateway
-  decisions, model-proxy egress + redactions, queue activity). It is served on the API
-  address and is **bearer-gated** — scrape it with the admin token, ideally over the
-  private network:
+- **Metrics:** `GET /metrics` exposes Prometheus counters and histograms — model-proxy
+  egress volume/errors/latency and sandbox kills today, with gateway-decision and delivery
+  counters registered for later. It is served on the API address and is **bearer-gated** —
+  scrape it with the admin token, ideally over the private network. See the dedicated
+  **[Observability guide](observability.md)** for the full series list, the `ironctl metrics`
+  CLI, and an importable Grafana dashboard.
 
   ```yaml
   scrape_configs:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,135 @@
+# Observability — Prometheus `/metrics`
+
+IronClaw's control plane ships a built-in Prometheus endpoint at **`GET /metrics`**.
+It is always wired (no flag needed) and is served on the same address as the API
+(`--api-addr`, default `127.0.0.1:8787`). The exposition is hand-rolled in
+`internal/host/metrics` — no Prometheus client library is pulled into the host, keeping
+the dependency surface minimal — and emits the standard text format
+(`text/plain; version=0.0.4`).
+
+The same endpoint backs the CLI: `ironctl metrics` and `ironctl status` scrape `/metrics`
+to print a model-call usage summary, so you can spot-check it without a Prometheus server.
+
+## Reaching the endpoint
+
+`/metrics` is **bearer-gated** whenever an API token is set (`IRONCLAW_API_TOKEN`). Scrape
+it with the admin token, and keep it on the private network — do not expose it at the
+public edge (the [deployment guide](deployment.md#reverse-proxy-tls-termination) shows how
+to hide it behind the reverse proxy).
+
+```bash
+# With an API token (recommended): pass it as a bearer credential.
+curl -s -H "Authorization: Bearer $IRONCLAW_API_TOKEN" http://127.0.0.1:8787/metrics
+
+# Token-less dev runs (no IRONCLAW_API_TOKEN): the endpoint is open on the mesh boundary.
+curl -s http://127.0.0.1:8787/metrics
+```
+
+A quick human-readable summary of the model-call series, without Prometheus:
+
+```bash
+ironctl metrics            # model calls, error %, avg latency
+ironctl metrics --json     # same, machine-readable
+ironctl status             # broader control-plane status, includes model usage
+```
+
+If the endpoint returns `404 metrics not configured`, the control plane was started with
+metrics disabled — the standard `controlplane` binary always enables them.
+
+## Exposed series
+
+All series are namespaced `ironclaw_*`. Counters are monotonic; the latency histogram uses
+buckets `0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10` seconds (plus `+Inf`).
+
+### Live today
+
+These are recorded by the running control plane:
+
+| Series | Type | Meaning |
+| --- | --- | --- |
+| `ironclaw_model_calls_total` | counter | Model-host requests forwarded by the egress proxy. |
+| `ironclaw_model_call_errors_total` | counter | Forwarded requests that errored (HTTP ≥ 400 or denied by the egress policy). |
+| `ironclaw_model_call_duration_seconds` | histogram | Model-host request latency. Emits `_bucket{le=...}`, `_sum`, `_count`. |
+| `ironclaw_sandbox_kills_total` | counter | Sandboxes killed/stopped by the stuck-session sweeper. |
+
+The model-call series come from the **model-proxy audit** — every egress request the proxy
+forwards (the sandbox's only network path) is counted and timed at the host, so the numbers
+reflect real, host-observed traffic rather than anything the sandbox self-reports.
+
+### Registered, not yet emitting
+
+These series are declared in the registry (so the metric names are stable) but are **not yet
+incremented** by any call site — they currently read `0`. Instrumentation is tracked as a
+follow-up; do not build alerts on them until they go live:
+
+| Series | Type | Intended meaning |
+| --- | --- | --- |
+| `ironclaw_gateway_decisions_total{decision="approved"\|"rejected"}` | counter | Gateway change decisions by outcome. |
+| `ironclaw_deliveries_total` | counter | Outbound messages delivered to a channel. |
+| `ironclaw_sandbox_launches_total` | counter | Sandboxes launched. |
+
+## Prometheus scrape config
+
+Drop this into `prometheus.yml`. Replace the target with your control-plane API address and
+supply the admin token (omit the `authorization` block only for token-less dev runs):
+
+```yaml
+scrape_configs:
+  - job_name: ironclaw
+    metrics_path: /metrics
+    scheme: http            # use https if a TLS-terminating proxy fronts the API
+    authorization:
+      credentials: <IRONCLAW_API_TOKEN>
+    static_configs:
+      - targets: ["127.0.0.1:8787"]   # control-plane --api-addr
+```
+
+For Kubernetes, a `PodMonitor`/`ServiceMonitor` works the same way — point it at the API
+port and reference a secret holding `IRONCLAW_API_TOKEN`.
+
+## Grafana dashboard
+
+A ready-to-import dashboard lives at
+[`deploy/grafana/ironclaw-overview.json`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/grafana/ironclaw-overview.json).
+It charts model-call volume, error rate, and latency percentiles (p50/p90/p99) derived from
+the histogram, plus sandbox kills.
+
+1. In Grafana, **Dashboards → New → Import**.
+2. Upload the JSON (or paste its contents).
+3. Pick your Prometheus data source when prompted.
+
+The dashboard's PromQL building blocks, if you want to roll your own panels:
+
+```promql
+# Model-call rate (req/s)
+rate(ironclaw_model_calls_total[5m])
+
+# Error ratio (%)
+100 * rate(ironclaw_model_call_errors_total[5m]) / rate(ironclaw_model_calls_total[5m])
+
+# Latency percentiles
+histogram_quantile(0.50, sum(rate(ironclaw_model_call_duration_seconds_bucket[5m])) by (le))
+histogram_quantile(0.90, sum(rate(ironclaw_model_call_duration_seconds_bucket[5m])) by (le))
+histogram_quantile(0.99, sum(rate(ironclaw_model_call_duration_seconds_bucket[5m])) by (le))
+
+# Average latency (s)
+rate(ironclaw_model_call_duration_seconds_sum[5m]) / rate(ironclaw_model_call_duration_seconds_count[5m])
+
+# Sandbox kills (per minute)
+60 * rate(ironclaw_sandbox_kills_total[5m])
+```
+
+## Security notes
+
+- **Bearer-gated.** `/metrics` requires the admin token whenever one is set; it is not a
+  public endpoint. Keep it on the private network and off the public edge.
+- **No secrets in metrics.** Series carry only counts and timings — never tokens, keys, or
+  message content. (Logs are likewise secret-redacted; see the deployment guide.)
+- **Host-observed, not sandbox-reported.** The model-call series come from the egress proxy
+  on the host side of the trust boundary, so a compromised sandbox cannot forge them.
+
+## See also
+
+- [Production deployment → Observability](deployment.md#observability) — where `/metrics`
+  sits in a hardened deployment, plus liveness/readiness probes, logs, and the audit log.
+- `ironctl metrics` / `ironctl status` — CLI consumers of this same endpoint.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
       - Quickstart: quickstart.md
       - Building from source: building.md
       - Production deployment: deployment.md
+      - Observability (metrics): observability.md
       - Troubleshooting: troubleshooting.md
       - FAQ: faq.md
   - Tutorials:


### PR DESCRIPTION
## Operator observability: document & package the existing `/metrics` endpoint

Closes **IRO-215**. Turns the already-shipped Prometheus `/metrics` endpoint
(`internal/host/metrics`, mounted by `internal/host/api`) into a documented,
packaged operator feature. No new endpoint added.

### Deliverables
- **`docs/observability.md`** — how to reach `/metrics` (bearer-gated, default `127.0.0.1:8787`), the full `ironclaw_*` series list, a ready-to-paste Prometheus scrape config, PromQL building blocks, security notes, and the `ironctl metrics`/`status` CLI consumers.
- **`deploy/grafana/ironclaw-overview.json`** — importable Grafana dashboard: model-call volume, error rate, latency p50/p90/p99 (from the histogram), sandbox kills. Plus `deploy/grafana/README.md` import steps.
- **Cross-links** — deployment guide's Observability section now points to the new page; mkdocs nav gains an "Observability (metrics)" entry under Get Started.

### Honesty fix + flagged gap
The deployment guide previously claimed `/metrics` exposes "gateway decisions, model-proxy egress + redactions, queue activity." In reality only these are **emitted today**:

- `ironclaw_model_calls_total`, `ironclaw_model_call_errors_total`, `ironclaw_model_call_duration_seconds` (histogram) — model-proxy audit
- `ironclaw_sandbox_kills_total`

These are **registered but never incremented** (always `0`): `ironclaw_gateway_decisions_total`, `ironclaw_deliveries_total`, `ironclaw_sandbox_launches_total`. The docs label them clearly and a follow-up issue tracks wiring them (gateway-decision counting touches the gateway/trust path → needs security review).

### Verification
- `mkdocs build --strict` clean (no broken links/anchors) after fixing the deployment anchor.
- Dashboard JSON validates (`python -m json.tool`).

### Security lenses
Touches **secret hygiene** (documents that `/metrics` carries only counts/timings, never secrets) and notes the endpoint is **bearer-gated** and host-observed (sandbox can't forge series). No boundary changes.