### PR TITLE
docs(onboard): tell demo users which API token to paste (IRO-214)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ read, write, schedule, and reply.
 > ```
 >
 > Open **http://127.0.0.1:8787/ui/**, pick **Mock Agent (offline)** in the Chat tab, and
-> watch the agent reply — production seals each sandbox with gVisor and `network=none`.
+> watch the agent reply. If the console prompts for an API token, paste `ironclaw-demo` (the
+> demo's fixed loopback token). Production seals each sandbox with gVisor and `network=none`.
 > [Zero-credential quickstart →](docs/quickstart.md)
 
 ## Get running in under two minutes

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -3,6 +3,7 @@
 #   bash container/build.sh                              # build the sandbox image once
 #   docker compose -f docker-compose.demo.yml up --build # start the demo control-plane
 #   open http://127.0.0.1:8787/ui/                       # Chat → "Mock Agent (offline)" → say hi
+#                                                         # (if it asks for an API token, paste: ironclaw-demo)
 #   docker compose -f docker-compose.demo.yml down       # tear it down
 #
 # This is a STANDALONE compose file (run it with -f, NOT alongside docker-compose.yml).


### PR DESCRIPTION
## What

Final first-run friction sweep (IRO-214) surfaced one new-user dead end on the **README hero demo path**:

The above-the-fold "Want to see it work first" block tells a brand-new user to open the demo console at `http://127.0.0.1:8787/ui/` and chat — but never mentions that the demo pins a fixed loopback API token (`ironclaw-demo`). On a fresh browser the console's `/v1` calls 401 and it correctly prompts **"Add an API token to connect"** — but the token *value* was only documented in `docs/quickstart.md`, so a user following just the README hits a wall.

## Change

One-line copy fix on the two surfaces a demo-runner actually reads, matching the wording already in `docs/quickstart.md`:

- **README hero block** — add: *"If the console prompts for an API token, paste `ironclaw-demo` (the demo's fixed loopback token)."*
- **docker-compose.demo.yml header comment** — add the same hint next to the `open …/ui/` step.

No code, no behavior change — docs/comment only.

## Verification

- Reproduced live: built `controlplane`/`ironctl` from `origin/main`, ran `--dev`, rendered the console at 1440×900 and 390×844. Confirmed the console shows "Add an API token to connect" + reveals the token field when `sessionStorage` has no token (`web/static/app.js` 401 path), and that `docker-compose.demo.yml` pins `IRONCLAW_API_TOKEN: ironclaw-demo`.
- Severity: **medium** — not a hard blocker (console guides you to the field) but the value isn't discoverable from the README alone.

Part of the IRO-214 friction sweep. Other findings (chat empty-state, mobile nav touch-target size) are filed as separate child issues; this PR carries only the merge-ready copy fix.