### PR TITLE
feat(console): centered empty-state for Chat playground conversation area (IRO-218)

### DIFF
--- a/web/static/chat.js
+++ b/web/static/chat.js
@@ -32,11 +32,47 @@ const Chat = (() => {
 
   function append(node) {
     const host = $("chat-transcript");
+    // The empty state is purely a before-first-message orientation cue: the
+    // moment any real card (a "you"/agent bubble or the error diagnostic) lands
+    // it must yield, so clear it on every append (IRO-218).
+    const placeholder = host.querySelector(".empty");
+    if (placeholder) placeholder.remove();
     host.append(node);
     host.scrollTop = host.scrollHeight;
   }
 
   function conv() { return $("chat-ag").value.trim(); }
+
+  // renderEmpty draws a centered orientation cue in the otherwise-blank
+  // conversation region before the first message (IRO-218). It reuses the
+  // shared emptyState() pattern (muted icon + title + one line) so the Chat
+  // playground reads like the Agents/Sessions tabs. It is a no-op once any real
+  // message bubble exists, and append() removes it the instant one appears.
+  function renderEmpty() {
+    const host = $("chat-transcript");
+    if (!host) return;
+    const existing = host.querySelector(".empty");
+    if (existing) existing.remove();
+    if (host.querySelector(".chat-msg")) return; // real transcript present — no cue
+    const sel = $("chat-ag");
+    const ag = sel ? sel.value.trim() : "";
+    let box;
+    if (!ag) {
+      // No agent picked yet — point attention at the selector above.
+      box = emptyState("Pick an agent to start", "", null, null, EMPTY_ICONS.agents);
+      box.querySelector("p").innerHTML =
+        "Choose an agent group above — the demo ships with <strong>Mock Agent (offline)</strong>, " +
+        "which runs the full engage → sandbox → reply path with no API key.";
+    } else {
+      // Agent picked, transcript still blank — invite the first message.
+      const opt = sel.selectedOptions && sel.selectedOptions[0];
+      const name = (opt ? opt.text : ag).split("·")[0].trim() || ag;
+      box = emptyState("Say hi to " + name,
+        "Your message runs the real engage / delivery path. First reply can take a few seconds while the sandbox spins up.",
+        null, null, EMPTY_ICONS.channels);
+    }
+    host.append(box);
+  }
 
   // populate fills the agent picker, preserving the current selection.
   async function populate() {
@@ -50,6 +86,7 @@ const Chat = (() => {
       for (const a of (list || [])) sel.append(el("option", { value: a.id, text: (a.name || a.id) + "  ·  " + a.id }));
       if (current) sel.value = current;
     } catch (_) { /* leave the existing options */ }
+    renderEmpty(); // refresh the before-first-message orientation cue (IRO-218)
   }
 
   // select switches to a specific agent (used by the Agents page "Chat" action).
@@ -64,6 +101,7 @@ const Chat = (() => {
     $("chat-status").textContent = "ready — say hello";
     awaitingSince = 0;
     staleNoted = false;
+    renderEmpty();
   }
 
   async function send() {
@@ -167,6 +205,7 @@ const Chat = (() => {
       $("chat-status").textContent = conv() ? "ready — say hello" : "pick an agent group";
       awaitingSince = 0;
       staleNoted = false;
+      renderEmpty();
     });
   }
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -502,6 +502,9 @@ details[open] > summary { margin-bottom: 8px; }
 #chat-transcript {
   flex: 1; overflow-y: auto; padding: 18px 2px; display: flex; flex-direction: column; gap: 14px;
 }
+/* Center the before-first-message empty state in the otherwise-blank log: in the
+   flex column, margin:auto absorbs the free space on both axes (IRO-218). */
+#chat-transcript .empty { margin: auto; }
 .chat-msg { display: flex; gap: 10px; max-width: 78%; }
 .chat-msg .av {
   width: 28px; height: 28px; border-radius: 8px; flex: 0 0 28px; display: grid; place-items: center;


### PR DESCRIPTION
## What

Adds a centered empty-state inside the Chat playground conversation region (`#chat-transcript`), shown only before the first message. Closes the "is this broken?" beat on the demo hero surface (60-second zero-credential chat) where the only guidance was the low-contrast, spatially-disconnected right-aligned status microcopy.

Reuses the shared `emptyState()` pattern (muted icon + title + one line) so Chat reads like the Agents/Sessions tabs (IRO-130 unified empty-states). No new tokens.

### Two states
- **No agent selected** — person glyph + `Pick an agent to start` + a line pointing at the selector and naming the offline **Mock Agent** (full engage → sandbox → reply path, no API key).
- **Agent selected, no messages** — chat-bubble glyph + `Say hi to <Agent name>` + a line setting first-reply latency expectations.

It is vertically centered via `margin:auto` in the flex-column transcript, and `append()` removes it the instant the first bubble (or the error diagnostic card) lands.

## How verified

Built `controlplane --dev` (console is `go:embed`, so the binary was rebuilt, not source-trusted) and drove the live console via chrome-devtools at **1440×900** and **390×844**:

| viewport | no agent | Mock Agent selected |
|---|---|---|
| 1440×900 | ✅ centered cue | ✅ "Say hi to Mock Agent (offline)" |
| 390×844 | ✅ centered, wraps cleanly | ✅ centered, wraps cleanly |

- Empty-state disappears on send (verified `#chat-transcript .empty` removed, 1 bubble present).
- Styling matches the Agents/Sessions tab empty states (same dashed `.empty` card, `--muted` text, `EMPTY_ICONS` glyphs).

## Security lenses

None touched — pure console (static JS/CSS) presentation change. No control-plane mutation, no queue/trust-boundary surface.

cc @ UXDesigner for empty-state copy/visual review before merge (per the issue request).

Refs IRO-218.