### PR TITLE
fix(console): mobile bottom-nav 44px touch targets via More overflow (IRO-219)

### DIFF
--- a/web/static/app.js
+++ b/web/static/app.js
@@ -330,6 +330,9 @@ function refreshPanel(name) {
   if (name === "channels") refreshMgGroups();
 }
 
+// Sections reachable only via the mobile "More" overflow sheet.
+const MORE_PANELS = ["channels", "skills", "mcp", "setup", "audit", "about"];
+
 function showPanel(name) {
   for (const tab of document.querySelectorAll(".nav-item")) {
     const on = tab.dataset.panel === name;
@@ -339,12 +342,41 @@ function showPanel(name) {
     if (on) tab.setAttribute("aria-current", "page");
     else tab.removeAttribute("aria-current");
   }
+  // On mobile the current section may live in the More sheet; mirror its active
+  // highlight onto the More tab so the bar still shows where you are.
+  const more = document.getElementById("nav-more");
+  if (more) more.classList.toggle("has-active", MORE_PANELS.includes(name));
+  closeMoreSheet();
   for (const panel of document.querySelectorAll(".panel")) {
     const on = panel.id === name;
     panel.classList.toggle("active", on);
     panel.hidden = !on;
   }
   refreshPanel(name);
+}
+
+// Mobile overflow sheet (the "More" bottom-nav tab).
+function openMoreSheet() {
+  const sheet = document.getElementById("nav-more-sheet");
+  const more = document.getElementById("nav-more");
+  if (!sheet || !more) return;
+  sheet.hidden = false;
+  more.setAttribute("aria-expanded", "true");
+  const first = sheet.querySelector(".nav-item");
+  if (first) first.focus();
+}
+function closeMoreSheet(restoreFocus) {
+  const sheet = document.getElementById("nav-more-sheet");
+  const more = document.getElementById("nav-more");
+  if (!sheet || !more || sheet.hidden) return;
+  sheet.hidden = true;
+  more.setAttribute("aria-expanded", "false");
+  if (restoreFocus) more.focus();
+}
+function toggleMoreSheet() {
+  const sheet = document.getElementById("nav-more-sheet");
+  if (!sheet) return;
+  if (sheet.hidden) openMoreSheet(); else closeMoreSheet(true);
 }
 
 // goPanel switches tabs programmatically (used by cross-page CTAs).
@@ -389,7 +421,8 @@ function init() {
   if (rs) rs.addEventListener("click", () => Sessions.load());
 
   for (const tab of document.querySelectorAll(".nav-item")) {
-    tab.addEventListener("click", () => showPanel(tab.dataset.panel));
+    // The "More" tab opens the overflow sheet rather than switching a panel.
+    if (tab.dataset.panel) tab.addEventListener("click", () => showPanel(tab.dataset.panel));
     // Mark the section that loads active on first paint so the state is exposed
     // before the first navigation, not only after a click.
     if (tab.classList.contains("active")) tab.setAttribute("aria-current", "page");
@@ -402,6 +435,19 @@ function init() {
   for (const b of document.querySelectorAll("[data-go]")) {
     b.addEventListener("click", () => goPanel(b.dataset.go));
   }
+
+  // Mobile "More" overflow sheet: toggle, plus Escape / outside-click to close.
+  const moreBtn = document.getElementById("nav-more");
+  if (moreBtn) moreBtn.addEventListener("click", toggleMoreSheet);
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closeMoreSheet(true);
+  });
+  document.addEventListener("click", (e) => {
+    const sheet = document.getElementById("nav-more-sheet");
+    if (!sheet || sheet.hidden) return;
+    if (e.target.closest("#nav-more-sheet") || e.target.closest("#nav-more")) return;
+    closeMoreSheet();
+  });
 
   // Associate static field labels now and keep lazily-rendered forms covered.
   linkFieldLabels();

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -43,31 +43,62 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h4l2 5 4-12 2 7h6"/></svg>
           <span>Sessions</span>
         </button>
-        <button class="nav-item" data-panel="channels" type="button">
+        <button class="nav-item nav-secondary" data-panel="channels" type="button">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="2.2"/><path d="M5.6 5.6a9 9 0 0 0 0 12.8M18.4 5.6a9 9 0 0 1 0 12.8M8.5 8.5a5 5 0 0 0 0 7M15.5 8.5a5 5 0 0 1 0 7"/></svg>
           <span>Channels</span>
         </button>
-        <button class="nav-item" data-panel="skills" type="button">
+        <button class="nav-item nav-secondary" data-panel="skills" type="button">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 4 6v6c0 5 3.4 8.4 8 10 4.6-1.6 8-5 8-10V6l-8-4Z"/><path d="m12 8-1.2 2.6L8 11l2 1.8L9.4 16 12 14.5 14.6 16 14 12.8 16 11l-2.8-.4Z"/></svg>
           <span>Skills</span>
         </button>
-        <button class="nav-item" data-panel="mcp" type="button">
+        <button class="nav-item nav-secondary" data-panel="mcp" type="button">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="12" rx="2"/><path d="M8 20h8M12 16v4M7 8h2M7 12h6"/></svg>
           <span>MCP</span>
         </button>
-        <button class="nav-item" data-panel="setup" type="button">
+        <button class="nav-item nav-secondary" data-panel="setup" type="button">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h10M18 6h2M4 12h2M10 12h10M4 18h7M15 18h5"/><circle cx="16" cy="6" r="2"/><circle cx="8" cy="12" r="2"/><circle cx="13" cy="18" r="2"/></svg>
           <span>Setup</span>
         </button>
-        <button class="nav-item" data-panel="audit" type="button">
+        <button class="nav-item nav-secondary" data-panel="audit" type="button">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3h9l4 4v14a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z"/><path d="M14 3v4h4M8 13h8M8 17h5"/></svg>
           <span>Audit</span>
         </button>
-        <button class="nav-item" data-panel="about" type="button">
+        <button class="nav-item nav-secondary" data-panel="about" type="button">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 11v5M12 8h.01"/></svg>
           <span>About</span>
         </button>
+        <button class="nav-item nav-more" id="nav-more" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="nav-more-sheet">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="12" r="1.4"/><circle cx="12" cy="12" r="1.4"/><circle cx="19" cy="12" r="1.4"/></svg>
+          <span>More</span>
+        </button>
       </nav>
+
+      <div class="nav-more-sheet" id="nav-more-sheet" role="menu" aria-label="More sections" hidden>
+        <button class="nav-item" role="menuitem" data-panel="channels" type="button">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="2.2"/><path d="M5.6 5.6a9 9 0 0 0 0 12.8M18.4 5.6a9 9 0 0 1 0 12.8M8.5 8.5a5 5 0 0 0 0 7M15.5 8.5a5 5 0 0 1 0 7"/></svg>
+          <span>Channels</span>
+        </button>
+        <button class="nav-item" role="menuitem" data-panel="skills" type="button">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 4 6v6c0 5 3.4 8.4 8 10 4.6-1.6 8-5 8-10V6l-8-4Z"/><path d="m12 8-1.2 2.6L8 11l2 1.8L9.4 16 12 14.5 14.6 16 14 12.8 16 11l-2.8-.4Z"/></svg>
+          <span>Skills</span>
+        </button>
+        <button class="nav-item" role="menuitem" data-panel="mcp" type="button">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="12" rx="2"/><path d="M8 20h8M12 16v4M7 8h2M7 12h6"/></svg>
+          <span>MCP</span>
+        </button>
+        <button class="nav-item" role="menuitem" data-panel="setup" type="button">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h10M18 6h2M4 12h2M10 12h10M4 18h7M15 18h5"/><circle cx="16" cy="6" r="2"/><circle cx="8" cy="12" r="2"/><circle cx="13" cy="18" r="2"/></svg>
+          <span>Setup</span>
+        </button>
+        <button class="nav-item" role="menuitem" data-panel="audit" type="button">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3h9l4 4v14a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z"/><path d="M14 3v4h4M8 13h8M8 17h5"/></svg>
+          <span>Audit</span>
+        </button>
+        <button class="nav-item" role="menuitem" data-panel="about" type="button">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 11v5M12 8h.01"/></svg>
+          <span>About</span>
+        </button>
+      </div>
 
       <div class="side-foot">
         <div class="conn" id="conn">

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -149,6 +149,10 @@ code {
 }
 .nav-badge:empty { display: none; }
 
+/* Mobile-only overflow nav: hidden on desktop, where all sections fit the rail. */
+.nav-more { display: none; }
+.nav-more-sheet { display: none; }
+
 .side-foot { border-top: 1px solid var(--border-soft); padding-top: 12px; margin-top: 6px; }
 .conn { display: flex; align-items: center; gap: 8px; padding: 4px 8px; }
 .conn .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--faint); box-shadow: 0 0 0 3px rgba(255,255,255,0.03); }
@@ -536,11 +540,33 @@ details[open] > summary { margin-bottom: 8px; }
 
 /* ---- Responsive -------------------------------------------------------- */
 @media (max-width: 760px) {
-  .sidebar { position: fixed; bottom: 0; top: auto; left: 0; right: 0; width: 100%; height: auto; flex-direction: row; z-index: 30; padding: 6px; gap: 2px; overflow-x: auto; border-right: none; border-top: 1px solid var(--border); }
+  .sidebar { position: fixed; bottom: 0; top: auto; left: 0; right: 0; width: 100%; height: auto; flex-direction: row; z-index: 30; padding: 6px; gap: 2px; border-right: none; border-top: 1px solid var(--border); }
   .side-brand, .side-label, .side-foot { display: none; }
+  /* Bottom tab-bar: 5 primary sections + a More overflow, each >=44x44 (WCAG 2.5.5). */
   .side-nav { flex-direction: row; }
-  .nav-item { flex-direction: column; gap: 3px; font-size: 10px; padding: 6px 8px; }
+  .nav-secondary { display: none; }
+  .nav-more { display: flex; }
+  .nav-item { flex: 1 1 0; flex-direction: column; justify-content: center; gap: 3px; font-size: 10px; padding: 6px 4px; min-width: 44px; min-height: 44px; position: relative; }
   .nav-item span:not(.nav-badge) { display: none; }
+  .nav-more span:not(.nav-badge) { display: block; font-size: 9px; }
+  /* Active highlight when the current section lives inside the More sheet. */
+  .nav-more.has-active { background: var(--accent-soft); color: #ffd9bf; border-color: var(--accent-line); }
+  .nav-more.has-active svg { opacity: 1; color: var(--accent-2); }
+  /* Badge floats over the (now icon-only) Approvals target instead of trailing it. */
+  .nav-badge { position: absolute; top: 2px; right: 18px; margin-left: 0; }
+
+  /* Overflow sheet: opens above the bar, labelled targets, each >=44px. */
+  .nav-more-sheet[hidden] { display: none; }
+  .nav-more-sheet:not([hidden]) {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px;
+    position: fixed; left: 0; right: 0; bottom: 56px; z-index: 31;
+    padding: 12px; background: var(--surface);
+    border-top: 1px solid var(--border);
+    box-shadow: 0 -10px 28px rgba(0,0,0,0.28);
+  }
+  .nav-more-sheet .nav-item { min-height: 60px; padding: 8px 4px; }
+  .nav-more-sheet .nav-item span:not(.nav-badge) { display: block; font-size: 11px; }
+
   .content { padding-bottom: 60px; }
   main { padding: 20px 16px 80px; }
 }


### PR DESCRIPTION
## What

At the 390×844 mobile viewport the console sidebar collapses to a bottom icon tab-bar. All **11 sections** were squished to ~35px each — below the **WCAG 2.5.5 / Apple HIG 44px** minimum touch target (easy to mis-tap, Fitts's Law). Filed in IRO-219 from the IRO-214 first-run sweep.

This implements **Option 1 (recommended overflow menu)**: 5 primary sections in the bar + a **More** tab that opens a sheet for the rest.

| | Targets in bar | Sheet | Size at 390px |
|---|---|---|---|
| Before | 11 | — | ~35×41 ❌ |
| After | 5 primary + More | 6 sections | bar **60×48**, sheet **118×60** ✅ |

**Split**: primary = Dashboard, Agents, Chat, Approvals, Sessions · More = Channels, Skills, MCP, Setup, Audit, About.

## Preserved
- Approvals count badge (floats over its icon on mobile).
- Active highlight mirrors onto **More** when the current section lives in the sheet.
- **a11y**: nav keeps `aria-label="Console sections"`; sheet is `role=menu`/`menuitem`; More exposes `aria-haspopup`/`aria-expanded`/`aria-controls`; **Escape** and outside-click close the sheet and restore focus to More; icon-only buttons keep `aria-label` from their text.
- **Desktop (>760px) unchanged** — all 11 sections on the vertical rail; More + sheet hidden.

## Verification (controlplane `--dev`, console is `go:embed` — rebuilt the binary)
Measured in a true 390px viewport (DevTools/iframe):
- Bar: 6 targets, min dimension **48px** (≥44). ✅
- Sheet: 6 targets, min dimension **60px** (≥44). ✅
- Approvals badge "3" visible. ✅
- Pick from sheet → panel switches, sheet closes, More shows active. ✅
- Clicking More does **not** switch panels (fixed a latent `showPanel(undefined)` double-fire from the shared nav-item click loop). ✅
- Escape closes + restores focus to More. ✅
- Desktop: 11 visible, More/sheet hidden. ✅

## Review gate
Per the issue, @UXDesigner to **confirm the 5/6 overflow split** before merge.