### PR TITLE
feat(deploy): one-click PaaS templates (Fly.io + Render + Railway) + Deploy buttons (IRO-229)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ installs the host binaries (`ironclaw-controlplane.exe` + `ironctl.exe`) and `--
 **agent sandbox needs WSL2 or Linux** — see [Windows via WSL2](#windows-via-wsl2).
 Version pinning, system-wide installs, and building from source are all in [Installation](#installation).
 
+### One-click cloud deploy
+
+Run the **hardened control-plane** on a PaaS in ~2 minutes with zero local tooling — the
+approval gateway, encrypted per-session queues, host-side credential custody, and the web
+console:
+
+[![Deploy to Fly.io](https://img.shields.io/badge/Deploy-Fly.io-8B5CF6?logo=flydotio&logoColor=white)](deploy/fly/)
+[![Deploy to Render](https://img.shields.io/badge/Deploy-Render-46E3B7?logo=render&logoColor=000)](https://render.com/deploy?repo=https://github.com/IronSecCo/ironclaw)
+[![Deploy on Railway](https://img.shields.io/badge/Deploy-Railway-0B0D0E?logo=railway&logoColor=white)](deploy/railway/)
+
+> These PaaS paths run the **control-plane only** — a single container has no gVisor and
+> no Docker socket, so **agent sandboxes don't launch there** (same boundary as the
+> [hardened Compose path](deploy/docker-compose.prod.yml)). For full agent isolation use
+> a gVisor host or k8s node. Details + env in the
+> [deployment guide](docs/deployment.md) (**Path D**).
+
 ## CLI-first and API-first
 
 This is a feature, not a missing dashboard. Every capability is a documented HTTP endpoint **and** an

--- a/deploy/fly/README.md
+++ b/deploy/fly/README.md
@@ -1,0 +1,42 @@
+# Deploy IronClaw on Fly.io
+
+One-command deploy of the IronClaw **control-plane** to [Fly.io](https://fly.io) using
+[`fly.toml`](./fly.toml).
+
+> **What this runs.** Fly deploys the trusted IronClaw **control-plane** (approval
+> gateway, encrypted SQLCipher per-session queues, host-side model-credential custody,
+> API + web console). It does **not** run agent sandboxes — a single Fly Machine has no
+> gVisor (`runsc`) and no Docker socket, the same boundary as the
+> [hardened Docker Compose path](../docker-compose.prod.yml). For **full agent
+> isolation** use a gVisor host ([`deploy/install.sh`](../install.sh)) or a runsc k8s
+> node ([`deploy/helm`](../helm/ironclaw)).
+
+## Deploy
+
+```sh
+# From a checkout of this repo:
+fly launch --copy-config --no-deploy            # creates the app from deploy/fly/fly.toml
+fly volume create ironclaw_state --size 1       # 1 GB persistent SQLCipher state
+fly secrets set IRONCLAW_API_TOKEN=$(openssl rand -hex 32) \
+                ANTHROPIC_API_KEY=sk-ant-...     # secrets — never in fly.toml
+fly deploy
+fly open /ui/                                    # web console first-run screen
+```
+
+Pin the image by digest in `fly.toml` for a reproducible, cosign-verifiable deploy
+(`ghcr.io/ironsecco/ironclaw-controlplane@sha256:<digest>`).
+
+## Configure (env)
+
+| Variable | Where | Notes |
+|---|---|---|
+| `IRONCLAW_API_TOKEN` | `fly secrets set` | admin/console bearer; leave unset to mint+print once to `fly logs` |
+| `ANTHROPIC_API_KEY` | `fly secrets set` | (or `OPENAI_API_KEY` / `OPENROUTER_API_KEY`) held host-side |
+| `IRONCLAW_DEV` | `[env]` in `fly.toml` | `0` = production; `1` only for a throwaway demo box |
+
+> **First-boot volume ownership.** The image runs as the non-root uid `65532`; a fresh
+> Fly volume mounts root-owned. If `fly logs` shows a permission error writing the state
+> dir, run `fly ssh console -C "chown -R 65532:65532 /var/lib/ironclaw/state"` once and
+> restart the Machine.
+
+See [docs/deployment.md "Path D"](../../docs/deployment.md) for the full guide.

--- a/deploy/fly/fly.toml
+++ b/deploy/fly/fly.toml
@@ -1,0 +1,70 @@
+# IronClaw control-plane — Fly.io one-click / CLI deploy.
+#
+#   fly launch --copy-config --no-deploy            # create the app from this file
+#   fly volume create ironclaw_state --size 1       # 1 GB persistent SQLCipher state
+#   fly secrets set IRONCLAW_API_TOKEN=$(openssl rand -hex 32) \
+#                   ANTHROPIC_API_KEY=sk-ant-...     # secrets — never in this file
+#   fly deploy
+#   fly open /ui/                                    # the web console first-run screen
+#
+# WHAT THIS RUNS — read before you trust it. This deploys the trusted IronClaw
+# CONTROL-PLANE (the mandatory approval gateway, the encrypted SQLCipher per-session
+# queues, host-side model-credential custody, the API + web console). It does NOT run
+# agent sandboxes: a single Fly Machine has no gVisor (runsc) and no Docker socket, so
+# the agent execution sandbox cannot launch here — exactly like the hardened Docker
+# Compose path (deploy/docker-compose.prod.yml). For FULL agent isolation you need a
+# gVisor-capable host (deploy/install.sh) or a runsc-capable k8s node (deploy/helm).
+# This PaaS path gets you a running, hardened control-plane and the console first-run
+# screen with zero local tooling. See docs/deployment.md "Path D".
+
+app = "ironclaw-controlplane"
+primary_region = "iad"
+
+[build]
+  # Pin by digest in production for reproducible, cosign-verifiable deploys:
+  #   docker buildx imagetools inspect ghcr.io/ironsecco/ironclaw-controlplane:v0.1.112
+  #   image = "ghcr.io/ironsecco/ironclaw-controlplane@sha256:<digest>"
+  image = "ghcr.io/ironsecco/ironclaw-controlplane:latest"
+
+[env]
+  # Bind inside the Machine; Fly's edge terminates TLS and proxies 443 -> 8787.
+  IRONCLAW_API_ADDR = "0.0.0.0:8787"
+  IRONCLAW_LOG_FORMAT = "json"
+  IRONCLAW_STATE_DIR = "/var/lib/ironclaw/state"
+  # Production posture: 0 keeps the unauthenticated dev owner/agent-group OUT. Set to
+  # "1" ONLY for a throwaway demo box (seeds the offline mock-agent + a dev owner).
+  IRONCLAW_DEV = "0"
+
+# Secrets are set with `fly secrets set` and injected at runtime — NEVER committed here:
+#   IRONCLAW_API_TOKEN   bearer for the admin API + console (else minted+printed in logs)
+#   ANTHROPIC_API_KEY    (or OPENAI_API_KEY / OPENROUTER_API_KEY) — held host-side only
+
+[http_service]
+  internal_port = 8787
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    method = "GET"
+    path = "/healthz"        # unauthenticated by design
+    interval = "15s"
+    timeout = "3s"
+    grace_period = "10s"
+
+# Durable, encrypted (SQLCipher) per-session state: queues, the gateway change store,
+# the append-only audit log, sealed per-session keys, and the minted admin token.
+# Losing this loses the token and all state — keep a backup.
+[mounts]
+  source = "ironclaw_state"
+  destination = "/var/lib/ironclaw/state"
+  # NOTE (first-boot ownership): the image runs as the non-root uid 65532. A brand-new
+  # Fly volume mounts root-owned, so the first boot may fail to initialise the token
+  # file. If `fly logs` shows a permission error writing the state dir, run once:
+  #   fly ssh console -C "chown -R 65532:65532 /var/lib/ironclaw/state"
+  # then restart the Machine. See docs/deployment.md "Path D" troubleshooting.
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -1,0 +1,65 @@
+# Deploy IronClaw on Railway
+
+One-click-ish deploy of the IronClaw **control-plane** to [Railway](https://railway.com).
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new)
+
+> **What this runs.** Railway deploys the trusted IronClaw **control-plane** — the
+> mandatory approval gateway, the encrypted SQLCipher per-session queues, host-side
+> model-credential custody, and the API + web console. It does **not** run agent
+> sandboxes: a single Railway container has no gVisor (`runsc`) and no Docker socket,
+> so the agent execution sandbox cannot launch here — the same boundary as the
+> [hardened Docker Compose path](../docker-compose.prod.yml). For **full agent
+> isolation** use a gVisor host ([`deploy/install.sh`](../install.sh)) or a runsc k8s
+> node ([`deploy/helm`](../helm/ironclaw)). This path gets you a hardened control-plane
+> and the console first-run screen with zero local tooling.
+
+## Deploy
+
+You have two source options; both reach the same running control-plane.
+
+**A. Prebuilt image (no build, fastest).** In the Railway dashboard:
+*New Project → Deploy a Docker Image →* `ghcr.io/ironsecco/ironclaw-controlplane:latest`
+(pin a `@sha256:<digest>` for a reproducible, cosign-verifiable deploy).
+
+**B. Build from this repo.** *New Project → Deploy from GitHub repo →* select your fork.
+Set the service **Config-as-code** path to `deploy/railway/railway.json` (root directory
+= repo root). Railway builds the control-plane from
+[`container/controlplane.Dockerfile`](../../container/controlplane.Dockerfile) (CGO +
+SQLCipher).
+
+## Configure (required)
+
+1. **Networking → target port `8787`.** The control-plane listens on `8787`; set the
+   service's exposed/target port to `8787` so Railway's edge proxies `443 → 8787`.
+2. **Variables:**
+
+   | Variable | Value | Notes |
+   |---|---|---|
+   | `IRONCLAW_API_ADDR` | `0.0.0.0:8787` | bind address inside the container |
+   | `IRONCLAW_LOG_FORMAT` | `json` | structured logs |
+   | `IRONCLAW_STATE_DIR` | `/var/lib/ironclaw/state` | durable state path |
+   | `IRONCLAW_DEV` | `0` | `0` = production; `1` only for a throwaway demo box |
+   | `IRONCLAW_API_TOKEN` | `openssl rand -hex 32` | admin/console bearer; leave unset to mint+print once to the logs |
+   | `ANTHROPIC_API_KEY` | `sk-ant-…` | (or `OPENAI_API_KEY` / `OPENROUTER_API_KEY`) held host-side, never in a sandbox |
+
+3. **Volume.** Attach a Railway **Volume** mounted at `/var/lib/ironclaw/state` so the
+   encrypted SQLCipher queues, the gateway change store, the audit log, sealed keys, and
+   the minted admin token survive restarts. Losing this loses the token and all state.
+
+   > **First-boot ownership.** The image runs as the non-root uid `65532`; a fresh
+   > Railway volume mounts root-owned. If the first boot logs a permission error writing
+   > the state dir, open the service shell and run
+   > `chown -R 65532:65532 /var/lib/ironclaw/state`, then redeploy.
+
+## Verify
+
+Open the service URL at `/ui/` — you should land on the IronClaw web console first-run
+screen. `GET /healthz` returns `ok` once the control-plane is up.
+
+## One-click template (follow-up)
+
+A curated, hosted Railway **template** (volume + env pre-wired so the button is truly
+one-click) must be registered in a Railway account; that registration and end-to-end
+verification are tracked as a QA follow-up to IRO-229. Until then, the button above opens
+Railway's New-Project flow and you complete the **Configure** steps above.

--- a/deploy/railway/railway.json
+++ b/deploy/railway/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "//": "IronClaw control-plane — Railway deploy config. Point a Railway service's 'Config as code' path at deploy/railway/railway.json with the repo root as the service root. Builds the control-plane image from the in-repo Dockerfile (CGO + SQLCipher), or skip the build and deploy the prebuilt GHCR image (ghcr.io/ironsecco/ironclaw-controlplane) from the dashboard. See deploy/railway/README.md.",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "container/controlplane.Dockerfile"
+  },
+  "deploy": {
+    "healthcheckPath": "/healthz",
+    "healthcheckTimeout": 300,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/deploy/render/README.md
+++ b/deploy/render/README.md
@@ -1,0 +1,44 @@
+# Deploy IronClaw on Render
+
+One-click deploy of the IronClaw **control-plane** to [Render](https://render.com) using
+the [`render.yaml`](./render.yaml) Blueprint.
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/IronSecCo/ironclaw)
+
+> **What this runs.** Render deploys the trusted IronClaw **control-plane** (approval
+> gateway, encrypted SQLCipher per-session queues, host-side model-credential custody,
+> API + web console). It does **not** run agent sandboxes — a single Render instance has
+> no gVisor (`runsc`) and no Docker socket, the same boundary as the
+> [hardened Docker Compose path](../docker-compose.prod.yml). For **full agent
+> isolation** use a gVisor host ([`deploy/install.sh`](../install.sh)) or a runsc k8s
+> node ([`deploy/helm`](../helm/ironclaw)).
+
+## Deploy
+
+Click the button (it reads `deploy/render/render.yaml` from your fork), or in the Render
+dashboard: **New → Blueprint →** point at this repo. Render provisions the service + a
+1 GB persistent disk and prompts for the secret env vars.
+
+The Blueprint pulls the prebuilt image `ghcr.io/ironsecco/ironclaw-controlplane:latest`
+(pin a `@sha256:<digest>` for a reproducible, cosign-verifiable deploy).
+
+> **Persistent disks require a paid instance type** (not available on the free tier). The
+> Blueprint defaults to the `starter` plan for this reason.
+
+## Configure (env)
+
+Render prompts for these at deploy time (`sync: false`, never stored in Git):
+
+| Variable | Notes |
+|---|---|
+| `IRONCLAW_API_TOKEN` | admin/console bearer; leave unset to mint+print once to the Render log stream |
+| `ANTHROPIC_API_KEY` | (or `OPENAI_API_KEY` / `OPENROUTER_API_KEY`) held host-side, never in a sandbox |
+
+`IRONCLAW_DEV` defaults to `0` (production). Set to `1` only for a throwaway demo box.
+
+> **First-boot disk ownership.** The image runs as the non-root uid `65532`; a fresh
+> Render disk mounts root-owned. If the first boot logs a permission error writing the
+> state dir, open a shell on the instance and run
+> `chown -R 65532:65532 /var/lib/ironclaw/state`, then redeploy.
+
+See [docs/deployment.md "Path D"](../../docs/deployment.md) for the full guide.

--- a/deploy/render/render.yaml
+++ b/deploy/render/render.yaml
@@ -1,0 +1,60 @@
+# IronClaw control-plane — Render Blueprint (one-click "Deploy to Render").
+#
+# Deploy: push this repo to your Git host and click the README "Deploy to Render"
+# button, or in the Render dashboard: New > Blueprint > point at this repo. Render reads
+# this file, provisions the service + disk, and prompts for the secret env vars below.
+#
+# WHAT THIS RUNS — read before you trust it. This deploys the trusted IronClaw
+# CONTROL-PLANE (approval gateway, encrypted SQLCipher per-session queues, host-side
+# model-credential custody, API + web console). It does NOT run agent sandboxes: a
+# single Render instance has no gVisor (runsc) and no Docker socket, so the agent
+# execution sandbox cannot launch here — same boundary as the hardened Docker Compose
+# path. For FULL agent isolation use a gVisor host (deploy/install.sh) or a runsc k8s
+# node (deploy/helm). This path gets you a hardened control-plane + the console
+# first-run screen with zero local tooling. See docs/deployment.md "Path D".
+#
+# Persistent disks require a paid instance type (not available on the free tier).
+
+services:
+  - type: web
+    name: ironclaw-controlplane
+    runtime: image
+    image:
+      # Pin by digest in production for reproducible, cosign-verifiable deploys:
+      #   ghcr.io/ironsecco/ironclaw-controlplane@sha256:<digest>
+      url: ghcr.io/ironsecco/ironclaw-controlplane:latest
+    region: oregon
+    plan: starter            # disks need a paid plan; "starter" is the smallest paid tier
+    healthCheckPath: /healthz # unauthenticated by design
+    autoDeploy: false        # don't redeploy on a floating :latest moving under you
+    envVars:
+      # Render injects PORT and routes 443 -> PORT. Bind the control-plane to it.
+      - key: PORT
+        value: "8787"
+      - key: IRONCLAW_API_ADDR
+        value: 0.0.0.0:8787
+      - key: IRONCLAW_LOG_FORMAT
+        value: json
+      - key: IRONCLAW_STATE_DIR
+        value: /var/lib/ironclaw/state
+      # Production posture: 0 keeps the unauthenticated dev owner/agent-group OUT.
+      # Set to "1" ONLY for a throwaway demo box (seeds the offline mock-agent).
+      - key: IRONCLAW_DEV
+        value: "0"
+      # Secrets — Render prompts for these at deploy time (sync:false = not in Git).
+      # Bearer for the admin API + console. Leave unset to have the entrypoint mint one
+      # and print it ONCE to the logs (claim it from the Render log stream).
+      - key: IRONCLAW_API_TOKEN
+        sync: false
+      # Model credential — held host-side, never enters a sandbox. Set at least one.
+      - key: ANTHROPIC_API_KEY
+        sync: false
+    # Durable, encrypted (SQLCipher) state. NOTE (first-boot ownership): the image runs
+    # as the non-root uid 65532; a fresh Render disk mounts root-owned. If the first
+    # boot logs a permission error writing the state dir, open a shell on the instance
+    # and `chown -R 65532:65532 /var/lib/ironclaw/state`, then redeploy. See
+    # docs/deployment.md "Path D" troubleshooting.
+    disk:
+      name: ironclaw-state
+      mountPath: /var/lib/ironclaw/state
+      sizeGB: 1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,8 +9,10 @@ exist. This page is the *how*.
 
 ## Pick a deployment path
 
-There are three supported ways to run the control-plane in production. They differ in
-**how much sandbox isolation you get**, because that depends on the host kernel.
+There are three supported ways to run the control-plane in production, plus a
+zero-tooling **one-click PaaS** path ([Path D](#path-d-one-click-paas-flyio-render-railway)).
+They differ in **how much sandbox isolation you get**, because that depends on the host
+kernel.
 
 | | Bare-host (systemd / launchd) | Hardened Docker Compose | Kubernetes (Helm) |
 |---|---|---|---|
@@ -233,6 +235,72 @@ Full value reference and validation commands are in the chart
 [README](https://github.com/IronSecCo/ironclaw/blob/main/deploy/helm/ironclaw/README.md).
 The chart is validated with `helm lint` and `helm template` rendering against the
 Kubernetes schema; a live-cluster apply is left to the operator.
+
+---
+
+## Path D — One-click PaaS (Fly.io / Render / Railway)
+
+The fastest way to a running, hardened control-plane with **zero local tooling**: click a
+Deploy button (or run one CLI command) and a managed platform pulls the published image,
+provisions a persistent volume, and fronts it with TLS.
+
+| Provider | Template | One-click |
+|---|---|---|
+| Fly.io | [`deploy/fly/fly.toml`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/fly/fly.toml) | `fly launch --copy-config` |
+| Render | [`deploy/render/render.yaml`](https://github.com/IronSecCo/ironclaw/blob/main/deploy/render/render.yaml) | [Deploy to Render](https://render.com/deploy?repo=https://github.com/IronSecCo/ironclaw) |
+| Railway | [`deploy/railway/`](https://github.com/IronSecCo/ironclaw/tree/main/deploy/railway) | [Deploy on Railway](https://railway.com/new) |
+
+!!! warning "What the PaaS path runs — and what it doesn't"
+    These templates run the **trusted control-plane only**: the mandatory approval
+    gateway, the encrypted SQLCipher per-session queues, host-side model-credential
+    custody, and the API + web console. A single PaaS container has **no gVisor (`runsc`)
+    and no Docker socket**, so the **agent execution sandbox does not launch here** —
+    exactly the boundary as [Path B (Compose)](#path-b-hardened-docker-compose). For
+    **full agent isolation** use [Path A (gVisor host)](#path-a-bare-host-install-full-gvisor-isolation)
+    or [Path C (runsc k8s node)](#path-c-kubernetes-helm). A PaaS deploy gets you to the
+    console first-run screen; running agents that execute tool calls under isolation is a
+    gVisor-host concern.
+
+Each template defaults to the **hardened image posture**: the published
+`ghcr.io/ironsecco/ironclaw-controlplane` image runs as the non-root uid `65532`, holds
+no secrets (the model credential and admin token arrive at runtime), and exposes only the
+unauthenticated `/healthz` for platform checks. Pin the image by `@sha256:<digest>` for a
+reproducible, cosign-verifiable deploy.
+
+### Required environment
+
+The same env names as [Path B](#1-configure-secrets) — set them through each provider's
+secrets UI, never in a committed file:
+
+| Variable | Required | Notes |
+|---|---|---|
+| `IRONCLAW_API_TOKEN` | recommended | admin/console bearer. Leave unset and the entrypoint mints one and prints it **once** to the deploy logs — claim it from the log stream. |
+| `ANTHROPIC_API_KEY` | for live models | (or `OPENAI_API_KEY` / `OPENROUTER_API_KEY`) held host-side, never enters a sandbox. |
+| `IRONCLAW_API_ADDR` | yes | bind address — `0.0.0.0:8787` (the platform proxies `443 → 8787`). |
+| `IRONCLAW_STATE_DIR` | yes | `/var/lib/ironclaw/state` — mount the persistent volume here. |
+| `IRONCLAW_DEV` | no | `0` (default, production). Set `1` only on a throwaway demo box. |
+
+### Persistence
+
+Each template mounts a **1 GB volume at `/var/lib/ironclaw/state`** — the encrypted
+SQLCipher queues, the gateway change store, the audit log, sealed per-session keys, and
+the minted admin token. Losing this loses the token and all state; back it up.
+
+!!! note "First-boot volume ownership"
+    The image runs as the non-root uid `65532`, but a brand-new PaaS volume mounts
+    root-owned, so the first boot can fail to initialise the state dir. If the deploy
+    logs show a permission error writing `/var/lib/ironclaw/state`, run a one-time
+    `chown -R 65532:65532 /var/lib/ironclaw/state` on the instance (`fly ssh console`,
+    the Render/Railway shell), then restart. The per-provider READMEs
+    ([fly](https://github.com/IronSecCo/ironclaw/blob/main/deploy/fly/README.md),
+    [render](https://github.com/IronSecCo/ironclaw/blob/main/deploy/render/README.md),
+    [railway](https://github.com/IronSecCo/ironclaw/blob/main/deploy/railway/README.md))
+    carry the exact command.
+
+### Verify
+
+Open the deployed URL at `/ui/` — you land on the IronClaw web console first-run screen.
+`GET /healthz` returns `ok` once the control-plane is up.
 
 ---
 


### PR DESCRIPTION
## What

One-click cloud deploy templates that run the **hardened IronClaw control-plane** on a PaaS with zero local tooling, plus README **Deploy** buttons and a deployment-guide **Path D**.

- `deploy/fly/fly.toml` — Fly.io app config: `ironclaw_state` volume at `/var/lib/ironclaw/state`, `/healthz` check, non-root image, secrets via `fly secrets set`.
- `deploy/render/render.yaml` — Render Blueprint: 1 GB disk, `PORT`→8787 wiring, `sync:false` secret prompts, `/healthz` check.
- `deploy/railway/railway.json` + `README.md` — Railway deploy config (Dockerfile build or prebuilt GHCR image), env + volume steps.
- Per-provider READMEs with env tables and the first-boot volume-ownership note.
- README: **One-click cloud deploy** buttons row near the install section.
- `docs/deployment.md`: **Path D — One-click PaaS** with required env, persistence, and the honest caveat.

## Posture / lenses

- **Secured by default:** templates default to the published image's hardened posture — non-root uid `65532`, no baked secrets (model key + admin token injected at runtime), only the unauthenticated `/healthz` exposed. Pin-by-digest documented for reproducibility + cosign-verifiability.
- **Fail loud / honest:** a single PaaS container has no gVisor/Docker socket, so **agent sandboxes do not launch there** — documented prominently (control-plane only, same boundary as Path B). Full agent isolation stays on the gVisor-host / k8s paths.
- **No trust-model change:** no signing/attestation/required-check/installer-verification changes; this adds deploy templates + docs only.

## Verification

- JSON/YAML/TOML all parse.
- Anchor slugs verified against Python-Markdown default slugify (`Fly.io`→`flyio`).
- **Provider end-to-end deploy + console-first-run screenshot for all three providers is delegated to a QA follow-up** (needs Fly/Render/Railway accounts), per the issue.

Closes IRO-229 (templates + buttons + docs). Provider verification tracked in the QA follow-up.