### PR TITLE
feat(metrics): wire gateway decisions, deliveries, sandbox launches (IRO-217)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -601,7 +601,7 @@ func main() {
 		gateway.NewManualApprover(),
 		respawnApplier,
 		store,
-	).SetAudit(audit)
+	).SetAudit(audit).SetMetrics(m)
 
 	// WithRegistry attaches the control-plane registry so the /v1/registry admin
 	// endpoints are live and the approvals read-model (/v1/ui/approvals) can
@@ -681,6 +681,7 @@ func main() {
 		Image:            *sandboxImage,
 		KeyDir:           filepath.Join(*stateDir, "keys"),
 		WorkspaceRoot:    filepath.Join(*stateDir, "workspaces"),
+		OnLaunch:         m.SandboxLaunches.Inc,
 	})
 	if err != nil {
 		logger.Error("session manager", "error", err)
@@ -740,7 +741,8 @@ func main() {
 	pendingQuestions := questions.NewStore()
 	deliverer := delivery.New(channelReg, gw, reg, manager.OutboundReader).
 		WithInboundWriter(manager.InboundWriter).
-		WithQuestions(pendingQuestions)
+		WithQuestions(pendingQuestions).
+		WithMetrics(m.Deliveries)
 	// In-session skill install (RFC-0006): when skills are enabled, let an agent PROPOSE
 	// a curated, signed skill from chat. Delivery resolves+signature-verifies the named
 	// skill through the SAME resolver the operator `ironctl skill add` path uses, then

--- a/deploy/grafana/ironclaw-overview.json
+++ b/deploy/grafana/ironclaw-overview.json
@@ -204,8 +204,8 @@
     },
     {
       "type": "timeseries",
-      "title": "Sandbox launches (per minute) — instrumentation pending",
-      "description": "ironclaw_sandbox_launches_total is registered but not yet incremented; this panel reads 0 until that instrumentation lands.",
+      "title": "Sandbox launches (per minute)",
+      "description": "Rate of sandboxes that actually started, from ironclaw_sandbox_launches_total. Compare against the kills panel to spot crash-loops.",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
       "id": 8,

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -50,23 +50,16 @@ These are recorded by the running control plane:
 | `ironclaw_model_calls_total` | counter | Model-host requests forwarded by the egress proxy. |
 | `ironclaw_model_call_errors_total` | counter | Forwarded requests that errored (HTTP ≥ 400 or denied by the egress policy). |
 | `ironclaw_model_call_duration_seconds` | histogram | Model-host request latency. Emits `_bucket{le=...}`, `_sum`, `_count`. |
+| `ironclaw_sandbox_launches_total` | counter | Sandboxes launched (incremented per sandbox that actually starts). |
 | `ironclaw_sandbox_kills_total` | counter | Sandboxes killed/stopped by the stuck-session sweeper. |
+| `ironclaw_gateway_decisions_total{decision="approved"\|"rejected"}` | counter | Gateway change decisions by outcome — verifier rejects, human approve/reject, and auto-approve. |
+| `ironclaw_deliveries_total` | counter | Outbound messages successfully delivered to a channel adapter. |
 
 The model-call series come from the **model-proxy audit** — every egress request the proxy
 forwards (the sandbox's only network path) is counted and timed at the host, so the numbers
-reflect real, host-observed traffic rather than anything the sandbox self-reports.
-
-### Registered, not yet emitting
-
-These series are declared in the registry (so the metric names are stable) but are **not yet
-incremented** by any call site — they currently read `0`. Instrumentation is tracked as a
-follow-up; do not build alerts on them until they go live:
-
-| Series | Type | Intended meaning |
-| --- | --- | --- |
-| `ironclaw_gateway_decisions_total{decision="approved"\|"rejected"}` | counter | Gateway change decisions by outcome. |
-| `ironclaw_deliveries_total` | counter | Outbound messages delivered to a channel. |
-| `ironclaw_sandbox_launches_total` | counter | Sandboxes launched. |
+reflect real, host-observed traffic rather than anything the sandbox self-reports. The
+gateway-decision, delivery, and sandbox-launch counters are likewise recorded host-side, at
+the gateway decision path, the outbound delivery loop, and the session launcher respectively.
 
 ## Prometheus scrape config
 
@@ -115,8 +108,15 @@ histogram_quantile(0.99, sum(rate(ironclaw_model_call_duration_seconds_bucket[5m
 # Average latency (s)
 rate(ironclaw_model_call_duration_seconds_sum[5m]) / rate(ironclaw_model_call_duration_seconds_count[5m])
 
-# Sandbox kills (per minute)
+# Sandbox launches / kills (per minute)
+60 * rate(ironclaw_sandbox_launches_total[5m])
 60 * rate(ironclaw_sandbox_kills_total[5m])
+
+# Gateway decisions (per minute), split by outcome
+60 * rate(ironclaw_gateway_decisions_total[5m])
+
+# Outbound deliveries (per minute)
+60 * rate(ironclaw_deliveries_total[5m])
 ```
 
 ## Security notes

--- a/internal/host/delivery/delivery.go
+++ b/internal/host/delivery/delivery.go
@@ -47,18 +47,27 @@ type SkillInstallResolver func(skill, version string, group contract.AgentGroupI
 // in that case schedule_task actions are refused rather than executed.
 type InboundWriterFactory func(contract.SessionID) (contract.InboundWriter, error)
 
+// Counter is the minimal metrics sink for the outbound-delivery counter. The
+// daemon passes the ironclaw_deliveries_total counter; *metrics.Counter satisfies
+// it. A tiny interface so delivery does not import the metrics package and tests
+// can assert against a fake.
+type Counter interface {
+	Inc()
+}
+
 // Delivery polls outbound queues and delivers via channel adapters. It dedups
 // delivered messages in memory (mirrored in the inbound `delivered` table once
 // persistence lands) and re-authorizes any privilege-bearing system action the
 // sandbox emits through the gateway.
 type Delivery struct {
-	registry  *channels.Registry
-	gw        *gateway.Gateway
-	reg       registry.Registry
-	newReader OutboundReaderFactory
-	newWriter InboundWriterFactory // optional; enables schedule_task
-	questions *questions.Store     // optional; enables ask_user_question tracking
-	skillProp SkillInstallResolver // optional; enables the in-session skill_install proposal
+	registry   *channels.Registry
+	gw         *gateway.Gateway
+	reg        registry.Registry
+	newReader  OutboundReaderFactory
+	newWriter  InboundWriterFactory // optional; enables schedule_task
+	questions  *questions.Store     // optional; enables ask_user_question tracking
+	skillProp  SkillInstallResolver // optional; enables the in-session skill_install proposal
+	deliveries Counter              // optional; counts each successful channel send
 
 	mu        sync.Mutex
 	delivered map[contract.MessageID]struct{}
@@ -133,6 +142,15 @@ func (d *Delivery) WithQuestions(s *questions.Store) *Delivery {
 // provisioned can ever be proposed, and a human still approves it.
 func (d *Delivery) WithSkillResolver(f SkillInstallResolver) *Delivery {
 	d.skillProp = f
+	return d
+}
+
+// WithMetrics wires the counter incremented once per outbound message that is
+// successfully handed to a channel adapter (ironclaw_deliveries_total). Returns d
+// for chaining. When unset, delivery records no metric. Agent-to-agent routing and
+// gateway-routed system actions are not channel sends and are not counted.
+func (d *Delivery) WithMetrics(deliveries Counter) *Delivery {
+	d.deliveries = deliveries
 	return d
 }
 
@@ -412,6 +430,9 @@ func (d *Delivery) deliver(ctx context.Context, sess registry.Session, msg contr
 	}
 	if _, err := adapter.Deliver(ctx, msg); err != nil {
 		return fmt.Errorf("host/delivery: adapter %q deliver: %w", channel, err)
+	}
+	if d.deliveries != nil {
+		d.deliveries.Inc()
 	}
 	return nil
 }

--- a/internal/host/delivery/delivery_test.go
+++ b/internal/host/delivery/delivery_test.go
@@ -437,3 +437,36 @@ func TestSkillInstallRejectsBadPayload(t *testing.T) {
 		t.Fatal("expected a skill_install missing its version to be refused")
 	}
 }
+
+// fakeCounter is a delivery.Counter that tallies Inc calls.
+type fakeCounter struct{ n int }
+
+func (c *fakeCounter) Inc() { c.n++ }
+
+// TestDeliveryMetricCounts asserts the deliveries counter moves once per
+// successful channel send and not on a deduped re-poll.
+func TestDeliveryMetricCounts(t *testing.T) {
+	d, adapter, _, _, w := newTestDelivery(t)
+	c := &fakeCounter{}
+	d = d.WithMetrics(c)
+	ct, pid := "fake", "C1"
+	if err := w.WriteMessageOut(contract.MessageOut{ID: "o1", Seq: 1, Kind: contract.KindChat, ChannelType: &ct, PlatformID: &pid, Content: "hi"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if c.n != 1 {
+		t.Fatalf("deliveries counter = %d after one send, want 1", c.n)
+	}
+	if len(adapter.Delivered()) != 1 {
+		t.Fatalf("adapter delivered %d, want 1", len(adapter.Delivered()))
+	}
+	// A second poll dedups: no further channel send, no further increment.
+	if err := d.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if c.n != 1 {
+		t.Fatalf("deliveries counter = %d after dedup re-poll, want 1", c.n)
+	}
+}

--- a/internal/host/gateway/gateway.go
+++ b/internal/host/gateway/gateway.go
@@ -264,13 +264,23 @@ func (a *LogApplier) Applied() []contract.ChangeID {
 	return out
 }
 
+// DecisionRecorder is the metrics sink for gateway decisions. The daemon passes
+// *metrics.Metrics, which records ironclaw_gateway_decisions_total by outcome via
+// GatewayDecision. A tiny interface so the gateway does not import the metrics
+// package and tests can assert against a fake.
+type DecisionRecorder interface {
+	// GatewayDecision records one terminal decision; approved selects the series.
+	GatewayDecision(approved bool)
+}
+
 // Gateway implements the mandatory-mutation protocol over the contract types.
 type Gateway struct {
 	chain    VerifierChain
 	approver contract.Approver
 	applier  contract.Applier
 	store    contract.ChangeStore
-	audit    *AuditLog // nil = audit disabled (Append is a safe no-op)
+	audit    *AuditLog        // nil = audit disabled (Append is a safe no-op)
+	metrics  DecisionRecorder // nil = decisions not metered
 }
 
 // New constructs a Gateway from its collaborators. The chain runs first
@@ -284,6 +294,21 @@ func New(chain VerifierChain, approver contract.Approver, applier contract.Appli
 func (g *Gateway) SetAudit(a *AuditLog) *Gateway {
 	g.audit = a
 	return g
+}
+
+// SetMetrics attaches the decision recorder. A nil recorder leaves decisions
+// unmetered. It returns the gateway for chaining. Every terminal decision —
+// verifier reject, human approve/reject, and auto-approve — is recorded by outcome.
+func (g *Gateway) SetMetrics(r DecisionRecorder) *Gateway {
+	g.metrics = r
+	return g
+}
+
+// recordDecision meters one terminal decision. Nil-safe.
+func (g *Gateway) recordDecision(approved bool) {
+	if g.metrics != nil {
+		g.metrics.GatewayDecision(approved)
+	}
 }
 
 // Submit runs the full mandatory-mutation flow for req:
@@ -320,6 +345,7 @@ func (g *Gateway) Submit(ctx context.Context, req contract.ChangeRequest) (contr
 		// A verifier errored; treat as reject and record it.
 		d := contract.Decision{Outcome: OutcomeReject, DecidedBy: "verifier", DecidedAt: time.Now().UTC()}
 		_ = g.store.SetDecision(req.ID, d)
+		g.recordDecision(false)
 		_ = g.audit.Append(AuditEntry{Stage: AuditVerdict, ChangeID: req.ID, Kind: req.Kind, Detail: "error: " + err.Error()})
 		return req.ID, err
 	}
@@ -328,6 +354,7 @@ func (g *Gateway) Submit(ctx context.Context, req contract.ChangeRequest) (contr
 	switch verdict {
 	case contract.VerdictReject:
 		d := contract.Decision{Outcome: OutcomeReject, DecidedBy: "verifier", DecidedAt: time.Now().UTC()}
+		g.recordDecision(false)
 		_ = g.audit.Append(AuditEntry{Stage: AuditDecision, ChangeID: req.ID, Kind: req.Kind, Detail: "reject (verifier): " + reason})
 		return req.ID, g.store.SetDecision(req.ID, d)
 
@@ -339,6 +366,7 @@ func (g *Gateway) Submit(ctx context.Context, req contract.ChangeRequest) (contr
 		if err := g.store.SetDecision(req.ID, d); err != nil {
 			return req.ID, err
 		}
+		g.recordDecision(d.Outcome == OutcomeApprove)
 		_ = g.audit.Append(AuditEntry{Stage: AuditDecision, ChangeID: req.ID, Kind: req.Kind, Detail: d.Outcome + " by " + string(d.DecidedBy)})
 		if d.Outcome != OutcomeApprove {
 			return req.ID, nil
@@ -354,6 +382,7 @@ func (g *Gateway) Submit(ctx context.Context, req contract.ChangeRequest) (contr
 		if err := g.store.SetDecision(req.ID, d); err != nil {
 			return req.ID, err
 		}
+		g.recordDecision(true)
 		_ = g.audit.Append(AuditEntry{Stage: AuditDecision, ChangeID: req.ID, Kind: req.Kind, Detail: "auto-approve (all verifiers passed)"})
 		if err := g.applier.Apply(ctx, req, d); err != nil {
 			return req.ID, err

--- a/internal/host/gateway/gateway_test.go
+++ b/internal/host/gateway/gateway_test.go
@@ -223,3 +223,79 @@ func waitPending(t *testing.T, store *MemoryStore, id contract.ChangeID) {
 	}
 	t.Fatalf("change %q never became pending", id)
 }
+
+// recordingRecorder is a DecisionRecorder that counts approve/reject calls.
+type recordingRecorder struct {
+	mu                 sync.Mutex
+	approved, rejected int
+}
+
+func (r *recordingRecorder) GatewayDecision(approved bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if approved {
+		r.approved++
+		return
+	}
+	r.rejected++
+}
+
+func (r *recordingRecorder) counts() (int, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.approved, r.rejected
+}
+
+// TestSubmitMetricsAutoApprove asserts an all-pass (no human) submit records one
+// approve decision.
+func TestSubmitMetricsAutoApprove(t *testing.T) {
+	rec := &recordingRecorder{}
+	gw := New(VerifierChain{fixedVerifier{name: "ok", verdict: contract.VerdictPass}},
+		NewManualApprover(), NewLogApplier(), NewMemoryStore()).SetMetrics(rec)
+	if _, err := gw.Submit(context.Background(), contract.ChangeRequest{ID: "m1", Kind: contract.ChangePersona}); err != nil {
+		t.Fatal(err)
+	}
+	if a, r := rec.counts(); a != 1 || r != 0 {
+		t.Fatalf("auto-approve: approved=%d rejected=%d, want 1/0", a, r)
+	}
+}
+
+// TestSubmitMetricsVerifierReject asserts a verifier reject records one reject.
+func TestSubmitMetricsVerifierReject(t *testing.T) {
+	rec := &recordingRecorder{}
+	gw := New(VerifierChain{fixedVerifier{name: "deny", verdict: contract.VerdictReject, reason: "no"}},
+		NewManualApprover(), NewLogApplier(), NewMemoryStore()).SetMetrics(rec)
+	if _, err := gw.Submit(context.Background(), contract.ChangeRequest{ID: "m2"}); err != nil {
+		t.Fatal(err)
+	}
+	if a, r := rec.counts(); a != 0 || r != 1 {
+		t.Fatalf("verifier reject: approved=%d rejected=%d, want 0/1", a, r)
+	}
+}
+
+// TestSubmitMetricsHumanDecisions asserts a human approve and a human reject each
+// record the matching series.
+func TestSubmitMetricsHumanDecisions(t *testing.T) {
+	rec := &recordingRecorder{}
+	store := NewMemoryStore()
+	gw := New(VerifierChain{AlwaysRequireHuman{}}, NewManualApprover(), NewLogApplier(), store).SetMetrics(rec)
+
+	for id, outcome := range map[contract.ChangeID]string{"ha": OutcomeApprove, "hr": OutcomeReject} {
+		cid, out := id, outcome
+		done := make(chan error, 1)
+		go func() {
+			_, err := gw.Submit(context.Background(), contract.ChangeRequest{ID: cid})
+			done <- err
+		}()
+		waitPending(t, store, cid)
+		if err := gw.Decide(cid, contract.Decision{Outcome: out, DecidedBy: "admin", DecidedAt: time.Now()}); err != nil {
+			t.Fatal(err)
+		}
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if a, r := rec.counts(); a != 1 || r != 1 {
+		t.Fatalf("human decisions: approved=%d rejected=%d, want 1/1", a, r)
+	}
+}

--- a/internal/host/session/manager.go
+++ b/internal/host/session/manager.go
@@ -116,6 +116,13 @@ type Config struct {
 	// hiding it behind "launched sandbox". Zero applies a small default; a negative
 	// value disables the probe.
 	EarlyExitGrace time.Duration
+
+	// OnLaunch is an optional hook fired once per sandbox that actually starts
+	// (not on the already-running no-op, nor on a launch that lost the race and is
+	// torn down). The daemon wires it to the ironclaw_sandbox_launches_total
+	// counter, mirroring the SandboxKills increment on the kill path. Nil is a
+	// no-op. It must not block — it runs inline on the Wake path.
+	OnLaunch func()
 }
 
 // defaultEarlyExitGrace is the post-launch wait before probing for an early exit.
@@ -467,6 +474,9 @@ func (m *Manager) Wake(id contract.SessionID) error {
 	}
 	m.running[id] = &tracked{handle: handle, launchedAt: m.cfg.Clock().UTC()}
 	m.mu.Unlock()
+	if m.cfg.OnLaunch != nil {
+		m.cfg.OnLaunch()
+	}
 	m.cfg.Logger.Printf("host/session: launched sandbox for %s", id)
 	// If the isolator can report an early exit (the Docker fallback), watch for a
 	// container that dies on startup so a silent failure surfaces in the host log

--- a/internal/host/session/manager_test.go
+++ b/internal/host/session/manager_test.go
@@ -416,3 +416,51 @@ func (b *syncBuffer) String() string {
 	defer b.mu.Unlock()
 	return b.buf.String()
 }
+
+// TestManagerWakeFiresOnLaunch asserts the OnLaunch hook fires exactly once per
+// sandbox that actually starts — once on the first Wake, not on the idempotent
+// no-op second Wake, and again on a relaunch after the sandbox dies. This backs
+// the ironclaw_sandbox_launches_total metric wiring (IRO-217).
+func TestManagerWakeFiresOnLaunch(t *testing.T) {
+	iso := &fakeIsolator{}
+	cust, err := keys.New([32]byte{})
+	if err != nil {
+		t.Fatalf("keys.New: %v", err)
+	}
+	var launches int32
+	m, err := New(Config{
+		Factory:       queue.NewFactory(t.TempDir()),
+		Keys:          cust,
+		Isolator:      iso,
+		Registry:      registry.NewMemRegistry(),
+		KeyDir:        t.TempDir(),
+		WorkspaceRoot: t.TempDir(),
+		OnLaunch:      func() { atomic.AddInt32(&launches, 1) },
+	})
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	const id contract.SessionID = "ses_metric"
+
+	if err := m.Wake(id); err != nil {
+		t.Fatalf("Wake: %v", err)
+	}
+	if got := atomic.LoadInt32(&launches); got != 1 {
+		t.Fatalf("OnLaunch fired %d times after first Wake, want 1", got)
+	}
+	// Idempotent second Wake (sandbox alive) must not fire OnLaunch.
+	if err := m.Wake(id); err != nil {
+		t.Fatalf("second Wake: %v", err)
+	}
+	if got := atomic.LoadInt32(&launches); got != 1 {
+		t.Fatalf("OnLaunch fired %d times after no-op Wake, want 1", got)
+	}
+	// The sandbox dies out-of-band; the next Wake relaunches and fires again.
+	atomic.StoreInt32(&iso.last.dead, 1)
+	if err := m.Wake(id); err != nil {
+		t.Fatalf("Wake after death: %v", err)
+	}
+	if got := atomic.LoadInt32(&launches); got != 2 {
+		t.Fatalf("OnLaunch fired %d times after relaunch, want 2", got)
+	}
+}

--- a/internal/smoke/metrics_wiring_test.go
+++ b/internal/smoke/metrics_wiring_test.go
@@ -1,0 +1,142 @@
+package smoke
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+	"github.com/IronSecCo/ironclaw/internal/host/channels"
+	"github.com/IronSecCo/ironclaw/internal/host/delivery"
+	"github.com/IronSecCo/ironclaw/internal/host/gateway"
+	"github.com/IronSecCo/ironclaw/internal/host/isolation"
+	"github.com/IronSecCo/ironclaw/internal/host/keys"
+	"github.com/IronSecCo/ironclaw/internal/host/metrics"
+	hostqueue "github.com/IronSecCo/ironclaw/internal/host/queue"
+	"github.com/IronSecCo/ironclaw/internal/host/registry"
+	"github.com/IronSecCo/ironclaw/internal/host/session"
+)
+
+// nopHandle is a launched-sandbox handle that reports alive forever and stops
+// cleanly — enough to drive the Manager's launch path without a real runtime.
+type nopHandle struct{}
+
+func (nopHandle) Stop(context.Context) error { return nil }
+func (nopHandle) Alive(context.Context) bool { return true }
+
+// nopIsolator hands back a nopHandle on every launch.
+type nopIsolator struct{}
+
+func (nopIsolator) Launch(context.Context, isolation.SandboxSpec) (isolation.Handle, error) {
+	return nopHandle{}, nil
+}
+
+// passVerifier lets a change through with no human, so an auto-approve decision
+// is recorded without an out-of-band approval step.
+type passVerifier struct{}
+
+func (passVerifier) Name() string { return "pass" }
+func (passVerifier) Verify(context.Context, contract.ChangeRequest) (contract.Verdict, string, error) {
+	return contract.VerdictPass, "ok", nil
+}
+
+// rejectVerifier rejects every change, recording a reject decision.
+type rejectVerifier struct{}
+
+func (rejectVerifier) Name() string { return "reject" }
+func (rejectVerifier) Verify(context.Context, contract.ChangeRequest) (contract.Verdict, string, error) {
+	return contract.VerdictReject, "nope", nil
+}
+
+// TestMetricsWiringMovesOffZero is the end-to-end proof for IRO-217: it wires ONE
+// *metrics.Metrics through the three real subsystems exactly as the daemon does
+// (gateway .SetMetrics, delivery .WithMetrics, session OnLaunch), drives one real
+// event into each, then scrapes the live /metrics HTTP handler and asserts the
+// three previously-dead series have moved off 0. A fake isolator/adapter stands in
+// for gVisor/Docker — the wiring, not the runtime, is what this guards.
+func TestMetricsWiringMovesOffZero(t *testing.T) {
+	m := metrics.New()
+
+	// --- Gateway: one auto-approve + one reject decision ---
+	approveGW := gateway.New(gateway.VerifierChain{passVerifier{}},
+		gateway.NewManualApprover(), gateway.NewLogApplier(), gateway.NewMemoryStore()).SetMetrics(m)
+	if _, err := approveGW.Submit(context.Background(), contract.ChangeRequest{ID: "ok1", Kind: contract.ChangePersona}); err != nil {
+		t.Fatalf("approve submit: %v", err)
+	}
+	rejectGW := gateway.New(gateway.VerifierChain{rejectVerifier{}},
+		gateway.NewManualApprover(), gateway.NewLogApplier(), gateway.NewMemoryStore()).SetMetrics(m)
+	if _, err := rejectGW.Submit(context.Background(), contract.ChangeRequest{ID: "no1"}); err != nil {
+		t.Fatalf("reject submit: %v", err)
+	}
+
+	// --- Delivery: one successful channel send ---
+	reg := registry.NewMemRegistry()
+	mg, _ := reg.GetOrCreateMessagingGroup("fake", "C1", "", true, contract.UnknownPublic)
+	// ResolveSession registers the session in reg so the delivery Poll lists it.
+	if _, err := reg.ResolveSession("g1", mg.ID, nil, contract.SessionShared); err != nil {
+		t.Fatalf("resolve session: %v", err)
+	}
+	st := hostqueue.NewMemStore()
+	hostView := hostqueue.NewMemOutbound(st)
+	sandboxWriter := hostqueue.NewMemOutbound(st)
+	channelReg := channels.NewRegistry()
+	if err := channelReg.Register(channels.NewFakeAdapter("fake")); err != nil {
+		t.Fatalf("register adapter: %v", err)
+	}
+	deliverer := delivery.New(channelReg, approveGW, reg,
+		func(id contract.SessionID) (contract.OutboundReader, error) { return hostView, nil }).
+		WithMetrics(m.Deliveries)
+	ct, pid := "fake", "C1"
+	if err := sandboxWriter.WriteMessageOut(contract.MessageOut{ID: "o1", Seq: 1, Kind: contract.KindChat, ChannelType: &ct, PlatformID: &pid, Content: "hi"}); err != nil {
+		t.Fatalf("write outbound: %v", err)
+	}
+	if err := deliverer.Poll(context.Background()); err != nil {
+		t.Fatalf("delivery poll: %v", err)
+	}
+
+	// --- Session launch: one real launch via the Manager's Wake path ---
+	cust, err := keys.New([32]byte{})
+	if err != nil {
+		t.Fatalf("keys.New: %v", err)
+	}
+	mgr, err := session.New(session.Config{
+		Factory:       hostqueue.NewFactory(t.TempDir()),
+		Keys:          cust,
+		Isolator:      nopIsolator{},
+		Registry:      registry.NewMemRegistry(),
+		KeyDir:        t.TempDir(),
+		WorkspaceRoot: t.TempDir(),
+		OnLaunch:      m.SandboxLaunches.Inc,
+	})
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	if err := mgr.Wake("ses_metric"); err != nil {
+		t.Fatalf("wake: %v", err)
+	}
+
+	// --- Scrape the live /metrics handler and assert the dead series moved ---
+	srv := httptest.NewServer(m.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("scrape: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	out := string(raw)
+
+	for _, want := range []string{
+		`ironclaw_gateway_decisions_total{decision="approved"} 1`,
+		`ironclaw_gateway_decisions_total{decision="rejected"} 1`,
+		"ironclaw_deliveries_total 1",
+		"ironclaw_sandbox_launches_total 1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("scrape missing %q (series still 0 / wrong value) in:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## What

Three control-plane `/metrics` series were **registered** in `internal/host/metrics` but **never incremented** by any call site, so they always read `0`. This wires them at their real call sites onto the same `*metrics.Metrics` exposed at `/metrics`.

| Series | Wired at |
| --- | --- |
| `ironclaw_gateway_decisions_total{decision="approved"\|"rejected"}` | each terminal gateway decision in `Gateway.Submit` (verifier reject, human approve/reject, auto-approve) via new nil-safe `DecisionRecorder` hook `Gateway.SetMetrics` |
| `ironclaw_deliveries_total` | `Delivery.deliver` after a successful `adapter.Deliver`, via `Delivery.WithMetrics` |
| `ironclaw_sandbox_launches_total` | `session.Manager.Wake` on a genuinely-new tracked launch, via `session.Config.OnLaunch` (mirrors the existing `SandboxKills.Inc()`) |

## Security review (trust-model path — CEO)

This touches the **gateway decision path**, so flagging for security review:

- **Observe-only.** `recordDecision` sits alongside the existing audit appends. Verdict aggregation, the `AlwaysRequireHuman` floor, the approver, the applier, and the store are all unchanged. No decision is gated, skipped, or altered.
- **Host-side only.** Metrics are passive atomic counters on the host. A compromised sandbox cannot read or forge them; queue/isolation/egress boundaries are untouched.
- **No secrets.** Counters carry only counts — no IDs, payloads, tokens, or message content.
- **Concurrency-safe.** Privileged `Submit` runs in a background goroutine; the counters are atomic.

The delivery counter does **not** count dedup re-polls, agent-to-agent routing, or gateway-routed system actions (those aren't channel sends). The launch counter does **not** fire on the idempotent no-op Wake or a raced teardown.

## Verification

- `CGO_ENABLED=1 go build ./...` ✅
- `CGO_ENABLED=1 go test ./internal/host/... ./internal/smoke/ ./cmd/...` → 842 passed ✅
- Unit tests assert each call site moves its counter (gateway approve/reject/human, delivery once-per-send + dedup, launch once-per-real-launch).
- **Hermetic `/metrics` scrape** (`internal/smoke/TestMetricsWiringMovesOffZero`): wires one `*metrics.Metrics` through the three real subsystems, drives one event into each, scrapes the live `/metrics` handler, and asserts all three series read non-zero — satisfying the board's "verify the series move off 0 in a local scrape" requirement.

## Docs / dashboard

- `docs/observability.md`: moved the three series from "registered, not yet emitting" → "Live today"; added PromQL building blocks.
- `deploy/grafana/ironclaw-overview.json`: "Sandbox launches" panel drops its "instrumentation pending" note.

Closes IRO-217.