### PR TITLE
docs(community): adoption-metrics + launch engagement playbook (IRO-237)

### DIFF
--- a/community/README.md
+++ b/community/README.md
@@ -1,0 +1,20 @@
+# Community & Growth Ops
+
+Internal operating docs for IronClaw's go-to-market and community growth (WS-E, owned by
+Growth/DevRel). These are **team operating docs**, not end-user documentation — they are
+version-controlled here but intentionally **not** published to the docs site
+(`ironsecco.github.io/ironclaw`).
+
+| Doc | Purpose | Cadence |
+| --- | --- | --- |
+| [adoption-metrics.md](adoption-metrics.md) | Tracked snapshot of stars, traffic, clones, downloads, discussions. Baseline + targets. | Weekly refresh |
+| [launch-engagement-playbook.md](launch-engagement-playbook.md) | Where we post, monitoring cadence, reusable response templates. | Updated per launch |
+
+Refresh the metrics snapshot with:
+
+```bash
+scripts/community/adoption-snapshot.sh            # prints a Markdown snapshot block
+```
+
+> Traffic/clone/referrer endpoints require **push access** to the repo. The script uses
+> the GitHub CLI (`gh`) authenticated as a maintainer.

--- a/community/adoption-metrics.md
+++ b/community/adoption-metrics.md
@@ -1,0 +1,73 @@
+# IronClaw Adoption Metrics
+
+A tracked snapshot of IronClaw's adoption signals: stars, repo traffic (views + clones),
+release downloads, referrers, and community activity. This is the single place we record
+**where we are vs. where we want to be**, refreshed weekly.
+
+- **Owner:** Growth / DevRel (WS-E)
+- **Cadence:** weekly (Mondays), via the `community-metrics-weekly` routine
+- **Refresh command:** `scripts/community/adoption-snapshot.sh` (prints a ready-to-paste snapshot block)
+- **Data source:** GitHub REST API — `repos/IronSecCo/ironclaw` + `/traffic/*` + `/releases`
+  (traffic endpoints require maintainer push access)
+
+## How to read these numbers (honesty notes)
+
+Credibility over hype — for a security audience, accurate measurement is the brand. Two
+caveats apply to every snapshot:
+
+1. **Clone counts are CI-inflated.** `release.yml` cuts a release on every push to `main`,
+   and CI runners clone the repo each run. The raw `clones.count` is therefore dominated by
+   our own automation. **Unique cloners** is better but still noisy. Treat **stars** and
+   **unique visitors** as the honest external-adoption signal, especially pre-launch.
+2. **Traffic is a 14-day rolling window.** GitHub only exposes the trailing 14 days for
+   views/clones/referrers. We snapshot weekly so we keep a longer record than the API does.
+
+## Baseline & targets
+
+Repo went public **2026-06-16**. The launch (IRO-40) is **human-gated and not yet fired** —
+so the numbers below are the **pre-launch baseline**, not a launched-product readout.
+
+| Signal | Baseline (2026-06-30) | Launch-week target | 30-day post-launch target |
+| --- | --- | --- | --- |
+| Stars | 11 | 150+ | 500+ |
+| Unique visitors (14d) | 44 | 1,000+ | 2,500+ |
+| Forks | 2 | 20+ | 60+ |
+| Release downloads (latest tag) | 24 | 200+ | 750+ |
+| Discussions (non-seed threads) | 0 | 10+ | 30+ |
+| External contributors (PRs merged) | 0 | 1+ | 5+ |
+
+Targets are directional, set against comparable security-OSS launches at similar stage;
+revise after the first real launch-week data lands.
+
+## Weekly snapshots
+
+> Newest first. Append a new block each Monday by running the refresh command and pasting
+> its output above the previous block.
+
+### Snapshot — 2026-06-30 (pre-launch baseline)
+
+| Metric | Value | Notes |
+| --- | --- | --- |
+| Stars | 11 | |
+| Forks | 2 | |
+| Watchers | 0 | |
+| Open issues | 13 | incl. tracked work + GFIs |
+| Views (14d) | 471 | 44 unique visitors |
+| Clones (14d) | 6905 | 632 unique — **CI-inflated** (release-per-push) |
+| Release downloads (all-time) | 1451 | across 91 releases |
+| Latest release | v0.1.112 | 24 downloads |
+| Top referrers | — | github.com (18u) · cla-assistant.io (2u) · reddit.com (3u) · goodfirstissues.com (2u) |
+
+> Clone counts are dominated by CI runners (a release is cut on every push to main).
+> Treat **unique visitors** and **stars** as the honest adoption signal pre-launch.
+
+**Read:** Genuinely early/quiet, exactly as expected for a pre-launch repo. The signal worth
+noting is that `reddit.com` and `goodfirstissues.com` already appear as referrers — the
+good-first-issue seeding (IRO-209) and early directory submissions are pulling a trickle of
+real humans before any announcement. Discussions are seeded but have no organic threads yet.
+
+## Related
+
+- Launch engagement playbook: [launch-engagement-playbook.md](launch-engagement-playbook.md)
+- Launch gate / readiness: tracked in IRO-40
+- Directory & awesome-list discoverability: IRO-177, IRO-98

--- a/community/launch-engagement-playbook.md
+++ b/community/launch-engagement-playbook.md
@@ -1,0 +1,121 @@
+# IronClaw Launch-Week Engagement Playbook
+
+How we show up, monitor, and respond during launch week and the weeks after. The goal is a
+**community flywheel**: fast, credible, human responses convert curiosity into stars, stars
+into contributors. This playbook makes that repeatable instead of improvised.
+
+- **Owner:** Growth / DevRel (WS-E)
+- **Gate:** launch execution is gated on **WS-G green + WS-H UX bar cleared + WS-A/B/C done**
+  (IRO-40). This playbook is staged and ready; **do not post launch threads before the gate.**
+- **Golden rule:** every claim we make maps to something shipped and verifiable. No vaporware.
+  When in doubt, confirm capability with QA before publishing.
+
+---
+
+## 1. Where we post (channel map)
+
+Sequenced, not simultaneous. Lead with the channels where a security/dev audience evaluates
+substance, then amplify.
+
+| Order | Channel | Format | Primary message angle | Copy source |
+| --- | --- | --- | --- | --- |
+| 1 | **Show HN** | Show HN post + first comment | "Secured, open-source alternative to openclaw/nanoclaw — gVisor isolation, approval gateway, signed supply chain." Lead with the demo. | launch-announcement doc (IRO-186) |
+| 2 | **r/selfhosted** | text post | Self-host trust + one-command zero-cred demo | launch-announcement doc |
+| 3 | **r/opensource / r/devops** | text post | OSS + supply-chain attestation story | launch-announcement doc |
+| 4 | **Project blog** | long-form announcement | Full positioning + comparison + demo embed | docs/blog (IRO-118) |
+| 5 | **X / Mastodon** | thread | Demo GIF + 5 differentiators, 1 per post | launch-announcement doc |
+| 6 | **LinkedIn** | single post | Trust/compliance framing for orgs | launch-announcement doc |
+| 7 | **GitHub Discussions → Announcements** | pinned post | "We launched" + how to get involved | this repo |
+
+Channel-fit reminder: **HN ≠ Reddit ≠ LinkedIn.** HN wants substance and a working demo and
+punishes marketing tone. Reddit wants a self-hoster talking to self-hosters. LinkedIn tolerates
+the trust/compliance angle. Reuse the *claims*, rewrite the *voice* per channel.
+
+## 2. Monitoring cadence (launch day → week)
+
+| Window | Cadence | What to watch |
+| --- | --- | --- |
+| Launch day, first 4h | every **15–20 min** | HN comments, Reddit comments, new issues, Discussions Q&A |
+| Launch day, rest | every **45–60 min** | same + X/Mastodon replies, new stars velocity |
+| Days 2–7 | **2–3×/day** | issues, Discussions, PR queue, AWL/directory mentions |
+| Steady state | **1×/day** + weekly metrics | issues, Discussions, contributor PRs |
+
+Response-time goal: **first reply within 30 min** during the launch-day windows; same business
+day thereafter. On HN especially, a fast, substantive author reply to the top critical comment
+is worth more than the post itself.
+
+Surfaces to keep open: HN thread · Reddit thread(s) · `github.com/IronSecCo/ironclaw/issues` ·
+`/discussions` · X/Mastodon notifications · `scripts/community/adoption-snapshot.sh` for live numbers.
+
+## 3. Response templates
+
+Adapt tone per surface; keep substance constant. Never paste secrets or internal infra details.
+Every security claim must trace to shipped, verifiable capability (cite docs/threat-model.md,
+SBOM/attestation, or a QA report).
+
+### 3a. "How is this different from openclaw/nanoclaw?"
+> IronClaw is the **security-hardened** path. Same in-session agent UX, but every run is isolated
+> in a gVisor sandbox, credentials sit behind a deny-by-default approval gateway (the agent
+> proposes, a human approves), queues are encrypted at rest, and the supply chain is signed +
+> attested (cosign, SBOM, SLSA provenance, reproducible builds). Full comparison: [link to
+> docs/comparison.md]. If trust/isolation isn't a concern for you, the upstreams are great — we
+> exist for the people who need to prove what ran.
+
+### 3b. "Is this actually secure or is 'secured' just marketing?"
+> Fair question — for a security tool, claims should be checkable. Concretely: gVisor
+> (runsc) isolation [threat-model.md], approval gateway with deny-by-default credential vault,
+> encrypted SQLCipher queues, and a signed/attested release (`cosign verify` works on the
+> published image and binaries; SBOM + SLSA provenance attached). Here's the verification
+> walkthrough: [link]. Found a gap? That's exactly what we want — open an issue or email security.
+
+### 3c. "Show me it working"
+> 30-second, zero-credential demo: `[one-command demo]` — it stands up the control plane, an
+> isolated sandbox, and a mock agent so you can watch the propose → approve → execute loop with
+> nothing to sign up for. Walkthrough: [link]. The animated demo is on the README and landing page.
+
+### 3d. New issue (bug)
+> Thanks for the report — and for trying IronClaw this early. To get this triaged fast: what OS +
+> version, what command, and the output of `ironctl doctor`? If it's a sandbox issue, the early-exit
+> diagnostics in the logs (`ic-sbx-<id>`) help a lot. Tracking this now.
+
+### 3e. New issue / Discussion (feature idea)
+> Love this — added to Ideas. Want to scope it together? If you're up for a PR, I can point you at
+> the right files and we'll tag it good-first-issue. Roadmap context: [ROADMAP.md].
+
+### 3f. First-time contributor PR
+> Welcome, and thank you — first-time contributor 🎉. CI will run the standard checks; the
+> 5-minute contributor quickstart is in CONTRIBUTING.md. I'll review within a day. Don't worry
+> about getting it perfect — we'll iterate together.
+
+### 3g. Skeptical / negative comment
+> Appreciate the pushback — keeps us honest. [Address the specific point with a fact + link.] If we
+> got something wrong, I genuinely want to fix it; here's where to file it: [link].
+
+> Never argue, never overclaim, never get defensive. Concede real limitations openly — for a
+> security audience, admitting a boundary builds more trust than spinning it.
+
+## 4. Pre-launch checklist (Growth-owned slice)
+
+- [ ] Launch gate (IRO-40) confirmed green by CEO/board — **hard dependency**
+- [ ] Every claim in launch copy re-verified against shipped capability (QA sign-off cited)
+- [ ] Baseline metrics snapshot captured the morning of launch (`adoption-snapshot.sh`)
+- [ ] Demo verified working on a clean machine that day
+- [ ] Discussions categories seeded; Announcements post drafted & ready to pin
+- [ ] Response templates loaded; monitoring surfaces bookmarked
+- [ ] Comparison page, threat-model, and verification walkthrough links live and correct
+- [ ] Team coverage agreed for the first-4-hours window
+
+## 5. After launch
+
+- Capture a metrics snapshot at **24h, 72h, and 1 week**; record reads in adoption-metrics.md.
+- Collect social proof (notable stars, quotes, mentions) → file a child issue to curate a wall.
+- Feed every recurring onboarding-friction question back to Forge (WS-D) and UXDesigner (WS-H).
+- Post a "thank you + what's next" Announcements thread at the end of week one.
+
+## Related
+
+- Adoption metrics: [adoption-metrics.md](adoption-metrics.md)
+- Launch announcement copy: IRO-186 (`launch-announcement` doc)
+- Launch kit / claim-tagged copy: IRO-99 (`launch-kit` doc)
+- Comparison / positioning: docs/comparison.md
+- Contributor on-ramp: ROADMAP.md, CONTRIBUTING.md (IRO-209)

--- a/scripts/community/adoption-snapshot.sh
+++ b/scripts/community/adoption-snapshot.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# adoption-snapshot.sh — print a Markdown adoption-metrics snapshot for IronClaw.
+#
+# Pulls stars/forks, 14-day traffic (views + clones), top referrers, and aggregate
+# release download counts via the GitHub API, then emits a Markdown block you can paste
+# into community/adoption-metrics.md as the latest weekly snapshot.
+#
+# Requires: gh (authenticated with push access — traffic endpoints need it), python3.
+# Usage:    scripts/community/adoption-snapshot.sh
+set -euo pipefail
+
+REPO="${IRONCLAW_REPO:-IronSecCo/ironclaw}"
+TODAY="$(date -u +%Y-%m-%d)"
+
+command -v gh >/dev/null || { echo "error: gh not found" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "error: python3 not found" >&2; exit 1; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+gh api "repos/${REPO}" --jq '{stars:.stargazers_count, forks:.forks_count, watchers:.subscribers_count, open_issues:.open_issues_count}' > "$work/core.json"
+gh api "repos/${REPO}/traffic/views"   > "$work/views.json"
+gh api "repos/${REPO}/traffic/clones"  > "$work/clones.json"
+gh api "repos/${REPO}/traffic/popular/referrers" > "$work/referrers.json"
+# Slim releases server-side to avoid huge payloads: keep only what we aggregate.
+gh api "repos/${REPO}/releases" --paginate \
+  --jq '.[] | {tag_name, published_at, downloads: ([.assets[].download_count] | add // 0)}' \
+  | python3 -c 'import sys,json; print(json.dumps([json.loads(l) for l in sys.stdin if l.strip()]))' \
+  > "$work/releases.json"
+
+WORK="$work" TODAY="$TODAY" python3 <<'PY'
+import json, os
+w = os.environ["WORK"]
+load = lambda n: json.load(open(os.path.join(w, n)))
+
+core, views, clones, referrers, releases = (
+    load("core.json"), load("views.json"), load("clones.json"),
+    load("referrers.json"), load("releases.json"),
+)
+
+dl_total = sum(r.get("downloads", 0) for r in releases)
+latest = max(releases, key=lambda r: r.get("published_at", "")) if releases else None
+top_ref = " · ".join(f"{r['referrer']} ({r['uniques']}u)" for r in referrers[:4]) or "—"
+
+print(f"### Snapshot — {os.environ['TODAY']}\n")
+print("| Metric | Value | Notes |")
+print("| --- | --- | --- |")
+print(f"| Stars | {core['stars']} | |")
+print(f"| Forks | {core['forks']} | |")
+print(f"| Watchers | {core['watchers']} | |")
+print(f"| Open issues | {core['open_issues']} | incl. tracked work + GFIs |")
+print(f"| Views (14d) | {views['count']} | {views['uniques']} unique visitors |")
+print(f"| Clones (14d) | {clones['count']} | {clones['uniques']} unique — **CI-inflated** (release-per-push) |")
+print(f"| Release downloads (all-time) | {dl_total} | across {len(releases)} releases |")
+print(f"| Latest release | {latest['tag_name'] if latest else '—'} | {latest['downloads'] if latest else 0} downloads |")
+print(f"| Top referrers | — | {top_ref} |")
+print()
+print("> Clone counts are dominated by CI runners (a release is cut on every push to main).")
+print("> Treat **unique visitors** and **stars** as the honest adoption signal pre-launch.")
+PY


### PR DESCRIPTION
## What
Stands up community-growth operating infrastructure (WS-E, IRO-237):

- **`community/adoption-metrics.md`** — tracked baseline of stars, 14-day traffic (views/clones), release downloads, referrers, and Discussions activity. Includes honesty notes (clone counts are CI-inflated by release-per-push; stars + unique visitors are the real signal), a baseline→target table, and the first pre-launch snapshot (2026-06-30).
- **`community/launch-engagement-playbook.md`** — channel map (HN→Reddit→blog→social→LinkedIn, sequenced), monitoring cadence, 7 reusable response templates, pre-launch checklist (gated on IRO-40), post-launch steps.
- **`scripts/community/adoption-snapshot.sh`** — reproducible weekly snapshot generator (GitHub API → ready-to-paste Markdown). Verified working: produced the embedded baseline.
- **`community/README.md`** — index. These are team-ops docs, **not** published to the docs site (not in mkdocs nav).

## Scope notes
- GitHub Discussions was **already enabled + structured** (Announcements/Q&A/Ideas/Show&Tell/General/Polls) and **seeded** (Welcome #116, Q&A starter #225, Ideas starter #226) — verified high-quality, no placeholder content. Scope item 1 satisfied; no changes needed.
- Docs-only / growth-ops content. No code paths, no trust-model surface.

Closes the doc+playbook+metrics portion of IRO-237. Weekly refresh routine set up separately on the issue.