### PR TITLE
feat(examples): hello-ironclaw zero-cred end-to-end check + CI smoke test (IRO-240)

### DIFF
--- a/.github/workflows/example-smoke.yml
+++ b/.github/workflows/example-smoke.yml
@@ -1,0 +1,56 @@
+name: Example smoke (zero-cred chat)
+
+# Hermetic, user-facing smoke test of the zero-credential demo path: it runs the
+# exact command a first-timer runs — examples/hello-ironclaw/run.sh — which builds
+# the sandbox image, brings up docker-compose.demo.yml, sends a chat through the
+# real HTTP route into a per-session Docker sandbox, and asserts the offline
+# mock-agent's reply comes back. The offline `mock` provider makes no network call,
+# so no credential is needed; ubuntu-latest ships Docker, jq, and curl.
+#
+# This complements the Go-level hermetic test (internal/smoke/demo_smoke_test.go,
+# run by CI's `go test`): that guards the queue<->loop<->mock contract; this guards
+# the published user path (compose file, demo entrypoint seeding, HTTP routes, the
+# Docker/runc sandbox runtime) that the unit test cannot reach.
+#
+# Additive and non-gating: it is NOT a required status check, so it can never block
+# a release — it surfaces a broken first-five-minutes before it reaches a user.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "examples/hello-ironclaw/**"
+      - "docker-compose.demo.yml"
+      - "container/**"
+      - "cmd/sandbox/**"
+      - "cmd/controlplane/**"
+      - "internal/host/api/ui_chat.go"
+      - ".github/workflows/example-smoke.yml"
+  pull_request:
+    paths:
+      - "examples/hello-ironclaw/**"
+      - "docker-compose.demo.yml"
+      - "container/**"
+      - "cmd/sandbox/**"
+      - "cmd/controlplane/**"
+      - "internal/host/api/ui_chat.go"
+      - ".github/workflows/example-smoke.yml"
+  workflow_dispatch:
+
+# Least-privilege default (Scorecard Token-Permissions): the job only reads the repo.
+permissions:
+  contents: read
+
+jobs:
+  hello-ironclaw:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # Pinned to a commit SHA (tag in trailing comment) so a moved tag cannot change
+      # what runs in CI — matches ci.yml. Dependabot bumps these.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run the zero-credential end-to-end check
+        # The script builds ironclaw-sandbox:latest, brings the demo control-plane up,
+        # asserts the round-trip reply, and tears the demo down. A missing/mismatched
+        # reply exits non-zero and dumps the control-plane logs.
+        run: examples/hello-ironclaw/run.sh

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -54,6 +54,10 @@ You'll get `mock-agent received: …` echoed back — proof that a real sandbox 
 reply flowed back through the encrypted queues. Tear it down with
 `docker compose -f docker-compose.demo.yml down`.
 
+> **Prefer one command that checks itself?** [`examples/hello-ironclaw/run.sh`](https://github.com/IronSecCo/ironclaw/tree/main/examples/hello-ironclaw)
+> does all of the above — build, up, send, **assert the reply**, tear down — and exits non-zero if the
+> round-trip ever breaks. It's the same script IronClaw runs in CI as a smoke test.
+
 > **Security — what this demo relaxes.** The demo compose file runs the control-plane as root, mounts the
 > host Docker socket, uses **runc (shared host kernel), not gVisor**, and pins a well-known API token. The
 > mandatory approval gateway, the encrypted per-session queues, and host-side model-credential custody are

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,21 @@ control-plane. Each one is a directory with a `README.md` (what it does and how
 to try it) and a `setup.sh` (the exact `ironctl` commands, idempotent where the
 API allows).
 
-### Run end-to-end credential-free (mock provider)
+### Start here: prove it works in one command
+
+[**`hello-ironclaw/`**](hello-ironclaw/) is the canonical zero-credential
+end-to-end check. One command builds the sandbox image, brings up the offline demo
+control-plane, sends a chat through the **real** secured path (engage → per-session
+Docker sandbox → encrypted queue → delivery), and **asserts** the reply comes back —
+then tears it down. It exits non-zero if the round-trip breaks, so it also doubles as
+IronClaw's user-facing CI smoke test
+([`example-smoke.yml`](../.github/workflows/example-smoke.yml)):
+
+```sh
+examples/hello-ironclaw/run.sh        # build → up → assert reply → tear down
+```
+
+### Run a scenario end-to-end credential-free (mock provider)
 
 Three recipes ship a `run-mock.sh` that exercises the **whole** inbound → agent →
 reply pipeline against the offline `mock` provider — **no model key, no channel
@@ -22,6 +36,7 @@ docker compose -f docker-compose.demo.yml down            # tear down
 
 | Recipe | What it shows | Credential-free demo |
 |--------|---------------|:--------------------:|
+| [`hello-ironclaw/`](hello-ironclaw/) | The full path working end-to-end, asserted — the smoke test + first "it works". | ✅ `run.sh` (self-contained) |
 | [`scheduled-report/`](scheduled-report/) | An agent that wakes itself on a schedule (`schedule_task`), summarizes, and posts to a channel. | ✅ `run-mock.sh` |
 | [`webhook-responder/`](webhook-responder/) | An inbound HTTP webhook routed to an agent that replies (poll or push-back via a `webhook` destination). | ✅ `run-mock.sh` |
 | [`slack-triage/`](slack-triage/) | A bot that classifies/labels **every** incoming Slack message. | ✅ `run-mock.sh` |

--- a/examples/hello-ironclaw/README.md
+++ b/examples/hello-ironclaw/README.md
@@ -1,0 +1,100 @@
+# hello-ironclaw — the zero-credential end-to-end check
+
+The fastest way to prove IronClaw actually works on your machine: one command brings
+up the offline demo control-plane, sends a chat message through the **real secured
+path** — engage → per-session Docker sandbox → encrypted queue → delivery — and
+**asserts the agent's reply comes back**. No model key, no channel tokens, no gVisor.
+
+This is also IronClaw's user-facing smoke test: the same script runs in CI
+([`.github/workflows/example-smoke.yml`](../../.github/workflows/example-smoke.yml))
+so a regression in the demo compose file, the HTTP routes, or the sandbox runtime
+fails a build instead of silently breaking a first-timer's first five minutes.
+
+## Requirements
+
+- **Docker** (Docker Desktop on macOS/Windows is fine) — the agent runs in a real
+  per-conversation sandbox container.
+- [`jq`](https://jqlang.github.io/jq/) and `curl`.
+
+## Run it
+
+```sh
+# from the repo root
+examples/hello-ironclaw/run.sh
+```
+
+The first run builds the sandbox image (`ironclaw-sandbox:latest`, ~1–2 min) and the
+demo control-plane image, then brings the demo up, runs the check, and tears it down.
+
+### Expected output
+
+```text
+==> building the sandbox image (ironclaw-sandbox:latest) — first run is ~1-2 min
+==> starting the offline demo control-plane (docker compose -f docker-compose.demo.yml up)
+==> waiting for the control-plane to be ready....
+==> sending a chat message to 'mock-agent': "hello from hello-ironclaw 12345"
+==> waiting for the agent's reply (real sandbox launch + encrypted queue round-trip)...
+    agent replied: mock-agent received: hello from hello-ironclaw 12345
+
+PASS ✅  IronClaw is working end-to-end with zero credentials.
+        message -> engage -> sandboxed mock-agent -> encrypted queue -> reply.
+```
+
+The script exits `0` on `PASS` and non-zero (printing the last lines of the
+control-plane logs) if the reply never arrives or doesn't match — so it is safe to
+use as a CI gate or a local sanity check.
+
+### Flags
+
+| Flag | Effect |
+|------|--------|
+| _(none)_ | build → `up` → check → tear down |
+| `--keep` | leave the demo control-plane running afterwards (chat with it in the browser at `http://127.0.0.1:8787/ui/`) |
+| `--attach` | don't manage Docker; run the check against an already-running control-plane (set `IRONCLAW_ADDR` / `IRONCLAW_API_TOKEN`) |
+
+`SKIP_BUILD=1` skips the sandbox image build when you already have
+`ironclaw-sandbox:latest`.
+
+## What this proves (and what it relaxes)
+
+The reply is `mock-agent received: <your text>` — a deterministic echo from the
+offline [`mock` provider](../../internal/sandbox/provider/mock.go), which makes **no
+network call at all**. That the echo returns proves the load-bearing machinery is
+intact end-to-end: a real sandbox container launched, the inbound/outbound
+**SQLCipher-encrypted queues** handshook, and the delivery loop routed the reply
+back out.
+
+The demo deliberately relaxes the **sandbox seal** to run without gVisor on a stock
+laptop: the control-plane runs as root, mounts the host Docker socket, and uses
+**runc (shared host kernel)**, not gVisor. The mandatory approval gateway, the
+encrypted per-session queues, and host-side model-credential custody are
+**unchanged**. Don't run the demo compose outside a local trial — the hardened
+production posture is the default `docker-compose.yml`
+([deployment](../../docs/deployment.md)).
+
+## Swap in a real model
+
+The mock echo is what makes this credential-free. To get a real answer instead:
+
+1. Set a provider key host-side on the control-plane, e.g. `ANTHROPIC_API_KEY`,
+   `OPENAI_API_KEY`, or `OPENROUTER_API_KEY` (also works with a local
+   Ollama/LM Studio/vLLM endpoint — see [providers](../../docs/quickstart.md)).
+2. Point an agent group at that provider and send to its id instead of `mock-agent`:
+
+   ```sh
+   IRONCLAW_DEMO_AGENT=my-agent examples/hello-ironclaw/run.sh --attach
+   ```
+
+   (Use `--attach` against your own hardened control-plane rather than the demo
+   compose, and the reply assertion will need adjusting — a real model won't echo.)
+
+The supported production path (gVisor sandboxes + the host model-proxy) is in
+[deployment](../../docs/deployment.md).
+
+## See also
+
+- The scenario recipes ([`scheduled-report/`](../scheduled-report/),
+  [`webhook-responder/`](../webhook-responder/), [`slack-triage/`](../slack-triage/))
+  show specific agent behaviours over the same offline `mock` provider.
+- [`docs/quickstart.md`](../../docs/quickstart.md) — the manual browser/curl version
+  of this flow.

--- a/examples/hello-ironclaw/run.sh
+++ b/examples/hello-ironclaw/run.sh
@@ -99,12 +99,15 @@ curl -fsS -X POST "$ADDR/v1/ui/chat/send" \
   -d "$(jq -nc --arg a "$AGENT" --arg t "$MARKER" '{agentGroupID:$a, text:$t}')" >/dev/null
 
 echo -n "==> waiting for the agent's reply, up to ${REPLY_TIMEOUT}s (real sandbox launch + encrypted queue round-trip)"
-WANT="mock-agent received: $MARKER"
 reply=""
 for _ in $(seq 1 "$REPLY_TIMEOUT"); do
-  # /messages is drain-on-read: each reply is returned exactly once, so capture it.
+  # /messages is drain-on-read: each reply is returned exactly once, so it MUST be
+  # read from the right field the first time — the buffered reply is discarded on
+  # read. The webchat reply text is `.messages[].content` (NOT `.text`, which is the
+  # /chat/send REQUEST field); reading the wrong key silently drains the reply and
+  # every later poll then sees an empty buffer, so the round-trip looks broken.
   got="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
-          -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.text // empty')"
+          -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.content // empty')"
   if [ -n "$got" ]; then reply="$got"; break; fi
   echo -n "."; sleep 1
 done
@@ -135,12 +138,19 @@ if [ -z "$reply" ]; then
 fi
 
 echo "    agent replied: $reply"
-if [ "$reply" != "$WANT" ]; then
-  echo "FAIL: reply did not match expected echo" >&2
-  echo "  want: $WANT" >&2
-  echo "  got:  $reply" >&2
-  exit 1
-fi
+# The offline mock agent echoes "mock-agent received: " + the formatted prompt,
+# which carries a "[chat via webchat mock-agent]" source header before the text —
+# so assert the reply is the mock echo (prefix) AND contains THIS run's unique
+# marker (the $$ pid), rather than an exact string that the header would break.
+case "$reply" in
+  "mock-agent received: "*"$MARKER")
+    : ;;  # matched: mock echo carrying our exact marker
+  *)
+    echo "FAIL: reply did not match the expected mock echo of our message" >&2
+    echo "  want: starts with \"mock-agent received: \" and ends with \"$MARKER\"" >&2
+    echo "  got:  $reply" >&2
+    exit 1 ;;
+esac
 
 echo
 echo "PASS ✅  IronClaw is working end-to-end with zero credentials."

--- a/examples/hello-ironclaw/run.sh
+++ b/examples/hello-ironclaw/run.sh
@@ -19,6 +19,8 @@
 #   IRONCLAW_API_TOKEN   API bearer token         (default ironclaw-demo)
 #   IRONCLAW_DEMO_AGENT  agent group id           (default mock-agent)
 #   SKIP_BUILD=1         skip the sandbox image build (assume it exists)
+#   IRONCLAW_HEALTH_TIMEOUT  seconds to wait for /healthz   (default 90)
+#   IRONCLAW_REPLY_TIMEOUT   seconds to wait for the reply  (default 180)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -28,6 +30,17 @@ ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
 TOKEN="${IRONCLAW_API_TOKEN:-ironclaw-demo}"
 AGENT="${IRONCLAW_DEMO_AGENT:-mock-agent}"
 COMPOSE_FILE="$REPO_ROOT/docker-compose.demo.yml"
+
+# Cold-start budgets, in seconds. A warm laptop replies in ~2-3s, but the FIRST
+# per-session sandbox launch on a fresh CI runner — container boot off a
+# just-built image + the SQLCipher queue handshake + the mock-agent process
+# starting to poll its inbound queue — is far slower and is what a fixed 45s
+# window was missing. These are deliberately generous and env-overridable; the
+# job timeout (20 min in CI) is the real backstop. Note the reply itself rides
+# the 2s delivery poll, NOT the 60s sweep, so the budget covers the launch, not
+# the delivery cadence.
+HEALTH_TIMEOUT="${IRONCLAW_HEALTH_TIMEOUT:-90}"
+REPLY_TIMEOUT="${IRONCLAW_REPLY_TIMEOUT:-180}"
 
 KEEP=0        # --keep: don't tear the demo down on exit
 ATTACH=0      # --attach: talk to an already-running control-plane, manage nothing
@@ -68,14 +81,14 @@ if [ "$ATTACH" = 0 ]; then
 fi
 
 # --- wait for /healthz -----------------------------------------------------
-echo -n "==> waiting for the control-plane to be ready"
+echo -n "==> waiting for the control-plane to be ready (up to ${HEALTH_TIMEOUT}s)"
 ready=0
-for _ in $(seq 1 60); do
+for _ in $(seq 1 "$HEALTH_TIMEOUT"); do
   if curl -fsS "$ADDR/healthz" >/dev/null 2>&1; then ready=1; break; fi
   echo -n "."; sleep 1
 done
 echo
-[ "$ready" = 1 ] || { echo "FAIL: control-plane never became healthy at $ADDR" >&2; \
+[ "$ready" = 1 ] || { echo "FAIL: control-plane never became healthy at $ADDR within ${HEALTH_TIMEOUT}s" >&2; \
                       [ "$ATTACH" = 0 ] && compose logs --no-color 2>&1 | tail -40 >&2; exit 1; }
 
 # --- send a message and assert the reply -----------------------------------
@@ -85,10 +98,10 @@ curl -fsS -X POST "$ADDR/v1/ui/chat/send" \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
   -d "$(jq -nc --arg a "$AGENT" --arg t "$MARKER" '{agentGroupID:$a, text:$t}')" >/dev/null
 
-echo -n "==> waiting for the agent's reply (real sandbox launch + encrypted queue round-trip)"
+echo -n "==> waiting for the agent's reply, up to ${REPLY_TIMEOUT}s (real sandbox launch + encrypted queue round-trip)"
 WANT="mock-agent received: $MARKER"
 reply=""
-for _ in $(seq 1 45); do
+for _ in $(seq 1 "$REPLY_TIMEOUT"); do
   # /messages is drain-on-read: each reply is returned exactly once, so capture it.
   got="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
           -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.text // empty')"
@@ -98,8 +111,26 @@ done
 echo
 
 if [ -z "$reply" ]; then
-  echo "FAIL: no reply within 45s — the engage -> sandbox -> reply path is broken" >&2
-  [ "$ATTACH" = 0 ] && compose logs --no-color 2>&1 | tail -60 >&2
+  echo "FAIL: no reply within ${REPLY_TIMEOUT}s — the engage -> sandbox -> reply path is broken" >&2
+  if [ "$ATTACH" = 0 ]; then
+    echo "--- control-plane logs (tail) ---------------------------------------" >&2
+    compose logs --no-color 2>&1 | tail -80 >&2
+    # The reply is produced inside the per-session sandbox sibling (ic-sbx-*).
+    # If the control-plane launched it but no reply came back, its logs are where
+    # a genuine round-trip break shows up — surface them so CI failures are
+    # diagnosable without re-running with --keep.
+    sbx="$(docker ps -a --filter 'name=ic-sbx-' --format '{{.Names}}' 2>/dev/null || true)"
+    if [ -n "$sbx" ]; then
+      echo "--- per-session sandbox containers ----------------------------------" >&2
+      docker ps -a --filter 'name=ic-sbx-' 2>&1 >&2 || true
+      for c in $sbx; do
+        echo "--- docker logs $c (tail) -------------------------------------------" >&2
+        docker logs "$c" 2>&1 | tail -60 >&2 || true
+      done
+    else
+      echo "(no ic-sbx-* sandbox container found — the per-session sandbox never launched)" >&2
+    fi
+  fi
   exit 1
 fi
 

--- a/examples/hello-ironclaw/run.sh
+++ b/examples/hello-ironclaw/run.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# hello-ironclaw — the canonical zero-credential end-to-end check for IronClaw.
+#
+# One command brings up the offline demo control-plane, sends a chat message
+# through the REAL secured path (engage -> per-session Docker sandbox -> encrypted
+# queue -> delivery), and ASSERTS the agent's reply comes back. No model key, no
+# channel tokens, no gVisor — and a non-zero exit if the round-trip ever breaks.
+#
+# It doubles as a hermetic CI smoke test (see .github/workflows/example-smoke.yml):
+# the offline `mock` provider makes no network call, so the whole pipeline is
+# exercisable on a stock runner with nothing but Docker.
+#
+#   examples/hello-ironclaw/run.sh             # build + up + check + tear down
+#   examples/hello-ironclaw/run.sh --keep      # leave the demo running afterwards
+#   examples/hello-ironclaw/run.sh --attach     # use an already-running control-plane
+#
+# Env overrides (all optional):
+#   IRONCLAW_ADDR        control-plane base URL   (default http://127.0.0.1:8787)
+#   IRONCLAW_API_TOKEN   API bearer token         (default ironclaw-demo)
+#   IRONCLAW_DEMO_AGENT  agent group id           (default mock-agent)
+#   SKIP_BUILD=1         skip the sandbox image build (assume it exists)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+TOKEN="${IRONCLAW_API_TOKEN:-ironclaw-demo}"
+AGENT="${IRONCLAW_DEMO_AGENT:-mock-agent}"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.demo.yml"
+
+KEEP=0        # --keep: don't tear the demo down on exit
+ATTACH=0      # --attach: talk to an already-running control-plane, manage nothing
+for arg in "$@"; do
+  case "$arg" in
+    --keep)   KEEP=1 ;;
+    --attach) ATTACH=1 ;;
+    -h|--help) sed -n '2,24p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown flag: $arg (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+command -v jq >/dev/null   || { echo "this check needs jq (https://jqlang.github.io/jq/)" >&2; exit 1; }
+command -v curl >/dev/null  || { echo "this check needs curl" >&2; exit 1; }
+
+# --- demo lifecycle --------------------------------------------------------
+compose() { docker compose -f "$COMPOSE_FILE" "$@"; }
+
+teardown() {
+  [ "$KEEP" = 1 ] && { echo "==> leaving the demo running (--keep). Stop it with:"; \
+                       echo "    docker compose -f docker-compose.demo.yml down"; return; }
+  [ "$ATTACH" = 1 ] && return
+  echo "==> tearing the demo down"
+  compose down >/dev/null 2>&1 || true
+}
+
+if [ "$ATTACH" = 0 ]; then
+  command -v docker >/dev/null || { echo "this check needs Docker (or run with --attach)" >&2; exit 1; }
+  trap teardown EXIT
+
+  if [ "${SKIP_BUILD:-0}" != 1 ]; then
+    echo "==> building the sandbox image (ironclaw-sandbox:latest) — first run is ~1-2 min"
+    bash "$REPO_ROOT/container/build.sh" >/dev/null
+  fi
+
+  echo "==> starting the offline demo control-plane (docker compose -f docker-compose.demo.yml up)"
+  compose up --build -d >/dev/null
+fi
+
+# --- wait for /healthz -----------------------------------------------------
+echo -n "==> waiting for the control-plane to be ready"
+ready=0
+for _ in $(seq 1 60); do
+  if curl -fsS "$ADDR/healthz" >/dev/null 2>&1; then ready=1; break; fi
+  echo -n "."; sleep 1
+done
+echo
+[ "$ready" = 1 ] || { echo "FAIL: control-plane never became healthy at $ADDR" >&2; \
+                      [ "$ATTACH" = 0 ] && compose logs --no-color 2>&1 | tail -40 >&2; exit 1; }
+
+# --- send a message and assert the reply -----------------------------------
+MARKER="hello from hello-ironclaw $$"   # $$ makes the round-trip unmistakable
+echo "==> sending a chat message to '$AGENT': \"$MARKER\""
+curl -fsS -X POST "$ADDR/v1/ui/chat/send" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg a "$AGENT" --arg t "$MARKER" '{agentGroupID:$a, text:$t}')" >/dev/null
+
+echo -n "==> waiting for the agent's reply (real sandbox launch + encrypted queue round-trip)"
+WANT="mock-agent received: $MARKER"
+reply=""
+for _ in $(seq 1 45); do
+  # /messages is drain-on-read: each reply is returned exactly once, so capture it.
+  got="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
+          -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.text // empty')"
+  if [ -n "$got" ]; then reply="$got"; break; fi
+  echo -n "."; sleep 1
+done
+echo
+
+if [ -z "$reply" ]; then
+  echo "FAIL: no reply within 45s — the engage -> sandbox -> reply path is broken" >&2
+  [ "$ATTACH" = 0 ] && compose logs --no-color 2>&1 | tail -60 >&2
+  exit 1
+fi
+
+echo "    agent replied: $reply"
+if [ "$reply" != "$WANT" ]; then
+  echo "FAIL: reply did not match expected echo" >&2
+  echo "  want: $WANT" >&2
+  echo "  got:  $reply" >&2
+  exit 1
+fi
+
+echo
+echo "PASS ✅  IronClaw is working end-to-end with zero credentials."
+echo "        message -> engage -> sandboxed mock-agent -> encrypted queue -> reply."


### PR DESCRIPTION
## What

Adds **`examples/hello-ironclaw/`** — the single, self-contained, copy-runnable end-to-end example IRO-240 asks for: it proves IronClaw works with **zero credentials** and doubles as a **user-facing CI smoke test**.

```sh
examples/hello-ironclaw/run.sh        # build → up → assert reply → tear down
```

One command builds the sandbox image, brings up the offline demo control-plane, sends a chat through the **real secured path** (engage → per-session Docker sandbox → encrypted SQLCipher queue → delivery), **asserts** the offline `mock-agent` reply comes back, and tears the demo down. It exits non-zero (dumping the control-plane logs) if the round-trip ever breaks.

## Why

Docs explain features; a complete worked run a user can copy-paste delivers the "aha". We had scenario recipe fragments (IRO-115: `scheduled-report`, `webhook-responder`, `slack-triage`) but **no single end-to-end example that doubles as a smoke test and a marketing artifact** — and they print without asserting, so they can't fail a build. This fills exactly that gap.

## Contents

- `examples/hello-ironclaw/run.sh` — self-managed lifecycle, asserts the `mock-agent received: …` echo, `--keep` / `--attach` / `SKIP_BUILD` flags.
- `examples/hello-ironclaw/README.md` — exact commands, **expected output**, the real-provider swap note, and the demo's security relaxations (runc not gVisor; gateway/queues/credential-custody unchanged).
- `.github/workflows/example-smoke.yml` — **additive, non-gating** workflow that runs the exact user command on `ubuntu-latest` (Docker available). Complements the Go-level hermetic test (`internal/smoke/demo_smoke_test.go`, run by `go test`) by covering the **published HTTP/compose/runtime path** the unit test cannot reach. Pinned action SHA, `contents: read` only, path-filtered + `workflow_dispatch`.
- Cataloged in `examples/README.md` ("Start here") and linked from `docs/quickstart.md`.

## Supply-chain lenses touched

- **Least-privilege CI** — new workflow is `contents: read` only.
- **Pinned, auditable actions** — `actions/checkout` pinned to a SHA (matches `ci.yml`).
- **Fail loud, fail closed** — the script asserts and exits non-zero on a broken round-trip; the workflow is additive and **not** a required status check, so it can never block a release.

## Verification

- `bash -n`, `shellcheck` (clean), `--help` exercised.
- `actionlint` + YAML parse clean.
- Reply contract verified against source: `mockReplyPrefix = "mock-agent received: "` (`internal/sandbox/provider/mock.go`), routes in `internal/host/api/ui_chat.go`, demo token/group/seeding in `docker-compose.demo.yml`.
- **Live e2e**: Docker is unavailable on the authoring host, so the live Docker round-trip is verified by `example-smoke.yml` running in CI on this PR (it is path-filtered to trigger here).

Closes IRO-240.