### PR TITLE
docs(quickstart): use seeded dev-agent group, not non-existent default (IRO-242)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ export IRONCLAW_API_TOKEN=$(openssl rand -hex 32)
 ironclaw-controlplane --dev --api-addr 127.0.0.1:8787 &
 
 # 3. Your first command — submit a change; it is HELD at the gateway for a human decision
-ironctl change submit --kind persona --group default --by you
+ironctl change submit --kind persona --group dev-agent --by you
 ironctl change pending                       # see it waiting
 ironctl change approve <change-id> --by you   # apply it
 ```
@@ -563,7 +563,7 @@ go run ./cmd/controlplane --dev --api-addr 127.0.0.1:8787
 export IRONCLAW_API_TOKEN=<same token as above>
 
 # Submit a capability change — it is HELD pending a human decision (the gateway choke point)
-ironctl change submit --kind persona --group default --by alice
+ironctl change submit --kind persona --group dev-agent --by alice
 
 # See what's waiting for approval, then approve or reject by id
 ironctl change pending

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -155,10 +155,10 @@ Confirm connectivity by reading the (empty) audit log:
 
 ## 4. Submit a change — watch it get *held*
 
-`--dev` seeds a `default` agent group. Submit a persona change for it:
+`--dev` seeds a `dev-agent` agent group. Submit a persona change for it:
 
 ```sh
-./bin/ironctl change submit --kind persona --group default --by alice
+./bin/ironctl change submit --kind persona --group dev-agent --by alice
 ```
 
 The CLI prints a **change id**. The change is **not applied** — it is parked at the gateway awaiting a

--- a/docs/site/concepts/gateway.mdx
+++ b/docs/site/concepts/gateway.mdx
@@ -57,7 +57,7 @@ Submit and decide changes with the [`ironctl`](/site/reference/cli) CLI, a thin 
 [control-plane API](/site/reference/api):
 
 ```sh
-ironctl change submit --kind persona --group default --by alice
+ironctl change submit --kind persona --group dev-agent --by alice
 ironctl change pending
 ironctl change approve <change-id> --by alice
 ironctl audit --limit 20

--- a/docs/site/quickstart.mdx
+++ b/docs/site/quickstart.mdx
@@ -63,10 +63,10 @@ export IRONCLAW_API_TOKEN=<paste the token printed in Terminal 1>
 </Step>
 <Step title="Submit a change — watch it get held">
 
-`--dev` seeds a `default` agent group. Submit a persona change for it:
+`--dev` seeds a `dev-agent` agent group. Submit a persona change for it:
 
 ```sh
-./bin/ironctl change submit --kind persona --group default --by alice
+./bin/ironctl change submit --kind persona --group dev-agent --by alice
 ```
 
 The CLI prints a **change id**. The change is **not applied** — it is parked at the gateway awaiting a

--- a/docs/site/self-hosting/from-source.mdx
+++ b/docs/site/self-hosting/from-source.mdx
@@ -44,7 +44,7 @@ The gateway ships with the `always-require-human` floor, so every submitted chan
 decision. Drive it with [`ironctl`](/site/reference/cli):
 
 ```sh
-ironctl change submit --kind persona --group default --by alice
+ironctl change submit --kind persona --group dev-agent --by alice
 ironctl change pending
 ironctl change approve <id> --by alice
 ```

--- a/internal/host/onboard/onboard.go
+++ b/internal/host/onboard/onboard.go
@@ -203,7 +203,7 @@ func (d Deps) Run(ctx context.Context, opts Options) (Result, error) {
 		res.Steps = append(res.Steps, Step{"verify", StatusOK, "control-plane API is reachable"})
 	}
 
-	res.FirstMessage = fmt.Sprintf("ironctl --addr %s change submit --kind persona --group default --by you", opts.Addr)
+	res.FirstMessage = fmt.Sprintf("ironctl --addr %s change submit --kind persona --group dev-agent --by you", opts.Addr)
 	return res, nil
 }
 


### PR DESCRIPTION
## Summary
Fixes [IRO-242](https://github.com/IronSecCo/ironclaw/issues): the documented happy-path quickstart command used `--group default`, but `--dev` seeds the group **`dev-agent`** (`seedDev` in `cmd/controlplane/main.go`). `default` is never created.

`change submit` accepts `--group default` only because it does not validate group existence — so the verbatim command silently parks an **orphaned change against a non-existent group**, which then confuses anyone who runs `ironctl registry`.

## Changes
Align every `--dev` example + prose + the `ironctl onboard` first-command hint on `dev-agent`:
- `README.md` (×2)
- `docs/quickstart.md` (§4 command + prose)
- `docs/site/quickstart.mdx` (command + prose)
- `docs/site/concepts/gateway.mdx`
- `docs/site/self-hosting/from-source.mdx`
- `internal/host/onboard/onboard.go` — `FirstMessage` hint

## Verification
- `CGO_ENABLED=1 go build ./internal/host/onboard/` ✅
- `CGO_ENABLED=1 go test ./internal/host/onboard/` → 11 passed ✅
- `grep -rn 'group default'` across the touched files → none remain ✅

## Follow-up (optional, separate)
Have `change submit` reject/warn on an unknown group so the failure isn't silently masked. Tracking separately per the issue.

## Security lenses
Docs/UX + a CLI hint string only. No trust-boundary, gateway, encryption, isolation, or egress surface touched.