### PR TITLE
fix(onboard): friendly Docker-daemon preflight in build.sh + quickstart nudge (IRO-245)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ read, write, schedule, and reply.
 
 > **Want to see it work first — no API key, no signup?**
 > One offline demo runs the full chat → per-session sandbox → reply loop on a stock
-> laptop, where a mock agent actually replies — no credentials, no gVisor required:
+> laptop, where a mock agent actually replies — no credentials, no gVisor required.
+> Make sure the **Docker daemon is running first** (start Docker Desktop, or
+> `sudo systemctl start docker` on Linux):
 >
 > ```sh
 > git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw

--- a/container/build.sh
+++ b/container/build.sh
@@ -32,6 +32,17 @@ pick_engine() {
 ENGINE="$(pick_engine)"
 [ -n "${ENGINE}" ] || { printf 'error: no container engine found (docker/podman/nerdctl/buildah)\n' >&2; exit 1; }
 
+# Preflight: for daemon-based engines, fail early with a friendly message if the
+# daemon is not reachable, rather than letting the build print a raw socket error.
+# buildah is daemonless, so it has nothing to check.
+if [ "${ENGINE}" != "buildah" ]; then
+  if ! "${ENGINE}" info >/dev/null 2>&1; then
+    printf 'error: %s is installed but its daemon is not reachable.\n' "${ENGINE}" >&2
+    printf '       Start the container runtime and retry (e.g. open Docker Desktop, or run `sudo systemctl start docker`).\n' >&2
+    exit 1
+  fi
+fi
+
 printf '==> Building %s with %s (context: %s)\n' "${IMAGE}" "${ENGINE}" "${REPO_ROOT}"
 if [ "${ENGINE}" = "buildah" ]; then
   buildah bud -t "${IMAGE}" -f "${REPO_ROOT}/container/Dockerfile" "${REPO_ROOT}"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,7 +22,8 @@ reply path with **no model key** and **no gVisor**, launching its per-conversati
 
 **Requires:** Docker (Docker Desktop on macOS is fine; on **Windows run this inside WSL2** — the
 sandbox launches Linux containers over `/var/run/docker.sock`, which native Windows doesn't expose)
-and a clone of the repo.
+and a clone of the repo. **Make sure the Docker daemon is running first** — start Docker Desktop
+(macOS) or `sudo systemctl start docker` (Linux/WSL2) before the commands below.
 
 ```sh
 git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw


### PR DESCRIPTION
## Summary
Fixes [IRO-245](https://github.com/IronSecCo/ironclaw/issues) — zero-cred demo had no Docker-daemon preflight; quickstart didn't tell users to start Docker first. Found by the IRO-239 dogfood pass.

### Repro (before)
On a clean machine with Docker **installed but not running**, `bash container/build.sh` exited 1 with a raw Docker API socket error and no guidance.

### Fix
- **`container/build.sh`**: engine-aware `<engine> info` preflight after engine selection. If a daemon-based engine (docker/nerdctl) is installed but unreachable, exit 1 with a friendly *'start the container runtime'* message instead of the raw socket error. `buildah` is daemonless and skipped; `podman info` works rootless.
- **`docs/quickstart.md`** + **README zero-cred demo**: one-line nudge to start the Docker daemon (Docker Desktop / `systemctl start docker`) before the commands.

### Verification
- `bash -n container/build.sh` → syntax OK.
- Reproduced the exact bug scenario locally (Docker installed, daemon down): build.sh now prints the friendly message and exits 1 (confirmed `EXIT=1`).

### Security lenses
None of the trust boundaries are touched. The preflight is a read-only `info` diagnostic; no secrets, no isolation/egress/queue changes. Docs-only nudge otherwise.