### PR TITLE
fix(ironctl): honor -h/--help on subcommands before dispatch (IRO-244)

### DIFF
--- a/cmd/ironctl/agent.go
+++ b/cmd/ironctl/agent.go
@@ -24,7 +24,7 @@ import (
 // from the built-in catalog package so the CLI and console can never disagree.
 func cmdAgent(addr string, args []string) error {
 	if len(args) < 1 {
-		agentUsage()
+		agentUsage(os.Stderr)
 		return fmt.Errorf("expected: agent <create|list|show|templates>")
 	}
 	switch args[0] {
@@ -37,7 +37,7 @@ func cmdAgent(addr string, args []string) error {
 	case "templates":
 		return cmdAgentTemplates()
 	default:
-		agentUsage()
+		agentUsage(os.Stderr)
 		return fmt.Errorf("unknown agent subcommand %q (want create|list|show|templates)", args[0])
 	}
 }
@@ -665,8 +665,8 @@ func stdoutIsTerminal() bool {
 	return fi.Mode()&os.ModeCharDevice != 0
 }
 
-func agentUsage() {
-	fmt.Fprintln(os.Stderr, `agent subcommands:
+func agentUsage(w io.Writer) {
+	fmt.Fprintln(w, `agent subcommands:
   agent create [--name N] [--template T] [--model M] [--persona TEXT] [--tool X ...] [--all-tools] [--yes]
                run with no flags in a terminal for a guided wizard
   agent list

--- a/cmd/ironctl/help_test.go
+++ b/cmd/ironctl/help_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWantsHelp(t *testing.T) {
+	cases := []struct {
+		args []string
+		want bool
+	}{
+		{[]string{"change", "pending", "--help"}, true},
+		{[]string{"change", "pending", "-h"}, true},
+		{[]string{"change", "submit", "--help"}, true},
+		{[]string{"audit", "-h"}, true},
+		{[]string{"registry", "--help"}, true},
+		{[]string{"change", "pending"}, false},
+		{[]string{"audit", "--limit", "10"}, false},
+		{nil, false},
+	}
+	for _, c := range cases {
+		if got := wantsHelp(c.args); got != c.want {
+			t.Errorf("wantsHelp(%v) = %v, want %v", c.args, got, c.want)
+		}
+	}
+}
+
+// TestRunSubcommandHelp guards the IRO-244 regression: a `-h`/`--help` flag after
+// a subcommand must print usage and exit 0 (return nil) WITHOUT dispatching the
+// action — so probing for options never reaches the network or executes a command.
+// run() with these args must not require a live control-plane.
+func TestRunSubcommandHelp(t *testing.T) {
+	for _, args := range [][]string{
+		{"change", "pending", "--help"},
+		{"change", "pending", "-h"},
+		{"change", "history", "--help"},
+		{"change", "submit", "--help"},
+		{"audit", "--help"},
+		{"registry", "--help"},
+		{"agent", "--help"},
+		// Global flags before the subcommand must not defeat the guard.
+		{"--addr", "http://127.0.0.1:1", "change", "pending", "--help"},
+	} {
+		if err := run(args); err != nil {
+			t.Errorf("run(%v) = %v, want nil (help should exit 0 without dispatching)", args, err)
+		}
+	}
+}
+
+// TestHelpForWritesToWriter confirms help output is routed to the provided writer
+// (callers pass os.Stdout for exit-0 help), and that registry/agent get their own
+// block while other commands fall back to the full reference.
+func TestHelpForWritesToWriter(t *testing.T) {
+	cases := []struct {
+		args    []string
+		wantSub string
+	}{
+		{[]string{"change", "pending", "--help"}, "usage:"},
+		{[]string{"registry", "--help"}, "registry subcommands"},
+		{[]string{"agent", "--help"}, "agent subcommands"},
+	}
+	for _, c := range cases {
+		var buf bytes.Buffer
+		helpFor(c.args, &buf)
+		if !bytes.Contains(buf.Bytes(), []byte(c.wantSub)) {
+			t.Errorf("helpFor(%v) output %q does not contain %q", c.args, buf.String(), c.wantSub)
+		}
+	}
+}

--- a/cmd/ironctl/main.go
+++ b/cmd/ironctl/main.go
@@ -91,6 +91,16 @@ parse:
 		return nil
 	}
 
+	// A `-h`/`--help` flag *after* the subcommand (e.g. `change pending --help`)
+	// prints the relevant usage block to stdout and exits 0, before the action
+	// runs. Top-level `help`/`--help`/`-h` is already handled above; without this
+	// guard a subcommand that takes no flags silently ignores the flag and
+	// executes, so a user merely probing for options would run the command.
+	if wantsHelp(args) {
+		helpFor(args, os.Stdout)
+		return nil
+	}
+
 	// Top-level "audit" command.
 	if args[0] == "audit" {
 		return cmdAudit(addr, args[1:])
@@ -171,6 +181,34 @@ parse:
 		usage()
 		return fmt.Errorf("unknown change verb %q", verb)
 	}
+}
+
+// wantsHelp reports whether a `-h`/`--help` flag appears anywhere in args. It is
+// used to intercept subcommand-level help before the action runs.
+func wantsHelp(args []string) bool {
+	for _, a := range args {
+		if a == "-h" || a == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
+// helpFor writes the usage block most relevant to the requested command. Commands
+// with their own reference (registry, agent) get it; everything else falls back to
+// the full top-level reference.
+func helpFor(args []string, w io.Writer) {
+	if len(args) > 0 {
+		switch args[0] {
+		case "registry":
+			registryUsage(w)
+			return
+		case "agent":
+			agentUsage(w)
+			return
+		}
+	}
+	printReference(w)
 }
 
 func cmdSubmit(addr string, args []string) error {

--- a/cmd/ironctl/registry.go
+++ b/cmd/ironctl/registry.go
@@ -15,7 +15,7 @@ import (
 // of the control-plane registry admin API (/v1/registry/*, see internal/host/api).
 func cmdRegistry(addr string, args []string) error {
 	if len(args) < 1 {
-		registryUsage()
+		registryUsage(os.Stderr)
 		return fmt.Errorf("expected a registry resource (agent-group|messaging-group|wiring|user|role|member|destination|session|access)")
 	}
 	resource, rest := args[0], args[1:]
@@ -39,7 +39,7 @@ func cmdRegistry(addr string, args []string) error {
 	case "access":
 		return cmdRegAccess(addr, rest)
 	default:
-		registryUsage()
+		registryUsage(os.Stderr)
 		return fmt.Errorf("unknown registry resource %q", resource)
 	}
 }
@@ -320,8 +320,8 @@ func cmdRegAccess(addr string, args []string) error {
 	return reqJSON(http.MethodGet, addr+"/v1/registry/access?"+q.Encode(), nil)
 }
 
-func registryUsage() {
-	fmt.Fprintln(os.Stderr, `registry subcommands (thin clients of /v1/registry/*):
+func registryUsage(w io.Writer) {
+	fmt.Fprintln(w, `registry subcommands (thin clients of /v1/registry/*):
   registry agent-group     put --id <id> [--name N] [--folder F] | get --id <id>
   registry messaging-group create --channel C --platform P [--instance I] [--group] [--policy strict|public]
   registry messaging-group get --id <id> | wirings --id <id>


### PR DESCRIPTION
Fixes IRO-244: subcommand-level --help/-h was ignored and the command executed instead (e.g. `ironctl change pending --help` dumped live JSON). Adds a wantsHelp guard in run() that prints the relevant usage block to stdout and exits 0 before dispatch; registry/agent route to their own reference, others fall back to printReference. registryUsage/agentUsage made writer-aware. Verified: build (CGO), go test ./cmd/ironctl/ = 80 passed (adds help_test.go), go vet clean. Security lenses: none touched (CLI-local help text only).