### PR TITLE
feat(delivery): delivery-path observability logger + resilient per-session poll (standalone hardening)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -742,7 +742,8 @@ func main() {
 	deliverer := delivery.New(channelReg, gw, reg, manager.OutboundReader).
 		WithInboundWriter(manager.InboundWriter).
 		WithQuestions(pendingQuestions).
-		WithMetrics(m.Deliveries)
+		WithMetrics(m.Deliveries).
+		WithLogger(logger.Logger)
 	// In-session skill install (RFC-0006): when skills are enabled, let an agent PROPOSE
 	// a curated, signed skill from chat. Delivery resolves+signature-verifies the named
 	// skill through the SAME resolver the operator `ironctl skill add` path uses, then

--- a/internal/host/delivery/delivery.go
+++ b/internal/host/delivery/delivery.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -68,6 +69,7 @@ type Delivery struct {
 	questions  *questions.Store     // optional; enables ask_user_question tracking
 	skillProp  SkillInstallResolver // optional; enables the in-session skill_install proposal
 	deliveries Counter              // optional; counts each successful channel send
+	logger     *slog.Logger         // optional; enables per-poll delivery observability
 
 	mu        sync.Mutex
 	delivered map[contract.MessageID]struct{}
@@ -154,6 +156,19 @@ func (d *Delivery) WithMetrics(deliveries Counter) *Delivery {
 	return d
 }
 
+// WithLogger wires a structured logger for delivery observability. Per poll it
+// records, per session, the number of due outbound rows read, and for each
+// handled message its channel and platform id — COUNTS AND COORDINATES ONLY,
+// never message content (mirroring the sandbox loop's "wrote reply (N bytes)"
+// discipline for a security product). This is the host-side counterpart that
+// makes the delivery path auditable: a reply a sandbox writes but that never
+// surfaces at its destination is now visible here instead of silently lost.
+// Returns d for chaining; when unset delivery logs nothing.
+func (d *Delivery) WithLogger(l *slog.Logger) *Delivery {
+	d.logger = l
+	return d
+}
+
 // Poll reads due outbound messages for every active session and delivers them.
 //
 //   - DEDUP: a message already in the in-memory delivered set is skipped (no
@@ -168,8 +183,12 @@ func (d *Delivery) WithMetrics(deliveries Counter) *Delivery {
 //     origin chat is always allowed; any other destination must be a known
 //     destination of the agent group).
 //
-// Poll returns the first error it hits; partial progress (already-delivered
-// messages) is retained in the dedup set.
+// Poll returns the first message-handling error it hits, but keeps sweeping the
+// remaining sessions so one stuck or denied session cannot starve delivery for
+// the rest. Infrastructure faults for a single session (opening its outbound
+// view, reading its due rows) are non-fatal: they are logged and that session is
+// skipped for the cycle. Partial progress (already-delivered messages) is
+// retained in the dedup set.
 func (d *Delivery) Poll(ctx context.Context) error {
 	if d.reg == nil || d.newReader == nil {
 		return fmt.Errorf("host/delivery: Poll requires a registry and an outbound-reader factory")
@@ -178,25 +197,44 @@ func (d *Delivery) Poll(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("host/delivery: list sessions: %w", err)
 	}
+	var firstErr error
 	for _, sess := range sessions {
-		if err := d.pollSession(ctx, sess); err != nil {
-			return err
+		if err := d.pollSession(ctx, sess); err != nil && firstErr == nil {
+			firstErr = err
 		}
 	}
-	return nil
+	return firstErr
 }
 
-// pollSession delivers the due messages for one session.
+// pollSession delivers the due messages for one session. A failure to open the
+// outbound reader or read its due rows is an infrastructure fault (a
+// missing/locked queue file, a key-custody miss, a cross-boundary read gap), not
+// a delivery decision: it is logged and the session is skipped for this cycle
+// (returns nil) rather than aborting the whole poll. Only a message-handling
+// error is returned to Poll.
 func (d *Delivery) pollSession(ctx context.Context, sess registry.Session) error {
 	reader, err := d.newReader(sess.ID)
 	if err != nil {
-		return fmt.Errorf("host/delivery: open outbound reader for %s: %w", sess.ID, err)
+		if d.logger != nil {
+			d.logger.Warn("delivery: open outbound reader failed", "session", sess.ID, "error", err)
+		}
+		return nil
 	}
 	defer reader.Close()
 
 	due, err := reader.DueMessages()
 	if err != nil {
-		return fmt.Errorf("host/delivery: due messages for %s: %w", sess.ID, err)
+		if d.logger != nil {
+			d.logger.Warn("delivery: read due outbound failed", "session", sess.ID, "error", err)
+		}
+		return nil
+	}
+	if d.logger != nil {
+		// COUNTS ONLY — never message content. This is the decisive signal for a
+		// "reply written by the sandbox but never delivered" report: a nonzero
+		// sandbox write with a zero due-count here localizes the loss to the
+		// cross-boundary outbound read, not the adapter.
+		d.logger.Info("delivery: due outbound read", "session", sess.ID, "due", len(due))
 	}
 	for _, msg := range due {
 		if d.isDelivered(msg.ID) {
@@ -204,6 +242,14 @@ func (d *Delivery) pollSession(ctx context.Context, sess registry.Session) error
 		}
 		if err := d.handle(ctx, sess, msg); err != nil {
 			return err
+		}
+		if d.logger != nil {
+			// Coordinates only (channel + platform), never content: a reply whose
+			// channel/platform is empty (silently dropped by the webchat adapter) is
+			// now visible here, distinguishing that loss from a read-side gap.
+			d.logger.Info("delivery: handled outbound",
+				"session", sess.ID, "message", msg.ID, "kind", string(msg.Kind),
+				"channel", deref(msg.ChannelType), "platform", deref(msg.PlatformID))
 		}
 		d.markDelivered(msg.ID)
 	}

--- a/internal/host/delivery/logger_test.go
+++ b/internal/host/delivery/logger_test.go
@@ -1,0 +1,125 @@
+package delivery
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+	"github.com/IronSecCo/ironclaw/internal/host/channels"
+	"github.com/IronSecCo/ironclaw/internal/host/gateway"
+	"github.com/IronSecCo/ironclaw/internal/host/queue"
+	"github.com/IronSecCo/ironclaw/internal/host/registry"
+)
+
+// chatMsg builds a sandbox outbound chat reply addressed at the given channel /
+// platform coordinates (as the sandbox echoes back from session_routing).
+func chatMsg(id string, seq int64, channel, platform, content string) contract.MessageOut {
+	m := contract.MessageOut{ID: contract.MessageID(id), Seq: seq, Kind: contract.KindChat, Content: content}
+	if channel != "" {
+		c := channel
+		m.ChannelType = &c
+	}
+	if platform != "" {
+		p := platform
+		m.PlatformID = &p
+	}
+	return m
+}
+
+func newGateway() *gateway.Gateway {
+	return gateway.New(gateway.VerifierChain{gateway.AlwaysRequireHuman{}}, gateway.NewManualApprover(), gateway.NewLogApplier(), gateway.NewMemoryStore())
+}
+
+// TestPollLogsDueCountAndCoords verifies the delivery logger records the per-poll
+// due-row count and the handled message's channel/platform coordinates (never its
+// content) — the decisive diagnostic for a "reply written but never delivered"
+// report.
+func TestPollLogsDueCountAndCoords(t *testing.T) {
+	reg := registry.NewMemRegistry()
+	mg, _ := reg.GetOrCreateMessagingGroup("fake", "C1", "", true, contract.UnknownPublic)
+	if _, err := reg.ResolveSession("g1", mg.ID, nil, contract.SessionShared); err != nil {
+		t.Fatal(err)
+	}
+
+	store := queue.NewMemStore()
+	hostOut := queue.NewMemOutbound(store)
+	sandboxOut := queue.NewMemOutbound(store)
+
+	channelReg := channels.NewRegistry()
+	if err := channelReg.Register(channels.NewFakeAdapter("fake")); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	d := New(channelReg, newGateway(), reg, func(id contract.SessionID) (contract.OutboundReader, error) {
+		return hostOut, nil
+	}).WithLogger(slog.New(slog.NewTextHandler(&buf, nil)))
+
+	// Origin-chat reply: channel/platform match the session's messaging group.
+	if err := sandboxOut.WriteMessageOut(chatMsg("m1", 1, "fake", "C1", "secret reply body")); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if d.DeliveredCount() != 1 {
+		t.Fatalf("delivered = %d, want 1", d.DeliveredCount())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "due=1") {
+		t.Errorf("expected a due=1 count log, got:\n%s", out)
+	}
+	if !strings.Contains(out, "channel=fake") || !strings.Contains(out, "platform=C1") {
+		t.Errorf("expected handled coords log (channel=fake platform=C1), got:\n%s", out)
+	}
+	if strings.Contains(out, "secret reply body") {
+		t.Errorf("delivery log leaked message content:\n%s", out)
+	}
+}
+
+// TestPollSkipsBrokenSessionAndDeliversOthers verifies that a single session whose
+// outbound reader cannot be opened is logged and skipped without aborting the
+// whole poll — a broken/stuck session must not starve delivery for the rest.
+func TestPollSkipsBrokenSessionAndDeliversOthers(t *testing.T) {
+	reg := registry.NewMemRegistry()
+	mgA, _ := reg.GetOrCreateMessagingGroup("fake", "C1", "", true, contract.UnknownPublic)
+	mgB, _ := reg.GetOrCreateMessagingGroup("fake", "C2", "", true, contract.UnknownPublic)
+	// Broken session first so, under the old first-error-aborts behavior, it would
+	// have blocked the good session behind it.
+	broken, _ := reg.ResolveSession("gbroken", mgA.ID, nil, contract.SessionShared)
+	good, _ := reg.ResolveSession("ggood", mgB.ID, nil, contract.SessionShared)
+
+	store := queue.NewMemStore()
+	hostOut := queue.NewMemOutbound(store)
+	sandboxOut := queue.NewMemOutbound(store)
+
+	channelReg := channels.NewRegistry()
+	if err := channelReg.Register(channels.NewFakeAdapter("fake")); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	d := New(channelReg, newGateway(), reg, func(id contract.SessionID) (contract.OutboundReader, error) {
+		if id == broken.ID {
+			return nil, context.DeadlineExceeded
+		}
+		return hostOut, nil
+	}).WithLogger(slog.New(slog.NewTextHandler(&buf, nil)))
+
+	if err := sandboxOut.WriteMessageOut(chatMsg("m1", 1, "fake", "C2", "hi")); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("a broken session must not fail the poll: %v", err)
+	}
+	if d.DeliveredCount() != 1 {
+		t.Fatalf("delivered = %d, want 1 (good session delivered despite broken sibling)", d.DeliveredCount())
+	}
+	if out := buf.String(); !strings.Contains(out, "open outbound reader failed") {
+		t.Errorf("expected a warn log for the broken session, got:\n%s", out)
+	}
+	_ = good
+}


### PR DESCRIPTION
## Why (IRO-253)

The `hello-ironclaw` smoke check is RED on Linux CI Docker: the sandbox writes its reply to the per-session outbound queue (`sandbox/loop: wrote reply (N bytes)`) but the webchat drain (`GET /v1/ui/chat/mock-agent/messages`) stays empty. The **control-plane delivery path was completely silent** (`Delivery` had no logger), so the loss can't be localized between the two live hypotheses:

- **H2** — the host reads **0** due rows from the sandbox-written `outbound.db` across the container bind mount.
- **H1b** — the reply reaches delivery with an **empty `platform_id`** and is silently dropped by `WebchatAdapter.Deliver`.

Both produce the identical observable ("reply written, drain empty"). This PR adds the decisive diagnostic — and a real robustness fix.

## What

1. **`Delivery.WithLogger`** — per poll, logs the count of due outbound rows read **per session** and each handled message's **channel/platform coordinates**. Counts and coordinates **only, never message content** (mirrors the sandbox loop's `wrote reply (N bytes)` discipline for a security product). Wired in `cmd/controlplane/main.go`.
   - `due=0` with a nonzero sandbox write → **H2** (cross-boundary read).
   - handled log with empty `channel=`/`platform=` → **H1b** (adapter drop).

2. **Resilient `Poll`** — a single session whose outbound reader can't be opened or whose due rows can't be read is now **logged and skipped for the cycle** instead of aborting the whole sweep. Previously the first per-session infra fault returned early, starving every later session of delivery that tick — one stuck/broken session could silently block delivery for all others. Message-handling errors still surface (a2a refusals etc.), but no longer stop the remaining sessions. **This may itself be the root cause** if a sibling session's reader errors and sorts ahead of the mock-agent session.

## Security lenses

- **Trust boundary**: unchanged. The logger records counts + destination coordinates the host already computes; never sandbox content, never keys. No boundary widened. The resilient poll only stops one session's fault from starving others — every message still passes `destinationAllowed` and gateway re-authorization exactly as before.
- No egress/isolation/encryption change.

## Verify

- `CGO_ENABLED=1 go test ./internal/host/delivery/...` → 28 pass (incl. 2 new: content-never-logged + broken-session-doesn't-starve-sibling).
- `CGO_ENABLED=1 go build ./...` + `go vet` clean.

## Follow-up

This is step 1 of the IRO-253 plan (instrument). The disambiguating run must execute `example-smoke.yml`, which lives on the parent PR #247 branch — this logger needs to reach that run (merge to main → PR #247 rebase, or cherry-pick). Once CI shows H2 vs H1b, the targeted fix (host-authoritative delivery coords for H1b — trust-model-adjacent, CEO review) folds in.