### PR TITLE
fix(api): reject change submit against an unknown agent group (IRO-246)

### DIFF
--- a/internal/host/api/api.go
+++ b/internal/host/api/api.go
@@ -9,6 +9,7 @@ import (
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"strconv"
@@ -247,6 +248,20 @@ func (s *Server) handleSubmit(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.CreatedAt.IsZero() {
 		req.CreatedAt = time.Now().UTC()
+	}
+	// Reject a change aimed at an agent group the registry does not know about.
+	// Parking a change against a non-existent group returns 202 but produces an
+	// orphaned approval that can never meaningfully apply, and it silently masks
+	// operator typos (IRO-246). create_agent is exempt: it PROVISIONS a new group,
+	// so its target is not expected to exist yet. The check is skipped when no
+	// registry is attached (there is nothing to validate against). This is input
+	// validation at the API boundary — the gateway's human-approval floor is
+	// untouched.
+	if s.reg != nil && req.Kind != contract.ChangeCreateAgent && req.AgentGroupID != "" {
+		if _, ok := s.reg.GetAgentGroup(req.AgentGroupID); !ok {
+			http.Error(w, fmt.Sprintf("unknown agent group %q: no such group is registered; see `ironctl registry` for known groups", req.AgentGroupID), http.StatusBadRequest)
+			return
+		}
 	}
 	go func() {
 		// Background context: the submit outlives this HTTP request and lives until

--- a/internal/host/api/api_test.go
+++ b/internal/host/api/api_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/IronSecCo/ironclaw/internal/contract"
 	"github.com/IronSecCo/ironclaw/internal/host/gateway"
+	"github.com/IronSecCo/ironclaw/internal/host/registry"
 )
 
 func newTestServer() (*httptest.Server, *gateway.MemoryStore) {
@@ -116,6 +117,61 @@ func TestSubmitPendingApproveFlow(t *testing.T) {
 	}
 	st, _ := store.Status(sr.ID)
 	t.Fatalf("status = %q, want applied", st)
+}
+
+// TestSubmitRejectsUnknownGroup verifies the API-boundary input validation from
+// IRO-246: when a registry is attached, a change aimed at an agent group that is
+// not registered is rejected with 400 instead of silently parked at 202. A change
+// aimed at a known group still succeeds, and create_agent (which provisions a new
+// group) is exempt.
+func TestSubmitRejectsUnknownGroup(t *testing.T) {
+	store := gateway.NewMemoryStore()
+	gw := gateway.New(
+		gateway.VerifierChain{gateway.AlwaysRequireHuman{}},
+		gateway.NewManualApprover(),
+		gateway.NewLogApplier(),
+		store,
+	)
+	reg := registry.NewMemRegistry()
+	if err := reg.PutAgentGroup(registry.AgentGroup{ID: "dev-agent", Name: "Dev Agent", Folder: "dev-agent"}); err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(New(gw).WithRegistry(reg).Handler())
+	defer srv.Close()
+
+	// Unknown group -> 400.
+	body, _ := json.Marshal(contract.ChangeRequest{Kind: contract.ChangePersona, AgentGroupID: "nope", RequestedBy: "cli:you"})
+	resp, err := http.Post(srv.URL+"/v1/changes", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("unknown-group submit status = %d, want 400", resp.StatusCode)
+	}
+
+	// Known group -> 202.
+	body, _ = json.Marshal(contract.ChangeRequest{Kind: contract.ChangePersona, AgentGroupID: "dev-agent", RequestedBy: "cli:you"})
+	resp, err = http.Post(srv.URL+"/v1/changes", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("known-group submit status = %d, want 202", resp.StatusCode)
+	}
+
+	// create_agent is exempt: it provisions a NEW group, so an as-yet-unknown
+	// target must not be rejected here.
+	body, _ = json.Marshal(contract.ChangeRequest{Kind: contract.ChangeCreateAgent, AgentGroupID: "brand-new", RequestedBy: "cli:you"})
+	resp, err = http.Post(srv.URL+"/v1/changes", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("create_agent submit status = %d, want 202 (exempt from group check)", resp.StatusCode)
+	}
 }
 
 func TestHistoryEndpoint(t *testing.T) {


### PR DESCRIPTION
## Summary
`ironctl change submit --kind persona --group <anything> ...` returned `HTTP 202` even when `<anything>` was not a registered agent group, parking an orphaned approval that can never meaningfully apply and silently masking operator typos (this was the root cause behind IRO-242's `--group default` looking like it worked).

This validates the target group exists at the API boundary (`handleSubmit`) when a registry is attached, rejecting unknown groups with **HTTP 400** and a clear hint pointing at `ironctl registry`.

## Scope / safety
- **Input validation only** — the gateway's mandatory human-approval floor is untouched; no trust-boundary, signing, isolation, or egress change.
- `create_agent` is **exempt**: it provisions a *new* group, so its target is not expected to exist yet.
- Skipped when no registry is attached (nothing to validate against).
- **No regression to the `--dev` seeded `dev-agent` flow or the demo**: the dev-agent group is seeded via `PutAgentGroup`, so `--group dev-agent` still returns 202.

## Verification
- `CGO_ENABLED=1 go build/vet ./internal/host/api/...` clean.
- New `TestSubmitRejectsUnknownGroup`: unknown group → 400, known group → 202, create_agent → 202 (exempt).
- Full `internal/host/api` + `internal/host/onboard` suites pass (dev-agent flow intact).

Fixes IRO-246.