### PR TITLE
fix(isolation): scope docker sandbox binds per session (IRO-259)

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -41,11 +41,14 @@ services:
       IRONCLAW_DEV: "1"
       # Launch each sandbox as a sibling Docker container (runc) — no gVisor needed.
       IRONCLAW_RUNTIME: "docker"
-      # Carry the per-session queues/key into each sandbox at the SAME absolute path the
-      # control-plane uses. The control-plane writes them under /var/lib/ironclaw/state
-      # (the host bind below); the sandbox sibling must bind that HOST path at the same
-      # container target, or the queue handshake won't line up. ${PWD} is the host
-      # compose-project dir, so this resolves to a real host path the Docker daemon sees.
+      # BASE host<->container mapping the Docker isolator uses to scope each sandbox's
+      # binds PER SESSION. It is NOT a whole-dir share: the isolator translates only the
+      # session's own queue files + key file from the control-plane's container view
+      # (/var/lib/ironclaw/state/...) to the host path below, and binds ONLY those at the
+      # SAME absolute path the sandbox reads (the queue handshake needs the paths to line
+      # up). The host master key and sibling session keys under this dir are NEVER mounted
+      # into a sandbox (IRO-259). ${PWD} is the host compose-project dir, so this resolves
+      # to a real host path the Docker daemon sees.
       IRONCLAW_DOCKER_BINDS: "${PWD}/.ironclaw-demo-state:/var/lib/ironclaw/state"
       # network=none for every sandbox sibling, exactly as the production gVisor posture
       # enforces (internal/host/isolation/oci.go REFUSES to launch with a network stack).

--- a/examples/red-team-escape/README.md
+++ b/examples/red-team-escape/README.md
@@ -40,7 +40,7 @@ normal tool API proves the tools are polite; it does not prove the *box* is a bo
 | **Sibling breakout** — inspect / spawn / kill siblings   | No Docker client **and** no Engine socket to reach    | Isolation |
 | **Host filesystem** — read arbitrary host paths          | Host root fs is outside the sandbox mount namespace   | Isolation |
 | **Self-modification** — enable a new tool / capability   | Mandatory gateway holds it for a human decision       | Mandatory gateway |
-| **Cross-session / key custody** — read the master key    | Per-session binds; key via per-session tmpfs (gVisor) | Encryption at rest |
+| **Cross-session / key custody** — read the master key    | Per-session binds only; trust root never mounted in   | Encryption at rest |
 
 ### Network egress — `network=none`
 
@@ -76,38 +76,40 @@ silently made.
   This is a real security regression: do not ship until it is fixed.
 - **GAP** — a **known, tracked** relaxation of the *laptop demo* (the runc fallback),
   not the sealed production posture. Printed loudly and honestly; does **not** fail the
-  run. See below.
+  run. The harness supports this verdict for honesty; with the cross-session key-custody
+  gap now closed (see below), no attack currently reports `GAP`.
 
 ## Honest scope: demo (runc) vs production (gVisor)
 
 The demo trades the *kernel* seal for laptop-friendliness. `docker-compose.demo.yml`
 says so out loud: it runs the runc runtime (**shared host kernel**, not gVisor), the
 control-plane as root, and mounts the Docker socket **into the control-plane** (not the
-sandbox). The **network egress**, **Docker-socket / sibling breakout**, and
-**gateway self-modification** boundaries this harness asserts hold **identically** on
-both paths — that is why they are core PASS assertions.
+sandbox). The **network egress**, **Docker-socket / sibling breakout**, **gateway
+self-modification**, and **cross-session key custody** boundaries this harness asserts
+hold **identically** on both paths — that is why they are core PASS assertions.
 
-Two things the demo genuinely relaxes, which **production gVisor closes**:
+The one thing the demo genuinely relaxes, which **production gVisor closes**:
 
-1. **Shared kernel.** runc shares the host kernel; gVisor (`runsc`) interposes a
-   user-space kernel with a seccomp-bounded host surface, all caps dropped,
-   `no_new_privs`, and a read-only rootfs. The demo cannot demonstrate this on a stock
-   laptop without gVisor installed — so the harness does not claim to.
-2. **Whole-state-dir bind (`GAP` row).** The runc fallback binds the **entire**
-   control-plane state directory read-write into every sandbox so the per-session queue
-   paths line up. That also exposes the host master key and sibling sessions' key
-   material to a compromised sandbox. On the gVisor posture each sandbox binds **only
-   its own** `/queue` files (read-only inbound, read-write outbound) and receives its
-   key via a per-session tmpfs, so nothing cross-session is reachable. This is a real
-   defect on the demo path, filed and tracked as **IRO-259** — the harness surfaces it
-   as a `GAP` rather than pretending it is contained. Reproduced: a compromised sandbox
-   can `head -c 40 /var/lib/ironclaw/state/host-master.key` (the host master key) and
-   read sibling `keys/<session>/session.key` files. The fix is per-session binds in the
-   Docker isolator instead of the whole-state-dir bind; once it lands this row becomes a
-   core PASS assertion.
+- **Shared kernel.** runc shares the host kernel; gVisor (`runsc`) interposes a
+  user-space kernel with a seccomp-bounded host surface, all caps dropped,
+  `no_new_privs`, and a read-only rootfs. The demo cannot demonstrate this on a stock
+  laptop without gVisor installed — so the harness does not claim to.
 
-We would rather ship a harness that tells the truth — "here is what held, and here is
-the one gap we are closing" — than one that only ever prints green.
+**Cross-session key custody used to be a gap on the demo path (IRO-259) — it is now
+closed.** The runc fallback originally bind-mounted the **entire** control-plane state
+directory into every sandbox so the per-session queue paths lined up, which also
+exposed the host master key and sibling sessions' key material to a compromised
+sandbox. The Docker isolator now scopes its binds **per session** — it translates and
+mounts only that session's own `sessions/<id>` queue files (read-only inbound,
+read-write outbound) and its `keys/<id>/session.key` (read-only), exactly as the
+gVisor/OCI posture does — so `host-master.key`, `sealed-keys.json`, and every sibling
+`keys/<session>/session.key` are never mounted in and are unreachable from inside the
+box. The harness asserts this directly as a **core PASS** row (probing all three), so a
+future change that re-widens the bind to the whole state dir would fail the run.
+
+We would rather ship a harness that tells the truth — "here is exactly what held, and
+here is the single seal only production gVisor adds" — than one that only ever prints
+green.
 
 ## Flags
 

--- a/examples/red-team-escape/run.sh
+++ b/examples/red-team-escape/run.sh
@@ -223,20 +223,32 @@ else
   fail "self-modification: enable a new tool" "held at gateway (pending human approval)" "change did NOT reach the gateway pending queue"
 fi
 
-# 6) CROSS-SESSION / KEY CUSTODY — defence in depth. On the sealed production posture
-#    (gVisor) each sandbox binds ONLY its own /queue files and gets its key via a
-#    per-session tmpfs, so sibling sessions and the host master key are invisible. The
-#    laptop demo runs the runc fallback, which binds the WHOLE control-plane state dir
-#    read-write into every sandbox (docker-compose.demo.yml) — a documented, tracked
-#    relaxation (see README + the linked defect). We probe it honestly: this is a GAP
-#    on the demo path, NOT a core-containment failure that fails the run.
+# 6) CROSS-SESSION / KEY CUSTODY — the host trust root. Each sandbox must bind ONLY
+#    its own per-session subtree, never the control-plane state dir. Both postures now
+#    enforce this: the sealed gVisor path binds only its /queue files + a per-session
+#    tmpfs key, and the runc fallback (this demo) scopes its binds per session too
+#    (IRO-259: the Docker isolator translates only the session's own queue/key paths,
+#    so the host master key and sibling session keys are never mounted in). This is a
+#    CORE containment assertion: if a future change re-widens the bind to the whole
+#    state dir, the master key / sibling keys become reachable and this row FAILS.
 statedir="/var/lib/ironclaw/state"
-keys_seen="$(sbx "ls $statedir/host-master.key $statedir/keys 2>/dev/null | wc -l | tr -d ' '")"
-if [ "${keys_seen:-0}" = "0" ]; then
-  pass "cross-session: read the host master key / sibling session keys" "state dir not visible" "no key material reachable"
+# Probe the crown jewels directly. The host master key (the trust root that seals every
+# session key) and the sealed-key store (which holds ALL sessions' sealed keys) must be
+# unreadable. And the sandbox must see at most its OWN plaintext session key — never a
+# sibling's: per-session binds expose exactly one keys/<id>/session.key (the Docker
+# daemon creates only that scaffold), whereas a whole-state-dir re-widening would expose
+# host-master.key, sealed-keys.json, AND every sibling keys/<other>/session.key at once.
+master_seen="$(sbx "[ -r $statedir/host-master.key ] && echo YES || echo NO")"
+sealed_seen="$(sbx "[ -r $statedir/sealed-keys.json ] && echo YES || echo NO")"
+keyfiles="$(sbx "ls $statedir/keys/*/session.key 2>/dev/null | wc -l | tr -d ' '")"; keyfiles="${keyfiles:-0}"
+if [ "$master_seen" = "NO" ] && [ "$sealed_seen" = "NO" ] && [ "$keyfiles" -le 1 ]; then
+  pass "cross-session: read the host master key / sibling session keys" \
+       "trust root not mounted (per-session binds only)" \
+       "master key + sealed store unreachable; only own session key visible ($keyfiles)"
 else
-  gap "cross-session: read the host master key / sibling session keys" "state dir not visible (prod gVisor)" \
-      "demo runc binds whole state dir RW -> key material reachable"
+  fail "cross-session: read the host master key / sibling session keys" \
+       "trust root not mounted (per-session binds only)" \
+       "leaked -> master:$master_seen sealed:$sealed_seen session-keys-visible:$keyfiles (want <=1)"
 fi
 
 # --- results table ----------------------------------------------------------
@@ -256,9 +268,8 @@ echo "==========================================================================
 if [ "$GAP_FOUND" = 1 ]; then
   echo
   echo "NOTE: one or more GAP rows above are KNOWN, TRACKED relaxations of the laptop"
-  echo "      demo (runc fallback), not the sealed gVisor posture. The cross-session"
-  echo "      key-custody gap is tracked as IRO-259 (fix: per-session binds in the Docker"
-  echo "      isolator). See this example's README for what production gVisor closes."
+  echo "      demo (runc fallback), not the sealed gVisor posture. See this example's"
+  echo "      README for what the production gVisor posture closes."
 fi
 
 echo

--- a/internal/host/isolation/docker.go
+++ b/internal/host/isolation/docker.go
@@ -29,16 +29,30 @@ import (
 // the Docker Engine API over a unix socket (no docker CLI dependency).
 type DockerIsolator struct {
 	client  *http.Client
-	network string   // docker network to attach (e.g. a private bridge)
-	binds   []string // volume binds replicated into every sandbox, "name:/mount[:ro]"
-	user    string   // container user, e.g. "0:0"
+	network string            // docker network to attach (e.g. a private bridge)
+	mounts  []dockerBaseMount // host<->container base mappings for per-session bind scoping
+	user    string            // container user, e.g. "0:0"
+}
+
+// dockerBaseMount is one host<->container path mapping parsed from a
+// "hostPath:containerPath[:ro]" bind string. It is NOT replicated wholesale into
+// every sandbox; it is the translation table Launch uses to remap the per-session
+// paths a spec references (queue files, key file, sockets) from the control-plane's
+// container-view (e.g. /var/lib/ironclaw/state/...) to the host path the Docker
+// daemon must bind, then binds ONLY those precise paths. This is what keeps the host
+// master key and sibling session keys — which no spec references — out of every
+// sandbox (IRO-259), matching the hardened gVisor/OCI granularity.
+type dockerBaseMount struct {
+	host      string // host-side path the Docker daemon sees
+	container string // path the control-plane + sandbox see (spec paths are in this view)
 }
 
 // NewDocker constructs a DockerIsolator. socket is the Docker Engine API socket
 // (e.g. /var/run/docker.sock); network is the docker network to attach; binds are
-// the volume mounts ("vol:/path") that carry the per-session queues/key and the
-// model-proxy socket into the sandbox at the SAME paths the control plane uses; and
-// user is the container uid:gid.
+// the BASE host<->container mappings ("hostPath:containerPath[:ro]") used to
+// translate the per-session paths in each SandboxSpec (queues/key/sockets) into the
+// host paths the sandbox binds — the isolator then mounts ONLY those per-session
+// paths, never the whole shared subtree; and user is the container uid:gid.
 func NewDocker(socket, network string, binds []string, user string) *DockerIsolator {
 	return &DockerIsolator{
 		client: &http.Client{
@@ -50,9 +64,30 @@ func NewDocker(socket, network string, binds []string, user string) *DockerIsola
 			},
 		},
 		network: network,
-		binds:   binds,
+		mounts:  parseDockerBaseMounts(binds),
 		user:    user,
 	}
+}
+
+// parseDockerBaseMounts turns "hostPath:containerPath[:ro]" strings into base
+// mappings. The optional trailing ":ro" (a mount mode from the legacy bind syntax)
+// is dropped — per-session read-only/read-write is decided per path in sessionBinds,
+// not by the base mapping. Malformed entries (missing the host<->container colon)
+// are skipped.
+func parseDockerBaseMounts(binds []string) []dockerBaseMount {
+	var out []dockerBaseMount
+	for _, b := range binds {
+		b = strings.TrimSpace(b)
+		if b == "" {
+			continue
+		}
+		parts := strings.Split(b, ":")
+		if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+			continue
+		}
+		out = append(out, dockerBaseMount{host: parts[0], container: parts[1]})
+	}
+	return out
 }
 
 type dockerCreateReq struct {
@@ -87,7 +122,7 @@ func (d *DockerIsolator) Launch(ctx context.Context, spec SandboxSpec) (Handle, 
 		User:   d.user,
 		Labels: map[string]string{"ironclaw.session": string(spec.SessionID)},
 		HostConfig: dockerHostConfig{
-			Binds:       d.binds,
+			Binds:       d.sessionBinds(spec),
 			NetworkMode: d.network,
 			AutoRemove:  false,
 		},
@@ -101,6 +136,90 @@ func (d *DockerIsolator) Launch(ctx context.Context, spec SandboxSpec) (Handle, 
 		return nil, fmt.Errorf("host/isolation: docker start %s: %w", name, err)
 	}
 	return &dockerHandle{iso: d, id: created.ID}, nil
+}
+
+// sessionBinds computes the PER-SESSION bind list for spec: only the precise paths
+// the sandbox needs (its own queue files, key file, workspace, and host-mediated
+// sockets), each translated from the control-plane's container-view to the host path
+// the Docker daemon binds. It deliberately mirrors the hardened gVisor/OCI mount
+// granularity (internal/host/isolation/oci.go) — inbound read-only, outbound
+// read-write, key read-only, sockets read-write — so a runc-fallback sandbox is
+// scoped to exactly its own session subtree. The host master key, the sealed-key
+// store, and sibling sessions/keys are NEVER referenced by a spec, so they are never
+// bound: no sandbox can read another session's key or the host trust root (IRO-259).
+//
+// A spec path that falls under no base mapping is left UNBOUND (it was never part of
+// the shared subtree), preserving the prior behavior for paths outside the mapped
+// state dir (e.g. a model-proxy socket the operator did not map in for the offline
+// mock demo, which makes no model call).
+func (d *DockerIsolator) sessionBinds(spec SandboxSpec) []string {
+	type want struct {
+		path string
+		ro   bool
+	}
+	wants := []want{
+		{spec.ReadOnlyInboundPath, true},    // inbound queue: sandbox reads only
+		{spec.ReadWriteOutboundPath, false}, // outbound queue: sandbox is sole writer
+		{spec.KeyPath, true},                // per-session key file: read only
+		{spec.WorkspacePath, false},         // durable workspace (when set): rw
+		{spec.MemoryPath, false},            // durable per-group memory (when set): rw
+		{spec.SharedReadOnlyPath, true},     // global shared assets (when set): ro
+		{spec.ModelProxySocket, false},      // host model-proxy socket: rw (needs connect)
+		{spec.EgressSocket, false},          // optional egress-broker socket: rw
+		{spec.MCPSocket, false},             // optional per-session MCP socket: rw
+	}
+	for _, sm := range spec.SkillMounts {
+		wants = append(wants, want{sm.HostPath, true}) // installed-skill bundles: ro
+	}
+
+	seen := make(map[string]struct{})
+	var binds []string
+	for _, w := range wants {
+		if w.path == "" {
+			continue
+		}
+		hostPath, ok := d.hostPathFor(w.path)
+		if !ok {
+			// Not under any mapped subtree: leave it unbound, as before.
+			continue
+		}
+		bind := hostPath + ":" + w.path
+		if w.ro {
+			bind += ":ro"
+		}
+		if _, dup := seen[bind]; dup {
+			continue
+		}
+		seen[bind] = struct{}{}
+		binds = append(binds, bind)
+	}
+	return binds
+}
+
+// hostPathFor translates a control-plane container-view path to the host path the
+// Docker daemon must bind, using the longest-matching base mapping. ok is false when
+// no base mapping covers the path (the caller then skips the bind). The longest match
+// wins so a nested mapping is preferred over a broader one.
+func (d *DockerIsolator) hostPathFor(containerPath string) (string, bool) {
+	best := -1
+	var host string
+	for _, m := range d.mounts {
+		if containerPath == m.container {
+			if len(m.container) > best {
+				best, host = len(m.container), m.host
+			}
+			continue
+		}
+		if strings.HasPrefix(containerPath, m.container+"/") {
+			if len(m.container) > best {
+				best, host = len(m.container), m.host+containerPath[len(m.container):]
+			}
+		}
+	}
+	if best < 0 {
+		return "", false
+	}
+	return host, true
 }
 
 type dockerHandle struct {

--- a/internal/host/isolation/docker_test.go
+++ b/internal/host/isolation/docker_test.go
@@ -87,10 +87,18 @@ func TestDockerLaunchAndStop(t *testing.T) {
 	go srv.Serve(ln)
 	t.Cleanup(func() { srv.Close() })
 
-	d := NewDocker(sock, "none", []string{"vol:/p"}, "0:0")
+	// Base mapping: host ./state <-> container /var/lib/ironclaw/state. The spec's
+	// per-session paths live under the container view; Launch must bind ONLY those,
+	// translated to host paths — never the whole state dir.
+	d := NewDocker(sock, "none", []string{"/host/state:/var/lib/ironclaw/state"}, "0:0")
 	h, err := d.Launch(context.Background(), SandboxSpec{
-		SessionID: "ses_x", Image: "img",
-		ReadOnlyInboundPath: "/i", ReadWriteOutboundPath: "/o", ModelProxySocket: "/m",
+		SessionID:             "ses_x",
+		Image:                 "img",
+		ReadOnlyInboundPath:   "/var/lib/ironclaw/state/sessions/ses_x/inbound.db",
+		ReadWriteOutboundPath: "/var/lib/ironclaw/state/sessions/ses_x/outbound.db",
+		KeyPath:               "/var/lib/ironclaw/state/keys/ses_x/session.key",
+		// A socket outside the mapped subtree must be LEFT UNBOUND (as before).
+		ModelProxySocket: "/run/ironclaw/modelproxy.sock",
 	})
 	if err != nil {
 		t.Fatalf("Launch: %v", err)
@@ -111,14 +119,101 @@ func TestDockerLaunchAndStop(t *testing.T) {
 	if cb.HostConfig.NetworkMode != "none" {
 		t.Errorf("NetworkMode = %q, want none", cb.HostConfig.NetworkMode)
 	}
-	if len(cb.HostConfig.Binds) != 1 || cb.HostConfig.Binds[0] != "vol:/p" {
-		t.Errorf("Binds = %v, want [vol:/p]", cb.HostConfig.Binds)
+	got := strings.Join(cb.HostConfig.Binds, "\n")
+	wantBinds := []string{
+		"/host/state/sessions/ses_x/inbound.db:/var/lib/ironclaw/state/sessions/ses_x/inbound.db:ro",
+		"/host/state/sessions/ses_x/outbound.db:/var/lib/ironclaw/state/sessions/ses_x/outbound.db",
+		"/host/state/keys/ses_x/session.key:/var/lib/ironclaw/state/keys/ses_x/session.key:ro",
+	}
+	for _, w := range wantBinds {
+		if !strings.Contains(got, w) {
+			t.Errorf("Binds missing %q\n  got: %v", w, cb.HostConfig.Binds)
+		}
+	}
+	// The whole state dir, the host master key, sibling keys, and the unmapped socket
+	// must NOT appear as binds — that is the IRO-259 isolation guarantee.
+	for _, forbidden := range []string{
+		"/host/state:/var/lib/ironclaw/state", // whole state dir
+		"host-master.key",
+		"sealed-keys.json",
+		"modelproxy.sock", // unmapped: left unbound
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Errorf("Binds must not contain %q\n  got: %v", forbidden, cb.HostConfig.Binds)
+		}
 	}
 	if err := h.Stop(context.Background()); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
 	if !removed {
 		t.Error("container was not removed on Stop")
+	}
+}
+
+// TestDockerSessionBinds asserts the per-session bind scoping (IRO-259): a base
+// host<->container mapping over the whole state dir must yield binds ONLY for the
+// session's own queue files, key, and mapped sockets/skills — never the state dir
+// itself, the host master key, the sealed-key store, or any sibling session's key.
+func TestDockerSessionBinds(t *testing.T) {
+	const state = "/var/lib/ironclaw/state"
+	d := NewDocker("/x.sock", "none", []string{
+		"/host/state:" + state,
+		"/host/run:/run/ironclaw", // a second mapping covers the sockets
+	}, "0:0")
+	spec := SandboxSpec{
+		SessionID:             "ses_a",
+		ReadOnlyInboundPath:   state + "/sessions/ses_a/inbound.db",
+		ReadWriteOutboundPath: state + "/sessions/ses_a/outbound.db",
+		KeyPath:               state + "/keys/ses_a/session.key",
+		WorkspacePath:         state + "/workspaces/ses_a",
+		ModelProxySocket:      "/run/ironclaw/modelproxy.sock",
+		EgressSocket:          "/run/ironclaw/egress/ses_a.sock",
+		SkillMounts:           []SkillMount{{Name: "demo", HostPath: state + "/skills/demo/1.0.0"}},
+	}
+	binds := d.sessionBinds(spec)
+	joined := strings.Join(binds, "\n")
+
+	wantContains := map[string]bool{
+		"/host/state/sessions/ses_a/inbound.db:" + state + "/sessions/ses_a/inbound.db:ro": true,
+		"/host/state/sessions/ses_a/outbound.db:" + state + "/sessions/ses_a/outbound.db":  true,
+		"/host/state/keys/ses_a/session.key:" + state + "/keys/ses_a/session.key:ro":       true,
+		"/host/state/workspaces/ses_a:" + state + "/workspaces/ses_a":                      true,
+		"/host/run/modelproxy.sock:/run/ironclaw/modelproxy.sock":                          true,
+		"/host/run/egress/ses_a.sock:/run/ironclaw/egress/ses_a.sock":                      true,
+		"/host/state/skills/demo/1.0.0:" + state + "/skills/demo/1.0.0:ro":                 true,
+	}
+	for w := range wantContains {
+		if !strings.Contains(joined, w) {
+			t.Errorf("sessionBinds missing %q\n  got: %v", w, binds)
+		}
+	}
+	// Never expose the trust root or any sibling's key material.
+	for _, forbidden := range []string{
+		"/host/state:" + state, // whole state dir
+		"host-master.key",
+		"sealed-keys.json",
+		"keys/ses_b",     // a sibling session's key dir
+		"sessions/ses_b", // a sibling session's queues
+	} {
+		if strings.Contains(joined, forbidden) {
+			t.Errorf("sessionBinds must not contain %q\n  got: %v", forbidden, binds)
+		}
+	}
+
+	// A path outside every base mapping is left unbound (skipped), not identity-bound.
+	unmapped := d.sessionBinds(SandboxSpec{ReadWriteOutboundPath: "/some/host/only/out.db"})
+	if len(unmapped) != 0 {
+		t.Errorf("unmapped spec path should yield no binds, got %v", unmapped)
+	}
+
+	// Longest-prefix wins: a nested mapping overrides a broader one.
+	d2 := NewDocker("/x.sock", "none", []string{
+		"/broad:" + state,
+		"/narrow:" + state + "/sessions",
+	}, "0:0")
+	nb := d2.sessionBinds(SandboxSpec{ReadWriteOutboundPath: state + "/sessions/ses_a/outbound.db"})
+	if len(nb) != 1 || !strings.HasPrefix(nb[0], "/narrow/ses_a/outbound.db:") {
+		t.Errorf("longest-prefix mapping not preferred, got %v", nb)
 	}
 }
 


### PR DESCRIPTION
## What & why

The Docker runtime (the runc fallback used on hosts without gVisor, e.g. the laptop demo) bind-mounted the **entire control-plane state dir** into every sandbox. From inside any sandbox an occupant could read the **host master key** (`host-master.key`), the **sealed-key store** (`sealed-keys.json`, holding every session's sealed key), and every **sibling session's** plaintext key + queues — a critical isolation break surfaced by the IRO-257 red-team pass.

## Fix

The Docker isolator now derives **per-session binds** from each `SandboxSpec`'s own paths and mounts **only those**, mirroring the hardened gVisor/OCI mount granularity:

| resource | mode |
|---|---|
| `sessions/<id>/inbound.db` | **ro** |
| `sessions/<id>/outbound.db` | rw |
| `keys/<id>/session.key` | **ro** |
| workspace / memory | rw (when set) |
| shared / skill bundles | ro (when set) |
| model-proxy / egress / MCP sockets | rw (when mapped) |

`IRONCLAW_DOCKER_BINDS` is reinterpreted as a **base host↔container mapping** used to translate the control-plane's container-view spec paths to the host paths the Docker daemon binds. A path outside every mapping is left unbound (unchanged behavior). The master key, sealed store, and sibling `keys/<other>` / `sessions/<other>` subtrees are never referenced by a spec, so they are **never mounted in**.

## Proof (live demo sandbox)

```
$ docker exec -u 65532:65532 <sbx> head -c16 /var/lib/ironclaw/state/host-master.key
head: cannot open '.../host-master.key' for reading: No such file or directory
$ docker exec -u 65532:65532 <sbx> cat /var/lib/ironclaw/state/sealed-keys.json
cat: .../sealed-keys.json: No such file or directory
# state tree inside sandbox: only keys/<own>/session.key + sessions/<own>/{in,out}bound.db
# docker inspect mounts: inbound.db rw=false, outbound.db rw=true, session.key rw=false — no whole-state-dir bind
```

The full red-team harness now reports **7/7 core PASS**, including the cross-session key-custody row (previously a tracked `GAP`).

## Regression guard

`examples/red-team-escape` promotes the cross-session key-custody row from a `GAP` to a **CORE pass/fail** assertion: it probes the master key, the sealed store, and the count of visible session keys directly, so any future change that re-widens the bind to the whole state dir **fails the run**.

## Verification
- `CGO_ENABLED=1 go build ./...` — green
- `CGO_ENABLED=1 go test ./internal/host/isolation/` — 72 pass (new `TestDockerSessionBinds` + updated `TestDockerLaunchAndStop`)
- Full `examples/red-team-escape/run.sh` end-to-end on macOS/colima — 7/7 core PASS; demo engage→reply (queue round-trip) unaffected

## Security lens
Trust-boundary / isolation + encryption-at-rest. No sandbox can reach the host trust root or another session's key. Human-approval gateway and per-session queue encryption are unchanged.

Closes IRO-259.