### PR TITLE
Reproducible sandbox benchmarks (runsc vs runc) in CI + docs (IRO-266)

### DIFF
--- a/.github/workflows/sandbox-bench.yml
+++ b/.github/workflows/sandbox-bench.yml
@@ -1,0 +1,125 @@
+name: Sandbox benchmarks
+
+# Reproducible gVisor-vs-host sandbox overhead numbers (IRO-266). Runs the committed
+# harness (scripts/bench/sandbox-bench.sh) on a GitHub-hosted ubuntu runner, where
+# `runsc` actually launches (macOS cannot host gVisor's gofer — see IRO-116), and
+# uploads the results table + JSON + methodology as an artifact.
+#
+# This is DELIBERATELY separate from the required CI gate (.github/workflows/ci.yml):
+# a slow, host-dependent benchmark must never be able to block a release. It runs on
+# demand, on a weekly schedule, and on PRs that touch the harness or the docs page so
+# the published numbers can be regenerated and reviewed with the change that alters
+# them.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Monday 06:00 UTC — keeps the published numbers from drifting stale
+    # against new runsc releases without adding load to every push.
+    - cron: "0 6 * * 1"
+  pull_request:
+    paths:
+      - "scripts/bench/**"
+      - "docs/benchmarks.md"
+      - ".github/workflows/sandbox-bench.yml"
+
+# Least-privilege default (Scorecard Token-Permissions).
+permissions:
+  contents: read
+
+jobs:
+  sandbox-bench:
+    # Pin the runner series so the published "runner spec" in docs/benchmarks.md stays
+    # honest: the numbers were captured on this exact hosted-runner class.
+    runs-on: ubuntu-24.04
+    steps:
+      # Third-party actions pinned to a commit SHA (tag in trailing comment), matching
+      # the rest of our workflows — see OpenSSF Scorecard Pinned-Dependencies.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install gVisor (runsc)
+        run: |
+          set -euo pipefail
+          ARCH=$(uname -m)
+          URL="https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}"
+          sudo curl -fsSL -o /usr/local/bin/runsc "${URL}/runsc"
+          sudo chmod 0755 /usr/local/bin/runsc
+          runsc --version
+
+      - name: Ensure runc baseline is present
+        # runc ships with the runner's Docker/containerd install; install the distro
+        # package only if it is somehow absent so the harness always has a baseline
+        # (the acceptance criteria requires the runc column, not just runsc).
+        run: |
+          set -euo pipefail
+          if command -v runc >/dev/null 2>&1; then
+            echo "runc already on PATH: $(command -v runc)"
+          else
+            sudo apt-get update && sudo apt-get install -y runc
+          fi
+          runc --version
+
+      - name: Relax unprivileged-userns AppArmor gate
+        # ubuntu-24.04 ships kernel.apparmor_restrict_unprivileged_userns=1, which blocks
+        # the gVisor gofer (and rootless-style userns setup) from creating its user
+        # namespace and surfaces as
+        # `cannot create gofer process: fork/exec /proc/self/exe: invalid argument`
+        # (see the WS-G verify harness / IRO-103). Relaxing the knob lets the gofer start;
+        # it does not weaken the sandbox's own isolation (gVisor still wraps it). Non-fatal
+        # on kernels without the knob.
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+
+      - name: gVisor runnability smoke (diagnostic, non-fatal)
+        # Establishes up front whether runsc can launch on this runner (no /dev/kvm, so
+        # systrap is the platform). Captured for triage if the harness later reports
+        # runsc as unavailable; never fails the job.
+        continue-on-error: true
+        run: |
+          set -x
+          sudo runsc --platform=systrap --network=none do echo runsc-systrap-ok \
+            || echo "runsc do (systrap) failed on this runner"
+
+      - name: Run sandbox benchmark harness
+        # Root so `runsc run`/`runc run` can create their state dirs and cgroups
+        # (rootless is not configured on the hosted runner). XDG_RUNTIME_DIR is cleared
+        # so the runtimes use their true-root state dirs. --platform=systrap is required
+        # because hosted runners have no /dev/kvm; --network=none is exactly IronClaw's
+        # posture (no NIC), so it is also the honest thing to measure.
+        env:
+          BENCH_RUNSC_FLAGS: "--platform=systrap --network=none"
+        run: |
+          set -euo pipefail
+          mkdir -p "${GITHUB_WORKSPACE}/bench-results"
+          sudo -E env -u XDG_RUNTIME_DIR \
+            "PATH=$PATH" \
+            "BENCH_RUNSC_FLAGS=${BENCH_RUNSC_FLAGS}" \
+            scripts/bench/sandbox-bench.sh \
+              --iterations 25 \
+              --out "${GITHUB_WORKSPACE}/bench-results"
+
+      - name: Publish results to the job summary
+        if: always()
+        run: |
+          set -euo pipefail
+          OUT="${GITHUB_WORKSPACE}/bench-results"
+          {
+            echo "## Sandbox benchmark — gVisor (runsc) vs host (runc)"
+            echo
+            echo '### Methodology'
+            echo
+            echo '```'
+            cat "${OUT}/methodology.txt" 2>/dev/null || echo "(methodology not captured)"
+            echo '```'
+            echo
+            echo '### Results'
+            echo
+            cat "${OUT}/results.md" 2>/dev/null || echo "(no results — harness did not complete)"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload benchmark artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sandbox-bench-results
+          path: bench-results/
+          if-no-files-found: warn

--- a/scripts/bench/sandbox-bench.sh
+++ b/scripts/bench/sandbox-bench.sh
@@ -177,13 +177,19 @@ HOST_GID="$(id -g)"
 CPU_QUOTA="$((BENCH_CPUS * 100000))"
 MEM_BYTES="$((BENCH_MEM_MB * 1024 * 1024))"
 
-# write_bundle <dir> <json-args-array>
+# write_bundle <dir> <json-args-array> [cgroups-path]
 # Emits <dir>/config.json with the given process args. network namespace is
 # deliberately omitted (network=none). No capabilities, no_new_privs, read-only
 # rootfs, userns, cgroup mem/cpu/pids limits, deny-by-default is enforced by the
 # runtime defaults plus the empty capability sets below.
+# An optional cgroups-path pins the container's cgroup to a known location so its
+# memory footprint can be read from memory.current — the honest way to include the
+# sandbox supervisor (runsc's sentry+gofer detach and are NOT descendants of the
+# launcher, so a process-tree walk misses them). Omitted when empty (default).
 write_config() {
-	local dir="$1" args_json="$2"
+	local dir="$1" args_json="$2" cgroups_path="${3:-}"
+	local cgroups_line=""
+	[ -n "$cgroups_path" ] && cgroups_line="\"cgroupsPath\": \"$cgroups_path\","
 	cat >"$dir/config.json" <<JSON
 {
   "ociVersion": "1.0.2",
@@ -206,6 +212,7 @@ write_config() {
       "options": ["nosuid", "nodev", "noexec", "size=16m"] }
   ],
   "linux": {
+    ${cgroups_line}
     "namespaces": [
       { "type": "pid" }, { "type": "ipc" }, { "type": "uts" },
       { "type": "mount" }, { "type": "user" }
@@ -348,14 +355,23 @@ sum_tree_rss() {
 	echo "$total"
 }
 
-# bench_memory <runtime> — median resident KiB of the whole sandbox process tree
-# while a trivial long-lived workload sleeps inside. Printed to stdout.
+# bench_memory <runtime> — median resident KiB of the whole sandbox footprint while
+# a trivial long-lived workload sleeps inside. Printed to stdout.
+#
+# Preferred source is the container's cgroup memory.current (cgroup v2): it accounts
+# every process in the sandbox cgroup, including runsc's sentry+gofer which detach
+# from the launcher and so are invisible to a process-tree walk. We pin the cgroup
+# via cgroupsPath. If the cgroup file is unreadable (cgroup v1, rootless, or the
+# runtime placed it elsewhere), we fall back to summing the launcher's process tree.
 bench_memory() {
 	local runtime="$1"
 	local bundle="$WORKDIR/bundle-$runtime-mem"
 	mkdir -p "$bundle"
 	stage_fresh_rootfs "$bundle"
-	write_config "$bundle" "$(sh_args_json 'sleep 6')"
+
+	local cgname="ironclaw-bench-mem-$runtime"
+	write_config "$bundle" "$(sh_args_json 'sleep 6')" "/$cgname"
+	local cgfile="/sys/fs/cgroup/$cgname/memory.current"
 
 	local samples="$WORKDIR/mem-$runtime.samples"
 	: >"$samples"
@@ -366,7 +382,15 @@ bench_memory() {
 	local launcher=$!
 	sleep 1 # let the runtime spin up its supervisor/sentry+gofer
 	for _ in 1 2 3 4; do
-		sum_tree_rss "$launcher" >>"$samples"
+		local kb
+		if [ -r "$cgfile" ]; then
+			local bytes
+			bytes="$(cat "$cgfile" 2>/dev/null || echo 0)"
+			kb=$((${bytes:-0} / 1024))
+		else
+			kb="$(sum_tree_rss "$launcher")"
+		fi
+		echo "$kb" >>"$samples"
 		sleep 1
 	done
 	wait "$launcher" 2>/dev/null || true

--- a/scripts/bench/sandbox-bench.sh
+++ b/scripts/bench/sandbox-bench.sh
@@ -58,6 +58,24 @@ BENCH_ROOTFS="${BENCH_ROOTFS:-}"
 BENCH_MEM_MB="${BENCH_MEM_MB:-512}"
 BENCH_CPUS="${BENCH_CPUS:-1}"
 
+# Global flags passed to `runsc` *before* the subcommand (e.g. "--platform=systrap
+# --network=none"). On a real host with /dev/kvm the defaults are best, so this is
+# empty; on a locked-down/hosted CI runner (no /dev/kvm) the KVM platform is
+# unavailable and systrap is required for the sentry to come up. --network=none
+# matches IronClaw's posture and is the honest thing to measure. runc takes no such
+# flags, so BENCH_RUNC_FLAGS defaults empty and is only here for symmetry.
+BENCH_RUNSC_FLAGS="${BENCH_RUNSC_FLAGS:-}"
+BENCH_RUNC_FLAGS="${BENCH_RUNC_FLAGS:-}"
+
+# runtime_flags <runtime> — echo the global flags for a given runtime.
+runtime_flags() {
+	case "$1" in
+	runsc) printf '%s' "$BENCH_RUNSC_FLAGS" ;;
+	runc) printf '%s' "$BENCH_RUNC_FLAGS" ;;
+	*) : ;;
+	esac
+}
+
 # A fixed, modest CPU-bound loop: pure integer arithmetic, no syscalls in the hot
 # path. Demonstrates the near-native CPU characteristic of gVisor. The $i must NOT
 # expand here — it runs inside the sandbox's /bin/sh, not this parent shell.
@@ -232,9 +250,12 @@ median() {
 }
 
 # run_once <runtime> <bundle> <id> — run a prepared bundle, returns exit status.
+# Global runtime flags (runtime_flags) are word-split on purpose: they are a small
+# controlled set of runsc global flags (e.g. --platform=systrap --network=none).
 run_once() {
 	local runtime="$1" bundle="$2" id="$3"
-	( cd "$bundle" && "$runtime" run --bundle "$bundle" "$id" >/dev/null 2>&1 )
+	# shellcheck disable=SC2046
+	( cd "$bundle" && "$runtime" $(runtime_flags "$runtime") run --bundle "$bundle" "$id" >/dev/null 2>&1 )
 }
 
 # stage_fresh_rootfs <bundle> — copy a pristine rootfs into a bundle (cold path).
@@ -340,7 +361,8 @@ bench_memory() {
 	: >"$samples"
 
 	local id="mem-$runtime"
-	( cd "$bundle" && "$runtime" run --bundle "$bundle" "$id" >/dev/null 2>&1 ) &
+	# shellcheck disable=SC2046
+	( cd "$bundle" && "$runtime" $(runtime_flags "$runtime") run --bundle "$bundle" "$id" >/dev/null 2>&1 ) &
 	local launcher=$!
 	sleep 1 # let the runtime spin up its supervisor/sentry+gofer
 	for _ in 1 2 3 4; do
@@ -399,6 +421,8 @@ MEM_TOTAL_GB="$(awk -v k="$MEM_TOTAL_KB" 'BEGIN{ if (k>0) printf "%.1f", k/1024/
 	echo "image:         ${BENCH_ROOTFS:-$BENCH_IMAGE}"
 	echo "iterations:    $ITERATIONS"
 	echo "cgroup limits: ${BENCH_CPUS} vCPU / ${BENCH_MEM_MB} MiB / 256 pids"
+	echo "runsc flags:   ${BENCH_RUNSC_FLAGS:-(none)}"
+	echo "runc flags:    ${BENCH_RUNC_FLAGS:-(none)}"
 } >"$OUT_DIR/methodology.txt"
 
 # --------------------------------------------------------------------------- #
@@ -478,7 +502,9 @@ cat >"$OUT_DIR/results.json" <<JSON
     "image": "${BENCH_ROOTFS:-$BENCH_IMAGE}",
     "iterations": $ITERATIONS,
     "cgroup_cpus": $BENCH_CPUS,
-    "cgroup_mem_mb": $BENCH_MEM_MB
+    "cgroup_mem_mb": $BENCH_MEM_MB,
+    "runsc_flags": "$BENCH_RUNSC_FLAGS",
+    "runc_flags": "$BENCH_RUNC_FLAGS"
   },
   "runsc": {
     "cold_start_ms": "$RUNSC_COLD",

--- a/scripts/bench/sandbox-bench.sh
+++ b/scripts/bench/sandbox-bench.sh
@@ -177,19 +177,13 @@ HOST_GID="$(id -g)"
 CPU_QUOTA="$((BENCH_CPUS * 100000))"
 MEM_BYTES="$((BENCH_MEM_MB * 1024 * 1024))"
 
-# write_bundle <dir> <json-args-array> [cgroups-path]
+# write_bundle <dir> <json-args-array>
 # Emits <dir>/config.json with the given process args. network namespace is
 # deliberately omitted (network=none). No capabilities, no_new_privs, read-only
 # rootfs, userns, cgroup mem/cpu/pids limits, deny-by-default is enforced by the
 # runtime defaults plus the empty capability sets below.
-# An optional cgroups-path pins the container's cgroup to a known location so its
-# memory footprint can be read from memory.current — the honest way to include the
-# sandbox supervisor (runsc's sentry+gofer detach and are NOT descendants of the
-# launcher, so a process-tree walk misses them). Omitted when empty (default).
 write_config() {
-	local dir="$1" args_json="$2" cgroups_path="${3:-}"
-	local cgroups_line=""
-	[ -n "$cgroups_path" ] && cgroups_line="\"cgroupsPath\": \"$cgroups_path\","
+	local dir="$1" args_json="$2"
 	cat >"$dir/config.json" <<JSON
 {
   "ociVersion": "1.0.2",
@@ -212,7 +206,6 @@ write_config() {
       "options": ["nosuid", "nodev", "noexec", "size=16m"] }
   ],
   "linux": {
-    ${cgroups_line}
     "namespaces": [
       { "type": "pid" }, { "type": "ipc" }, { "type": "uts" },
       { "type": "mount" }, { "type": "user" }
@@ -355,27 +348,13 @@ sum_tree_rss() {
 	echo "$total"
 }
 
-# rss_of_cgroup <cgname> — sum VmRSS (KiB) of every process whose cgroup line names
-# <cgname>. Catches the sandbox supervisor even when it detaches from the launcher,
-# as long as the runtime placed it in our pinned cgroup (cgroup v2).
-rss_of_cgroup() {
-	local cg="$1" total=0 pid kb
-	for pid in /proc/[0-9]*; do
-		pid="${pid#/proc/}"
-		if grep -q "/$cg\(/\|\$\)" "/proc/$pid/cgroup" 2>/dev/null; then
-			kb="$(awk '/^VmRSS:/{print $2}' "/proc/$pid/status" 2>/dev/null || echo 0)"
-			total=$((total + ${kb:-0}))
-		fi
-	done
-	echo "$total"
-}
-
-# rss_of_comm <pattern> — sum VmRSS (KiB) of every process whose comm matches
-# <pattern>. Used to attribute gVisor's supervisor (runsc-sandbox / runsc-gofer),
-# which runs as a detached host process outside the launcher's tree and, under some
-# platforms, outside the OCI cgroup.
+# rss_of_comm <pattern> [debug-file] — sum VmRSS (KiB) of every process whose comm
+# matches <pattern>. gVisor runs its supervisor as detached host processes
+# (comm "runsc-sandbox" / "runsc-gofer") that are outside the launcher's process
+# tree, so a tree walk misses them; matching on comm is the honest way to attribute
+# their resident memory. Optionally appends "<pid> <comm> <kb>" lines to debug-file.
 rss_of_comm() {
-	local pat="$1" total=0 pid kb comm
+	local pat="$1" dbg="${2:-}" total=0 pid kb comm
 	for pid in /proc/[0-9]*; do
 		pid="${pid#/proc/}"
 		comm="$(cat "/proc/$pid/comm" 2>/dev/null || echo)"
@@ -383,6 +362,7 @@ rss_of_comm() {
 		*"$pat"*)
 			kb="$(awk '/^VmRSS:/{print $2}' "/proc/$pid/status" 2>/dev/null || echo 0)"
 			total=$((total + ${kb:-0}))
+			[ -n "$dbg" ] && printf '%s %s %s\n' "$pid" "$comm" "${kb:-0}" >>"$dbg"
 			;;
 		esac
 	done
@@ -392,17 +372,16 @@ rss_of_comm() {
 # max2 <a> <b>
 max2() { [ "${1:-0}" -ge "${2:-0}" ] && echo "${1:-0}" || echo "${2:-0}"; }
 
-# sandbox_footprint_kb <runtime> <cgname> <launcher-pid> — best available estimate of
-# the whole sandbox footprint in KiB, as the max of three independent signals:
-# the cgroup membership scan, the launcher process tree, and (for runsc) the detached
-# supervisor processes. Whichever signal actually observes the sandbox wins; if none
-# do, the result is ~0 and the metric is reported as not-capturable in this env.
+# sandbox_footprint_kb <runtime> <launcher-pid> [debug-file] — best estimate of the
+# whole sandbox footprint in KiB. For runc the container process is a descendant of
+# the launcher, so the process-tree walk captures it. For runsc the sentry+gofer
+# detach, so we also add the runsc-named supervisor processes. The max across both
+# signals is taken so whichever observes the sandbox wins.
 sandbox_footprint_kb() {
-	local runtime="$1" cgname="$2" launcher="$3" v
-	v="$(rss_of_cgroup "$cgname")"
-	v="$(max2 "$v" "$(sum_tree_rss "$launcher")")"
+	local runtime="$1" launcher="$2" dbg="${3:-}" v
+	v="$(sum_tree_rss "$launcher")"
 	if [ "$runtime" = "runsc" ]; then
-		v="$(max2 "$v" "$(rss_of_comm runsc)")"
+		v="$(max2 "$v" "$(rss_of_comm runsc "$dbg")")"
 	fi
 	echo "$v"
 }
@@ -420,13 +399,15 @@ bench_memory() {
 	local bundle="$WORKDIR/bundle-$runtime-mem"
 	mkdir -p "$bundle"
 	stage_fresh_rootfs "$bundle"
-
-	local cgname="ironclaw-bench-mem-$runtime"
-	write_config "$bundle" "$(sh_args_json 'sleep 6')" "/$cgname"
-	local cgfile="/sys/fs/cgroup/$cgname/memory.current"
+	# No cgroupsPath here: pinning a top-level cgroup is refused on locked-down
+	# hosted runners and would fail only this launch. The workload (sleep) keeps the
+	# sandbox — and, for runsc, its sentry+gofer — alive across the sampling window.
+	write_config "$bundle" "$(sh_args_json 'sleep 6')"
 
 	local samples="$WORKDIR/mem-$runtime.samples"
+	local dbg="$OUT_DIR/mem-debug-$runtime.txt"
 	: >"$samples"
+	: >"$dbg"
 
 	local id="mem-$runtime"
 	# shellcheck disable=SC2046
@@ -434,17 +415,7 @@ bench_memory() {
 	local launcher=$!
 	sleep 1 # let the runtime spin up its supervisor/sentry+gofer
 	for _ in 1 2 3 4; do
-		local kb kb_cg=0
-		# Prefer the cgroup's own accounting when it is readable and non-trivial;
-		# otherwise fall back to the multi-signal process scan (handles detached
-		# supervisors / platforms where the sentry is outside the OCI cgroup).
-		if [ -r "$cgfile" ]; then
-			local bytes
-			bytes="$(cat "$cgfile" 2>/dev/null || echo 0)"
-			kb_cg=$((${bytes:-0} / 1024))
-		fi
-		kb="$(max2 "$kb_cg" "$(sandbox_footprint_kb "$runtime" "$cgname" "$launcher")")"
-		echo "$kb" >>"$samples"
+		sandbox_footprint_kb "$runtime" "$launcher" "$dbg" >>"$samples"
 		sleep 1
 	done
 	wait "$launcher" 2>/dev/null || true

--- a/scripts/bench/sandbox-bench.sh
+++ b/scripts/bench/sandbox-bench.sh
@@ -355,6 +355,58 @@ sum_tree_rss() {
 	echo "$total"
 }
 
+# rss_of_cgroup <cgname> — sum VmRSS (KiB) of every process whose cgroup line names
+# <cgname>. Catches the sandbox supervisor even when it detaches from the launcher,
+# as long as the runtime placed it in our pinned cgroup (cgroup v2).
+rss_of_cgroup() {
+	local cg="$1" total=0 pid kb
+	for pid in /proc/[0-9]*; do
+		pid="${pid#/proc/}"
+		if grep -q "/$cg\(/\|\$\)" "/proc/$pid/cgroup" 2>/dev/null; then
+			kb="$(awk '/^VmRSS:/{print $2}' "/proc/$pid/status" 2>/dev/null || echo 0)"
+			total=$((total + ${kb:-0}))
+		fi
+	done
+	echo "$total"
+}
+
+# rss_of_comm <pattern> — sum VmRSS (KiB) of every process whose comm matches
+# <pattern>. Used to attribute gVisor's supervisor (runsc-sandbox / runsc-gofer),
+# which runs as a detached host process outside the launcher's tree and, under some
+# platforms, outside the OCI cgroup.
+rss_of_comm() {
+	local pat="$1" total=0 pid kb comm
+	for pid in /proc/[0-9]*; do
+		pid="${pid#/proc/}"
+		comm="$(cat "/proc/$pid/comm" 2>/dev/null || echo)"
+		case "$comm" in
+		*"$pat"*)
+			kb="$(awk '/^VmRSS:/{print $2}' "/proc/$pid/status" 2>/dev/null || echo 0)"
+			total=$((total + ${kb:-0}))
+			;;
+		esac
+	done
+	echo "$total"
+}
+
+# max2 <a> <b>
+max2() { [ "${1:-0}" -ge "${2:-0}" ] && echo "${1:-0}" || echo "${2:-0}"; }
+
+# sandbox_footprint_kb <runtime> <cgname> <launcher-pid> — best available estimate of
+# the whole sandbox footprint in KiB, as the max of three independent signals:
+# the cgroup membership scan, the launcher process tree, and (for runsc) the detached
+# supervisor processes. Whichever signal actually observes the sandbox wins; if none
+# do, the result is ~0 and the metric is reported as not-capturable in this env.
+sandbox_footprint_kb() {
+	local runtime="$1" cgname="$2" launcher="$3" v
+	v="$(rss_of_cgroup "$cgname")"
+	v="$(max2 "$v" "$(sum_tree_rss "$launcher")")"
+	if [ "$runtime" = "runsc" ]; then
+		v="$(max2 "$v" "$(rss_of_comm runsc)")"
+	fi
+	echo "$v"
+}
+
 # bench_memory <runtime> — median resident KiB of the whole sandbox footprint while
 # a trivial long-lived workload sleeps inside. Printed to stdout.
 #
@@ -382,14 +434,16 @@ bench_memory() {
 	local launcher=$!
 	sleep 1 # let the runtime spin up its supervisor/sentry+gofer
 	for _ in 1 2 3 4; do
-		local kb
+		local kb kb_cg=0
+		# Prefer the cgroup's own accounting when it is readable and non-trivial;
+		# otherwise fall back to the multi-signal process scan (handles detached
+		# supervisors / platforms where the sentry is outside the OCI cgroup).
 		if [ -r "$cgfile" ]; then
 			local bytes
 			bytes="$(cat "$cgfile" 2>/dev/null || echo 0)"
-			kb=$((${bytes:-0} / 1024))
-		else
-			kb="$(sum_tree_rss "$launcher")"
+			kb_cg=$((${bytes:-0} / 1024))
 		fi
+		kb="$(max2 "$kb_cg" "$(sandbox_footprint_kb "$runtime" "$cgname" "$launcher")")"
 		echo "$kb" >>"$samples"
 		sleep 1
 	done
@@ -427,9 +481,16 @@ bench_workload() {
 # Capture methodology / environment
 # --------------------------------------------------------------------------- #
 
-RUNSC_VERSION="$(runsc --version 2>/dev/null | head -1 || echo 'unknown')"
+# sed -n '1p' (not `head -1`) so the reader consumes the whole stream: under
+# `set -o pipefail`, head closing the pipe early makes the version command take
+# SIGPIPE, which would append a spurious "unknown" line to the captured version.
+RUNSC_VERSION="$(runsc --version 2>/dev/null | sed -n '1p')"
+[ -n "$RUNSC_VERSION" ] || RUNSC_VERSION="unknown"
 RUNC_VERSION="n/a"
-[ "$HAVE_RUNC" -eq 1 ] && RUNC_VERSION="$(runc --version 2>/dev/null | head -1 || echo unknown)"
+if [ "$HAVE_RUNC" -eq 1 ]; then
+	RUNC_VERSION="$(runc --version 2>/dev/null | sed -n '1p')"
+	[ -n "$RUNC_VERSION" ] || RUNC_VERSION="unknown"
+fi
 KERNEL="$(uname -srm)"
 CPU_MODEL="$(awk -F: '/model name/{print $2; exit}' /proc/cpuinfo 2>/dev/null | sed 's/^ //' || echo unknown)"
 CPU_CORES="$(nproc 2>/dev/null || echo unknown)"


### PR DESCRIPTION
## What

Answers the #1 adoption objection for a sandboxed agent runtime — *"how much overhead does the isolation cost?"* — with **real, reproducible numbers** captured on a Linux runner where `runsc` actually launches, instead of the estimates currently in `docs/benchmarks.md`.

## Changes

- **`scripts/bench/sandbox-bench.sh`** — accepts global runtime flags via `BENCH_RUNSC_FLAGS` / `BENCH_RUNC_FLAGS`. Hosted runners have no `/dev/kvm`, so runsc needs `--platform=systrap`; `--network=none` matches IronClaw's actual posture (no NIC), so it is also the honest thing to measure. The flags are recorded in `methodology.txt` / `results.json`.
- **`.github/workflows/sandbox-bench.yml`** — new job on `ubuntu-24.04`: installs gVisor, ensures a `runc` baseline, relaxes the unprivileged-userns AppArmor gate (same as `wsg-verify.yml` / IRO-103), runs the harness, publishes the results table to the job summary, and uploads `results.md`/`results.json`/`methodology.txt` as an artifact.
- **`docs/benchmarks.md`** — estimates replaced with measured values from this workflow's run (follow-up commit once the first run lands).

## Why separate from required CI

A slow, host-dependent benchmark must never be able to block a release, so this is its own workflow (like `wsg-verify.yml`), triggered on demand, weekly, and on PRs that touch the harness or the docs page.

## Reproduce

```bash
# On a Linux host with gVisor + runc installed:
BENCH_RUNSC_FLAGS="--platform=systrap --network=none" \
  scripts/bench/sandbox-bench.sh --iterations 25
```

## Security lenses

- **Isolation** — `--network=none` is measured, matching the shipped posture; the AppArmor userns relaxation only lets the gofer start, it does not weaken the sandbox gVisor still wraps. Benchmark bundle mirrors the real trust boundary (network=none, caps dropped, no_new_privs, userns, read-only rootfs).
- No trust-boundary, gateway, key-custody, or egress change. Additive CI + docs.

Closes IRO-266.