### PR TITLE
docs: Security and isolation trust page (IRO-268)

### DIFF
--- a/docs/assets/isolation-architecture.svg
+++ b/docs/assets/isolation-architecture.svg
@@ -1,0 +1,191 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 738" width="1000" height="738"
+     font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+     role="img" aria-labelledby="ia-title ia-desc">
+  <title id="ia-title">IronClaw isolation architecture: how a compromised agent is contained</title>
+  <desc id="ia-desc">A static architecture diagram in two zones. On the left, an untrusted sandbox
+  (gVisor runtime, network=none, read-only rootfs, dropped capabilities, no_new_privs, non-root user
+  namespace) holds the agent loop and tools, assumed fully compromised. A gVisor wall (boundary B1)
+  separates it from the trusted host on the right. The only crossings are two host-owned unix sockets
+  (to the model proxy that holds the provider key, and the opt-in egress broker that is deny-by-default)
+  plus the per-session encrypted queues (inbound.db bound read-only, outbound.db append-only). Inside the
+  trusted host sit the API with bearer auth, the gateway change-gate that enforces a mandatory human-approval
+  floor over change-kinds, the router/delivery/sweep, and the vault injector, a separate host principal behind
+  the broker. A legend maps each of the six red-team escape attempts from IRO-257 to the control that contains
+  it: network egress, Docker Engine socket, sibling breakout, host filesystem read, self-modification, and
+  cross-session key theft.</desc>
+
+  <defs>
+    <pattern id="ia-wall" width="8" height="8" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">
+      <rect width="8" height="8" fill="#16224a"/>
+      <line x1="0" y1="0" x2="0" y2="8" stroke="#24345f" stroke-width="3"/>
+    </pattern>
+    <marker id="ia-arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#1d4ed8"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="1000" height="738" fill="#ffffff"/>
+
+  <!-- ============ TITLE ============ -->
+  <text x="30" y="38" font-size="25" font-weight="700" fill="#16224a">IronClaw isolation architecture</text>
+  <text x="30" y="62" font-size="14" fill="#3a4a6b">The host is trusted; the agent is not. A compromised agent still cannot escape the box, read another session, or bypass the human gate.</text>
+
+  <!-- ============ SANDBOX ZONE (untrusted) ============ -->
+  <rect x="30" y="88" width="300" height="316" rx="12" fill="#fdeceb" stroke="#b42318" stroke-width="2"/>
+  <text x="46" y="112" font-size="15" font-weight="700" fill="#7a271a">SANDBOX &#183; untrusted</text>
+  <text x="46" y="130" font-size="11" fill="#7a271a">gVisor runtime (runc fallback) &#183; network=none</text>
+
+  <!-- agent core -->
+  <rect x="50" y="146" width="260" height="86" rx="8" fill="#ffffff" stroke="#b42318" stroke-width="1.5"/>
+  <text x="180" y="180" font-size="15" font-weight="700" fill="#7a271a" text-anchor="middle">Agent loop + tools</text>
+  <text x="180" y="200" font-size="11.5" fill="#9a3324" text-anchor="middle">assumed fully compromised (A1):</text>
+  <text x="180" y="216" font-size="11.5" fill="#9a3324" text-anchor="middle">arbitrary code as the sandbox's own uid</text>
+
+  <!-- hardening chips -->
+  <g font-size="10.5" fill="#7a271a">
+    <rect x="50"  y="248" width="118" height="24" rx="12" fill="#fbdedb" stroke="#b42318" stroke-width="1"/>
+    <text x="109" y="264" text-anchor="middle">read-only rootfs</text>
+    <rect x="176" y="248" width="134" height="24" rx="12" fill="#fbdedb" stroke="#b42318" stroke-width="1"/>
+    <text x="243" y="264" text-anchor="middle">dropped capabilities</text>
+    <rect x="50"  y="278" width="118" height="24" rx="12" fill="#fbdedb" stroke="#b42318" stroke-width="1"/>
+    <text x="109" y="294" text-anchor="middle">no_new_privs</text>
+    <rect x="176" y="278" width="134" height="24" rx="12" fill="#fbdedb" stroke="#b42318" stroke-width="1"/>
+    <text x="243" y="294" text-anchor="middle">non-root user ns</text>
+  </g>
+  <!-- no NIC banner -->
+  <rect x="50" y="314" width="260" height="30" rx="8" fill="#b42318"/>
+  <text x="180" y="333" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">&#9673; no network interface but loopback</text>
+  <text x="180" y="390" font-size="10.5" fill="#7a271a" text-anchor="middle" font-style="italic">Everything it emits is untrusted output.</text>
+
+  <!-- ============ B1 WALL ============ -->
+  <rect x="340" y="88" width="26" height="316" rx="4" fill="url(#ia-wall)"/>
+  <text x="353" y="246" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle" transform="rotate(-90 353 246)">B1 &#183; gVisor wall</text>
+
+  <!-- ============ TRUSTED HOST ZONE ============ -->
+  <rect x="376" y="88" width="594" height="316" rx="12" fill="#f4f9ff" stroke="#2563eb" stroke-width="2"/>
+  <text x="392" y="112" font-size="15" font-weight="700" fill="#16224a">TRUSTED HOST &#183; the trust root</text>
+  <text x="392" y="130" font-size="11" fill="#3a4a6b">host OS/root &#183; control-plane binary &#183; provider &amp; master/session keys</text>
+
+  <!-- wall-facing choke points (the only crossings) -->
+  <!-- inbound.db -->
+  <rect x="392" y="146" width="176" height="36" rx="6" fill="#eaf2ff" stroke="#1d4ed8" stroke-width="1.5"/>
+  <text x="480" y="164" font-size="12" font-weight="700" fill="#16224a" text-anchor="middle">inbound.db</text>
+  <text x="480" y="177" font-size="10" fill="#3a4a6b" text-anchor="middle">encrypted &#183; read-only to sandbox</text>
+  <!-- outbound.db -->
+  <rect x="392" y="188" width="176" height="36" rx="6" fill="#eaf2ff" stroke="#1d4ed8" stroke-width="1.5"/>
+  <text x="480" y="206" font-size="12" font-weight="700" fill="#16224a" text-anchor="middle">outbound.db</text>
+  <text x="480" y="219" font-size="10" fill="#3a4a6b" text-anchor="middle">encrypted &#183; append-only</text>
+  <!-- model proxy -->
+  <rect x="392" y="234" width="176" height="42" rx="6" fill="#dbe7ff" stroke="#1d4ed8" stroke-width="1.5"/>
+  <text x="480" y="252" font-size="12" font-weight="700" fill="#16224a" text-anchor="middle">Model proxy</text>
+  <text x="480" y="266" font-size="10" fill="#3a4a6b" text-anchor="middle">holds provider key &#183; injects host-side</text>
+  <!-- egress broker -->
+  <rect x="392" y="282" width="176" height="42" rx="6" fill="#dbe7ff" stroke="#1d4ed8" stroke-width="1.5"/>
+  <text x="480" y="300" font-size="12" font-weight="700" fill="#16224a" text-anchor="middle">Egress broker (opt-in)</text>
+  <text x="480" y="314" font-size="10" fill="#3a4a6b" text-anchor="middle">deny-by-default allowlist</text>
+  <!-- vault injector -->
+  <rect x="392" y="330" width="176" height="40" rx="6" fill="#eef4ff" stroke="#1d4ed8" stroke-width="1.25" stroke-dasharray="4 3"/>
+  <text x="480" y="348" font-size="12" font-weight="700" fill="#16224a" text-anchor="middle">Vault injector</text>
+  <text x="480" y="361" font-size="10" fill="#3a4a6b" text-anchor="middle">separate host principal, behind broker</text>
+
+  <!-- deeper control-plane column -->
+  <rect x="584" y="146" width="374" height="224" rx="8" fill="#ffffff" stroke="#8fb4ff" stroke-width="1.25"/>
+  <text x="600" y="166" font-size="12" font-weight="700" fill="#16224a">Control-plane process</text>
+
+  <!-- API -->
+  <rect x="600" y="176" width="342" height="34" rx="6" fill="#eaf2ff" stroke="#1d4ed8" stroke-width="1.25"/>
+  <text x="771" y="198" font-size="12" font-weight="600" fill="#16224a" text-anchor="middle">API + bearer auth &#183; Tailscale interface only (B5)</text>
+
+  <!-- Gateway change-gate (emphasis: amber human-approval floor) -->
+  <rect x="600" y="216" width="342" height="76" rx="6" fill="#fdf1d6" stroke="#b7791f" stroke-width="2"/>
+  <text x="771" y="236" font-size="13" font-weight="700" fill="#7a4d00" text-anchor="middle">Gateway &#183; change-gate</text>
+  <text x="771" y="253" font-size="10.5" fill="#7a4d00" text-anchor="middle">deterministic verifier chain + mandatory human-approval floor</text>
+  <text x="771" y="272" font-size="10" fill="#7a4d00" text-anchor="middle">change-kinds: enabled_tools &#183; create_agent &#183; mcp_register</text>
+  <text x="771" y="285" font-size="10" fill="#7a4d00" text-anchor="middle">skill_install &#183; mcp_access &#183; permissions / mounts &#183; none auto-applied</text>
+
+  <!-- Router -->
+  <rect x="600" y="298" width="342" height="34" rx="6" fill="#eaf2ff" stroke="#1d4ed8" stroke-width="1.25"/>
+  <text x="771" y="320" font-size="12" font-weight="600" fill="#16224a" text-anchor="middle">Router / delivery / sweep &#183; host owns routing &amp; identity</text>
+
+  <text x="771" y="356" font-size="10.5" fill="#3a4a6b" text-anchor="middle" font-style="italic">Provider key, master key &amp; session keys never leave the host.</text>
+
+  <!-- ===== crossings: agent (x=310) <-> host choke points (x=392) ===== -->
+  <g stroke="#1d4ed8" stroke-width="2" fill="none">
+    <!-- inbound: RO bind mount, host -> agent -->
+    <path d="M392 164 L310 172" marker-start="url(#ia-arr)"/>
+    <!-- outbound: append, agent -> host -->
+    <path d="M310 196 L392 206" marker-end="url(#ia-arr)"/>
+    <!-- model proxy socket -->
+    <path d="M310 210 L392 255" marker-end="url(#ia-arr)"/>
+    <!-- egress broker socket -->
+    <path d="M310 224 L392 303" marker-end="url(#ia-arr)"/>
+    <!-- broker -> vault injector (host-internal) -->
+    <path d="M480 324 L480 330" marker-end="url(#ia-arr)"/>
+  </g>
+  <g font-size="9.5" fill="#1d4ed8" font-weight="600">
+    <text x="318" y="150">RO bind mount (B2)</text>
+    <text x="318" y="240">unix socket</text>
+    <text x="318" y="330">unix socket (opt-in)</text>
+  </g>
+  <text x="318" y="194" font-size="9.5" fill="#1d4ed8" font-weight="600" text-anchor="start">append (B2)</text>
+
+  <!-- ============ LEGEND: red-team escape mapping ============ -->
+  <line x1="30" y1="424" x2="970" y2="424" stroke="#b9d4ff" stroke-width="1.5"/>
+  <text x="30" y="448" font-size="16" font-weight="700" fill="#16224a">Every red-team escape attempt is contained
+    <tspan font-size="12" font-weight="400" fill="#3a4a6b"> &#183; IRO-257, verified end-to-end by examples/red-team-escape</tspan>
+  </text>
+
+  <!-- rows -->
+  <g font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+    <!-- Row 1 -->
+    <rect x="30" y="462" width="940" height="38" rx="6" fill="#f4f9ff"/>
+    <circle cx="52" cy="481" r="11" fill="#16224a"/><text x="52" y="485" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">1</text>
+    <text x="74" y="486" font-size="13" font-weight="700" fill="#16224a">Network egress (enumerate NICs, DNS)</text>
+    <text x="392" y="486" font-size="11" fill="#33415c">network=none: only loopback exists, so DNS/HTTP have nowhere to go</text>
+    <rect x="806" y="470" width="56" height="22" rx="11" fill="#dbe7ff"/><text x="834" y="485" font-size="10.5" font-weight="700" fill="#1d4ed8" text-anchor="middle">B1</text>
+    <rect x="870" y="470" width="98" height="22" rx="11" fill="#e6f4ec" stroke="#0f5132" stroke-width="1"/><text x="919" y="485" font-size="10" font-weight="700" fill="#0f5132" text-anchor="middle">&#10003; CONTAINED</text>
+
+    <!-- Row 2 -->
+    <rect x="30" y="502" width="940" height="38" rx="6" fill="#ffffff"/>
+    <circle cx="52" cy="521" r="11" fill="#16224a"/><text x="52" y="525" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">2</text>
+    <text x="74" y="526" font-size="13" font-weight="700" fill="#16224a">Host escape via Docker Engine socket</text>
+    <text x="392" y="526" font-size="11" fill="#33415c">the Engine socket is never bound into the sandbox</text>
+    <rect x="806" y="510" width="56" height="22" rx="11" fill="#dbe7ff"/><text x="834" y="525" font-size="10.5" font-weight="700" fill="#1d4ed8" text-anchor="middle">B1</text>
+    <rect x="870" y="510" width="98" height="22" rx="11" fill="#e6f4ec" stroke="#0f5132" stroke-width="1"/><text x="919" y="525" font-size="10" font-weight="700" fill="#0f5132" text-anchor="middle">&#10003; CONTAINED</text>
+
+    <!-- Row 3 -->
+    <rect x="30" y="542" width="940" height="38" rx="6" fill="#f4f9ff"/>
+    <circle cx="52" cy="561" r="11" fill="#16224a"/><text x="52" y="565" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">3</text>
+    <text x="74" y="566" font-size="13" font-weight="700" fill="#16224a">Sibling container breakout</text>
+    <text x="392" y="566" font-size="11" fill="#33415c">no docker client + no socket &#8594; the daemon is unreachable</text>
+    <rect x="806" y="550" width="56" height="22" rx="11" fill="#dbe7ff"/><text x="834" y="565" font-size="10.5" font-weight="700" fill="#1d4ed8" text-anchor="middle">B1</text>
+    <rect x="870" y="550" width="98" height="22" rx="11" fill="#e6f4ec" stroke="#0f5132" stroke-width="1"/><text x="919" y="565" font-size="10" font-weight="700" fill="#0f5132" text-anchor="middle">&#10003; CONTAINED</text>
+
+    <!-- Row 4 -->
+    <rect x="30" y="582" width="940" height="38" rx="6" fill="#ffffff"/>
+    <circle cx="52" cy="601" r="11" fill="#16224a"/><text x="52" y="605" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">4</text>
+    <text x="74" y="606" font-size="13" font-weight="700" fill="#16224a">Read arbitrary host filesystem paths</text>
+    <text x="392" y="606" font-size="11" fill="#33415c">host root is outside the sandbox mount namespace (read-only rootfs)</text>
+    <rect x="806" y="590" width="56" height="22" rx="11" fill="#dbe7ff"/><text x="834" y="605" font-size="10.5" font-weight="700" fill="#1d4ed8" text-anchor="middle">B1</text>
+    <rect x="870" y="590" width="98" height="22" rx="11" fill="#e6f4ec" stroke="#0f5132" stroke-width="1"/><text x="919" y="605" font-size="10" font-weight="700" fill="#0f5132" text-anchor="middle">&#10003; CONTAINED</text>
+
+    <!-- Row 5 -->
+    <rect x="30" y="622" width="940" height="38" rx="6" fill="#f4f9ff"/>
+    <circle cx="52" cy="641" r="11" fill="#16224a"/><text x="52" y="645" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">5</text>
+    <text x="74" y="646" font-size="13" font-weight="700" fill="#16224a">Self-modification (enable a new tool)</text>
+    <text x="392" y="646" font-size="11" fill="#33415c">request_capability_change is held at the gateway's human-approval floor</text>
+    <rect x="806" y="630" width="56" height="22" rx="11" fill="#dbe7ff"/><text x="834" y="645" font-size="10.5" font-weight="700" fill="#1d4ed8" text-anchor="middle">B3</text>
+    <rect x="870" y="630" width="98" height="22" rx="11" fill="#e6f4ec" stroke="#0f5132" stroke-width="1"/><text x="919" y="645" font-size="10" font-weight="700" fill="#0f5132" text-anchor="middle">&#10003; CONTAINED</text>
+
+    <!-- Row 6 -->
+    <rect x="30" y="662" width="940" height="38" rx="6" fill="#ffffff"/>
+    <circle cx="52" cy="681" r="11" fill="#16224a"/><text x="52" y="685" font-size="12" font-weight="700" fill="#ffffff" text-anchor="middle">6</text>
+    <text x="74" y="686" font-size="13" font-weight="700" fill="#16224a">Cross-session key theft (master / sibling keys)</text>
+    <text x="392" y="686" font-size="11" fill="#33415c">per-session binds only; master key + sealed store never mounted (IRO-259)</text>
+    <rect x="800" y="670" width="62" height="22" rx="11" fill="#dbe7ff"/><text x="831" y="685" font-size="10.5" font-weight="700" fill="#1d4ed8" text-anchor="middle">B2&#183;B1</text>
+    <rect x="870" y="670" width="98" height="22" rx="11" fill="#e6f4ec" stroke="#0f5132" stroke-width="1"/><text x="919" y="685" font-size="10" font-weight="700" fill="#0f5132" text-anchor="middle">&#10003; CONTAINED</text>
+  </g>
+
+  <!-- footer -->
+  <text x="30" y="726" font-size="10.5" fill="#5a6b8c">Static rendering of the §3 trust boundaries (B1 to B5). Boundary labels match docs/threat-model.md; component names match the codebase.</text>
+</svg>

--- a/docs/security-isolation.md
+++ b/docs/security-isolation.md
@@ -1,0 +1,120 @@
+---
+title: "Security and isolation: proof, not promises"
+description: One page that makes IronClaw's security differentiator legible. See the isolation architecture, the red-team attempts we run against our own sandbox, and the measured overhead you pay for the wall.
+---
+
+# Security and isolation
+
+Most AI-agent tools ask you to trust the agent. IronClaw does not. It assumes the
+agent inside the sandbox is already compromised, running attacker code as its own
+user, and is built so that even then it cannot escape the box, read another
+session, reach the network, or change its own permissions without a human.
+
+This page is the proof of that claim in one place: the architecture that draws the
+line, the attacks we run against our own sandbox to test the line, and the
+measured cost of holding it.
+
+## How the box is drawn
+
+The host is the trust root. The agent is not. Everything the agent can touch lives
+on the left of the wall below. The only ways across are a handful of host-owned
+choke points, and every change the agent asks for is held for a human.
+
+<figure markdown="span">
+  [![IronClaw isolation architecture: an untrusted gVisor sandbox on the left, separated by the B1 gVisor wall from the trusted host on the right. The only crossings are host-owned unix sockets and per-session encrypted queues. A legend maps each of six red-team escape attempts to the control that contains it.](assets/isolation-architecture.svg){ width="100%" }](assets/isolation-architecture.svg)
+  <figcaption>The trust boundaries from the <a href="threat-model.md">threat model</a> (B1 to B5), rendered as one static picture. Open the image for a full-size view. Every component name matches the codebase.</figcaption>
+</figure>
+
+The wall itself is [gVisor](https://gvisor.dev/) (`runsc`), a user-space kernel
+that gives the agent a full Linux syscall surface while the real host kernel stays
+behind a seccomp-bounded, capability-dropped boundary. Sandboxes run with
+`network=none`, a read-only rootfs, `no_new_privs`, and a non-root user namespace.
+The only crossings are two host-owned unix sockets (the model proxy that holds
+your provider key, and the opt-in egress broker that is deny-by-default) plus the
+per-session encrypted queues (`inbound.db` bound read-only, `outbound.db`
+append-only).
+
+## What a compromised agent still cannot do
+
+We do not just assert the wall holds. We attack it. The
+[red-team escape harness](https://github.com/IronSecCo/ironclaw/tree/main/examples/red-team-escape)
+stands up the offline demo control-plane, engages a real per-session sandbox, and
+then runs each attack below **from inside that sandbox**, as the sandbox's own
+user, exactly the privilege a jailbroken agent would have. It asserts each one is
+contained.
+
+| # | Attack from inside the sandbox | What contains it | Boundary |
+| --- | --- | --- | --- |
+| 1 | Network egress: enumerate NICs, resolve DNS | `network=none`, so only loopback exists and a packet has nowhere to go | B1 |
+| 2 | Host escape via the Docker Engine socket | The Engine socket is never bound into the sandbox | B1 |
+| 3 | Sibling container breakout | No docker client and no socket, so the daemon is unreachable | B1 |
+| 4 | Read arbitrary host filesystem paths | Host root is outside the sandbox mount namespace (read-only rootfs) | B1 |
+| 5 | Self-modification: enable a new tool | The request is held at the gateway's mandatory human-approval floor | B3 |
+| 6 | Cross-session key theft (master and sibling keys) | Per-session binds only; the master key and sealed store are never mounted | B1, B2 |
+
+Every row is **contained** on the production gVisor posture. The self-modification
+case (row 5) is the one worth dwelling on: an agent can *ask* to enable a new tool,
+but it can never *apply* the change. The request lands on the encrypted outbound
+queue, the host turns it into a change request, and the gateway holds it in
+`GET /v1/changes/pending` until a human approves it. There is no bypass path.
+
+The same harness runs as a
+[continuous CI gate](https://github.com/IronSecCo/ironclaw/blob/main/.github/workflows/sandbox-containment.yml)
+that also carries a negative control: it deliberately weakens the sandbox and
+asserts the harness catches the regression, so the gate can never go quietly blind.
+
+!!! note "Honest scope: the laptop demo relaxes two things"
+    The zero-credential demo runs the `runc` fallback for laptop friendliness, which
+    shares the host kernel and (until the per-session bind fix, IRO-259, lands)
+    binds the whole state directory. The harness prints those as tracked gaps
+    rather than pretending they are closed. The network, Docker-socket,
+    sibling-breakout, and gateway boundaries hold **identically** on both paths.
+    See the [harness README](https://github.com/IronSecCo/ironclaw/tree/main/examples/red-team-escape)
+    for the full demo-versus-production accounting.
+
+## What the wall costs
+
+Isolation is not free, but the cost is bounded and predictable rather than a tax on
+every operation. Numbers below are the profile you should expect; reproduce them
+with the harness in [Performance and footprint](benchmarks.md).
+
+| Dimension | Overhead versus a `runc` baseline |
+| --- | --- |
+| CPU-bound reasoning | Near-native, within a few percent. Work that stays in userspace barely touches the wall. |
+| Memory per sandbox | A fixed additive cost, on the order of tens of MiB of RSS beyond the workload. |
+| Sandbox start | A one-time additive cost of roughly a couple hundred milliseconds, per launch, not per request. |
+| Syscall or I/O heavy bursts | The largest gap, often in the range of roughly 1.5x to 2.5x, because every syscall is mediated. This is the isolation you are buying. |
+| Network throughput | Not applicable. Sandboxes run `network=none` with no NIC, so gVisor's weakest dimension is removed by design. |
+
+The takeaway: agent reasoning runs near-native, per-sandbox memory is a roughly
+fixed cost so host capacity scales linearly with agent count, and the one real
+overhead sits on syscall-heavy bursts, which is exactly the mediation that makes
+the box a box.
+
+## Verify it yourself
+
+<div class="grid cards" markdown>
+
+-   :material-target: **[Run the red-team harness](https://github.com/IronSecCo/ironclaw/tree/main/examples/red-team-escape)**
+
+    One command, no credentials. It attacks a live sandbox from the inside and
+    prints a PASS or FAIL table.
+
+-   :material-shield-bug: **[Read the threat model](threat-model.md)**
+
+    The full boundary-by-boundary STRIDE analysis behind the diagram, and what
+    counts as a vulnerability.
+
+-   :material-speedometer: **[Reproduce the benchmarks](benchmarks.md)**
+
+    The measured overhead, the methodology, and how to run it on your own host.
+
+-   :material-lock-check: **[Verify a release](release-runbook.md#4-how-to-verify-a-release-user-facing)**
+
+    Every build is checksummed, keyless-signed with cosign, and carries
+    build-provenance attestations.
+
+</div>
+
+For the invariants that hold across all of this, start at the
+[Security and trust overview](security.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
   - Skills: skills.md
   - Security & Trust:
       - Overview: security.md
+      - Isolation, proven: security-isolation.md
       - Threat model: threat-model.md
       - Performance & footprint: benchmarks.md
   - Reference:


### PR DESCRIPTION
## What

Adds `docs/security-isolation.md`, a single visual page that makes IronClaw's security differentiator legible to prospective adopters, wired into the MkDocs nav under **Security & Trust > Isolation, proven**.

Closes IRO-268.

## Contents
- **Isolation architecture diagram** (`docs/assets/isolation-architecture.svg`, IRO-264) embedded as a scalable figure with a link to full size and an accessible caption.
- **Red-team escape table** (IRO-257): the six attempts run *from inside* a live sandbox, each mapped to the control that contains it and its trust boundary (B1 to B5). Links to the harness and the continuous CI gate.
- **Overhead profile** summarized from `docs/benchmarks.md`: near-native CPU, tens of MiB RSS per sandbox, ~couple hundred ms start, syscall-heavy bursts ~1.5x to 2.5x, network N/A (`network=none`).
- **Verify-it-yourself** cards linking the red-team harness, threat model, benchmarks, and release verification.
- **Honest scope** admonition on demo (runc) vs production (gVisor), matching the harness README.

## Acceptance criteria
- [x] New docs page added to the mkdocs nav.
- [x] Embeds the IRO-264 diagram, summarizes the red-team invariants proven, links to the containment report (red-team harness) + benchmarks.
- [x] WCAG AA (Material AA palette + AA-authored SVG), reduced-motion safe (fully static SVG, no animation), no em or en dashes in copy (verified in the page and the embedded SVG).

## Verification
`mkdocs build` with 0 errors; rendered at 1440x900 and 390x844. The diagram scales to full width and stays legible on mobile; tables, grid cards, and the admonition render correctly.

## Notes
- Also lands the IRO-264 SVG asset (previously only in a working tree) so the page ships complete, not as a stub.
- The embedded SVG's em/en dashes were replaced (middots and plain words) to satisfy the standing no-dash rule for public copy.