### PR TITLE
ci: gate sandbox containment on every push (IRO-261)

### DIFF
--- a/.github/workflows/sandbox-containment.yml
+++ b/.github/workflows/sandbox-containment.yml
@@ -85,8 +85,15 @@ jobs:
         run: |
           set -euo pipefail
           echo "==> bringing the demo up with a DELIBERATELY WEAKENED sandbox (bridge NIC, not network=none)"
-          # The sandbox image was already built by the previous step; reuse it.
-          docker compose -f docker-compose.demo.yml -f "$OVERRIDE" up --build -d
+          # Phase 1 already built both images (ironclaw-controlplane:demo and
+          # ironclaw-sandbox:latest), so bring the weakened demo up with --no-build:
+          # reuse those images and never re-load the repo as a build context. A rebuild
+          # here would choke loading the context on the root-owned .ironclaw-demo-state/
+          # runtime state phase 1 left behind (the state dir is a host bind the
+          # control-plane writes as root; the runner user cannot read it). Clear that
+          # leftover state with sudo first so this phase starts clean.
+          sudo rm -rf ./.ironclaw-demo-state
+          docker compose -f docker-compose.demo.yml -f "$OVERRIDE" up --no-build -d
 
           # run.sh --attach waits for /healthz itself, engages a sandbox against the
           # already-running (weakened) control-plane, attacks it, and manages no

--- a/.github/workflows/sandbox-containment.yml
+++ b/.github/workflows/sandbox-containment.yml
@@ -1,0 +1,107 @@
+name: Sandbox containment gate
+
+# Continuous proof of isolation (IRO-261). IronClaw's positioning is "isolation you
+# can prove, not just promise" — this gate makes that claim self-verifying on every
+# push instead of a harness someone remembers to run by hand.
+#
+# It runs the red-team escape harness (examples/red-team-escape, IRO-257) against the
+# offline, zero-credential demo control-plane and asserts every CORE containment
+# assertion holds. As of IRO-259 all SIX rows are core assertions on the demo runc
+# path — network egress, Docker-socket/host escape, sibling breakout, host filesystem,
+# self-modification held at the gateway, and cross-session key custody (host master
+# key + sibling session keys unreachable). A real regression that weakens the sandbox
+# turns this job RED.
+#
+# Two phases, one job (so the sandbox image is built once and reused):
+#   1. prove-contained    — run the harness; the sandbox MUST contain a fully
+#                           compromised agent (run.sh exits 0).
+#   2. regression-guard   — a NEGATIVE control. Bring the demo up with a deliberately
+#                           WEAKENED sandbox (every sibling gets the default bridge NIC
+#                           instead of network=none) and assert the harness CATCHES it
+#                           (run.sh exits non-zero). If the harness stays green against
+#                           a sandbox with a NIC, the gate is blind and cannot be
+#                           trusted — so THAT fails this job. This is how we prove the
+#                           gate actually catches regressions, not just that it is green.
+#
+# Posture, mirroring the WS-G no-secret harness (.github/workflows/wsg-verify.yml):
+#   - Additive and NOT a required status check — it must never be able to break a
+#     release; it surfaces a containment regression, it does not gate the merge queue.
+#   - No secrets: the offline `mock` provider makes no network call, so no model key or
+#     channel token is needed. ubuntu-latest ships Docker, jq, and curl.
+#   - Self-skips cleanly on a runner without a working Docker Engine.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Least-privilege default (Scorecard Token-Permissions): the job only reads the repo.
+permissions:
+  contents: read
+
+jobs:
+  sandbox-containment:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      # Pinned to a commit SHA (tag in trailing comment) so a moved tag cannot change
+      # what runs in CI — matches ci.yml. Dependabot bumps these.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Docker preflight (self-skip if unavailable)
+        id: docker
+        # Mirror the WS-G harness's "never block a release on an env we cannot run"
+        # posture: if the runner has no working Docker Engine, skip the containment
+        # phases instead of failing. Hosted ubuntu-latest always has Docker, so on the
+        # published runner this is always 'true'.
+        run: |
+          set -euo pipefail
+          if docker info >/dev/null 2>&1; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "Docker Engine available — running the containment gate."
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Sandbox containment gate skipped::No working Docker Engine on this runner; the escape harness needs one. Skipping (non-fatal)."
+          fi
+
+      - name: Prove containment holds (every CORE assertion PASSES)
+        if: steps.docker.outputs.available == 'true'
+        # Builds ironclaw-sandbox:latest, brings the demo control-plane up, engages a
+        # real per-session sandbox, attacks it from the inside assuming a fully
+        # compromised agent, and exits non-zero if any CORE containment assertion
+        # failed. Tears the demo down on exit.
+        run: examples/red-team-escape/run.sh
+
+      - name: Regression guard — prove the gate catches a weakened sandbox
+        if: steps.docker.outputs.available == 'true'
+        # NEGATIVE control. We deliberately break containment (hand every sandbox the
+        # default bridge NIC instead of network=none via the committed override) and
+        # assert the harness turns RED. A weakened sandbox that the harness reports as
+        # contained means the gate is blind — that is the failure this step exists to
+        # surface, and it fails the job.
+        env:
+          OVERRIDE: examples/red-team-escape/ci/weaken-network.override.yml
+        run: |
+          set -euo pipefail
+          echo "==> bringing the demo up with a DELIBERATELY WEAKENED sandbox (bridge NIC, not network=none)"
+          # The sandbox image was already built by the previous step; reuse it.
+          docker compose -f docker-compose.demo.yml -f "$OVERRIDE" up --build -d
+
+          # run.sh --attach waits for /healthz itself, engages a sandbox against the
+          # already-running (weakened) control-plane, attacks it, and manages no
+          # lifecycle of its own — so we own teardown. SKIP_BUILD=1 keeps it from
+          # rebuilding the (already-present) sandbox image.
+          set +e
+          SKIP_BUILD=1 examples/red-team-escape/run.sh --attach
+          rc=$?
+          set -e
+
+          echo "==> tearing the weakened demo down"
+          docker compose -f docker-compose.demo.yml -f "$OVERRIDE" down -v >/dev/null 2>&1 || true
+
+          if [ "$rc" -eq 0 ]; then
+            echo "::error title=Containment gate is blind::The escape harness reported PASS against a sandbox with a bridge NIC (network egress possible). The gate cannot catch a real regression and must not be trusted."
+            exit 1
+          fi
+          echo "==> regression guard OK: the harness correctly went RED (exit $rc) on the weakened sandbox."

--- a/examples/red-team-escape/README.md
+++ b/examples/red-team-escape/README.md
@@ -16,6 +16,10 @@ examples/red-team-escape/run.sh
 It prints a PASS/FAIL table and exits non-zero if any **core** containment assertion
 fails, so it works as a CI check as well as a demo.
 
+This harness runs on **every push** as the [Sandbox containment gate](../../.github/workflows/sandbox-containment.yml)
+(IRO-261): CI re-proves all six core assertions and, as a negative control, weakens the
+sandbox on purpose to confirm the gate actually turns red on a regression.
+
 ## The threat model (read this first)
 
 We assume the **worst realistic case**: the agent has been fully jailbroken and can

--- a/examples/red-team-escape/ci/weaken-network.override.yml
+++ b/examples/red-team-escape/ci/weaken-network.override.yml
@@ -1,0 +1,23 @@
+# Deliberately WEAKENED sandbox posture — the negative control for the containment
+# gate (.github/workflows/sandbox-containment.yml, IRO-261).
+#
+# docker-compose.demo.yml pins IRONCLAW_DOCKER_NETWORK: "none", so every per-session
+# sandbox sibling launches with NO network interface but `lo`. This override flips
+# that single knob to the default bridge network, handing each sandbox a real NIC and
+# thus network egress — exactly the regression the red-team harness's first CORE
+# assertion ("network egress: enumerate NICs / resolve DNS") exists to catch.
+#
+# Compose merges this on top of the demo file (`-f docker-compose.demo.yml -f this`),
+# replacing only the one environment value. The gate brings the demo up with this
+# override and asserts examples/red-team-escape/run.sh turns RED (exits non-zero). If
+# the harness stayed green against a sandbox that can reach the network, the gate would
+# be blind — so this override is how we prove the gate actually catches a weakened
+# sandbox, not just that it is green on a healthy one.
+#
+# This file is ONLY ever used by the regression-guard phase. It must never be wired
+# into the real demo path (docker-compose.demo.yml) or any deployment.
+services:
+  controlplane:
+    environment:
+      # bridge NIC instead of network=none — a real containment regression.
+      IRONCLAW_DOCKER_NETWORK: "bridge"


### PR DESCRIPTION
## What

Turns the red-team escape harness (`examples/red-team-escape`, IRO-257) from a one-shot demo into **continuous proof of isolation**. New workflow `.github/workflows/sandbox-containment.yml` runs on every push to `main` and every PR.

Closes IRO-261.

## How it meets the acceptance criteria

- **Runs the harness, asserts all core containment checks PASS.** Phase 1 runs `examples/red-team-escape/run.sh`, which exits non-zero if any core assertion fails. As of IRO-259 (merged) all **six** rows are core assertions on the demo runc path — network egress, Docker-socket/host escape, sibling breakout, host filesystem, self-modification held at the gateway, and cross-session key custody (host master key + sibling session keys unreachable).
- **Additive, no secrets, skips cleanly without Docker.** Not a required status check (never blocks a release); the offline `mock` provider makes no network call so no model key / channel token is needed; a `docker info` preflight self-skips the job on a runner without a working Engine. Mirrors the WS-G no-secret harness posture (`.github/workflows/wsg-verify.yml`).
- **A deliberately-weakened sandbox makes the gate RED.** Phase 2 is a negative control: it brings the demo up with a committed override (`examples/red-team-escape/ci/weaken-network.override.yml`) that flips `IRONCLAW_DOCKER_NETWORK` from `none` to `bridge` — handing every sandbox a real NIC — then asserts `run.sh --attach` turns RED. If the harness reported containment against a sandbox with network egress, the gate would be blind, so **that** fails the job. This proves the gate catches regressions rather than just sitting green.
- **README pointer.** `examples/red-team-escape/README.md` now points at the CI gate.

## Design notes / for review

- **One job, two phases** so the sandbox image is built once (phase 1) and reused (phase 2, `SKIP_BUILD=1`).
- **Overlap with `example-smoke.yml`:** that workflow already has a path-filtered, non-gating `red-team-escape` job (from #266). This new gate supersedes it (runs on *every* push, adds the regression guard). I left the example-smoke job in place to stay purely additive; happy to remove it as a fast-follow if reviewers prefer no duplication.
- Validated with `actionlint` + YAML parse. The workflow uses no `github.event.*` inputs, so no injection surface.

cc @Forge (owner of IRO-257 harness).