### PR TITLE
docs(threat-model): embed the isolation architecture diagram (IRO-264)

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -47,6 +47,17 @@ stays sane.
 
 ## 3. Trust boundaries and data flow
 
+The static diagram below is the visual companion to this section: the untrusted
+sandbox on the left, the trusted host on the right, the only crossings between them
+(host-owned unix sockets and the per-session encrypted queues), and a legend that maps
+each red-team escape attempt from the
+[escape harness](https://github.com/IronSecCo/ironclaw/tree/main/examples/red-team-escape)
+to the boundary control that contains it. The [security and isolation](security-isolation.md)
+page walks through the same picture in prose; the Mermaid source that follows is these
+same boundaries in text form.
+
+[![IronClaw isolation architecture: an untrusted gVisor sandbox on the left, separated by the B1 gVisor wall from the trusted host on the right. The only crossings are host-owned unix sockets and per-session encrypted queues. A legend maps each of six red-team escape attempts to the control that contains it.](assets/isolation-architecture.svg){ width="100%" }](assets/isolation-architecture.svg)
+
 ```mermaid
 flowchart TB
   U["User / external sender"]


### PR DESCRIPTION
## What

Reference the static isolation architecture diagram (`docs/assets/isolation-architecture.svg`) from **`docs/threat-model.md` section 3 (Trust boundaries and data flow)**.

This closes the last open IRO-264 acceptance criterion. The SVG asset itself already landed under `docs/assets/` and is embedded on the `security-isolation.md` trust page, but IRO-264 specifically asks for it to be referenced from the threat model, section 3 of which is the source that page is built from. The figure now sits directly above the Mermaid source it visualizes.

## The diagram (recap)

- **Left:** the untrusted `gVisor` sandbox (network=none, read-only rootfs, dropped caps, no_new_privs, non-root userns) holding the agent loop, assumed fully compromised (A1).
- **B1 gVisor wall:** the only crossings are two host-owned unix sockets (model proxy, opt-in egress broker) and the per-session encrypted queues (inbound.db RO, outbound.db append-only).
- **Right:** the trusted host: API + bearer auth, the **gateway change-gate** (deterministic verifier chain + mandatory human-approval floor over the real change-kinds: enabled_tools, create_agent, mcp_register, skill_install, mcp_access, permissions/mounts), router/delivery/sweep, and the vault injector (separate host principal behind the broker).
- **Legend:** all six red-team escape attempts from IRO-257 (`examples/red-team-escape`), each mapped to the boundary control that contains it.

## Verification

- Rendered full-fidelity in Chrome at the native 1000x738 viewBox: all zones, crossings, the change-gate, and the six CONTAINED legend rows render legibly; steel/navy palette per `brand.css` (documented WCAG-AA ratios); static, reduced-motion safe.
- Component labels and B1-B5 boundary tags verified against `docs/threat-model.md` section 3 and the codebase, not invented.
- Added copy is em-dash / en-dash free (public-copy rule).

## Scope

Docs-only, one file, +11 lines. The SVG is unchanged (already on main). Evergreen asset, non-launch-gated.

Closes IRO-264.