### PR TITLE
fix(brew): single rolling formula bump PR + track v0.1.143 (IRO-270)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -740,46 +740,54 @@ jobs:
             exit 0
           fi
 
-          branch="brew/track-${TAG}"
+          # ONE rolling bump branch (fixed name, no tag suffix). Every release reuses
+          # this single branch and its single open PR instead of stacking a fresh
+          # per-tag PR each time. The old per-tag flow (brew/track-vX.Y.Z) left an
+          # open PR behind on every release; once two were open they went
+          # DIRTY/CONFLICTING against main and each other, and the formula sat three
+          # releases stale (IRO-270). A rolling branch that is force-reset to the
+          # current main tip every release is always cleanly rebased onto main, so the
+          # tracking PR can never conflict, and there is never more than one open.
+          branch="brew/track"
           base_sha="$(git rev-parse HEAD)"
           # Blob OID of the formula already on main == the Contents API `sha` we must
           # pass to replace it. Git's blob hash and GitHub's content sha are the same.
+          # After the reset below the rolling branch == main, so this is the blob to
+          # replace on the branch too.
           file_sha="$(git rev-parse "HEAD:Formula/ironclaw.rb")"
           content_b64="$(base64 -w0 < Formula/ironclaw.rb)"
 
-          # Idempotent: drop a leftover branch from a re-run, then recreate it at the
-          # current main tip.
-          gh api -X DELETE "repos/${REPO}/git/refs/heads/${branch}" 2>/dev/null || true
-          gh api -X POST "repos/${REPO}/git/refs" \
-            -f "ref=refs/heads/${branch}" \
-            -f "sha=${base_sha}"
+          # Create the rolling branch at the current main tip, or force-reset it there
+          # if it already exists (leftover from a prior release whose PR is still open,
+          # or was merged without deleting the branch). Force-reset is what keeps the
+          # PR rebased and conflict-free — never a plain create-if-missing.
+          if gh api "repos/${REPO}/git/refs/heads/${branch}" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${REPO}/git/refs/heads/${branch}" \
+              -f "sha=${base_sha}" -F "force=true"
+          else
+            gh api -X POST "repos/${REPO}/git/refs" \
+              -f "ref=refs/heads/${branch}" \
+              -f "sha=${base_sha}"
+          fi
 
-          # Commit the regenerated formula onto that branch via the Contents API so
-          # the commit is signed by GitHub (required_signatures on main).
+          # Commit the regenerated formula onto the rolling branch via the Contents API
+          # so the commit is signed by GitHub (required_signatures on main).
           gh api -X PUT "repos/${REPO}/contents/Formula/ironclaw.rb" \
             -f "message=chore(brew): track ${TAG} in the Homebrew formula" \
             -f "content=${content_b64}" \
             -f "sha=${file_sha}" \
             -f "branch=${branch}"
 
-          # Open the tracking PR with the scoped reviewer-App token (PR_TOKEN), NOT the
-          # default GITHUB_TOKEN — the latter cannot create PRs while the repo setting
-          # "Allow GitHub Actions to create and approve pull requests" stays OFF
-          # (IRO-203 keeps it off; we ship branch-protection as a feature). The signed
-          # branch above is already pushed via GITHUB_TOKEN; only the PR remains.
-          #
+          # emit_manual_fallback writes the human runbook to the job summary and exits 1.
           # Do NOT swallow a failure: a silently-skipped PR strands `brew install` on a
           # stale release (it pinned v0.1.90 across v0.1.94/95/96 before IRO-202 caught
-          # it). Fail LOUD with a one-click manual fallback in the job summary, but treat
-          # an already-open PR as success.
-          #
-          # emit_manual_fallback writes the human runbook to the job summary and exits 1.
+          # it). Fail LOUD with a one-click manual fallback in the job summary.
           emit_manual_fallback() {
             echo "::error title=Homebrew formula bump PR not opened::${1}"
             {
               echo "### ⚠️ Homebrew formula bump for \`${TAG}\` needs a manual PR"
               echo
-              echo "The GitHub-signed branch [\`${branch}\`](https://github.com/${REPO}/tree/${branch}) was pushed, but the workflow could not open its PR:"
+              echo "The GitHub-signed rolling branch [\`${branch}\`](https://github.com/${REPO}/tree/${branch}) was updated to \`${TAG}\`, but the workflow could not open its PR:"
               echo
               echo '```'
               printf '%s\n' "${1}"
@@ -795,23 +803,52 @@ jobs:
             exit 1
           }
 
-          # No token => the App-token mint step (continue-on-error) failed. Don't try
-          # GITHUB_TOKEN as a fallback — it can't create the PR either and would just
-          # emit a confusing error. Go straight to the loud manual fallback.
-          if [ -z "${PR_TOKEN:-}" ]; then
-            emit_manual_fallback "scoped reviewer-App token was not minted for ${branch} (actions/create-github-app-token failed — see the 'Mint a scoped reviewer-App token' step)."
+          title="chore(brew): track ${TAG} in the Homebrew formula"
+          body="Automated by the Release workflow: regenerates \`Formula/ironclaw.rb\` from the signed \`SHA256SUMS\` of \`${TAG}\` so \`brew install ironsecco/ironclaw/ironclaw\` tracks the latest release. This is the single **rolling** bump PR — it is force-reset onto the current main tip every release, so it never conflicts and supersedes any prior bump. Opened by the reviewer App (PR creation only — a human still approves+merges). Merge to publish; the push trigger ignores this file so the merge does not cut another release."
+
+          # Is the rolling PR already open? The force-reset + signed commit above have
+          # already refreshed its diff to ${TAG}; we only need to refresh its metadata.
+          existing="$(gh pr list --repo "${REPO}" --head "${branch}" --state open \
+            --json number -q '.[0].number' 2>/dev/null || true)"
+
+          if [ -n "${existing:-}" ]; then
+            # Refresh title/body. gh pr edit works with the default GITHUB_TOKEN — the
+            # OFF repo setting only blocks PR *creation/approval*, not edits.
+            if gh pr edit "${existing}" --repo "${REPO}" --title "${title}" --body "${body}"; then
+              echo "Refreshed rolling tracking PR #${existing} to ${TAG}."
+            else
+              echo "::warning title=Rolling bump PR not refreshed::could not update PR #${existing} metadata (non-fatal; its diff already tracks ${TAG})."
+            fi
+          else
+            # No open rolling PR — create one. Creation needs the scoped reviewer-App
+            # token (PR_TOKEN); the default GITHUB_TOKEN cannot create PRs while the
+            # repo setting "Allow GitHub Actions to create and approve pull requests"
+            # stays OFF (IRO-203 keeps it off; we ship branch-protection as a feature).
+            if [ -z "${PR_TOKEN:-}" ]; then
+              emit_manual_fallback "scoped reviewer-App token was not minted for ${branch} (actions/create-github-app-token failed — see the 'Mint a scoped reviewer-App token' step)."
+            fi
+            if out="$(GH_TOKEN="${PR_TOKEN}" gh pr create \
+              --repo "${REPO}" \
+              --base main \
+              --head "${branch}" \
+              --title "${title}" \
+              --body "${body}" 2>&1)"; then
+              echo "Opened rolling tracking PR: ${out}"
+            elif printf '%s' "$out" | grep -qi 'already exists'; then
+              echo "A rolling tracking PR for ${branch} already exists — left it in place."
+            else
+              emit_manual_fallback "gh pr create failed for ${branch}: ${out}"
+            fi
           fi
 
-          body="Automated by the Release workflow: regenerates \`Formula/ironclaw.rb\` from the signed \`SHA256SUMS\` of \`${TAG}\` so \`brew install ironsecco/ironclaw/ironclaw\` tracks the latest release. Opened by the reviewer App (PR creation only — a human still approves+merges). Merge to publish; the push trigger ignores this file so the merge does not cut another release."
-          if out="$(GH_TOKEN="${PR_TOKEN}" gh pr create \
-            --repo "${REPO}" \
-            --base main \
-            --head "${branch}" \
-            --title "chore(brew): track ${TAG} in the Homebrew formula" \
-            --body "${body}" 2>&1)"; then
-            echo "Opened tracking PR: ${out}"
-          elif printf '%s' "$out" | grep -qi 'already exists'; then
-            echo "A tracking PR for ${TAG} already exists — left it in place."
-          else
-            emit_manual_fallback "gh pr create failed for ${branch}: ${out}"
-          fi
+          # Housekeeping: close any legacy per-tag bump PRs the pre-IRO-270 flow left
+          # open (brew/track-vX.Y.Z). They are superseded by the rolling PR and would
+          # otherwise sit CONFLICTING forever. Non-fatal — never block the release on
+          # cleanup of an old PR.
+          for stale in $(gh pr list --repo "${REPO}" --state open --json number,headRefName \
+              -q '.[] | select(.headRefName | startswith("brew/track-")) | .number' 2>/dev/null || true); do
+            gh pr close "${stale}" --repo "${REPO}" --delete-branch \
+              --comment "Superseded by the single rolling Homebrew bump PR tracking ${TAG} (IRO-270)." \
+              && echo "Closed superseded per-tag bump PR #${stale}." \
+              || echo "::warning::could not close superseded per-tag PR #${stale} (non-fatal)."
+          done

--- a/Formula/ironclaw.rb
+++ b/Formula/ironclaw.rb
@@ -16,28 +16,28 @@
 class Ironclaw < Formula
   desc "Security-hardened, self-hosted AI assistant platform (secured Go port)"
   homepage "https://github.com/IronSecCo/ironclaw"
-  version "0.1.138"
+  version "0.1.143"
   license "AGPL-3.0-or-later"
 
   on_macos do
     on_arm do
-      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.138/ironclaw_0.1.138_darwin_arm64.tar.gz"
-      sha256 "088242b6fad9edf92f66953adaf1168c134b27c92708002bfc547973d9a1c80a"
+      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.143/ironclaw_0.1.143_darwin_arm64.tar.gz"
+      sha256 "1c37c13dc12c9ef3092734fe264ca8cd47c4cb96dd07a072f8c7b6ebbeb455e2"
     end
     on_intel do
-      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.138/ironclaw_0.1.138_darwin_amd64.tar.gz"
-      sha256 "42a92fdbbddbf0be1213fc49932e8b47eaa43d173a891cf0f3d66eaa814d97eb"
+      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.143/ironclaw_0.1.143_darwin_amd64.tar.gz"
+      sha256 "bddc29ac9108035c619664d52e9ea0d8e6481299f9a3ece9b1945a2188ce1019"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.138/ironclaw_0.1.138_linux_arm64.tar.gz"
-      sha256 "2f081936f5f89ba50b02f8049c1df31edc1c3f4bc01f88e2a38fe0855ac3bcef"
+      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.143/ironclaw_0.1.143_linux_arm64.tar.gz"
+      sha256 "88e72fc68e44e88d11e0334e983b4737fb9e71f2243a0f5db5c8ddc824354968"
     end
     on_intel do
-      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.138/ironclaw_0.1.138_linux_amd64.tar.gz"
-      sha256 "3f5f9e290c01da6d1c885cb4c6f4111d6143ebe4df28823e2c7108d634af5c09"
+      url "https://github.com/IronSecCo/ironclaw/releases/download/v0.1.143/ironclaw_0.1.143_linux_amd64.tar.gz"
+      sha256 "7eb5b6f5aed6261756231ac98498b9bbe2c7667e6de0b01edc043028d4eca9da"
     end
   end
 
@@ -56,7 +56,7 @@ class Ironclaw < Formula
         ironctl doctor      # preflight: model creds, toolchain, sockets
 
       For production the control plane usually runs as a container:
-        ghcr.io/ironsecco/ironclaw-controlplane:v0.1.138
+        ghcr.io/ironsecco/ironclaw-controlplane:v0.1.143
       See https://ironsecco.github.io/ironclaw/quickstart/ for the full first-run flow.
     EOS
   end


### PR DESCRIPTION
## Problem (IRO-270)

The Homebrew auto-bump flow opened **one PR per release** on a per-tag branch (`brew/track-vX.Y.Z`) without superseding prior open bump PRs. Two piled up and went `DIRTY`/`CONFLICTING` against main and each other:
- #289 → v0.1.139 (superseded, now CLOSED)
- #290 → v0.1.141 (superseded, now CLOSED)

`Formula/ironclaw.rb` on main was left stale at **v0.1.138** while the latest release moved to **v0.1.143**.

## Fix

**1. Durable job fix (the recurrence root cause).** The `formula` job in `release.yml` now uses a **single rolling branch** (`brew/track`, no tag suffix). Every release **force-resets** it to the current main tip, then commits the regenerated formula via the signed Contents API. Because the branch is always rebased onto main tip:
- its single tracking PR can **never** go `CONFLICTING`,
- there is **never more than one** open bump PR,
- if the rolling PR is already open it is refreshed in place; otherwise it is created.

Any legacy per-tag `brew/track-v*` PRs still open are **closed as superseded** by the job (housekeeping for stragglers), non-fatally.

**2. Lands the pending bump.** `Formula/ironclaw.rb` now tracks **v0.1.143** — version/url/sha256 for all four archives regenerated from the release's signed `SHA256SUMS` (the same trust anchor `install.sh` uses), not hand-edited.

## Supply-chain lenses

- **Checksum-first / signing integrity** — sha256 values come straight from the release's signed `SHA256SUMS`; no recomputation, no weakening. Commit onto the rolling branch is GitHub-signed via the Contents API (satisfies `required_signatures` on main).
- **Least-privilege CI** — no permission changes; still `contents: write` + `pull-requests: write`, scoped reviewer-App token used only to *open* the PR (never approve/merge). `gh pr edit`/`close` for the rolling/superseded PRs use the default `GITHUB_TOKEN` (the OFF "Actions may create/approve PRs" setting only blocks create/approve).
- **Fail loud, fail closed** — the loud manual-fallback job-summary path is preserved for the create case; cleanup steps are non-fatal so they never block a release.

## Verification

- `brew style Formula/ironclaw.rb` → **1 file inspected, no offenses detected**
- `actionlint .github/workflows/release.yml` → **clean (exit 0)**
- YAML parse OK
- Formula sha256 values cross-checked against `v0.1.143` `SHA256SUMS` (script reads them directly).

Note: `brew audit [path]` is disabled by Homebrew for untapped files (needs a tapped name); `brew style` is the applicable lint here.

Acceptance criteria: (1) main tracks the latest release ✅ (v0.1.143, > the v0.1.141 named at filing time — drift noted), (2) #289 closed ✅ (both #289/#290 already CLOSED), (3) durable supersede/rolling-PR fix ✅, (4) verification noted ✅.

Prior self-bump work: IRO-203 / IRO-204. Refs IRO-270.