### PR TITLE
ci(reviewer): match rolling brew/track branch in the bump-PR guard (IRO-206)

### DIFF
--- a/.github/workflows/reviewer-approve.yml
+++ b/.github/workflows/reviewer-approve.yml
@@ -107,12 +107,14 @@ jobs:
           PR_AUTHOR=$(printf '%s' "$PR_JSON" | jq -r '.user.login')
           PR_HEAD=$(printf '%s' "$PR_JSON" | jq -r '.head.ref')
           if [ "$PR_AUTHOR" = "$APP_LOGIN" ]; then
-            # Is this the recognised formula bump? Branch brew/track-* AND the diff
-            # touches ONLY Formula/ironclaw.rb. Both must hold — a self-authored PR
-            # that merely renames its branch must not slip the gate.
+            # Is this the recognised formula bump? Head branch is the rolling
+            # `brew/track` (IRO-270) — or a legacy per-tag `brew/track-<tag>` from
+            # before the rolling switch — AND the diff touches ONLY
+            # Formula/ironclaw.rb. Both must hold — a self-authored PR that merely
+            # renames its branch must not slip the gate.
             CHANGED=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR}/files" --jq '.[].filename')
             case "$PR_HEAD" in
-              brew/track-*)
+              brew/track|brew/track-*)
                 if [ "$CHANGED" = "Formula/ironclaw.rb" ]; then
                   echo "::notice::PR #${PR} is the generated Homebrew formula bump (${PR_HEAD}); the reviewer App authored it, so it cannot self-approve. No approval posted — admin-merge is the recorded path for signed formula bumps (IRO-206)."
                   {
@@ -130,7 +132,7 @@ jobs:
                   } >> "$GITHUB_STEP_SUMMARY"
                   exit 0
                 fi
-                echo "::error::PR #${PR} is on a brew/track-* branch but changes more than Formula/ironclaw.rb (${CHANGED}); refusing to treat it as a generated bump." >&2
+                echo "::error::PR #${PR} is on a brew/track branch but changes more than Formula/ironclaw.rb (${CHANGED}); refusing to treat it as a generated bump." >&2
                 exit 1
                 ;;
             esac

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -108,8 +108,10 @@ release path depends on it, so landing the scaffold changes no current behaviour
 
 ## Homebrew formula bump PRs (the one self-authored case)
 
-The Release workflow's `formula` job (IRO-204) opens the `brew/track-<tag>` PR
-that points `brew install ironsecco/ironclaw/ironclaw` at each new release. Per
+The Release workflow's `formula` job (IRO-204) opens the rolling `brew/track` PR
+(one long-lived branch, force-reset to the release tip each cut — IRO-270; older
+releases used a per-tag `brew/track-<tag>` branch) that points
+`brew install ironsecco/ironclaw/ironclaw` at each new release. Per
 [IRO-203](https://github.com/IronSecCo/ironclaw/issues) the repo keeps *"Allow
 GitHub Actions to create and approve pull requests"* **off**, so the default
 `GITHUB_TOKEN` cannot open that PR; the job opens it with a scoped reviewer-App
@@ -125,8 +127,9 @@ approve its own bump PR — and it should not need to. The bump PR is:
 
 The board therefore accepts **admin-merge** for these bumps (IRO-206). To avoid
 a misleading red `reviewer-approve` run, the workflow recognises this narrow
-case — PR author == reviewer App **and** head branch `brew/track-*` **and** the
-diff is exactly `Formula/ironclaw.rb` — and exits cleanly with the admin-merge
+case — PR author == reviewer App **and** head branch `brew/track` (or a legacy
+`brew/track-*`) **and** the diff is exactly `Formula/ironclaw.rb` — and exits
+cleanly with the admin-merge
 runbook in its job summary instead of failing. **Every other self-authored PR
 still hard-fails:** the gate is unchanged for product code.
 


### PR DESCRIPTION
## What

IRO-270 switched the Homebrew bump PR to a single rolling `brew/track` branch (previously per-tag `brew/track-<tag>`). But `reviewer-approve.yml`'s guard — the one that recognises the self-authored, formula-only bump PR and **exits cleanly with the admin-merge runbook instead of a red run** (shipped in #243) — still matched only `brew/track-*`.

`brew/track` does **not** match the shell pattern `brew/track-*`, so the rolling bump PR falls through to the hard-fail `"Reviewer App is the PR author; refusing to self-approve"` path. That silently regressed #243: dispatching reviewer-approve on the rolling bump PR red-fails again.

## Fix

- Match both `brew/track` (rolling) **and** `brew/track-*` (legacy) in the formula-bump case.
- Correct the accompanying error message and `docs/pr-review-process.md` to the rolling branch name.

## Guard integrity

The narrow exception is unchanged in spirit: it still requires **PR author == reviewer App** AND head branch is a `brew/track`\* branch AND the diff is exactly `Formula/ironclaw.rb`. Every other self-authored PR still hard-fails — the review gate is intact for product code.

Verified: `brew/track` and `brew/track-v0.1.143` → graceful exit; `feature/x` → hard-fail. actionlint clean, YAML valid.

## Scope note

This restores the *no-red-run* behavior. It does **not** remove the admin-merge itself — that remains a board decision (a second author identity or a ruleset `bypass_actors` entry), tracked on IRO-206.

Closes the regression half of IRO-206.