### PR TITLE
content(growth): publish 'We tried to break our own sandbox' as docs blog (IRO-271)

### DIFF
--- a/docs/breaking-our-own-sandbox.md
+++ b/docs/breaking-our-own-sandbox.md
@@ -1,0 +1,166 @@
+---
+title: "We tried to break our own AI-agent sandbox. Here is what held."
+description: One command, no credentials. A red-team harness attacks a live IronClaw sandbox from the inside, as the agent's own user, and prints a PASS or FAIL table. Run it yourself.
+---
+
+# We tried to break our own AI-agent sandbox
+
+**One command, no credentials. It attacks a live IronClaw sandbox from the inside and prints a PASS or FAIL table. Run it yourself.**
+
+Most AI-agent tools ask you to trust the agent. To trust that the prompt-injection
+filter caught the bad instruction, that the tool allow-list was tight enough, that the
+model stayed aligned. That is a lot of trust to place in a probabilistic system that an
+attacker gets to send input to.
+
+IronClaw takes the opposite bet. We assume the agent is **already compromised**. We
+assume prompt-injection defences failed, the model was jailbroken, and attacker code is
+now running as the sandbox's own user, inside the box. Then we ask a much simpler,
+much harder question: **when that happens, does the isolation boundary still hold?**
+
+So we wrote a harness that tries to break out. It is in the repo, it takes one command,
+and it needs no API key and no channel tokens:
+
+```bash
+examples/red-team-escape/run.sh
+```
+
+It stands up the offline demo control-plane, engages a real per-session sandbox, and
+then runs a battery of escape, exfiltration, and self-modification attempts **from
+inside that sandbox**, as the sandbox's own user (uid 65532), the exact privilege a
+jailbroken agent would have. It prints a PASS or FAIL table and exits non-zero if any
+core containment assertion fails, so the same script is both a demo and a CI gate.
+
+## Why attack from the inside
+
+A test that only pokes the agent through its normal tool API proves the tools are
+polite. It does not prove the box is a box. The interesting question is not "can the
+model be tricked" (that is a different layer, and every model can be tricked eventually).
+The question is what a fully-compromised agent can actually reach. So the harness uses
+`docker exec` to run each probe as the sandbox's own uid, simulating an attacker who has
+already won the prompt-injection game and is now holding a shell inside the container.
+
+## The threats, and the control that stops each one
+
+We picked the six things a compromised agent would actually try:
+
+1. **Phone home.** Enumerate network interfaces, resolve a model-API hostname, open a
+   socket to exfiltrate data or receive commands.
+2. **Escape to the host.** Reach the Docker Engine socket, which is game-over if the
+   sandbox can touch it: whoever holds `/var/run/docker.sock` owns the host.
+3. **Break into a sibling.** Inspect, spawn, or kill the other session containers
+   running next to it.
+4. **Read the host filesystem.** Reach arbitrary host paths outside its own mounts.
+5. **Rewrite its own permissions.** Enable a new tool or capability for itself,
+   silently.
+6. **Steal another session's keys.** Read the host master key or a sibling session's
+   key material, which would unseal everyone's data.
+
+Here is what contains each one:
+
+| Attack from inside the sandbox | What contains it | Layer |
+| --- | --- | --- |
+| Network egress (enumerate NICs, resolve DNS) | `network=none`: no network namespace, so only loopback exists and a packet has nowhere to go | Isolation |
+| Host escape via the Docker Engine socket | The Engine socket is never bound into the sandbox | Trust boundary |
+| Sibling container breakout | No docker client and no socket, so the daemon is unreachable | Isolation |
+| Read arbitrary host filesystem paths | Host root is outside the sandbox mount namespace (read-only rootfs) | Isolation |
+| Self-modification (enable a new tool) | The request is held at the gateway's mandatory human-approval floor | Mandatory gateway |
+| Cross-session key theft (master and sibling keys) | Per-session binds only; the master key and sealed store are never mounted in | Encryption at rest |
+
+## The actual results
+
+This is the real table the harness printed on a real-Docker run. Not a mock, not a
+diagram, the literal program output (reproduced verbatim):
+
+```text
+==============================================================================
+ IronClaw red-team escape results  (attack -> expected -> observed)
+==============================================================================
+  RESULT  ATTACK                                          OBSERVED
+  ------  ----------------------------------------------  --------
+  PASS    network egress: enumerate NICs                  interfaces: lo
+                                                          (expected: only loopback (network=none))
+  PASS    network egress: DNS lookup of api.anthropic.com  getent exit 2
+                                                          (expected: resolution fails (no egress))
+  PASS    host escape: reach the Docker Engine socket     docker.sock ABSENT
+                                                          (expected: socket absent)
+  PASS    sibling breakout: orchestrate sibling containers  docker client ABSENT
+                                                          (expected: no docker client + no socket)
+  PASS    host escape: read arbitrary host paths          host paths CONTAINED
+                                                          (expected: host root not mounted)
+  PASS    self-modification: enable a new tool            queued in /v1/changes/pending, not applied
+                                                          (expected: held at gateway (pending human approval))
+  PASS    cross-session: read the host master key / sibling session keys  master key + sealed store unreachable; only own session key visible (1)
+                                                          (expected: trust root not mounted (per-session binds only))
+==============================================================================
+
+RESULT: every core containment assertion held. The sandbox contained a
+        fully-compromised agent (network, host escape, sibling breakout, self-mod).
+```
+
+Read that middle-of-the-table row again, the self-modification one, because it is the
+one that surprises people. A compromised agent **can** ask to enable a new tool for
+itself. That request is a real, supported operation. But it can never *apply* the
+change. The request lands on the encrypted outbound queue, the host turns it into a
+change request, and the gateway parks it in `GET /v1/changes/pending` until a human
+approves it. The probe fires that request and then asserts it is sitting in the pending
+queue, unapplied. The agent asked. Nothing happened. That is the design.
+
+## The one thing we are honest about
+
+We could have shipped a harness that only ever prints green. We did not, because a
+security audience can smell that from orbit.
+
+The zero-credential demo you just ran uses the `runc` fallback so it works on a stock
+laptop without gVisor installed. `runc` shares the host kernel. **Production uses
+gVisor** (`runsc`), a user-space kernel that puts the real host kernel behind a
+seccomp-bounded, capability-dropped boundary, with a read-only rootfs, `no_new_privs`,
+and a non-root user namespace. That kernel seal is the one thing the laptop demo cannot
+demonstrate without gVisor present, so the harness does not claim it does.
+
+Everything else in the table, the network wall, the Docker-socket boundary, the
+sibling-breakout wall, the gateway hold, and the per-session key custody, holds
+**identically** on both the demo `runc` path and the production gVisor path. Those are
+the core PASS rows. There is one more piece of honesty worth stating plainly: cross-
+session key custody used to be a real gap on the demo path. The
+`runc` fallback originally bind-mounted the entire control-plane state directory into
+every sandbox, which exposed the host master key. We found it with this harness, filed
+it, and fixed it: the isolator now scopes its binds per session, so the master key and
+every sibling key are no longer reachable. The harness now asserts that directly as a
+core PASS row, so a future regression that re-widens the mount would fail the run.
+
+That is the point of writing the harness. Not to produce a green checkmark for a
+landing page, but to have a thing that tells the truth about what our own box can and
+cannot contain, and that fails loudly the day someone weakens it.
+
+## It runs on every push
+
+This is not a one-time stunt. The same harness runs as a
+[continuous CI gate](https://github.com/IronSecCo/ironclaw/blob/main/.github/workflows/sandbox-containment.yml)
+on every push, and it carries a **negative control**: the gate deliberately weakens the
+sandbox (re-enabling a bridge network) and asserts the harness *catches* the regression.
+A containment gate that cannot fail is not a gate, so we prove ours can.
+
+## Run it yourself
+
+```bash
+git clone https://github.com/IronSecCo/ironclaw
+cd ironclaw
+examples/red-team-escape/run.sh
+```
+
+No key. No tokens. It will build the sandbox image, bring the demo up, attack it from
+the inside, print the table, and tear down. If you want to poke at the box yourself
+afterward, `run.sh --keep` leaves it running.
+
+If you care about running untrusted or semi-trusted AI agents anywhere near your data,
+we would genuinely like you to try to break it and tell us what you find. The threat
+model, the full boundary-by-boundary analysis, and the measured overhead you pay for the
+wall are all in the repo.
+
+- The harness: [`examples/red-team-escape/`](https://github.com/IronSecCo/ironclaw/tree/main/examples/red-team-escape)
+- The trust page: [Security and isolation](security-isolation.md)
+- The threat model: [STRIDE threat model](threat-model.md)
+- The measured cost: [Performance and footprint](benchmarks.md)
+
+IronClaw is AGPLv3 (commercial license available). Isolation you can prove, not just
+promise.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
   - Security & Trust:
       - Overview: security.md
       - Isolation, proven: security-isolation.md
+      - Breaking our own sandbox: breaking-our-own-sandbox.md
       - Threat model: threat-model.md
       - Performance & footprint: benchmarks.md
   - Reference:


### PR DESCRIPTION
## What

Publishes the security-proof writeup (long-form blog, Part 1 of `community/security-proof-writeup.md`, merged in #292) as a **canonical page on the live MkDocs docs site**, so the launch Show HN / Reddit posts have a stable URL to point at.

- New page: `docs/breaking-our-own-sandbox.md`
- Nav: added under **Security & Trust** (between "Isolation, proven" and "Threat model")
- Canonical URL after deploy: https://ironsecco.github.io/ironclaw/breaking-our-own-sandbox/

## Why

IRO-271 (launch execution) deliverable #2: land the blog on the project's own surface (not a personal social, fully agent-executable) so the gated HN/Reddit submissions have a canonical anchor.

## Accuracy

Content is the board-context, em-dash-clean copy from PR #292 (IRO-258). Every claim maps to the writeup's claim ledger (all backed by merged source). Internal links converted to relative docs links (`security-isolation.md`, `threat-model.md`, `benchmarks.md`) so the terminal block and cross-links resolve under `mkdocs build --strict`.

## Verification

`mkdocs build --strict` passes locally; the page renders (48K HTML). No new nav warnings.

Refs IRO-271, IRO-258.