### PR TITLE
docs(growth): social-proof wall + curation process (IRO-241)

### DIFF
--- a/community/README.md
+++ b/community/README.md
@@ -11,6 +11,7 @@ version-controlled here but intentionally **not** published to the docs site
 | [launch-engagement-playbook.md](launch-engagement-playbook.md) | Where we post, monitoring cadence, reusable response templates. | Updated per launch |
 | [amplification-submissions-queue.md](amplification-submissions-queue.md) | Staged newsletter / directory submissions, held for the IRO-40 launch gate. | Per launch wave |
 | [security-proof-writeup.md](security-proof-writeup.md) | "We tried to break our own sandbox" proof piece (blog + Show HN + social), built on the real red-team harness output. Gated draft, needs CEO/board sign-off. | Per launch |
+| [social-proof.md](social-proof.md) | Collection process, sourcing guardrails, and raw-capture ledger behind the public [social-proof wall](../docs/social-proof.md). | 24h / 72h / 1wk, then weekly |
 
 Refresh the metrics snapshot with:
 

--- a/community/social-proof.md
+++ b/community/social-proof.md
@@ -1,0 +1,69 @@
+# Social-proof curation (internal)
+
+Internal operating doc for how we collect and vet social proof, and what is allowed onto the
+public wall at [docs/social-proof.md](../docs/social-proof.md). This is a **team operating
+doc**, not published to the docs site. The public wall is the published artifact; this file
+is the collection process, the sourcing rules, and the raw-capture ledger behind it.
+
+- **Owner:** Growth / DevRel (WS-E)
+- **Feeds:** the public wall (`docs/social-proof.md`), future launch copy, and the
+  [launch-engagement-playbook](launch-engagement-playbook.md) flywheel (section 5).
+- **Cadence:** capture snapshots at **24h, 72h, and 1 week** post launch (mirrors the
+  playbook monitoring windows), then weekly in steady state.
+
+## Sourcing guardrails (hard rules)
+
+These are non negotiable and match the launch identity guardrails on IRO-271 / IRO-40.
+
+1. **Permitted sources only.** Collect mentions and quotes from the channels we actually
+   posted to or that are neutral public dev spaces:
+   - Project blog
+   - Pseudonymous Show HN post and its thread
+   - Owner Reddit posts (r/selfhosted, r/opensource, r/devops) and their threads
+   - Neutral dev channels: HN, Reddit, GitHub Discussions, newsletters, directory and
+     awesome-list listings
+2. **No personal-identity scraping.** Do **not** scrape, quote, or attribute anything via the
+   owner's personal GitHub, LinkedIn, or Instagram. The owner's personal accounts are off
+   limits as sources.
+3. **Stars stay org-level.** Cite star and fork **counts** and named **orgs** that have made
+   their use public. Do not build a wall of individual stargazer handles.
+4. **Public and verbatim.** Only quote what was posted publicly. Keep quotes exact, link the
+   source, and record the date. Never paraphrase a private DM or email as a public quote.
+5. **Opt-out honored.** If someone asks to be removed, remove them promptly. Note it below.
+6. **No vaporware.** A quote praising a capability only goes up if that capability is shipped
+   and verifiable (playbook golden rule).
+
+## Promotion rule (raw capture to public wall)
+
+A candidate moves from the ledger below to `docs/social-proof.md` only when it is:
+(a) from a permitted source, (b) public with a working link, (c) verbatim, and
+(d) not covered by an opt-out. Anything failing a check stays here or gets dropped.
+
+## Snapshot log
+
+| Date | Stars | Forks | Notes |
+| --- | --- | --- | --- |
+| 2026-07-02 (launch) | 13 | 2 | Baseline captured at launch. Refresh with `scripts/community/adoption-snapshot.sh`. |
+
+## Raw-capture ledger
+
+Drop candidates here as they come in, before vetting. Move vetted ones to the public wall.
+
+### Quote candidates
+
+_None yet. Add as: source link, handle/first name, channel, date, verbatim text, vetted? (y/n)._
+
+### Mention candidates
+
+_None yet. Add as: publication/list, link, date, one-line summary, vetted? (y/n)._
+
+### Opt-outs
+
+_None._
+
+## Related
+
+- Public wall: [docs/social-proof.md](../docs/social-proof.md)
+- Launch playbook (section 5, "After launch"): [launch-engagement-playbook.md](launch-engagement-playbook.md)
+- Adoption metrics: [adoption-metrics.md](adoption-metrics.md)
+- Amplification queue (newsletter / directory submissions): [amplification-submissions-queue.md](amplification-submissions-queue.md)

--- a/docs/social-proof.md
+++ b/docs/social-proof.md
@@ -1,0 +1,63 @@
+# Social proof
+
+What people are building, saying, and starring. This wall collects verifiable public
+signals about IronClaw: stars and notable adopters, quotable comments from public threads,
+and press, newsletter, and directory mentions.
+
+Every entry links back to a public source you can open and check yourself. We do not
+paraphrase private messages, and we do not attribute anything to a person who did not post
+it publicly. If we quote you and you would rather we did not, open an issue or email us and
+we will remove it.
+
+> Freshly launched. This wall fills in through launch week and beyond. Numbers below are
+> point in time snapshots, not live counters. The live counts are always on
+> [GitHub](https://github.com/IronSecCo/ironclaw).
+
+## Stars and adoption
+
+| Snapshot | Stars | Forks | Source |
+| --- | --- | --- | --- |
+| Launch day | 13 | 2 | [github.com/IronSecCo/ironclaw](https://github.com/IronSecCo/ironclaw) |
+
+Star history: [star-history.com/#IronSecCo/ironclaw](https://star-history.com/#IronSecCo/ironclaw&Date)
+
+Notable orgs and adopters land here as they show up in public star lists and public
+"we use this" posts. We only list an org when it has said so publicly or made its use public.
+
+## Quotes
+
+Quotable comments from public threads (Show HN, Reddit, X or Mastodon, GitHub Discussions).
+Each quote links to the original public post.
+
+*No public quotes captured yet. As launch threads go live, vetted quotes land here with a
+link to the source.*
+
+<!--
+Entry template (copy per quote, keep the source link, keep it verbatim):
+
+> "Exact quote, unedited."
+>
+> [Handle or first name], [Channel] ([link to the public post]) - [date]
+-->
+
+## Mentions
+
+Press, newsletters, and directory or awesome-list listings that reference IronClaw.
+
+*No external mentions captured yet. Submissions to newsletters and directories are staged in
+the launch amplification queue and land here once they publish.*
+
+<!--
+Entry template:
+
+- **[Publication or list name]** - [what they said, one line] ([link]) - [date]
+-->
+
+## Add your voice
+
+Using IronClaw and want to share? The best place is
+[GitHub Discussions](https://github.com/IronSecCo/ironclaw/discussions). Public posts there,
+on Show HN, or on Reddit are fair game for this wall, always with a link back to you.
+
+New to the project? Start with the [quickstart](quickstart.md) or the zero credential
+[demo](index.md#demo), and star the repo if it earns it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
       - Channel adapters: channels.md
       - Writing a channel adapter: writing-a-channel-adapter.md
   - Skills: skills.md
+  - Social proof: social-proof.md
   - Security & Trust:
       - Overview: security.md
       - Isolation, proven: security-isolation.md

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -355,6 +355,7 @@ docker compose -f docker-compose.demo.yml up --build -d    <span class="iro-code
         <li><a href="https://ironsecco.github.io/ironclaw/threat-model/">Threat model</a></li>
         <li><a href="https://ironsecco.github.io/ironclaw/security/">Security posture</a></li>
         <li><a href="https://ironsecco.github.io/ironclaw/comparison/">Comparison</a></li>
+        <li><a href="https://ironsecco.github.io/ironclaw/social-proof/">Social proof</a></li>
         <li><a href="https://ironsecco.github.io/ironclaw/roadmap/">Roadmap</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## What

Stands up the launch **social-proof wall** and the collection process behind it. Follow-up from IRO-237 / launch-engagement-playbook section 5. Unblocked by **IRO-271** (launch fired).

- **`docs/social-proof.md`** (published wall): star/adoption snapshots, quotable public comments, press/newsletter/directory mentions. Every entry links to its public source. Seeded honestly with the launch-day star snapshot (13 stars / 2 forks); quote + mention sections carry copy-ready templates and fill in over launch week. No fabricated proof.
- **`community/social-proof.md`** (internal): collection process, **sourcing guardrails**, and the raw-capture ledger that gates promotion onto the public wall.
- Wired into: docs nav (`mkdocs.yml`), landing footer (`overrides/home.html`, Understand column), community README index.

## Guardrails baked in (per IRO-271 / IRO-40 identity rules)

- Permitted sources only: project blog, pseudonymous Show HN, owner Reddit, neutral dev channels (HN, Reddit, Discussions, newsletters, directories).
- **No personal-identity scraping** of the owner's GitHub / LinkedIn / Instagram.
- Stars stay org-level (counts + public orgs, not individual stargazer handles).
- Public + verbatim quotes only, linked to source; opt-out honored; no vaporware.

## Verify

- `mkdocs build --strict` passes; nav renders "Social proof".
- Public copy contains no em/en-dashes (IRO-254 rule).
- Internal links resolve (quickstart, demo anchor, playbook, adoption-metrics).

## Cadence

Population is ongoing Growth ops: snapshots at 24h / 72h / 1 week, then weekly (mirrors playbook monitoring windows).