### PR TITLE
docs: Examples/use-cases gallery + homepage CTA polish (IRO-276)

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,73 +1,158 @@
 ---
-title: Examples
-description: Copy-pasteable, runnable agent recipes — three run end-to-end with no credentials.
+title: Examples & use cases
+description: A gallery of runnable IronClaw agent recipes — pick a card, copy the command, watch it run. Five need no credentials at all.
 ---
 
-# Examples
+# Examples & use cases
 
-Runnable recipes live in [`examples/`](https://github.com/IronSecCo/ironclaw/tree/main/examples)
-— each is a self-contained directory with a `README.md` (what it does) and a
-`setup.sh` (the exact `ironctl` commands). Three of them also ship a `run-mock.sh`
-that drives the **whole** inbound → agent → reply pipeline against the offline
-`mock` provider, so a fresh clone runs them with **no model key and no channel
-tokens**.
+Every recipe below is a self-contained directory in
+[`examples/`](https://github.com/IronSecCo/ironclaw/tree/main/examples) — a `README.md`
+that explains it and a script with the exact `ironctl` commands. Pick a card, copy the
+command, and watch it run. **Five of the nine need no credentials at all** — no model
+key, no channel token.
 
-## Run a recipe end-to-end, credential-free
+Not sure where to start? Run [**`hello-ironclaw`**](#run-it-now-no-credentials) — it
+proves the whole secured path end-to-end in one command.
 
-Bring up the [zero-credential demo control-plane](quickstart.md) once — it seeds an
-offline `mock-agent` whose `mock` provider makes no network call and needs no key —
-then run any recipe from the repo root:
+## Run it now, no credentials { #run-it-now-no-credentials }
 
-```sh
-docker compose -f docker-compose.demo.yml up -d --build   # seeds the offline mock-agent
-./examples/scheduled-report/run-mock.sh                   # cron-style self-scheduling summary
-./examples/webhook-responder/run-mock.sh                  # inbound webhook → agent reply
-./examples/slack-triage/run-mock.sh                       # classify/label every message
-docker compose -f docker-compose.demo.yml down            # tear down
-```
-
-With `mock` the replies are deterministic echoes that prove the pipeline; set a
-real model credential on the control-plane (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
-…) and the *same* recipes do real work with no wiring change.
-
-## The recipes
+Self-contained: one command builds the sandbox image, brings up the offline demo
+control-plane, runs the scenario, asserts the result, and tears everything down.
+Requires only Docker.
 
 <div class="grid cards" markdown>
 
--   :material-clock-outline: **[Scheduled report](https://github.com/IronSecCo/ironclaw/tree/main/examples/scheduled-report)** · *credential-free demo*
+-   :material-hand-wave: **[hello-ironclaw](https://github.com/IronSecCo/ironclaw/tree/main/examples/hello-ironclaw)** &nbsp;·&nbsp; *zero-cred · self-contained*
 
-    An agent that wakes itself on a schedule via the `schedule_task` tool,
+    ---
+
+    The canonical first "it works": sends a chat through the **real** secured path
+    (engage → per-session sandbox → encrypted queue → delivery) and **asserts** the
+    reply comes back. Doubles as the CI smoke test.
+
+    ```sh
+    examples/hello-ironclaw/run.sh
+    ```
+
+-   :material-shield-sword: **[red-team-escape](https://github.com/IronSecCo/ironclaw/tree/main/examples/red-team-escape)** &nbsp;·&nbsp; *zero-cred · self-contained*
+
+    ---
+
+    The other side of the coin: assumes a fully jailbroken agent and **tries to break
+    out** — network egress, host escape via the Docker socket, sibling breakout,
+    self-modification — then asserts every attack is contained.
+
+    ```sh
+    examples/red-team-escape/run.sh
+    ```
+
+</div>
+
+## The whole pipeline, still credential-free { #credential-free-mock }
+
+These drive the **entire** inbound → agent → reply pipeline against the offline `mock`
+provider. Bring the demo control-plane up once (it seeds an offline `mock-agent` that
+makes no network call and needs no key), then run any recipe from the repo root:
+
+```sh
+docker compose -f docker-compose.demo.yml up -d --build   # seeds the offline mock-agent
+# … run one or more recipes below …
+docker compose -f docker-compose.demo.yml down            # tear down
+```
+
+<div class="grid cards" markdown>
+
+-   :material-clock-outline: **[scheduled-report](https://github.com/IronSecCo/ironclaw/tree/main/examples/scheduled-report)** &nbsp;·&nbsp; *credential-free (mock)*
+
+    ---
+
+    An agent that wakes **itself** on a schedule via the `schedule_task` tool,
     summarizes, and posts the digest to a channel — no external cron.
 
--   :material-webhook: **[Webhook responder](https://github.com/IronSecCo/ironclaw/tree/main/examples/webhook-responder)** · *credential-free demo*
+    ```sh
+    ./examples/scheduled-report/run-mock.sh
+    ```
 
-    An inbound HTTP webhook routed through the real pipeline to an agent that
-    replies — poll the reply or push it back via a `webhook` destination.
+-   :material-webhook: **[webhook-responder](https://github.com/IronSecCo/ironclaw/tree/main/examples/webhook-responder)** &nbsp;·&nbsp; *credential-free (mock)*
 
--   :material-label-multiple: **[Slack triage](https://github.com/IronSecCo/ironclaw/tree/main/examples/slack-triage)** · *credential-free demo*
+    ---
 
-    A bot that classifies/labels **every** incoming Slack message
-    (`bug`/`question`/`feature`/`urgent`).
+    An inbound HTTP webhook routed through the real pipeline to an agent that replies —
+    poll the reply or push it back via a `webhook` destination.
 
--   :material-account: **[Personal assistant](https://github.com/IronSecCo/ironclaw/tree/main/examples/personal-assistant)**
+    ```sh
+    ./examples/webhook-responder/run-mock.sh
+    ```
+
+-   :material-label-multiple: **[slack-triage](https://github.com/IronSecCo/ironclaw/tree/main/examples/slack-triage)** &nbsp;·&nbsp; *credential-free (mock)*
+
+    ---
+
+    A bot that classifies and labels **every** incoming Slack message
+    (`bug` / `question` / `feature` / `urgent`).
+
+    ```sh
+    ./examples/slack-triage/run-mock.sh
+    ```
+
+</div>
+
+!!! note "With `mock`, the replies are deterministic echoes that prove the pipeline."
+    Set a real model credential on the control-plane (`ANTHROPIC_API_KEY`,
+    `OPENAI_API_KEY`, …) and the **same** recipes do real work with no wiring change.
+
+## Bring your own channel { #bring-your-own-channel }
+
+These configure a real channel wiring, so they need a
+[running control-plane](quickstart.md) and your own channel token. Each `setup.sh` is
+idempotent where the API allows; identifiers in the scripts (channel ids, handles) are
+placeholders — edit them for your setup.
+
+<div class="grid cards" markdown>
+
+-   :material-account: **[personal-assistant](https://github.com/IronSecCo/ironclaw/tree/main/examples/personal-assistant)** &nbsp;·&nbsp; *your channel*
+
+    ---
 
     A private 1:1 assistant on Telegram that replies to every message — plus a
     walk-through of the mandatory change-approval flow.
 
--   :material-message-text: **[Channel triage](https://github.com/IronSecCo/ironclaw/tree/main/examples/channel-triage)**
+    ```sh
+    cd examples/personal-assistant && ./setup.sh
+    ```
 
-    A quiet triage bot in a shared Slack channel: engages only on `@mention`, only
-    for known senders, and accumulates the context it stayed out of.
+-   :material-message-text: **[channel-triage](https://github.com/IronSecCo/ironclaw/tree/main/examples/channel-triage)** &nbsp;·&nbsp; *your channel*
 
--   :material-account-group: **[Multi-agent team](https://github.com/IronSecCo/ironclaw/tree/main/examples/multi-agent-team)**
+    ---
+
+    A quiet triage bot in a shared Slack channel: engages only on `@mention`, only for
+    known senders, and accumulates the context it stayed out of.
+
+    ```sh
+    cd examples/channel-triage && ./setup.sh
+    ```
+
+-   :material-account-group: **[multi-agent-team](https://github.com/IronSecCo/ironclaw/tree/main/examples/multi-agent-team)** &nbsp;·&nbsp; *your channel*
+
+    ---
 
     Two agents sharing one group chat (a frontline responder + a scribe), showing
     priorities, multi-agent wiring, and where `create_agent` sits.
 
--   :material-eye-outline: **[Keyword watcher](https://github.com/IronSecCo/ironclaw/tree/main/examples/keyword-watcher)**
+    ```sh
+    cd examples/multi-agent-team && ./setup.sh
+    ```
+
+-   :material-eye-outline: **[keyword-watcher](https://github.com/IronSecCo/ironclaw/tree/main/examples/keyword-watcher)** &nbsp;·&nbsp; *your channel*
+
+    ---
 
     A quiet ops agent in a Discord channel that engages only on a `pattern` match
-    (`deploy`/`incident`/`outage`), one session per incident thread.
+    (`deploy` / `incident` / `outage`), one session per incident thread.
+
+    ```sh
+    cd examples/keyword-watcher && ./setup.sh
+    ```
 
 </div>
 
@@ -75,4 +160,4 @@ real model credential on the control-plane (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY
 
 - [Quickstart](quickstart.md) — the zero-credential demo these recipes build on.
 - [Tutorials](tutorials/index.md) — guided walkthroughs from clone to a running agent.
-- [Channel adapters](channels.md) — the channels a recipe can ingest from and post to.
+- [Channel adapters](channels.md) — the 12 channels a recipe can ingest from and post to.

--- a/docs/stylesheets/brand.css
+++ b/docs/stylesheets/brand.css
@@ -123,6 +123,16 @@
   transform: translateY(-0.1rem);
 }
 
+/* Command blocks inside a card (e.g. the Examples gallery run commands) must
+   stay fully legible: a narrow 2-column card would otherwise clip the tail of a
+   long command behind a silent horizontal scroll, which reads as broken. Wrap
+   instead so the whole "exact run command" is always visible; the copy button
+   still copies the verbatim single line. */
+.md-typeset .grid.cards > ul > li .highlight code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 /* ---------------------------------------------------------------------------
    Inline code — subtle steel tint so it separates from prose (light only)
    --------------------------------------------------------------------------- */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,7 +118,7 @@ nav:
       - Run a 100% local model (Ollama): tutorials/local-model-ollama.md
       - Connect IronClaw to Slack: tutorials/connect-slack.md
       - Write a custom channel adapter: tutorials/custom-channel-adapter.md
-  - Examples: examples.md
+  - Examples & use cases: examples.md
   - Concepts:
       - IronClaw, Explained: ironclaw-explained.md
       - Architecture: architecture.md

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -30,12 +30,12 @@
       </p>
 
       <div class="iro-cta-row">
-        <a class="iro-btn iro-btn--primary" href="#demo">Run the demo
+        <a class="iro-btn iro-btn--primary" href="https://ironsecco.github.io/ironclaw/quickstart/">Run the quickstart demo
           <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
         </a>
-        <a class="iro-btn iro-btn--ghost" href="https://github.com/IronSecCo/ironclaw" rel="noopener">
-          <svg width="18" height="18" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
-          Star on GitHub ★
+        <a class="iro-btn iro-btn--ghost" href="https://ironsecco.github.io/ironclaw/examples/">
+          <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+          Browse the examples
         </a>
       </div>
 
@@ -118,7 +118,7 @@
         </article>
       </div>
       <p class="iro-aside">
-        <strong>Talk to it where you already work</strong> — 11 channel adapters
+        <strong>Talk to it where you already work</strong> — 12 channel adapters
         (<a href="https://ironsecco.github.io/ironclaw/channels/">Slack, Discord, Telegram, and more</a>).
       </p>
     </div>


### PR DESCRIPTION
## What & why (IRO-276)

OSS-success lever: reduce time-to-first-success. We ship 9 runnable `examples/` but a visitor had no visual way to pick one, and the homepage funnel could convert harder.

## Changes

**Examples page (`docs/examples.md`)** — rewritten as a responsive card gallery:
- One card per `examples/` entry, **all 9** (was 7; adds `hello-ironclaw` + `red-team-escape`).
- Each card: linked title (source on GitHub), credential tag, one-line what/why, and the **exact run command** in a copyable code block.
- Grouped by credential cost — *zero-cred self-contained* / *credential-free (mock)* / *bring-your-own-channel* — so the run-cost gradient is legible at a glance (information scent, progressive commitment).

**Homepage (`overrides/home.html`)**
- Hero CTAs sharpened per AC: **primary = quickstart**, **secondary = examples gallery**. (GitHub star stays in the Material header with live star count, the proof strip, and the final CTA — no regression.)
- Fixed channel-count drift **11 → 12** (per IRO-186; rest of the docs already said 12).

**Styling (`docs/stylesheets/brand.css`)**
- Small scoped rule so command blocks inside cards wrap instead of clipping the tail of a long command behind a silent horizontal scroll. Reuses the existing `.grid.cards` design-system block; copy button still copies the verbatim single line.

`nav` label updated to *Examples & use cases*.

## Design lenses
Information scent + Common Region (tiered grids), Recognition over Recall (copy the command, don't reconstruct it), Hick's Law (two hero CTAs, not three), Aesthetic-Usability (themed cards + hover lift, reduced-motion guarded).

## Verification (visual-truth gate)
- `mkdocs build --strict` → **exit 0**.
- Rendered `_site` locally and screenshotted **Examples** and **Home** at **1440x900** and **390x844**. Cards render in 2-col desktop / 1-col mobile; run commands wrap fully (no clip); hero CTAs and "12 channel adapters" confirmed in rendered output.

## Non-goals honored
No launch-gated marketing copy; no console app changes. Built in a fresh worktree off `origin/main`.