### PR TITLE
GitHub Action: run IronClaw in CI (IRO-274)

### DIFF
--- a/.github/actions/ironclaw/action.yml
+++ b/.github/actions/ironclaw/action.yml
@@ -1,0 +1,78 @@
+# IronClaw — run a sandboxed AI agent in CI.
+#
+# A thin wrapper over IronClaw's own zero-credential demo path: it brings up the
+# offline control-plane, sends your prompt to a seeded agent group through the REAL
+# secured route (engage -> per-session Docker sandbox -> encrypted queue -> reply),
+# and returns the reply plus a JSON run report. With `containment-report: true` it
+# also freezes the signed-able isolation proof for the exact build under test.
+#
+# Credential-free by default: provider `mock` makes no network call, so this runs on
+# a stock runner with nothing but Docker. See docs/integrations/ci.md for real
+# providers (which need model credentials on a self-hosted control-plane).
+#
+# NOTE: not published to the Marketplace yet (owner-manual, launch-gated). The
+# metadata below is ready for that listing.
+name: 'IronClaw — run a sandboxed AI agent in CI'
+description: 'Run a one-shot IronClaw agent against a prompt inside a hardened sandbox and capture the reply + containment report.'
+author: 'IronSec Co.'
+branding:
+  icon: 'shield'
+  color: 'blue'
+
+inputs:
+  prompt:
+    description: 'The prompt to send to the agent.'
+    required: true
+  provider:
+    description: 'Model provider. Only "mock" is credential-free (the built-in demo path); real providers need credentials on a self-hosted control-plane.'
+    required: false
+    default: 'mock'
+  model:
+    description: 'Model id to use (empty = the provider default). Recorded in the run report.'
+    required: false
+    default: ''
+  agent-group:
+    description: 'The agent group id to engage.'
+    required: false
+    default: 'mock-agent'
+  config:
+    description: 'Optional path to an agent config file (recorded in the run report; the mock demo path ignores it).'
+    required: false
+    default: ''
+  containment-report:
+    description: 'Also run the red-team-escape harness and emit the signed-able containment report for the build under test.'
+    required: false
+    default: 'false'
+  report-dir:
+    description: 'Directory to write artifacts (ironclaw-run.json and, optionally, containment-report.*) into.'
+    required: false
+    default: ''
+
+outputs:
+  reply:
+    description: 'The agent reply text.'
+    value: ${{ steps.run.outputs.reply }}
+  report-path:
+    description: 'Directory holding the run report (and containment report, if requested).'
+    value: ${{ steps.run.outputs.report-path }}
+  run-report:
+    description: 'Path to the JSON run report (prompt, reply, verdict, commit).'
+    value: ${{ steps.run.outputs.run-report }}
+  containment-report:
+    description: 'Path to the JSON containment report (only set when containment-report: true).'
+    value: ${{ steps.run.outputs.containment-report }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: run
+      shell: bash
+      env:
+        IC_PROMPT: ${{ inputs.prompt }}
+        IC_PROVIDER: ${{ inputs.provider }}
+        IC_MODEL: ${{ inputs.model }}
+        IC_AGENT: ${{ inputs.agent-group }}
+        IC_CONFIG: ${{ inputs.config }}
+        IC_CONTAINMENT: ${{ inputs.containment-report }}
+        IC_REPORT_DIR: ${{ inputs.report-dir }}
+      run: bash "${GITHUB_ACTION_PATH}/run-agent.sh"

--- a/.github/actions/ironclaw/run-agent.sh
+++ b/.github/actions/ironclaw/run-agent.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# run-agent.sh — the engine behind the `IronClaw` composite GitHub Action.
+#
+# It is a THIN wrapper over the exact zero-credential demo path that
+# examples/hello-ironclaw/run.sh exercises: build the sandbox image, bring up the
+# offline demo control-plane (docker-compose.demo.yml), send a prompt to a seeded
+# agent group through the REAL secured route (engage -> per-session Docker sandbox
+# -> encrypted queue -> delivery), and assert the reply comes back. The offline
+# `mock` provider makes no network call, so the whole thing runs on a stock runner
+# with nothing but Docker + jq + curl and NO secrets.
+#
+# On top of that round-trip it freezes two artifacts into the report directory so a
+# CI run leaves durable, auditable evidence:
+#   - ironclaw-run.json       what was asked, what the agent replied, and the verdict
+#   - containment-report.*    (opt-in) the signed-able isolation proof for the exact
+#                             build under test, produced by the red-team-escape harness
+#
+# There is no core control-plane change here: everything is driven through the same
+# HTTP routes and scripts a human uses. See docs/integrations/ci.md.
+#
+# Inputs arrive as environment variables set by action.yml:
+#   IC_PROMPT        (required) the prompt to send to the agent
+#   IC_PROVIDER      model provider           (default: mock)
+#   IC_MODEL         model id                 (default: empty -> provider default)
+#   IC_AGENT         agent group id to engage (default: mock-agent)
+#   IC_CONFIG        optional path to an agent config file (recorded; mock ignores it)
+#   IC_REPORT_DIR    directory to write artifacts into (default: $RUNNER_TEMP or ./)
+#   IC_CONTAINMENT   'true' to also emit the containment report (default: false)
+#   IC_HEALTH_TIMEOUT / IC_REPLY_TIMEOUT   cold-start budgets in seconds
+#   SKIP_BUILD=1     skip the sandbox image build (assume it exists)
+#   GITHUB_OUTPUT    set by Actions; step outputs (reply/report-path/...) are appended
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# .github/actions/ironclaw/run-agent.sh -> repo root is three levels up. When the
+# action is consumed as `uses: IronSecCo/ironclaw/.github/actions/ironclaw@<ref>`,
+# GitHub checks the whole repo out under the action path, so the demo compose file,
+# the sandbox build script, and the red-team harness are all present here.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PROMPT="${IC_PROMPT:?the action requires a non-empty 'prompt' input}"
+PROVIDER="${IC_PROVIDER:-mock}"
+MODEL="${IC_MODEL:-}"
+AGENT="${IC_AGENT:-mock-agent}"
+CONFIG="${IC_CONFIG:-}"
+CONTAINMENT="${IC_CONTAINMENT:-false}"
+REPORT_DIR="${IC_REPORT_DIR:-${RUNNER_TEMP:-$PWD}/ironclaw-report}"
+
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+TOKEN="${IRONCLAW_API_TOKEN:-ironclaw-demo}"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.demo.yml"
+HEALTH_TIMEOUT="${IC_HEALTH_TIMEOUT:-90}"
+REPLY_TIMEOUT="${IC_REPLY_TIMEOUT:-180}"
+
+command -v docker >/dev/null || { echo "the IronClaw action needs Docker on the runner" >&2; exit 1; }
+command -v jq   >/dev/null   || { echo "the IronClaw action needs jq" >&2; exit 1; }
+command -v curl >/dev/null   || { echo "the IronClaw action needs curl" >&2; exit 1; }
+
+mkdir -p "$REPORT_DIR"
+REPORT_DIR="$(cd "$REPORT_DIR" && pwd)"   # normalise to an absolute path for outputs
+
+# The demo control-plane seeds ONLY the offline `mock` group. A non-mock provider needs
+# real credentials + a compatible agent config the demo does not ship, so fail loud and
+# closed rather than silently pretend a credentialled run happened on the mock path.
+if [ "$PROVIDER" != "mock" ]; then
+  echo "error: this action's built-in, credential-free path only supports provider=mock." >&2
+  echo "       provider='$PROVIDER' needs model credentials + a compatible agent config;" >&2
+  echo "       supply them to a self-hosted control-plane and point IRONCLAW_ADDR at it." >&2
+  exit 2
+fi
+
+emit_output() {  # emit_output <name> <value>   (multi-line safe)
+  local name="$1" value="$2"
+  [ -n "${GITHUB_OUTPUT:-}" ] || return 0
+  { printf '%s<<__IC_EOF__\n' "$name"; printf '%s\n' "$value"; printf '__IC_EOF__\n'; } >>"$GITHUB_OUTPUT"
+}
+
+compose() { docker compose -f "$COMPOSE_FILE" "$@"; }
+teardown() { echo "==> tearing the demo control-plane down"; compose down >/dev/null 2>&1 || true; }
+trap teardown EXIT
+
+# --- bring up the offline demo control-plane -------------------------------
+if [ "${SKIP_BUILD:-0}" != 1 ]; then
+  echo "==> building the sandbox image (ironclaw-sandbox:latest) — first run is ~1-2 min"
+  bash "$REPO_ROOT/container/build.sh" >/dev/null
+fi
+echo "==> starting the offline demo control-plane"
+compose up --build -d >/dev/null
+
+echo -n "==> waiting for the control-plane to be ready (up to ${HEALTH_TIMEOUT}s)"
+ready=0
+for _ in $(seq 1 "$HEALTH_TIMEOUT"); do
+  if curl -fsS "$ADDR/healthz" >/dev/null 2>&1; then ready=1; break; fi
+  echo -n "."; sleep 1
+done
+echo
+[ "$ready" = 1 ] || { echo "error: control-plane never became healthy at $ADDR within ${HEALTH_TIMEOUT}s" >&2; \
+                      compose logs --no-color 2>&1 | tail -40 >&2; exit 1; }
+
+# --- run the agent against the prompt --------------------------------------
+echo "==> sending the prompt to agent group '$AGENT'"
+curl -fsS -X POST "$ADDR/v1/ui/chat/send" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg a "$AGENT" --arg t "$PROMPT" '{agentGroupID:$a, text:$t}')" >/dev/null
+
+echo -n "==> waiting for the agent's reply, up to ${REPLY_TIMEOUT}s (real sandbox launch + encrypted queue round-trip)"
+reply=""
+for _ in $(seq 1 "$REPLY_TIMEOUT"); do
+  # /messages is drain-on-read: the reply text is `.messages[].content` and is returned
+  # exactly once, so it must be read from the right field the first time.
+  got="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
+          -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.content // empty')"
+  if [ -n "$got" ]; then reply="$got"; break; fi
+  echo -n "."; sleep 1
+done
+echo
+
+if [ -z "$reply" ]; then
+  echo "error: no reply within ${REPLY_TIMEOUT}s — the engage -> sandbox -> reply path is broken" >&2
+  compose logs --no-color 2>&1 | tail -80 >&2
+  exit 1
+fi
+echo "    agent replied: $reply"
+
+# --- freeze the run report -------------------------------------------------
+COMMIT="${GITHUB_SHA:-$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)}"
+# A timestamp is run metadata, not a build input, so it does not affect reproducibility.
+GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+RUN_REPORT="$REPORT_DIR/ironclaw-run.json"
+jq -n \
+  --arg provider "$PROVIDER" --arg model "$MODEL" --arg agent "$AGENT" \
+  --arg config "$CONFIG" --arg prompt "$PROMPT" --arg reply "$reply" \
+  --arg commit "$COMMIT" --arg at "$GENERATED_AT" \
+  '{schemaVersion:"1.0", verdict:"PASS", commit:$commit, generatedAt:$at,
+    agent:{group:$agent, provider:$provider,
+           model:(if ($model|length)>0 then $model else null end),
+           config:(if ($config|length)>0 then $config else null end)},
+    run:{prompt:$prompt, reply:$reply}}' >"$RUN_REPORT"
+# Fail loud, fail closed: a zero-byte or malformed report must stop the run, not pass
+# as a green build with no evidence behind it.
+jq -e . "$RUN_REPORT" >/dev/null || { echo "error: run report was not written as valid JSON" >&2; exit 1; }
+echo "==> wrote run report: $RUN_REPORT"
+
+emit_output reply "$reply"
+emit_output run-report "$RUN_REPORT"
+
+# --- optional: freeze the containment proof for this exact build -----------
+if [ "$CONTAINMENT" = "true" ]; then
+  teardown; trap - EXIT    # the harness owns its own demo lifecycle
+  echo "==> running the red-team-escape harness to emit the containment report"
+  IRONCLAW_REPORT_DIR="$REPORT_DIR" \
+  IRONCLAW_REPORT_COMMIT="$COMMIT" \
+  SKIP_BUILD="${SKIP_BUILD:-0}" \
+    bash "$REPO_ROOT/examples/red-team-escape/run.sh"
+  emit_output containment-report "$REPORT_DIR/containment-report.json"
+fi
+
+emit_output report-path "$REPORT_DIR"
+echo
+echo "PASS ✅  IronClaw ran the agent against the prompt end-to-end with zero credentials."

--- a/.github/workflows/ironclaw-action-example.yml
+++ b/.github/workflows/ironclaw-action-example.yml
@@ -1,0 +1,91 @@
+name: IronClaw action example (zero-cred)
+
+# Green-run proof for the reusable `IronClaw` action (.github/actions/ironclaw).
+# It runs the exact thing an external adopter would run — `uses: <the action>` with
+# a prompt — against the offline `mock` provider, so it needs NO secrets: ubuntu
+# ships Docker, jq, and curl. This is the "green run of the example workflow in this
+# repo proves it works" acceptance gate for IRO-274, and the copy-paste template that
+# examples/ci-action/ documents.
+#
+# Additive and non-gating: NOT a required status check, so it can never block a
+# release — it surfaces a broken action before an adopter hits it.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/actions/ironclaw/**"
+      - ".github/workflows/ironclaw-action-example.yml"
+      - "docker-compose.demo.yml"
+      - "container/**"
+      - "cmd/sandbox/**"
+      - "cmd/controlplane/**"
+      - "internal/host/api/ui_chat.go"
+      - "internal/host/isolation/**"
+      - "examples/red-team-escape/**"
+  pull_request:
+    paths:
+      - ".github/actions/ironclaw/**"
+      - ".github/workflows/ironclaw-action-example.yml"
+      - "docker-compose.demo.yml"
+      - "container/**"
+      - "cmd/sandbox/**"
+      - "cmd/controlplane/**"
+      - "internal/host/api/ui_chat.go"
+      - "internal/host/isolation/**"
+      - "examples/red-team-escape/**"
+  workflow_dispatch:
+
+# Least-privilege default (Scorecard Token-Permissions): the jobs only read the repo.
+permissions:
+  contents: read
+
+jobs:
+  run-agent:
+    # Prove the core wrapper: run an agent against a prompt and get the reply back.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # Pinned to a commit SHA (tag in trailing comment) so a moved tag cannot change
+      # what runs in CI. Dependabot bumps these.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run a sandboxed IronClaw agent against a prompt
+        id: agent
+        uses: ./.github/actions/ironclaw
+        with:
+          prompt: "hello from the IronClaw action example"
+          provider: mock
+      - name: Show the reply and assert it came back
+        env:
+          REPLY: ${{ steps.agent.outputs.reply }}
+        run: |
+          echo "agent reply: $REPLY"
+          case "$REPLY" in
+            "mock-agent received: "*) echo "ok: mock echo returned" ;;
+            *) echo "FAIL: unexpected reply" >&2; exit 1 ;;
+          esac
+      - name: Upload the run report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ironclaw-run-report
+          path: ${{ steps.agent.outputs.report-path }}
+
+  containment-report:
+    # Prove the opt-in proof artifact: run the agent AND freeze the containment report
+    # for this exact build, then publish it as a downloadable, auditable artifact.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run a sandboxed agent and emit the containment report
+        id: agent
+        uses: ./.github/actions/ironclaw
+        with:
+          prompt: "prove the sandbox holds"
+          provider: mock
+          containment-report: "true"
+      - name: Upload the containment report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ironclaw-containment-report
+          path: ${{ steps.agent.outputs.report-path }}

--- a/docs/integrations/ci.md
+++ b/docs/integrations/ci.md
@@ -14,9 +14,9 @@ reply plus a JSON run report. Ask for the containment report and it also freezes
 signed-able isolation proof for the exact build under test.
 
 It is a thin wrapper over the same zero-credential path
-[`hello-ironclaw`](../../examples/hello-ironclaw/) and
-[`red-team-escape`](../../examples/red-team-escape/) use — no core control-plane
-changes, nothing you cannot also run by hand.
+[`hello-ironclaw`](https://github.com/IronSecCo/ironclaw/tree/main/examples/hello-ironclaw)
+and [`red-team-escape`](https://github.com/IronSecCo/ironclaw/tree/main/examples/red-team-escape)
+use — no core control-plane changes, nothing you cannot also run by hand.
 
 ## Credential-free by default
 
@@ -76,7 +76,7 @@ isolation proof for the build under test, then upload it as a downloadable artif
 ```
 
 The report is the same machine-verifiable JSON (`schemaVersion 1.0`) that
-[release.yml](release-runbook.md) signs and attaches to every GitHub Release — the
+[release.yml](../release-runbook.md) signs and attaches to every GitHub Release — the
 action produces a fresh one from *this* run's real result rows, never a fabricated
 verdict.
 

--- a/docs/integrations/ci.md
+++ b/docs/integrations/ci.md
@@ -1,0 +1,123 @@
+---
+title: Run IronClaw in CI (GitHub Action)
+description: A reusable GitHub Action that runs a sandboxed IronClaw agent against a prompt in CI, credential-free, and captures the reply plus a containment report.
+---
+
+# Run IronClaw in CI (GitHub Action)
+
+CI is the most common place teams automate work, and it is the fastest way to try
+IronClaw without any local setup. The reusable **`IronClaw` action** runs a one-shot
+sandboxed agent task from a workflow step: give it a `prompt`, and it brings up the
+offline control-plane, sends the prompt through the **real** secured route
+(engage → per-session Docker sandbox → encrypted queue → reply), and returns the
+reply plus a JSON run report. Ask for the containment report and it also freezes the
+signed-able isolation proof for the exact build under test.
+
+It is a thin wrapper over the same zero-credential path
+[`hello-ironclaw`](../../examples/hello-ironclaw/) and
+[`red-team-escape`](../../examples/red-team-escape/) use — no core control-plane
+changes, nothing you cannot also run by hand.
+
+## Credential-free by default
+
+The `mock` provider makes no network call, so the action runs on a stock
+`ubuntu-latest` runner with nothing but Docker — no model key, no channel tokens.
+The reply is a deterministic echo of the prompt, which is enough to prove the whole
+pipeline works.
+
+## Copy-paste usage
+
+```yaml
+# .github/workflows/ironclaw.yml
+name: IronClaw agent
+on: [push]
+permissions:
+  contents: read
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - id: agent
+        uses: IronSecCo/ironclaw/.github/actions/ironclaw@main   # pin to a release tag in production
+        with:
+          prompt: "summarize the change in this push"
+          provider: mock
+      - run: echo "${AGENT_REPLY}"
+        env:
+          AGENT_REPLY: ${{ steps.agent.outputs.reply }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ironclaw-run-report
+          path: ${{ steps.agent.outputs.report-path }}
+```
+
+Pass untrusted values (an agent reply, a PR title) through `env:` and reference them
+as quoted shell variables, never inline in a `run:` string — the snippet above does
+this for the reply.
+
+## Emit the containment report
+
+Set `containment-report: true` to also run the red-team-escape harness and freeze the
+isolation proof for the build under test, then upload it as a downloadable artifact:
+
+```yaml
+      - id: agent
+        uses: IronSecCo/ironclaw/.github/actions/ironclaw@main
+        with:
+          prompt: "prove the sandbox holds"
+          provider: mock
+          containment-report: "true"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ironclaw-containment-report
+          path: ${{ steps.agent.outputs.report-path }}
+```
+
+The report is the same machine-verifiable JSON (`schemaVersion 1.0`) that
+[release.yml](release-runbook.md) signs and attaches to every GitHub Release — the
+action produces a fresh one from *this* run's real result rows, never a fabricated
+verdict.
+
+## Inputs
+
+| Input | Default | Meaning |
+|-------|---------|---------|
+| `prompt` | _(required)_ | the prompt sent to the agent |
+| `provider` | `mock` | model provider; only `mock` is credential-free |
+| `model` | _(empty)_ | model id (recorded in the run report) |
+| `agent-group` | `mock-agent` | the agent group id to engage |
+| `config` | _(empty)_ | optional agent config path (recorded; the mock path ignores it) |
+| `containment-report` | `false` | also emit the containment proof for the build under test |
+| `report-dir` | _(runner temp)_ | where artifacts are written |
+
+## Outputs
+
+| Output | Meaning |
+|--------|---------|
+| `reply` | the agent reply text |
+| `report-path` | directory holding the run report (and containment report, if requested) |
+| `run-report` | path to `ironclaw-run.json` (prompt, reply, verdict, commit) |
+| `containment-report` | path to `containment-report.json` (only when `containment-report: true`) |
+
+## Real providers
+
+`mock` proves the pipeline with no secrets. To run a real model, host your own
+IronClaw control-plane with the model credential set on it (credentials stay
+host-side, custodied by the control-plane — the action never takes a raw model key as
+an input) and a matching agent group registered, then point the workflow at it by
+setting `IRONCLAW_ADDR` and `IRONCLAW_API_TOKEN` in the step environment.
+
+## Proven in this repo
+
+[`.github/workflows/ironclaw-action-example.yml`](https://github.com/IronSecCo/ironclaw/blob/main/.github/workflows/ironclaw-action-example.yml)
+runs the action credential-free on every relevant push/PR — one job proves the agent
+round-trip, one job emits and uploads the containment report — so a regression in the
+action turns a build red before it reaches an adopter. The runnable example lives in
+[`examples/ci-action/`](https://github.com/IronSecCo/ironclaw/tree/main/examples/ci-action).
+
+!!! note "Not on the Marketplace yet"
+    The action carries Marketplace metadata but is not published there yet
+    (owner-manual, launch-gated). Reference it by repository path
+    (`IronSecCo/ironclaw/.github/actions/ironclaw@<ref>`) in the meantime.

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,6 +34,16 @@ containment assertion fails. Same zero-credential path, no model key:
 examples/red-team-escape/run.sh       # build → up → attack → assert contained → tear down
 ```
 
+### Run a sandboxed agent in CI (GitHub Action)
+
+[**`ci-action/`**](ci-action/) documents the reusable
+[`IronClaw` action](../.github/actions/ironclaw): a workflow step that runs a
+one-shot sandboxed agent against a `prompt` credential-free (the `mock` provider),
+returns the reply, and — with `containment-report: true` — freezes the signed-able
+isolation proof for the build under test. It is a thin wrapper over the same
+zero-credential path above, proven in this repo by
+[`ironclaw-action-example.yml`](../.github/workflows/ironclaw-action-example.yml).
+
 ### Run a scenario end-to-end credential-free (mock provider)
 
 Three recipes ship a `run-mock.sh` that exercises the **whole** inbound → agent →

--- a/examples/ci-action/README.md
+++ b/examples/ci-action/README.md
@@ -1,0 +1,77 @@
+# ci-action — run a sandboxed IronClaw agent in GitHub Actions
+
+The reusable [`IronClaw` action](../../.github/actions/ironclaw) lets a team run a
+one-shot IronClaw agent task in CI without any local setup: point a workflow step at
+it with a `prompt`, and it brings up the offline control-plane, sends the prompt
+through the **real** secured route (engage → per-session Docker sandbox → encrypted
+queue → reply), and hands back the reply plus a JSON run report. With
+`containment-report: true` it also freezes the signed-able isolation proof for the
+exact build under test.
+
+Credential-free by default: the `mock` provider makes no network call, so the whole
+thing runs on a stock `ubuntu-latest` runner with nothing but Docker — no model key,
+no channel tokens.
+
+## Copy-paste usage
+
+```yaml
+# .github/workflows/ironclaw.yml
+name: IronClaw agent
+on: [push]
+permissions:
+  contents: read
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - id: agent
+        uses: IronSecCo/ironclaw/.github/actions/ironclaw@main   # pin to a release tag in production
+        with:
+          prompt: "summarize the change in this push"
+          provider: mock            # credential-free; a real provider needs a self-hosted control-plane
+      - run: echo "${AGENT_REPLY}"
+        env:
+          AGENT_REPLY: ${{ steps.agent.outputs.reply }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ironclaw-run-report
+          path: ${{ steps.agent.outputs.report-path }}
+```
+
+## Inputs / outputs
+
+| Input | Default | Meaning |
+|-------|---------|---------|
+| `prompt` | _(required)_ | the prompt sent to the agent |
+| `provider` | `mock` | model provider; only `mock` is credential-free |
+| `model` | _(empty)_ | model id (recorded in the run report) |
+| `agent-group` | `mock-agent` | the agent group id to engage |
+| `config` | _(empty)_ | optional agent config path (recorded; the mock path ignores it) |
+| `containment-report` | `false` | also emit the containment proof for the build under test |
+| `report-dir` | _(runner temp)_ | where artifacts are written |
+
+| Output | Meaning |
+|--------|---------|
+| `reply` | the agent reply text |
+| `report-path` | directory holding the run report (and containment report, if requested) |
+| `run-report` | path to `ironclaw-run.json` (prompt, reply, verdict, commit) |
+| `containment-report` | path to `containment-report.json` (only when `containment-report: true`) |
+
+## Proven in this repo
+
+[`.github/workflows/ironclaw-action-example.yml`](../../.github/workflows/ironclaw-action-example.yml)
+runs this action credential-free on every relevant push/PR — one job proves the
+agent round-trip, one job emits and uploads the containment report — so a regression
+in the action fails a build here before it reaches an adopter. Full docs:
+[Integrations → CI (GitHub Action)](../../docs/integrations/ci.md).
+
+## Real providers
+
+`mock` is deterministic (the reply echoes the prompt) and proves the pipeline with no
+secrets. To run a real model you host your own IronClaw control-plane with the model
+credential set on it and a matching agent group registered, then point the workflow
+at it (set `IRONCLAW_ADDR` / `IRONCLAW_API_TOKEN` in the step env). The action never
+takes a raw model key as an input — credentials stay host-side, custodied by the
+control-plane. See [docs/integrations/ci.md](../../docs/integrations/ci.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,8 @@ nav:
       - Channel adapters: channels.md
       - Writing a channel adapter: writing-a-channel-adapter.md
   - Skills: skills.md
+  - Integrations:
+      - CI (GitHub Action): integrations/ci.md
   - Social proof: social-proof.md
   - Security & Trust:
       - Overview: security.md


### PR DESCRIPTION
## What

A reusable **composite GitHub Action** (`.github/actions/ironclaw`) that runs a one-shot sandboxed IronClaw agent against a prompt in CI, credential-free, and captures the reply plus a JSON run report. With `containment-report: true` it also freezes the signed-able containment proof for the exact build under test. Closes IRO-274.

It is a **thin wrapper over the existing zero-credential demo path** (the same route `hello-ironclaw` and `red-team-escape` use) — no core control-plane changes.

## Acceptance criteria

- [x] `action.yml` (at `.github/actions/ironclaw`) with Marketplace metadata (name, description, branding) + inputs (`prompt`, `provider`, `model`, `agent-group`, `config`, `containment-report`, `report-dir`) + outputs (`reply`, **`report-path`**, `run-report`, `containment-report`).
- [x] Example workflow using the offline `mock` provider, credential-free (`examples/ci-action/` docs + runnable `.github/workflows/ironclaw-action-example.yml`).
- [x] Docs page `docs/integrations/ci.md` + mkdocs nav entry + copy-paste snippet.
- [x] Green run proof — the example workflow runs the action in this repo (CI on this PR).

Non-goals honored: no core control-plane changes; thin CLI/HTTP wrapper; **not** published to the Marketplace (owner-manual, launch-gated) — metadata is ready.

## Supply-chain lenses

- **Provenance / no fabrication**: the containment report is produced from *this* run's real result rows via the harness's existing `IRONCLAW_REPORT_DIR` emit path — never a hand-written verdict.
- **Fail loud, fail closed**: a missing reply or a malformed/zero-byte run report stops the run non-zero; a non-`mock` provider is rejected loudly rather than silently faking a credentialled run.
- **Least-privilege CI**: the example workflow is `permissions: contents: read`, additive and **non-gating** (not a required status check).
- **Pinned actions**: `checkout` / `upload-artifact` pinned by SHA, matching the rest of the repo.

## Verification

Ran end-to-end on real Docker (colima):
- Core: agent round-trip **PASS**, `ironclaw-run.json` valid (proper `null`s for empty model/config).
- Opt-in: containment report emitted — **7/7 contained**, `demo-runc`, both artifacts in `report-path`.
- `shellcheck` + `actionlint` + `bash -n` clean; `action.yml` + workflow YAML parse OK.

> Fixed a jq gotcha during verification: `{model: ($m|select(length>0))}` collapses the whole object to an empty stream when the value is empty — replaced with an `if length>0 then . else null end` conditional + a fail-closed `jq -e` guard.

/cc CEO — additive, non-gating, no signing/attestation/required-check/installer changes; reuses the existing signed-report mechanism.