### PR TITLE
fix(examples): poll .content not .text in run-mock recipes (IRO-279)

### DIFF
--- a/examples/scheduled-report/run-mock.sh
+++ b/examples/scheduled-report/run-mock.sh
@@ -24,7 +24,7 @@ send() { # send <text>
 wait_reply() { # poll until the agent replies (or give up after ~30s)
   for _ in $(seq 1 30); do
     out="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
-      -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.text // empty')"
+      -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.content // empty')"
     if [ -n "$out" ]; then printf '   %s\n' "$out"; return 0; fi
     sleep 1
   done

--- a/examples/slack-triage/run-mock.sh
+++ b/examples/slack-triage/run-mock.sh
@@ -31,7 +31,7 @@ send() {
 wait_reply() {
   for _ in $(seq 1 30); do
     out="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
-      -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.text // empty')"
+      -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.content // empty')"
     if [ -n "$out" ]; then printf '   -> %s\n' "$out"; return 0; fi
     sleep 1
   done

--- a/examples/webhook-responder/run-mock.sh
+++ b/examples/webhook-responder/run-mock.sh
@@ -27,7 +27,7 @@ curl -fsS -X POST "$ADDR/v1/ui/chat/send" \
 echo "==> Agent reply (polled back; a real model would triage the event):"
 for _ in $(seq 1 30); do
   out="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
-    -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.text // empty')"
+    -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.content // empty')"
   if [ -n "$out" ]; then printf '   %s\n' "$out"; exit 0; fi
   sleep 1
 done


### PR DESCRIPTION
## Problem
All three credential-free `run-mock.sh` recipes polled the webchat reply under `.messages[].text`, but that is the `/chat/send` **request** field. The reply text is returned under `.messages[].content`. Because `/messages` is drain-on-read, polling the wrong key silently drained the buffer and every recipe printed `(no reply within 30s ...)` even though the round-trip worked — the zero-credential demos read as broken on a fresh clone.

Affected:
- `examples/scheduled-report/run-mock.sh:27`
- `examples/slack-triage/run-mock.sh:34`
- `examples/webhook-responder/run-mock.sh:30`

## Fix
`.messages[]?.text` -> `.messages[]?.content` in the three `wait_reply` helpers. One line each. Mirrors the fix already documented in `examples/hello-ironclaw/run.sh` (IRO-247). Send-side `text` request field untouched.

## Verify
- `bash -n` clean on all three scripts.
- `grep` confirms no `.messages[].text` polls remain in `examples/`.
- Field matches the hello-ironclaw reference (`.messages[]?.content // empty`).
- IRO-275 QA confirmed patching `.text`->`.content` makes all three recipes pass end-to-end.

Client-only; no trust-model surface (signing/attestation/checks/installers untouched).

Found by: IRO-275 fresh-Docker dogfood. Note: scheduled-report also has a separate server-side `schedule_task` UNIQUE 500 tracked in IRO-278 (Forge) — out of scope here.