### PR TITLE
fix(host): single authoritative even-seq allocator for inbound (IRO-278)

### DIFF
--- a/internal/host/delivery/a2a.go
+++ b/internal/host/delivery/a2a.go
@@ -101,8 +101,10 @@ func (d *Delivery) writeA2AInbound(target, from registry.Session, msg contract.M
 
 	src := string(from.ID)
 	in := contract.MessageIn{
-		ID:              d.nextA2AID(target.ID),
-		Seq:             d.nextEvenSeq(),
+		ID: d.nextA2AID(target.ID),
+		// Seq==0: the inbound writer allocates the next EVEN seq atomically against the
+		// persisted target queue (IRO-278); do not mint seqs here.
+		Seq:             0,
 		Kind:            contract.KindChat,
 		Timestamp:       time.Now().UTC(),
 		Status:          contract.StatusQueued,

--- a/internal/host/delivery/delivery.go
+++ b/internal/host/delivery/delivery.go
@@ -73,9 +73,6 @@ type Delivery struct {
 
 	mu        sync.Mutex
 	delivered map[contract.MessageID]struct{}
-	// seqCtr generates EVEN host seq numbers for scheduled inbound messages,
-	// matching the frozen host-parity rule. Process-local and monotonic.
-	seqCtr int64
 	// scheduleCtr disambiguates generated scheduled-message IDs within a process.
 	scheduleCtr int64
 	// a2aCtr disambiguates generated agent-to-agent inbound message IDs.
@@ -356,8 +353,11 @@ func (d *Delivery) handleScheduleTask(sess registry.Session, msg contract.Messag
 	defer writer.Close()
 
 	in := contract.MessageIn{
-		ID:           d.nextScheduledID(sess.ID),
-		Seq:          d.nextEvenSeq(),
+		ID: d.nextScheduledID(sess.ID),
+		// Seq==0: the inbound writer allocates the next EVEN seq atomically against the
+		// persisted queue (IRO-278). Delivery must not mint seqs itself — it shares the
+		// messages_in table with the router and the sweep re-enqueuer.
+		Seq:          0,
 		Kind:         contract.KindTask,
 		Timestamp:    time.Now().UTC(),
 		Status:       contract.StatusScheduled,
@@ -441,14 +441,6 @@ func (d *Delivery) handleSkillInstall(sess registry.Session, msg contract.Messag
 	// the background like every other privileged action). The install is NOT applied here.
 	go func() { _, _ = d.gw.Submit(context.Background(), req) }()
 	return nil
-}
-
-// nextEvenSeq returns the next EVEN host seq (frozen host-parity rule).
-func (d *Delivery) nextEvenSeq() int64 {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	d.seqCtr += 2
-	return d.seqCtr
 }
 
 // nextScheduledID returns a process-unique id for a scheduled inbound message.

--- a/internal/host/queue/factory_test.go
+++ b/internal/host/queue/factory_test.go
@@ -166,3 +166,59 @@ func TestFactoryPaths(t *testing.T) {
 		}
 	}
 }
+
+// TestHostInboundSeqAllocationNoCollision reproduces the IRO-278 root cause: two
+// independent host inbound writer handles for the same session (mirroring the
+// router and the delivery/sweep re-enqueuer) each write with Seq==0. The writer
+// must allocate distinct EVEN seqs from the persisted MAX(seq), so neither
+// collides on the schema's UNIQUE(seq) — the bug that broke recurring
+// schedule_task and intermittently 500'd /chat/send.
+func TestHostInboundSeqAllocationNoCollision(t *testing.T) {
+	f := NewFactory(t.TempDir())
+	const sid = "sess-seq"
+	k := testKey(0x44)
+	if err := f.Provision(sid, k); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+
+	// Two separate writer handles, interleaved — the pre-fix code had each mint its
+	// own seq (router atomic vs delivery SELECT MAX+2) and collide at seq=2.
+	for i, id := range []string{"a", "b", "c", "d"} {
+		w, err := f.OpenHostInbound(sid, k)
+		if err != nil {
+			t.Fatalf("OpenHostInbound %d: %v", i, err)
+		}
+		if err := w.WriteMessageIn(contract.MessageIn{ID: contract.MessageID(id), Seq: 0, Content: id}); err != nil {
+			t.Fatalf("WriteMessageIn %q: %v", id, err)
+		}
+		w.Close()
+	}
+
+	sin, err := f.OpenSandboxInbound(sid, k)
+	if err != nil {
+		t.Fatalf("OpenSandboxInbound: %v", err)
+	}
+	defer sin.Close()
+	rows, err := sin.Query("SELECT seq FROM messages_in ORDER BY seq")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	var seqs []int64
+	for rows.Next() {
+		var s int64
+		if err := rows.Scan(&s); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		seqs = append(seqs, s)
+	}
+	want := []int64{2, 4, 6, 8}
+	if len(seqs) != len(want) {
+		t.Fatalf("got %d rows, want %d: %v", len(seqs), len(want), seqs)
+	}
+	for i, s := range seqs {
+		if s != want[i] {
+			t.Fatalf("seqs = %v, want %v (distinct even, no collision)", seqs, want)
+		}
+	}
+}

--- a/internal/host/queue/mem.go
+++ b/internal/host/queue/mem.go
@@ -67,13 +67,26 @@ var (
 )
 
 // WriteMessageIn inserts a message. The host is the inbound writer, so the seq
-// MUST be even; an odd seq is rejected to preserve seq parity.
+// MUST be even. Seq allocation is authoritative here to mirror the real writer
+// (queue.go): a caller passing Seq==0 gets the next EVEN seq (MAX+2, empty→2)
+// assigned under the store lock, so independent host writers never collide on the
+// unique-seq invariant (IRO-278). A non-zero odd seq is still rejected to preserve
+// host/sandbox seq parity.
 func (m *MemInbound) WriteMessageIn(msg contract.MessageIn) error {
-	if msg.Seq%2 != 0 {
+	if msg.Seq != 0 && msg.Seq%2 != 0 {
 		return fmt.Errorf("host/queue: MemInbound.WriteMessageIn requires an EVEN seq (host parity), got %d", msg.Seq)
 	}
 	m.store.mu.Lock()
 	defer m.store.mu.Unlock()
+	if msg.Seq == 0 {
+		var maxSeq int64
+		for _, e := range m.store.messagesIn {
+			if e.Seq > maxSeq {
+				maxSeq = e.Seq
+			}
+		}
+		msg.Seq = maxSeq + 2
+	}
 	for _, existing := range m.store.messagesIn {
 		if existing.ID == msg.ID {
 			return fmt.Errorf("host/queue: duplicate message_in id %q", msg.ID)

--- a/internal/host/queue/mem_test.go
+++ b/internal/host/queue/mem_test.go
@@ -10,16 +10,31 @@ import (
 func TestMemInboundSeqParity(t *testing.T) {
 	store := NewMemStore()
 	in := NewMemInbound(store)
-	// Even seq accepted (host parity).
-	if err := in.WriteMessageIn(contract.MessageIn{ID: "a", Seq: 0, Content: "hi"}); err != nil {
-		t.Fatalf("even seq should be accepted: %v", err)
-	}
+	// Explicit even seq accepted (host parity).
 	if err := in.WriteMessageIn(contract.MessageIn{ID: "b", Seq: 2}); err != nil {
 		t.Fatal(err)
 	}
 	// Odd seq rejected.
 	if err := in.WriteMessageIn(contract.MessageIn{ID: "c", Seq: 1}); err == nil {
 		t.Fatal("odd seq should be rejected on inbound (host writes even)")
+	}
+}
+
+// TestMemInboundSeqAllocation asserts the writer is the authoritative even-seq
+// allocator: Seq==0 callers each get a distinct even seq (MAX+2), so two
+// independent host writers never collide (the IRO-278 root cause).
+func TestMemInboundSeqAllocation(t *testing.T) {
+	store := NewMemStore()
+	in := NewMemInbound(store)
+	if err := in.WriteMessageIn(contract.MessageIn{ID: "a", Seq: 0}); err != nil {
+		t.Fatal(err)
+	}
+	if err := in.WriteMessageIn(contract.MessageIn{ID: "b", Seq: 0}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := in.PendingMessages(true)
+	if len(got) != 2 || got[0].Seq != 2 || got[1].Seq != 4 {
+		t.Fatalf("auto-allocated seqs should be 2 then 4, got %+v", got)
 	}
 }
 
@@ -39,15 +54,17 @@ func TestMemOutboundSeqParity(t *testing.T) {
 func TestMemInboundRoundTrip(t *testing.T) {
 	store := NewMemStore()
 	in := NewMemInbound(store)
-	in.WriteMessageIn(contract.MessageIn{ID: "m2", Seq: 2, Content: "second"})
-	in.WriteMessageIn(contract.MessageIn{ID: "m0", Seq: 0, Content: "first"})
+	// Explicit seqs, written out of order: the reader must order by seq, not by
+	// insertion order.
+	in.WriteMessageIn(contract.MessageIn{ID: "m4", Seq: 4, Content: "second"})
+	in.WriteMessageIn(contract.MessageIn{ID: "m2", Seq: 2, Content: "first"})
 
 	// Reader view (same shared store) sees both, ordered by seq.
 	got, err := in.PendingMessages(true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 2 || got[0].ID != "m0" || got[1].ID != "m2" {
+	if len(got) != 2 || got[0].ID != "m2" || got[1].ID != "m4" {
 		t.Fatalf("round-trip order wrong: %+v", got)
 	}
 }
@@ -55,8 +72,8 @@ func TestMemInboundRoundTrip(t *testing.T) {
 func TestMemInboundOnWakeGating(t *testing.T) {
 	store := NewMemStore()
 	in := NewMemInbound(store)
-	in.WriteMessageIn(contract.MessageIn{ID: "normal", Seq: 0})
-	in.WriteMessageIn(contract.MessageIn{ID: "wake", Seq: 2, OnWake: true})
+	in.WriteMessageIn(contract.MessageIn{ID: "normal", Seq: 2})
+	in.WriteMessageIn(contract.MessageIn{ID: "wake", Seq: 4, OnWake: true})
 
 	// Non-first poll hides on_wake messages.
 	got, _ := in.PendingMessages(false)

--- a/internal/host/queue/queue.go
+++ b/internal/host/queue/queue.go
@@ -44,18 +44,38 @@ func OpenInbound(path string, k contract.SessionKey) (contract.InboundWriter, er
 
 // WriteMessageIn inserts a row into messages_in. Times are stored RFC3339Nano in
 // UTC; pointer fields map to SQL NULL when nil.
+//
+// Seq allocation is authoritative HERE, not in the caller. Host-side inbound
+// writers (router, delivery, sweep) pass Seq==0 and this writer assigns the next
+// EVEN seq inside the same INSERT statement, computed from the persisted MAX(seq).
+// Because SQLite serializes writers (busy_timeout blocks a concurrent connection
+// until the first commits), the SELECT MAX(seq)+2 and the INSERT are one atomic
+// step — so two independent host writers to the same session queue can never mint
+// the same seq and collide on UNIQUE(seq) (IRO-278). A non-zero Seq is honored
+// verbatim (explicit seqs in tests / fixtures) but must not be minted by more than
+// one uncoordinated writer.
 func (h *hostInbound) WriteMessageIn(m contract.MessageIn) error {
-	_, err := h.db.Exec(`
-        INSERT INTO messages_in
-            (id, seq, kind, timestamp, status, process_after, recurrence, series_id,
-             tries, trigger, platform_id, channel_type, thread_id, content,
-             source_session_id, on_wake)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
-		string(m.ID), m.Seq, string(m.Kind), tsString(m.Timestamp), m.Status,
+	seqPlaceholder := "?"
+	args := []any{string(m.ID)}
+	if m.Seq == 0 {
+		// Next even seq, atomic within this write statement.
+		seqPlaceholder = "COALESCE((SELECT MAX(seq) FROM messages_in), 0) + 2"
+	} else {
+		args = append(args, m.Seq)
+	}
+	args = append(args,
+		string(m.Kind), tsString(m.Timestamp), m.Status,
 		tsPtr(m.ProcessAfter), strPtr(m.Recurrence), strPtr(m.SeriesID),
 		m.Tries, m.Trigger, strPtr(m.PlatformID), strPtr(m.ChannelType),
 		strPtr(m.ThreadID), m.Content, strPtr(m.SourceSessionID), boolInt(m.OnWake),
 	)
+	query := fmt.Sprintf(`
+        INSERT INTO messages_in
+            (id, seq, kind, timestamp, status, process_after, recurrence, series_id,
+             tries, trigger, platform_id, channel_type, thread_id, content,
+             source_session_id, on_wake)
+        VALUES (?,%s,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, seqPlaceholder)
+	_, err := h.db.Exec(query, args...)
 	return err
 }
 

--- a/internal/host/router/router.go
+++ b/internal/host/router/router.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/IronSecCo/ironclaw/internal/contract"
@@ -55,10 +54,6 @@ type Router struct {
 	reg       registry.Registry
 	newWriter InboundWriterFactory
 	waker     Waker
-	// seq generates EVEN host seq numbers (the frozen host-parity rule). It is
-	// process-local and monotonic across sessions; the in-memory queue enforces
-	// per-session uniqueness.
-	seq atomic.Int64
 }
 
 // New constructs a Router over the given registry, inbound-writer factory, and
@@ -67,9 +62,6 @@ type Router struct {
 func New(reg registry.Registry, newWriter InboundWriterFactory, waker Waker) *Router {
 	return &Router{reg: reg, newWriter: newWriter, waker: waker}
 }
-
-// nextSeq returns the next EVEN host sequence number.
-func (r *Router) nextSeq() int64 { return r.seq.Add(2) }
 
 // randSuffix returns a short random hex suffix for message IDs.
 func randSuffix() string {
@@ -256,8 +248,11 @@ func (r *Router) enqueue(ev types.InboundEvent, mg registry.MessagingGroup, w re
 	ct := ev.ChannelType
 	pid := ev.PlatformID
 	msg := contract.MessageIn{
-		ID:          contract.MessageID(fmt.Sprintf("in_%d_%s", time.Now().UnixNano(), randSuffix())),
-		Seq:         r.nextSeq(),
+		ID: contract.MessageID(fmt.Sprintf("in_%d_%s", time.Now().UnixNano(), randSuffix())),
+		// Seq==0: the inbound writer allocates the next EVEN seq atomically within the
+		// INSERT, coordinated with the persisted queue (IRO-278). The router must not
+		// mint seqs itself — it shares the messages_in table with delivery and sweep.
+		Seq:         0,
 		Kind:        contract.KindChat,
 		Timestamp:   time.Now().UTC(),
 		Status:      "queued",

--- a/internal/host/sweep/adapters.go
+++ b/internal/host/sweep/adapters.go
@@ -195,11 +195,6 @@ func (e *InboundEnqueue) Enqueue(sessionID contract.SessionID, prompt string, ru
 		return fmt.Errorf("host/sweep: enqueue %s: no session key (not provisioned)", sessionID)
 	}
 
-	seq, err := e.nextEvenSeq(sessionID, key)
-	if err != nil {
-		return fmt.Errorf("host/sweep: enqueue %s: next seq: %w", sessionID, err)
-	}
-
 	w, err := e.factory.OpenHostInbound(string(sessionID), key)
 	if err != nil {
 		return fmt.Errorf("host/sweep: enqueue %s: open inbound: %w", sessionID, err)
@@ -207,8 +202,12 @@ func (e *InboundEnqueue) Enqueue(sessionID contract.SessionID, prompt string, ru
 	defer w.Close()
 
 	in := contract.MessageIn{
-		ID:           e.nextID(sessionID),
-		Seq:          seq,
+		ID: e.nextID(sessionID),
+		// Seq==0: the inbound writer allocates the next EVEN seq atomically against the
+		// persisted queue (IRO-278). The old SELECT MAX(seq)+2 here was a non-atomic
+		// read-modify-write that raced the router/delivery writers and broke recurring
+		// schedule_task with "UNIQUE constraint failed: messages_in.seq".
+		Seq:          0,
 		Kind:         contract.KindTask,
 		Timestamp:    time.Now().UTC(),
 		Status:       contract.StatusScheduled,
@@ -227,30 +226,6 @@ func (e *InboundEnqueue) Enqueue(sessionID contract.SessionID, prompt string, ru
 	e.enqueued[dedupKey] = struct{}{}
 	e.mu.Unlock()
 	return nil
-}
-
-// nextEvenSeq returns the next EVEN inbound seq for the session (host parity),
-// strictly greater than the current MAX(seq). Inbound is host-written only, so all
-// existing seqs are even; an empty table starts at 2. Reading the current max
-// keeps the assigned seq unique against the schema's UNIQUE(seq) constraint.
-func (e *InboundEnqueue) nextEvenSeq(id contract.SessionID, key contract.SessionKey) (int64, error) {
-	db, err := e.factory.OpenSandboxInbound(string(id), key)
-	if err != nil {
-		return 0, err
-	}
-	defer db.Close()
-	var maxSeq sql.NullInt64
-	if err := db.QueryRow(`SELECT MAX(seq) FROM messages_in`).Scan(&maxSeq); err != nil {
-		return 0, err
-	}
-	if !maxSeq.Valid {
-		return 2, nil
-	}
-	next := maxSeq.Int64 + 2
-	if next%2 != 0 {
-		next++
-	}
-	return next, nil
 }
 
 // nextID returns a process-unique id for an enqueued scheduled message.

--- a/tools/icdemo/main.go
+++ b/tools/icdemo/main.go
@@ -54,12 +54,13 @@ func seed(dir, task string) {
 	in, err := hq.OpenInbound(dir+"/inbound.db", key)
 	must(err)
 	defer in.Close()
-	// Unique id + even seq per call so re-seeding the same session (to re-test a
-	// running sandbox) never collides on the messages_in primary key / seq parity.
+	// Unique id per call so re-seeding the same session (to re-test a running
+	// sandbox) never collides on the messages_in primary key. Seq==0 lets the inbound
+	// writer allocate the next EVEN seq atomically against the persisted queue.
 	n := time.Now().UnixNano()
 	msg := contract.MessageIn{
 		ID:        contract.MessageID(fmt.Sprintf("msg-%d", n)),
-		Seq:       n &^ 1, // even: host parity
+		Seq:       0,
 		Kind:      contract.KindChat,
 		Timestamp: time.Now().UTC(),
 		Status:    contract.StatusQueued, // a status the sandbox treats as pending


### PR DESCRIPTION
## Problem (IRO-278)
Three uncoordinated host-side writers minted EVEN `messages_in.seq` into the shared per-session inbound queue, colliding on the schema's `UNIQUE(seq)`:
- `router` — in-memory `atomic.Int64` seeded at 0 (`nextSeq`), never from persisted MAX;
- `delivery` — in-memory `seqCtr` (`nextEvenSeq`);
- `sweep` — non-atomic `SELECT MAX(seq)+2` (`nextEvenSeq`).

Impact:
1. **Recurring `schedule_task` never fired** — delivery poller failed every 2s: `UNIQUE constraint failed: messages_in.seq`.
2. **Intermittent HTTP 500 on `/v1/ui/chat/send`** — same collision on the primary chat path.

## Fix
Seq allocation moves into the inbound writer — the single place that touches the persisted table. Callers pass `Seq==0`; the writer assigns the next EVEN seq via `COALESCE((SELECT MAX(seq) FROM messages_in),0)+2` **inside the same INSERT statement**. SQLite serializes writers (`busy_timeout` blocks a concurrent connection until the first commits), so the read-and-insert is one atomic step and two independent writers can never mint the same seq.

- Removed `router.nextSeq`/`seq`, `delivery.nextEvenSeq`/`seqCtr`, `sweep.nextEvenSeq`.
- A non-zero `Seq` is still honored verbatim (explicit fixtures/tests); the mem writer mirrors the allocation and keeps parity (odd inbound seq rejected).
- `icdemo` seeds with `Seq==0`.

## Verification
- `TestHostInboundSeqAllocationNoCollision` — drives two interleaved host writer handles over one real encrypted session, asserts distinct even seqs `[2,4,6,8]` (the exact pre-fix collision at seq=2).
- `TestMemInboundSeqAllocation` + updated mem parity/round-trip/on-wake tests.
- `CGO_ENABLED=1 go build ./...` green; `go test ./internal/host/... ./internal/smoke/...` = 752 passed.

## Security review bar
**Trust boundary: unchanged.** The sandbox still holds only `InboundReader`; seq allocation runs host-side inside the host's RW handle. No boundary widened, no contract change (`InboundWriter` signature untouched).

Found by IRO-275 fresh-Docker dogfood. Verification owner: QA (IRO-275).