### PR TITLE
ci(examples): credential-free run-mock smoke matrix (IRO-284)

### DIFF
--- a/.github/workflows/example-smoke.yml
+++ b/.github/workflows/example-smoke.yml
@@ -19,8 +19,7 @@ on:
   push:
     branches: [main]
     paths:
-      - "examples/hello-ironclaw/**"
-      - "examples/red-team-escape/**"
+      - "examples/**"
       - "docker-compose.demo.yml"
       - "container/**"
       - "cmd/sandbox/**"
@@ -30,8 +29,7 @@ on:
       - ".github/workflows/example-smoke.yml"
   pull_request:
     paths:
-      - "examples/hello-ironclaw/**"
-      - "examples/red-team-escape/**"
+      - "examples/**"
       - "docker-compose.demo.yml"
       - "container/**"
       - "cmd/sandbox/**"
@@ -71,3 +69,67 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Try to break the sandbox and prove it holds
         run: examples/red-team-escape/run.sh
+
+  run-mock-examples:
+    # Credential-free SMOKE MATRIX over every examples/*/run-mock.sh recipe. Each mock
+    # recipe drives the offline mock-agent through the published HTTP chat route and
+    # ASSERTS a NON-EMPTY assistant reply — the exact regression IRO-279 slipped past,
+    # where the scripts polled `.text` (the /chat/send REQUEST field) instead of
+    # `.content` (the reply field) and, because /messages is drain-on-read, silently
+    # drained the reply to empty while still exiting 0. The recipes now fail-closed on
+    # an empty reply, so a wrong-field or broken round-trip turns this job red.
+    #
+    # The sandbox image + demo control-plane are built ONCE and shared across the whole
+    # matrix (build.sh + a single `compose up`), so one cold start covers every recipe
+    # and the per-recipe runtime stays tight — no rebuild per example. Same additive/
+    # non-gating posture as the jobs above: NOT a required check, so it surfaces a broken
+    # first-five-minutes without ever blocking a release.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Build the sandbox image once (ironclaw-sandbox:latest)
+        run: bash container/build.sh
+      - name: Bring the offline demo control-plane up once
+        run: docker compose -f docker-compose.demo.yml up --build -d
+      - name: Wait for the control-plane to be healthy
+        run: |
+          for _ in $(seq 1 90); do
+            if curl -fsS http://127.0.0.1:8787/healthz >/dev/null 2>&1; then
+              echo "control-plane healthy"; exit 0
+            fi
+            sleep 1
+          done
+          echo "FAIL: control-plane never became healthy within 90s" >&2
+          docker compose -f docker-compose.demo.yml logs --no-color 2>&1 | tail -60 >&2
+          exit 1
+      - name: Run every run-mock.sh and assert a non-empty reply
+        # Fail-closed: iterate all recipes, keep going so every failure is reported, then
+        # exit non-zero if ANY recipe failed. Each script self-asserts a non-empty reply
+        # (drain-on-read means the assertion MUST live inside the script's own poll loop —
+        # a re-read from CI here would see []), so a bare non-zero exit is a real break.
+        run: |
+          set -uo pipefail
+          fail=0
+          shopt -s nullglob
+          scripts=(examples/*/run-mock.sh)
+          if [ ${#scripts[@]} -eq 0 ]; then
+            echo "FAIL: no examples/*/run-mock.sh found — did the recipes move?" >&2
+            exit 1
+          fi
+          for s in "${scripts[@]}"; do
+            echo "::group::$s"
+            if bash "$s"; then
+              echo "PASS: $s"
+            else
+              echo "FAIL: $s (non-empty reply assertion failed)"; fail=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "$fail"
+      - name: Dump control-plane logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.demo.yml logs --no-color 2>&1 | tail -120
+      - name: Tear the demo down
+        if: always()
+        run: docker compose -f docker-compose.demo.yml down >/dev/null 2>&1 || true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,33 @@ go test ./...
 `make build vet test` runs the same checks. See [`docs/building.md`](docs/building.md)
 for the full build notes.
 
+### Examples smoke gate (credential-free)
+
+Changes under `examples/**` (or the demo control-plane / sandbox they exercise) trigger
+the [**Example smoke**](.github/workflows/example-smoke.yml) workflow. It runs
+`hello-ironclaw`, the `red-team-escape` proof, and a **credential-free smoke matrix**
+over every `examples/*/run-mock.sh` recipe against the offline `mock` provider — no model
+key, no channel tokens.
+
+Each `run-mock.sh` **must fail-closed on an empty assistant reply**. The chat
+`/messages` route is drain-on-read and the reply text lives in `.messages[].content`
+(NOT `.text`, which is the `/chat/send` *request* field); reading the wrong key silently
+drains the reply to empty. IRO-279 shipped exactly that regression — the scripts still
+exited 0 while returning nothing. So when you add or edit a mock recipe, keep the
+non-empty assertion (`return 1` / `exit 1` on an empty poll) so a wrong-field or broken
+round-trip turns the check red instead of passing silently. The sandbox image and demo
+control-plane are built once and shared across the matrix, so keep each recipe's own
+runtime tight. The job is additive and non-gating (not a required check).
+
+You can run the whole matrix locally:
+
+```bash
+bash container/build.sh                                # build ironclaw-sandbox:latest once
+docker compose -f docker-compose.demo.yml up --build -d
+for s in examples/*/run-mock.sh; do bash "$s" || echo "BROKE: $s"; done
+docker compose -f docker-compose.demo.yml down
+```
+
 ## The frozen contract
 
 `internal/contract/**` is the single seam shared by the control-plane (host) and the

--- a/community/adoption-metrics.md
+++ b/community/adoption-metrics.md
@@ -44,6 +44,32 @@ revise after the first real launch-week data lands.
 > Newest first. Append a new block each Monday by running the refresh command and pasting
 > its output above the previous block.
 
+### Snapshot — 2026-07-02 (pre-launch)
+
+| Metric | Value | Notes |
+| --- | --- | --- |
+| Stars | 13 | +2 vs. 2026-06-30 baseline |
+| Forks | 2 | flat |
+| Watchers / subscribers | 0 | |
+| Open issues | 17 | 16 are scoped good-first-issues (see below) |
+| Views (14d) | 580 | 51 unique visitors (was 44) |
+| Clones (14d) | 8637 | 801 unique — **CI-inflated** (release-per-push) |
+| Release downloads (all-time) | 2042 | across 116 releases |
+| Latest release | v0.1.153 | 23 downloads |
+| Top referrers | — | github.com (19u) · cla-assistant.io (3u) · linkedin.com (3u) · reddit.com (3u) · goodfirstissues.com (2u) · Google (2u) · ironsecco.github.io (1u) |
+
+> Clone counts are dominated by CI runners (a release is cut on every push to main).
+> Treat **unique visitors** and **stars** as the honest adoption signal pre-launch.
+
+**Read:** Still genuinely early/quiet, as expected pre-launch, but the trend is up and
+slightly wider: stars 11 → 13, unique visitors 44 → 51. The referrer mix is the honest
+signal — `goodfirstissues.com` persists (GFI seeding working), and two new organic sources
+appear: `linkedin.com` / `com.linkedin.android` and the docs site itself
+(`ironsecco.github.io`), meaning humans are arriving from the published docs, not just the
+repo. `Google` also shows up, an early sign the SEO work (IRO-277) is getting indexed. No
+announcement has fired (IRO-40 still gated), so every one of these is pre-launch trickle.
+Discussions remain seeded-only: 6 threads, 0 organic external threads, 0 comments.
+
 ### Snapshot — 2026-06-30 (pre-launch baseline)
 
 | Metric | Value | Notes |
@@ -70,14 +96,20 @@ real humans before any announcement. Discussions are seeded but have no organic 
 
 The pieces a prospective contributor lands on, kept alive independently of the launch gate:
 
-- **Good first issues:** 13 open and scoped, with labels + acceptance criteria + file pointers.
-  IRO-209 seeded 8 (#108, #109, #113, #191, #192, #193, #223, #224); IRO-263 added 5 more
+- **Good first issues:** 16 open and scoped, with labels + acceptance criteria + file pointers.
+  IRO-209 seeded 8 (#108, #109, #113, #191, #192, #193, #223, #224); IRO-263 added 5
   (#281 seccomp tests, #282 contract-enum tests, #283 `cmd/ironctl` `doc.go`, #284 stale-comment
-  fix, #285 tabwriter constants). Spread across sandbox / control-plane / cli / docs.
+  fix, #285 tabwriter constants); IRO-286 added 3 more from the fresh surface area
+  (#303 supported-providers reference table, #304 `examples/` capability matrix, #305 CI
+  status badges for the functional smoke workflows). Spread across sandbox / control-plane /
+  cli / docs / ci.
 - **Discussions:** the 3 seeds (#116, #225, #226) plus 3 evergreen technical Q&A entries added by
   IRO-263, sourced from the threat model + red-team harness (#270 how isolation works, #271 what
   the red-team harness proves, #272 where keys live). These are contributor/technical content,
-  distinct from the launch-gated announcement copy (IRO-186).
+  distinct from the launch-gated announcement copy (IRO-186). **Triage (2026-07-02):** all 6
+  threads reviewed — 0 organic/external threads and 0 comments, so nothing to answer or close;
+  the self-authored Q&A entries carry their full answers inline. Nothing actionable until real
+  visitors post.
 
 `goodfirstissues.com` already shows up as a referrer in the snapshot below, so the GFI surface is
 the honest early on-ramp worth growing pre-launch.

--- a/examples/scheduled-report/run-mock.sh
+++ b/examples/scheduled-report/run-mock.sh
@@ -21,14 +21,21 @@ send() { # send <text>
     -d "$(jq -nc --arg a "$AGENT" --arg t "$1" '{agentGroupID:$a, text:$t}')" >/dev/null
 }
 
-wait_reply() { # poll until the agent replies (or give up after ~30s)
+wait_reply() { # poll until the agent replies, or FAIL (non-zero) after ~30s
+  # /messages is drain-on-read and the reply text is `.messages[].content` (NOT
+  # `.text`, the /chat/send REQUEST field) — reading the wrong key drains the reply
+  # to empty and every later poll sees []. Asserting a NON-EMPTY reply here is the
+  # exact guard that catches an IRO-279-class regression, so an empty reply must
+  # FAIL the script (set -e propagates the non-zero return), never pass silently.
   for _ in $(seq 1 30); do
     out="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
       -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.content // empty')"
     if [ -n "$out" ]; then printf '   %s\n' "$out"; return 0; fi
     sleep 1
   done
-  echo "   (no reply within 30s — is the demo control-plane up and the sandbox image built?)" >&2
+  echo "FAIL: no reply within 30s — the .content round-trip returned empty." >&2
+  echo "      is the demo control-plane up and the sandbox image built?" >&2
+  return 1
 }
 
 echo "==> 1. Ask the reporter to schedule a recurring daily summary (schedule_task tool)"

--- a/examples/slack-triage/run-mock.sh
+++ b/examples/slack-triage/run-mock.sh
@@ -28,14 +28,21 @@ send() {
     -d "$(jq -nc --arg a "$AGENT" --arg t "$1" '{agentGroupID:$a, text:$t}')" >/dev/null
 }
 
-wait_reply() {
+wait_reply() { # poll until the agent replies, or FAIL (non-zero) after ~30s
+  # /messages is drain-on-read and the reply text is `.messages[].content` (NOT
+  # `.text`, the /chat/send REQUEST field) — reading the wrong key drains the reply
+  # to empty and every later poll sees []. Asserting a NON-EMPTY reply here is the
+  # exact guard that catches an IRO-279-class regression, so an empty reply must
+  # FAIL the script (set -e propagates the non-zero return), never pass silently.
   for _ in $(seq 1 30); do
     out="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
       -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.content // empty')"
     if [ -n "$out" ]; then printf '   -> %s\n' "$out"; return 0; fi
     sleep 1
   done
-  echo "   (no reply within 30s — is the demo control-plane up and the sandbox image built?)" >&2
+  echo "FAIL: no reply within 30s — the .content round-trip returned empty." >&2
+  echo "      is the demo control-plane up and the sandbox image built?" >&2
+  return 1
 }
 
 echo "Feeding sample channel messages to the triage agent."

--- a/examples/webhook-responder/run-mock.sh
+++ b/examples/webhook-responder/run-mock.sh
@@ -31,5 +31,6 @@ for _ in $(seq 1 30); do
   if [ -n "$out" ]; then printf '   %s\n' "$out"; exit 0; fi
   sleep 1
 done
-echo "   (no reply within 30s — is the demo control-plane up and the sandbox image built?)" >&2
+echo "FAIL: no reply within 30s — the .content round-trip returned empty." >&2
+echo "      is the demo control-plane up and the sandbox image built?" >&2
 exit 1


### PR DESCRIPTION
## What

Adds a **credential-free CI smoke matrix** over the examples suite so IRO-279-class regressions — a `run-mock.sh` polling the wrong JSON field (`.text` instead of `.content`) and silently returning an empty reply while exiting 0 — are caught automatically on every push/PR.

Closes IRO-284.

## Changes

- **`.github/workflows/example-smoke.yml`** — new `run-mock-examples` job:
  - Builds `ironclaw-sandbox:latest` + brings the demo control-plane up **once**, then runs **every** `examples/*/run-mock.sh` against the offline `mock` provider (no creds). One cold start covers the whole matrix; per-recipe runtime stays tight.
  - Fail-closed: iterates all recipes, reports each, exits non-zero if any fails. Dumps control-plane logs on failure.
  - Path filters widened to `examples/**`.
- **`examples/scheduled-report/run-mock.sh`, `examples/slack-triage/run-mock.sh`** — `wait_reply` now **returns non-zero on an empty reply** (previously it printed a warning and silently returned 0, so a drained/empty reply passed). `webhook-responder` already exited 1; aligned its FAIL message.
- **`CONTRIBUTING.md`** — documents the gate and the non-empty-reply requirement for new/edited mock recipes.

## Why this catches IRO-279

`/messages` is drain-on-read; the reply text is `.messages[].content`, not `.text` (the `/chat/send` request field). Reading the wrong key drains the reply to empty and every later poll sees `[]`. The assertion **must** live inside each script's own poll loop (a re-read from CI would see `[]`), so the recipes self-assert and CI just runs them fail-closed.

## Verification

Local harness (fake control-plane, loop shortened for speed):

- Server returns reply in **`.text`** (the IRO-279 bug) → empty `.content` → script **exits 1** ✅
- Server returns reply in **`.content`** → **exits 0** ✅
- `bash -n` clean on all three scripts; workflow YAML parses.

Additive / non-gating (not a required status check), same posture as the existing `hello-ironclaw` and `red-team-escape` jobs.