### PR TITLE
docs(providers): 'Choose your model provider' decision page + capability matrix (IRO-285)

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -47,10 +47,15 @@ enters a sandbox) and point an agent group at that provider. See the
 
 ## Which model providers are supported?
 
-**Anthropic, OpenAI, OpenRouter, and Codex**, plus a generic gateway URL
-(`IRONCLAW_MODEL_GATEWAY_URL`) — all reached through the host model-proxy, so keys
-stay host-side and never enter a sandbox. The zero-credential `mock` provider is
-built in for offline demos and tests.
+**Anthropic, OpenAI, OpenRouter, Codex, Google Gemini, Google Vertex AI**, a
+**local / self-hosted** OpenAI-compatible server (Ollama, LM Studio, vLLM,
+llama.cpp), plus a generic gateway URL (`IRONCLAW_MODEL_GATEWAY_URL`) — all reached
+through the host model-proxy, so keys stay host-side and never enter a sandbox. AWS
+**Bedrock** is landing and Azure OpenAI is incoming. The zero-credential `mock`
+provider is built in for offline demos and tests.
+
+To pick one, see [Choose your model provider](providers/index.md) — a capability
+matrix and a short decision guide.
 
 ## Which channels are supported?
 

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -1,0 +1,182 @@
+---
+title: "Choose your model provider"
+description: One page to pick the right model backend for IronClaw. Compare auth, streaming, and credential handling across mock, local, Anthropic, OpenAI, OpenRouter, Codex, Gemini, Vertex, Bedrock, and Azure, with a short decision guide and copy-paste setup.
+---
+
+# Choose your model provider
+
+IronClaw runs your agent behind a sealed sandbox and talks to whatever model you
+point it at. **You pick the backend per agent group** — the rest of the system does
+not change. This page helps you choose one, then links you straight to setup.
+
+!!! abstract "The one invariant, whatever you choose"
+    Every provider credential is held **host-side** and injected by the host
+    model-proxy on the way out. **No key ever enters a sandbox.** The agent sees a
+    model reply, never the secret that paid for it. That is true for a static API
+    key, an OAuth bearer, or AWS SigV4 credentials alike — the difference between
+    providers is *where the credential comes from*, not *whether it stays host-side*.
+    See [Security and isolation](../security-isolation.md).
+
+## Pick in 15 seconds
+
+<div class="grid cards" markdown>
+
+-   :material-lan-disconnect: __Local / offline / zero credential__
+
+    No cloud, no key, nothing leaves the box.
+
+    → **`mock`** for a demo or CI, **`local`** (Ollama / LM Studio / vLLM) for a
+    real model on your own hardware.
+
+-   :material-cloud-outline: __Hosted, fastest to first token__
+
+    You have an API key and want the strongest model now.
+
+    → **`anthropic`** (default), **`openai`**, **`openrouter`**, or **`gemini`**.
+
+-   :material-office-building-outline: __Enterprise / governed cloud__
+
+    Billing, IAM, and data boundary must live in your cloud account.
+
+    → **`bedrock`** (AWS), **`vertex`** (Google Cloud), or **`azure`** (incoming).
+
+-   :material-account-key-outline: __Reuse an existing subscription__
+
+    You already pay for ChatGPT or a gateway-fronted credential.
+
+    → **`codex`** (ChatGPT/Codex OAuth) via a local credential gateway.
+
+</div>
+
+## Capability matrix
+
+| Provider | Kind | Auth method | Credential source (host-side) | Streaming | Best for | Setup |
+|---|---|---|---|---|---|---|
+| **Mock** | `mock` | none | none — offline, deterministic | n/a | Demos, e2e tests, first run | [Quickstart](../quickstart.md#a-working-chat-in-5-minutes-no-credentials) |
+| **Local / self-hosted** | `local` | none (optional key) | `IRONCLAW_LOCAL_MODEL_KEY` only if your server requires one | server-dependent | 100% local model, no data egress | [Ollama tutorial](../tutorials/local-model-ollama.md) |
+| **Anthropic** _(default)_ | `anthropic` | API key | `ANTHROPIC_API_KEY` | yes (SSE) | Strongest default, tool use | [Quickstart](../quickstart.md#a-working-chat-in-5-minutes-no-credentials) |
+| **OpenAI** | `openai` | API key | `OPENAI_API_KEY` | yes (SSE) | GPT-class models | [Setup](#anthropic-openai-openrouter) |
+| **OpenRouter** | `openrouter` | API key | `OPENROUTER_API_KEY` | yes (SSE) | One key, many models | [Setup](#anthropic-openai-openrouter) |
+| **Google Gemini** | `gemini` | API key | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) | yes (SSE) | Hosted Google models, generous free tier | [Setup](#gemini-google-ai-studio) |
+| **Google Vertex AI** | `vertex` | OAuth2 bearer | gcloud ADC (`GOOGLE_VERTEX_USE_GCLOUD=1`) or `GOOGLE_VERTEX_ACCESS_TOKEN`; `GOOGLE_VERTEX_PROJECT` required | yes (SSE) | Gemini under GCP billing / IAM | [Setup](#vertex-ai-google-cloud) |
+| **AWS Bedrock** | `bedrock` | AWS SigV4 | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (+ `AWS_SESSION_TOKEN`), `AWS_REGION` | no (InvokeModel) | Claude/others under AWS billing / IAM | [Setup](#aws-bedrock-beta) |
+| **ChatGPT / Codex** | `codex` | OAuth via gateway | credential gateway (`IRONCLAW_MODEL_GATEWAY_URL`, e.g. OneCLI) | yes (SSE) | Reuse a ChatGPT/Codex subscription | [Setup](#codex-chatgpt-via-a-credential-gateway) |
+| **Azure OpenAI** | `azure` | API key | Azure OpenAI key + endpoint | — | Enterprise Azure tenants | :material-progress-clock: **incoming** ([IRO-284](https://github.com/IronSecCo/ironclaw/issues)) |
+
+!!! note "Streaming, and what it means here"
+    Where a provider streams, IronClaw consumes the upstream token stream and
+    **accumulates the full reply before it returns** — streaming is a transport
+    detail on the host side, not a partial-render feature in the console. Bedrock
+    uses the non-stream `InvokeModel` call today. Either way you get one complete,
+    audited reply.
+
+## Decision guide
+
+- **Just want to see it work?** Start with **`mock`** — no key, no network. The
+  [Quickstart](../quickstart.md) zero-credential demo replies in seconds.
+- **Privacy or air-gap is the constraint?** Run **`local`** against Ollama, LM
+  Studio, vLLM, or llama.cpp on your own box. Nothing leaves the machine, and no
+  cloud credential is required. See the [local model tutorial](../tutorials/local-model-ollama.md).
+- **You have an API key and want the best answer now?** Use **`anthropic`** (the
+  default), **`openai`**, **`openrouter`**, or **`gemini`**. One environment
+  variable and a restart.
+- **Procurement, billing, and IAM must stay in your cloud?** Use **`bedrock`**
+  (AWS), **`vertex`** (Google Cloud), or **`azure`** (incoming). Credentials come
+  from your existing cloud identity — SigV4, gcloud ADC, or an Azure key — and are
+  refreshed host-side.
+- **Already paying for ChatGPT?** Front a **`codex`** OAuth credential with a local
+  [credential gateway](../mcp.md) and reuse it.
+
+## Setup by provider
+
+Set **one** credential in the control-plane's environment and restart it. Every
+value below lives host-side only.
+
+### Anthropic, OpenAI, OpenRouter
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-…       # default provider
+# or
+export OPENAI_API_KEY=sk-…
+# or
+export OPENROUTER_API_KEY=sk-or-…
+```
+
+### Gemini (Google AI Studio)
+
+```bash
+export GOOGLE_API_KEY=…                  # GEMINI_API_KEY is honored as a fallback
+```
+
+### Vertex AI (Google Cloud)
+
+Vertex speaks the same wire format as Gemini but authenticates with a short-lived
+OAuth bearer that IronClaw refreshes host-side. A project is required; the region
+defaults when unset.
+
+```bash
+export GOOGLE_VERTEX_PROJECT=my-gcp-project   # or GOOGLE_CLOUD_PROJECT
+export GOOGLE_VERTEX_LOCATION=us-central1     # optional; provider default otherwise
+export GOOGLE_VERTEX_USE_GCLOUD=1             # use gcloud Application Default Credentials
+# or supply a token you refresh out of band:
+# export GOOGLE_VERTEX_ACCESS_TOKEN=ya29.…
+```
+
+### AWS Bedrock (beta)
+
+For orgs that consume models only through Bedrock. Credentials come from the
+standard AWS environment; the region selects the regional
+`bedrock-runtime.{region}.amazonaws.com` host.
+
+```bash
+export AWS_ACCESS_KEY_ID=AKIA…
+export AWS_SECRET_ACCESS_KEY=…
+export AWS_SESSION_TOKEN=…                # optional, for temporary credentials
+export AWS_REGION=us-east-1               # or AWS_DEFAULT_REGION
+```
+
+!!! info "Bedrock is landing"
+    The `bedrock` provider is in review ([IRO-273](https://github.com/IronSecCo/ironclaw/issues)).
+    Host-side SigV4 signing is validated against AWS's reference vectors; requests
+    use the non-stream `InvokeModel` API. This section documents the shipping shape.
+
+### Codex (ChatGPT) via a credential gateway
+
+The Codex path routes model egress through a local, operator-vetted credential
+gateway (such as OneCLI) that injects a ChatGPT/Codex OAuth token. The
+control-plane and sandbox then hold **no** model credential at all.
+
+```bash
+export IRONCLAW_MODEL_GATEWAY_URL=http://127.0.0.1:10255
+export IRONCLAW_MODEL_GATEWAY_HOSTS=chatgpt.com
+```
+
+### Azure OpenAI (incoming)
+
+Tracked in [IRO-284](https://github.com/IronSecCo/ironclaw/issues) and coordinated
+with the provider team. When it lands, Azure joins the enterprise row above with an
+API key plus your Azure OpenAI endpoint. Until then, use `bedrock`, `vertex`, or a
+direct `openai` key.
+
+## Point an agent group at a provider
+
+A provider credential being present does not force any group to use it — you opt a
+group in explicitly. Two surfaces:
+
+- **Web console** → **Agents** → edit a group → **Provider** field (leave blank for
+  the default Anthropic backend; set `openai`, `gemini`, `vertex`, `bedrock`,
+  `local`, etc. to route that group elsewhere). The group's provider and model show
+  on its card and in the first-run **Setup** checklist.
+- **CLI** — submit a model/persona change with `ironctl` and approve it through the
+  human gateway, so the switch lands on the [audit log](../observability.md) like any
+  other change. See the [Quickstart](../quickstart.md#4-submit-a-change-watch-it-get-held).
+
+Leaving the field blank keeps the sealed, single-provider default posture: only
+groups that opt in reach another backend.
+
+## See also
+
+- [Quickstart](../quickstart.md) — first working chat, then a real provider
+- [Run a 100% local model (Ollama)](../tutorials/local-model-ollama.md)
+- [Security and isolation](../security-isolation.md) — why keys stay host-side
+- [FAQ: which providers are supported?](../faq.md#which-model-providers-are-supported)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,8 @@ nav:
       - Observability (metrics): observability.md
       - Troubleshooting: troubleshooting.md
       - FAQ: faq.md
+  - Model providers:
+      - Choose your model provider: providers/index.md
   - Tutorials:
       - Overview: tutorials/index.md
       - Your first sandboxed agent in 5 minutes: tutorials/first-agent.md

--- a/web/static/setup.js
+++ b/web/static/setup.js
@@ -64,8 +64,8 @@ const Setup = (() => {
         "export OPENAI_API_KEY=sk-…",
         "export OPENROUTER_API_KEY=sk-or-…",
       ],
-      docLabel: "Model setup",
-      docHref: DOCS + "quickstart/",
+      docLabel: "Choose a provider",
+      docHref: DOCS + "providers/",
     },
     channel: {
       intro: "Arm a channel by exporting its bot token host-side, then restart:",


### PR DESCRIPTION
## What

New `docs/providers/index.md` — a single **Choose your model provider** decision page so users onboarding across a growing provider list (mock, local, Anthropic, OpenAI, OpenRouter, Codex, Gemini, Vertex, Bedrock, +Azure) can pick one in seconds.

## Contents (acceptance criteria)

- **Capability/comparison matrix** — provider, kind, auth method, host-side credential source, streaming support, best-for use case, and a setup link per row.
- **15-second card picker** + a short **decision guide** (local/offline → `mock`/`local`; hosted → Anthropic/OpenAI/OpenRouter/Gemini; enterprise → Bedrock/Vertex/Azure; subscription → Codex).
- **Per-provider setup** blocks with the exact host-side env vars.
- **Wired into mkdocs nav** under a new *Model providers* section.
- **Cross-links** every existing provider surface: Quickstart, Ollama tutorial, Security & isolation, observability/audit, and the FAQ; the FAQ now links back and its stale provider list is refreshed (adds Gemini/Vertex/local; notes Bedrock landing, Azure incoming).
- **Console model-selection surface**: the first-run **Setup** wizard's model-credential step now deep-links to this page (`web/static/setup.js`).
- **Coordination**: **Bedrock** marked *beta* (PR #300 in review, IRO-273); **Azure** marked *incoming* (IRO-284, Forge). Both appear in the matrix per AC.

## Provenance

Every fact sourced from code, not guessed: provider kinds from `internal/sandbox/provider/provider.go`, env-var wiring from `cmd/controlplane/main.go`, streaming per provider file (Bedrock non-stream `InvokeModel`; rest SSE-accumulated).

## Verification

- `mkdocs build --strict` — clean, no broken links/anchors from the new page.
- Rendered at **1440×900** and **390×844**: cards, admonition, TOC, and the matrix table all read correctly; mobile stacks to single column, table scrolls horizontally (standard Material behavior).

Note: authored in an isolated worktree off `origin/main` after a concurrent agent reset the shared checkout; no other agent's work touched.

Closes IRO-285.