### PR TITLE
fix(host): generalize IRO-278 seq fix + concurrency regression gate (IRO-283)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,33 @@ jobs:
       - name: test
         run: go test ./...
 
+  # Deterministic concurrency regression gate for the control-plane seq allocators
+  # (IRO-278 / IRO-283). Inbound (messages_in) and outbound (messages_out) seqs are
+  # minted atomically inside the INSERT; these packages own that invariant. Running
+  # their tests under -race on every push/PR means a reintroduced uncoordinated
+  # minter — the UNIQUE(seq) collision that broke recurring schedule_task and 500'd
+  # /chat/send — fails CI instead of shipping. Scoped to the queue-owning packages
+  # so the race build stays fast. -count=1 disables the test cache so the race
+  # detector actually re-executes the concurrent writers every run.
+  race:
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: "1"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.23.12"
+      - name: race (control-plane seq allocators)
+        run: |
+          go test -race -count=1 \
+            ./internal/host/queue/ \
+            ./internal/sandbox/queue/ \
+            ./internal/host/router/ \
+            ./internal/host/sweep/ \
+            ./internal/host/delivery/ \
+            ./test/parity/
+
   # Short bounded native-fuzz run over the highest-risk untrusted-input parsers
   # (skill manifest YAML, minisign signature/key blobs, name/version/asset path
   # validation). This is a regression smoke test, not an exhaustive campaign: each

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -37,6 +37,40 @@ To change the contract:
 Pinned crypto parameters (`CipherScheme`, `CipherPageSize`, `KDFRawKey`) and seq
 parity (host=even, sandbox=odd) are part of the contract and follow the same rule.
 
+## Seq allocation invariant (concurrency)
+
+Both message streams carry a `seq INTEGER UNIQUE` column. The single load-bearing
+rule for allocating it:
+
+> **Mint the next seq atomically inside the INSERT — never with a separate
+> read-modify-write, and never from more than one uncoordinated minter per
+> stream.**
+
+IRO-278 was a violation of this rule: three uncoordinated inbound minters (the
+router used an in-memory counter, while the sweep and delivery re-enqueuers each
+did `SELECT MAX(seq)+2` in Go) raced and picked the same seq, so one INSERT failed
+on `UNIQUE(seq)`. That broke recurring `schedule_task` and intermittently 500'd
+`/chat/send`. IRO-283 audited every seq/sequence write path and generalized the
+fix so the class cannot recur:
+
+| Stream / site | Table | Allocation | Status |
+|---|---|---|---|
+| `hostInbound.WriteMessageIn` (router, sweep, delivery, a2a all pass `Seq==0`) | `messages_in` (even) | `COALESCE((SELECT MAX(seq) FROM messages_in), 0) + 2` inside the INSERT | authoritative (IRO-278) |
+| `sandboxOutbound.WriteMessageOut` (sandbox, sole writer) | `messages_out` (odd) | `(COALESCE((SELECT MAX(seq) FROM messages_out), -1) + 1) \| 1` inside the INSERT | authoritative (IRO-283); no longer depends on the `s.mu` lock or on staying single-writer |
+| `questions.Store.Record` (`s.seq++`) | in-memory map, not persisted, no `UNIQUE` | mutex-guarded counter for question IDs only | benign — not a message-stream seq |
+
+Callers on the inbound path MUST pass `Seq==0` and let the writer mint; the
+outbound writer ignores any caller-supplied `Seq` outright. The odd expression
+forces the result odd (`| 1`) so parity holds even if a stray even seq ever
+appeared, and is provably equivalent to the `nextOddSeq` reference spec.
+
+Regression coverage is deterministic and runs under `-race` in CI (the `race` job
+in `ci.yml`): `TestHostInboundConcurrentWritersNoCollision` fans out independent
+inbound writer handles (router + sweep + delivery contention) and
+`TestSandboxOutboundConcurrentWritersNoCollision` fans out two independent outbound
+handles; both assert N distinct, correctly-parified seqs with zero collisions. A
+reintroduced uncoordinated minter fails that job instead of shipping.
+
 ## RFC log
 
 ### RFC-0001 (applied): add `OpenInboundRW` + wire the encrypted-SQLite binding

--- a/internal/host/queue/concurrency_test.go
+++ b/internal/host/queue/concurrency_test.go
@@ -1,0 +1,98 @@
+package queue
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/contract"
+)
+
+// TestHostInboundConcurrentWritersNoCollision is the deterministic concurrency
+// regression for IRO-278/IRO-283. It reproduces the exact production contention
+// that broke recurring schedule_task and 500'd /chat/send: several independent
+// host inbound writer handles for the SAME session — the router (a fresh
+// /chat/send), the sweep re-enqueuer (a recurring schedule firing), and the
+// delivery re-enqueuer — all writing with Seq==0 at the same time.
+//
+// Each writer opens its own handle (as the real code paths do), so nothing but
+// the authoritative in-INSERT allocator coordinates them. Pre-fix, the router
+// minted from an in-memory counter while sweep/delivery did SELECT MAX(seq)+2,
+// so two writers picked the same seq and one INSERT failed on UNIQUE(seq). Post
+// fix every writer mints atomically inside the INSERT, so the run must produce N
+// distinct EVEN seqs with zero errors under -race.
+func TestHostInboundConcurrentWritersNoCollision(t *testing.T) {
+	f := NewFactory(t.TempDir())
+	const sid = "sess-concurrent"
+	k := testKey(0x77)
+	if err := f.Provision(sid, k); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+
+	const writers = 24
+	var wg sync.WaitGroup
+	errs := make([]error, writers)
+	start := make(chan struct{})
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			w, err := f.OpenHostInbound(sid, k)
+			if err != nil {
+				errs[i] = fmt.Errorf("open %d: %w", i, err)
+				return
+			}
+			defer w.Close()
+			<-start // release all writers together to maximize contention
+			errs[i] = w.WriteMessageIn(contract.MessageIn{
+				ID:      contract.MessageID(fmt.Sprintf("in-%d", i)),
+				Seq:     0,
+				Content: fmt.Sprintf("msg-%d", i),
+			})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			// A UNIQUE(seq) collision surfaces here as the IRO-278 failure.
+			t.Fatalf("writer %d failed (seq collision regressed?): %v", i, err)
+		}
+	}
+
+	// Read every persisted seq and assert: exactly N rows, all distinct, all even.
+	sin, err := f.OpenSandboxInbound(sid, k)
+	if err != nil {
+		t.Fatalf("OpenSandboxInbound: %v", err)
+	}
+	defer sin.Close()
+	rows, err := sin.Query("SELECT seq FROM messages_in ORDER BY seq")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	seen := make(map[int64]struct{}, writers)
+	var count int
+	for rows.Next() {
+		var s int64
+		if err := rows.Scan(&s); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if s%2 != 0 {
+			t.Fatalf("seq %d is odd; host must write even seq", s)
+		}
+		if _, dup := seen[s]; dup {
+			t.Fatalf("duplicate seq %d — UNIQUE(seq) allocator is not authoritative", s)
+		}
+		seen[s] = struct{}{}
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	if count != writers {
+		t.Fatalf("got %d rows, want %d (a lost write means a swallowed collision)", count, writers)
+	}
+}

--- a/internal/sandbox/queue/queue.go
+++ b/internal/sandbox/queue/queue.go
@@ -312,38 +312,36 @@ func OpenOutbound(path string, k contract.SessionKey) (contract.OutboundWriter, 
 	return &sandboxOutbound{db: db}, nil
 }
 
-// WriteMessageOut appends an outbound message, assigning the next odd seq so the
-// host=even/sandbox=odd parity holds. Any Seq set by the caller is overwritten.
+// WriteMessageOut appends an outbound message. The next odd seq is minted
+// ATOMICALLY inside the INSERT — `(COALESCE(MAX(seq), -1) + 1) | 1` — never by a
+// separate read-modify-write. This generalizes the IRO-278 inbound fix to the
+// outbound stream: correctness no longer depends on the s.mu lock or on the
+// sandbox staying single-writer, so a future refactor that adds a second writer
+// (or drops the mutex) cannot resurrect the UNIQUE(seq) collision. The `| 1`
+// forces the result odd, preserving host=even/sandbox=odd parity even if a
+// legacy even seq ever slipped into the table; the expression is provably
+// equivalent to nextOddSeq (unit-tested in queue_test.go). Any Seq set by the
+// caller is ignored — the sandbox is the sole authority for outbound seqs.
 func (s *sandboxOutbound) WriteMessageOut(m contract.MessageOut) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 	defer cancel()
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
 
-	var maxSeq sql.NullInt64
-	if err := tx.QueryRowContext(ctx, `SELECT MAX(seq) FROM messages_out`).Scan(&maxSeq); err != nil {
-		return err
-	}
-	m.Seq = nextOddSeq(maxSeq.Int64, maxSeq.Valid)
-
-	if _, err := tx.ExecContext(ctx, `
+	if _, err := s.db.ExecContext(ctx, `
 		INSERT INTO messages_out
 			(id, seq, in_reply_to, timestamp, deliver_after, recurrence, kind,
 			 platform_id, channel_type, thread_id, content)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		string(m.ID), m.Seq, idArg(m.InReplyTo), formatTime(m.Timestamp),
+		VALUES (?, (COALESCE((SELECT MAX(seq) FROM messages_out), -1) + 1) | 1,
+		        ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		string(m.ID), idArg(m.InReplyTo), formatTime(m.Timestamp),
 		deliverAfterArg(m.DeliverAfter), m.Recurrence, string(m.Kind),
 		m.PlatformID, m.ChannelType, m.ThreadID, m.Content,
 	); err != nil {
 		return err
 	}
-	return tx.Commit()
+	return nil
 }
 
 // MarkProcessing records that the given inbound messages are being processed,
@@ -449,6 +447,11 @@ func (s *sandboxOutbound) Close() error {
 // nextOddSeq returns the smallest odd seq strictly greater than the current max.
 // With an empty table it returns 1. The sandbox always writes odd seq values so
 // it never collides with the host's even ones (frozen seq parity).
+//
+// This is the reference spec for the odd-seq math. WriteMessageOut no longer
+// calls it — it mints the seq atomically in SQL as `(COALESCE(MAX(seq),-1)+1)|1`,
+// which is provably equivalent (verified by TestNextOddSeqMatchesSQLExpression in
+// queue_test.go). Keep the two in lockstep if either changes.
 func nextOddSeq(maxSeq int64, present bool) int64 {
 	if !present {
 		return 1

--- a/internal/sandbox/queue/queue_test.go
+++ b/internal/sandbox/queue/queue_test.go
@@ -3,6 +3,8 @@ package queue
 import (
 	"database/sql"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -32,6 +34,125 @@ func TestNextOddSeq(t *testing.T) {
 				t.Fatalf("nextOddSeq(%d,%v) = %d is even; sandbox must write odd seq", tc.maxSeq, tc.present, got)
 			}
 		})
+	}
+}
+
+// TestNextOddSeqMatchesSQLExpression pins the equivalence between the nextOddSeq
+// reference spec and the SQL expression WriteMessageOut now mints with,
+// `(COALESCE(MAX(seq), -1) + 1) | 1`. If either drifts, the sandbox could mint an
+// even seq (breaking host=even/sandbox=odd parity) or a non-monotonic one.
+func TestNextOddSeqMatchesSQLExpression(t *testing.T) {
+	// sqlOdd mirrors the SQL: -1 stands in for MAX(seq) over an empty table.
+	sqlOdd := func(maxSeq int64, present bool) int64 {
+		base := int64(-1)
+		if present {
+			base = maxSeq
+		}
+		return (base + 1) | 1
+	}
+	for _, present := range []bool{false, true} {
+		for max := int64(0); max <= 64; max++ {
+			got := sqlOdd(max, present)
+			want := nextOddSeq(max, present)
+			if got != want {
+				t.Fatalf("SQL expr(%d,%v) = %d, nextOddSeq = %d", max, present, got, want)
+			}
+			if got%2 == 0 {
+				t.Fatalf("SQL expr(%d,%v) = %d is even; sandbox must write odd", max, present, got)
+			}
+		}
+	}
+}
+
+// TestSandboxOutboundConcurrentWritersNoCollision is the outbound sibling of the
+// IRO-278 inbound regression (IRO-283). It opens TWO independent outbound writer
+// handles to the same encrypted DB — each with its own s.mu — so the only thing
+// coordinating their seq allocation is the atomic `(COALESCE(MAX(seq),-1)+1)|1`
+// minted inside the INSERT, not any shared in-process lock. Many goroutines write
+// concurrently across both handles; the run must yield N distinct ODD seqs with
+// zero UNIQUE(seq) collisions under -race. This proves the hardening holds even
+// if the sandbox ever stops being a single serialized writer.
+func TestSandboxOutboundConcurrentWritersNoCollision(t *testing.T) {
+	path := t.TempDir() + "/outbound.db"
+	key := contract.SessionKey{}
+
+	handleA, err := OpenOutbound(path, key)
+	if err != nil {
+		t.Fatalf("OpenOutbound A: %v", err)
+	}
+	defer handleA.Close()
+	handleB, err := OpenOutbound(path, key)
+	if err != nil {
+		t.Fatalf("OpenOutbound B: %v", err)
+	}
+	defer handleB.Close()
+
+	const writers = 24
+	var wg sync.WaitGroup
+	errs := make([]error, writers)
+	start := make(chan struct{})
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			w := handleA
+			if i%2 == 1 {
+				w = handleB
+			}
+			<-start
+			errs[i] = w.WriteMessageOut(contract.MessageOut{
+				ID:      contract.MessageID(fmt.Sprintf("out-%d", i)),
+				Kind:    contract.KindChat,
+				Content: fmt.Sprintf("reply-%d", i),
+			})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("writer %d failed (odd-seq collision regressed?): %v", i, err)
+		}
+	}
+
+	// Read back every persisted seq: exactly N rows, all distinct, all odd.
+	reader, err := OpenOutbound(path, key)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reader.Close()
+	store, ok := reader.(*sandboxOutbound)
+	if !ok {
+		t.Fatalf("OpenOutbound returned %T, want *sandboxOutbound", reader)
+	}
+	rows, err := store.db.Query("SELECT seq FROM messages_out ORDER BY seq")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+
+	seen := make(map[int64]struct{}, writers)
+	var count int
+	for rows.Next() {
+		var s int64
+		if err := rows.Scan(&s); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if s%2 == 0 {
+			t.Fatalf("seq %d is even; sandbox must write odd seq", s)
+		}
+		if _, dup := seen[s]; dup {
+			t.Fatalf("duplicate seq %d — outbound allocator is not authoritative", s)
+		}
+		seen[s] = struct{}{}
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	if count != writers {
+		t.Fatalf("got %d rows, want %d (a lost write means a swallowed collision)", count, writers)
 	}
 }
 


### PR DESCRIPTION
## What

Generalizes the IRO-278 inbound seq-collision fix (PR #302) to the whole
control-plane and locks in deterministic concurrency regression coverage.

Closes IRO-283.

## Audit findings

Rule for every `seq INTEGER UNIQUE` stream: **mint the next seq atomically
inside the INSERT — never with a separate read-modify-write, and never from more
than one uncoordinated minter per stream.**

| Stream / site | Table | Allocation | Status |
|---|---|---|---|
| `hostInbound.WriteMessageIn` (router, sweep, delivery, a2a all pass `Seq==0`) | `messages_in` (even) | `COALESCE((SELECT MAX(seq) FROM messages_in),0)+2` in the INSERT | authoritative (IRO-278) |
| `sandboxOutbound.WriteMessageOut` (sandbox, sole writer) | `messages_out` (odd) | was `SELECT MAX(seq)` + Go compute under `s.mu` → **hardened** to `(COALESCE(MAX(seq),-1)+1)\|1` in the INSERT | authoritative (this PR) |
| `questions.Store.Record` (`s.seq++`) | in-memory, not persisted, no `UNIQUE` | mutex-guarded question-ID counter | benign |

The outbound writer's correctness previously depended on the `s.mu` lock and on
the sandbox staying a single serialized writer. Minting the odd seq atomically
in SQL removes both assumptions, so a future refactor cannot resurrect the
`UNIQUE(seq)` collision. The `| 1` forces odd (parity), and the expression is
provably equivalent to the retained `nextOddSeq` reference spec.

## Regression tests (run under `-race`)

- `TestHostInboundConcurrentWritersNoCollision` — independent inbound writer
  handles (router + sweep + delivery contention, the exact `/chat/send` +
  recurring-schedule race) fan out with `Seq==0`; assert N distinct even seqs,
  zero collisions.
- `TestSandboxOutboundConcurrentWritersNoCollision` — two independent outbound
  handles fan out; assert N distinct odd seqs, proving the in-INSERT allocator
  (not the mutex) coordinates.
- `TestNextOddSeqMatchesSQLExpression` — pins the SQL/Go equivalence.

## CI

New scoped `race` job runs the queue-owning packages
(`host/queue`, `sandbox/queue`, `router`, `sweep`, `delivery`, `test/parity`)
under `-race` on every push/PR, so a reintroduced uncoordinated minter fails CI
instead of shipping.

## Docs

`docs/contract.md` gains a "Seq allocation invariant (concurrency)" section with
the rule, the per-site audit table, and the regression coverage.

## Verification

- `go build ./internal/...` clean
- `go test -race -count=1 ./internal/host/queue/ ./internal/sandbox/queue/` — 36 pass
- `go test ./internal/host/queue/ ./internal/sandbox/queue/ ./test/parity/ ./internal/host/sweep/ ./internal/host/router/ ./internal/host/delivery/` — 138 pass
- `actionlint` clean; `mkdocs build --strict` clean