### PR TITLE
docs(growth): gVisor deep-dive + BYO-model follow-up posts + metrics refresh (IRO-290)

### DIFF
--- a/community/adoption-metrics.md
+++ b/community/adoption-metrics.md
@@ -44,6 +44,32 @@ revise after the first real launch-week data lands.
 > Newest first. Append a new block each Monday by running the refresh command and pasting
 > its output above the previous block.
 
+### Snapshot — 2026-07-03 (blog live, external threads not yet posted)
+
+| Metric | Value | Notes |
+| --- | --- | --- |
+| Stars | 13 | flat vs 2026-07-02 (13) and the IRO-286 baseline |
+| Forks | 2 | flat |
+| Watchers / subscribers | 0 | |
+| Open issues | 19 | includes tracked work + open PRs + GFIs |
+| Views (14d) | 580 | 51 unique visitors (flat) |
+| Clones (14d) | 8637 | 801 unique, **CI-inflated** (release-per-push) |
+| Release downloads (all-time) | 2134 | +92 vs 2026-07-02 (across 120 releases, all CI) |
+| Latest release | v0.1.158 | 23 downloads |
+| Top referrers | — | github.com (19u) · cla-assistant.io (3u) · linkedin.com (3u) · reddit.com (3u) |
+
+**Read:** Flat. Stars 13 -> 13, unique visitors 51 -> 51, no movement in the honest
+external signals. This is the expected result: the launch blog is published
+(`breaking-our-own-sandbox`, IRO-271), but the reach levers that actually move these
+numbers, the Show HN / Reddit launch threads and the remaining directory submissions,
+are **owner-manual** and have not been posted yet (external, no in-environment
+credentials; identity guardrails apply). Two follow-up posts shipped this round
+(gVisor deep-dive, bring-your-own-model), which grows the surface a visitor can land
+on but does not by itself drive traffic. The bottleneck for round 2 is distribution
+execution (owner posts the staged threads), not more content. Referrer mix narrowed
+vs 2026-07-02: `goodfirstissues.com`, `google`, and the docs site dropped out of the
+trailing 14-day window, consistent with no fresh inbound push.
+
 ### Snapshot — 2026-07-02 (pre-launch)
 
 | Metric | Value | Notes |

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -38,6 +38,7 @@ nav:
   - Security & Trust:
       - Overview: security.md
       - Isolation, proven: security-isolation.md
+      - Why we run AI agents in gVisor: gvisor-deep-dive.md
       - Credential vault: vault.md
       - Breaking our own sandbox: breaking-our-own-sandbox.md
       - Threat model: threat-model.md

--- a/docs/bring-your-own-model.md
+++ b/docs/bring-your-own-model.md
@@ -1,0 +1,76 @@
+---
+title: "Bring your own model: Ollama, Gemini, or Vertex in 5 minutes"
+description: "Run an IronClaw agent on the model you already have, local, private, or your own cloud account. The model key never enters the sandbox, and provider selection is configuration, not a fork."
+---
+
+## The job: run an agent on *your* model, not someone else's
+
+Plenty of agent runtimes assume one vendor and one cloud. The job a self-hoster is hiring for is the opposite:
+**"use the model I already have, whether local, private, or my own cloud account, without rebuilding anything."**
+IronClaw speaks the OpenAI-compatible API shape, so the model is a config choice, not a fork.
+
+> IronClaw ships more backends than the three below (Anthropic, OpenAI, OpenRouter, Codex, and a credential-free `mock` provider too). For the full list with an auth-and-streaming comparison and a short decision guide, see [Choose your model provider](providers/index.md).
+
+
+And because of how the runtime is built, **your model key never enters the agent sandbox**. Model calls are
+brokered host-side. Bringing your own model doesn't mean trusting the box with your credential.
+
+## Option A: Local model with Ollama (zero credentials)
+
+This is the fastest path and needs no API key at all.
+
+```bash
+# 1. Have a model running locally (Ollama shown; LM Studio / vLLM work the same way)
+ollama serve
+ollama pull llama3.1
+
+# 2. Point IronClaw at the local OpenAI-compatible endpoint
+#    The model proxy allows plain-HTTP loopback for local upstreams.
+ironctl onboard      # choose the local/OpenAI-compatible provider, endpoint http://localhost:11434/v1
+
+# 3. Run a conversation, and the agent now reasons on your local model,
+#    fully offline, no key, no cloud round-trip.
+```
+
+LM Studio and vLLM expose the same OpenAI-compatible surface; point the endpoint at theirs and it just works.
+The model never leaves your machine, and there is no telemetry phoning home. Full walkthrough: [Run a 100% local model (Ollama)](tutorials/local-model-ollama.md).
+
+## Option B: Google Gemini (AI Studio key)
+
+```bash
+export GEMINI_API_KEY=...     # or GOOGLE_API_KEY
+ironctl onboard                # choose the Gemini provider
+```
+
+IronClaw maps your key to Gemini's `x-goog-api-key` header host-side; the sandbox never sees it.
+
+## Option C: Google Vertex AI (your GCP project)
+
+```bash
+# Uses host-side OAuth against your GCP credentials; default region us-central1
+ironctl onboard                # choose the Vertex provider, set project + region
+```
+
+Vertex reuses the same Gemini request path with host-side OAuth injection. Same isolation guarantees, your
+cloud account.
+
+## Try it with no model at all: the `mock` provider
+
+Want to see the loop end-to-end before wiring a real model? IronClaw ships a **credential-free `mock`
+provider** and a seeded mock agent, so you can run the full message-to-reason-to-approve-to-execute loop with
+zero setup. That's also how our zero-credential hero demo works.
+
+## Why "5 minutes" is honest
+
+The slow part of most agent setups is credentials and cloud config. The local path removes both: a running
+Ollama plus `ironctl onboard` is the whole story. Hosted providers add exactly one secret (a key or OAuth),
+injected host-side. There's no model-specific rebuild; provider selection is configuration.
+
+## Where this is honest about its limits
+
+- **Still alpha.** Config formats can change between versions, so pin your version.
+- **Coverage is uneven by design.** The control plane, gateway, and encrypted queues carry real
+  test coverage. Live per-provider routing has lighter end-to-end coverage. The local and `mock`
+  paths are the ones you can verify offline today, and we would rather you know exactly which is which.
+
+Found a provider quirk? That's a great first issue. The repo is open and we triage fast.

--- a/docs/gvisor-deep-dive.md
+++ b/docs/gvisor-deep-dive.md
@@ -1,0 +1,164 @@
+---
+title: "Why we run AI agents in gVisor"
+description: "The security model behind IronClaw: why a sandboxed agent gets no network, no host secrets, and no way to change its own configuration, and what gVisor actually buys you."
+---
+# Why we run AI agents in gVisor
+
+Give an AI agent tools, and you've given it a way to act on the world: read a file,
+call an API, send a message, spend money. Give it a chat inbox, and you've given an
+**attacker** a way to steer those actions, a poisoned web page, a booby-trapped
+email, a hostile tool result. Prompt injection is not a corner case for an
+autonomous agent; it is the normal operating condition.
+
+So at IronClaw we start from an uncomfortable assumption and design backwards from
+it:
+
+> **Assume the agent is already compromised.** Treat every model output, every
+> inbound message, and every byte returned by an external API as hostile. Then build
+> walls that hold anyway.[^assume]
+
+That single asymmetry, *the host is trusted, the agent is not*, is the whole
+design. This post is about the most load-bearing wall it produces: running each
+agent inside a **gVisor** sandbox with **no network**, and what that actually buys
+you.
+
+## The thing most agent frameworks get wrong
+
+The dominant pattern for "autonomous agent" today is a loop with a shell tool,
+running as your user, on your machine, with your network and your credentials. It
+works beautifully right up until the model is talked into `curl | sh`-ing something,
+reading `~/.ssh`, or POSTing your environment variables to an attacker. The agent
+didn't "go rogue", it did exactly what the injected instructions said, with exactly
+the privileges you handed it.
+
+You cannot prompt-engineer your way out of this. A system prompt that says "never
+exfiltrate secrets" is a request, not a boundary. The fix has to live *below* the
+model, where the model's output can't reach it.
+
+## What "below the model" looks like
+
+In IronClaw, every agent session runs in its own sandbox container, and the sandbox
+is sealed along a small number of deliberately boring edges:[^b1]
+
+- **`network=none`.** The sandbox has no network namespace, no NIC, no DNS, no
+  routes. It cannot open a socket to the internet because there is nothing to open.
+  It reaches the model **only** through a host-owned Unix socket (a model proxy), and
+  it reaches approved external APIs **only** through a second host-owned socket (an
+  egress broker). Every byte that leaves crosses a host choke point.[^netnone]
+- **Read-only, sealed runtime.** The rootfs is read-only; mounts are
+  `nosuid,nodev,noexec`; capabilities are dropped; `no_new_privs` is set; the process
+  runs in a non-root user namespace. There is no interpreter and no source in the box
+  to rewrite, it's a compiled Go binary.[^sealed]
+- **Encrypted, per-session queues.** The agent talks to the outside world by reading
+  an inbound queue (read-only to it) and appending to an outbound queue. Each
+  session's queues are separate, encrypted SQLite databases with their own 256-bit
+  key. One session physically cannot read another's data, and nothing sits in
+  plaintext on disk.[^queues]
+
+And then the part people remember: that sandbox runs under **gVisor (`runsc`)**.
+
+## What gVisor adds, and what it doesn't
+
+`network=none` plus a read-only rootfs is already a strong box. gVisor hardens the
+one wall those controls *don't* directly cover: the **kernel** boundary.
+
+A normal container shares the host kernel. Every syscall the containerized process
+makes runs against the real kernel directly, so a kernel-level vulnerability is a
+container-escape vulnerability, the isolation is only as strong as the millions of
+lines of syscall-handling code in the host kernel. gVisor interposes a user-space
+kernel (written in Go) between the sandboxed process and the host: the agent's
+syscalls hit gVisor's reimplementation of the Linux ABI, not the host kernel
+directly. The host kernel surface the agent can actually touch shrinks to a small,
+audited interface.
+
+For an agent we are *assuming is compromised*, that is exactly the right place to
+spend defense. The threat we care about, "the agent finds a way to break out of its
+box and onto the host", is precisely a sandbox-escape threat, and a second
+independent kernel is a second thing an attacker has to defeat after they've already
+defeated the model.[^escape]
+
+Two honest caveats, because overclaiming is its own security smell:
+
+- **gVisor is not a VM, and it has its own attack surface.** It is a strong
+  additional isolation layer, not a magic one. We treat it as the trusted runtime
+  (it's inside the trust boundary), and we keep `network=none` and the sealed rootfs
+  in place *underneath* it so that gVisor is the second wall, never the only one.
+- **gVisor is Linux-only.** The production sandbox runtime is `runsc`, which only
+  runs on Linux. The entire IronClaw host side runs natively on macOS, but a real
+  agent sandbox there falls back to runc inside Docker Desktop's Linux VM, a
+  weaker, kernel-shared boundary. The laptop demo is for *seeing it work*; the sealed
+  production posture is Linux + gVisor.[^platform]
+
+> **This is not just a design claim.** The isolation boundary is exercised on every push by a red-team containment gate (`.github/workflows/sandbox-containment.yml`), and the `runsc` overhead is measured on Linux CI in [Performance and footprint](benchmarks.md). You can reproduce the escape attempts yourself: see [Breaking our own sandbox](breaking-our-own-sandbox.md).
+
+## The wall the model never sees: the approval gateway
+
+Isolation answers "what can a compromised agent reach?" It doesn't answer "what can a
+compromised agent *change about itself*?", and for a long-running agent that second
+question matters just as much. An agent that can quietly grant itself a new tool, a
+new egress destination, or a new mount has escalated, even without escaping the
+sandbox.
+
+So configuration changes don't go through the model's hands at all. **An agent cannot
+change its own configuration.** Every capability change, persona, tools, packages,
+wiring, permissions, mounts, even provisioning a brand-new agent, is held at a
+deterministic **gateway** for a human decision. Deny-by-default, with a mandatory
+human-approval floor that no change kind is allowed to skip.[^gateway]
+
+The agent can *ask* ("I'd like access to this MCP server / this skill / this egress
+host"). Only a human can *grant*. The ask is visible, the approver sees exactly the
+capabilities being requested in the change diff, so a trojaned skill that quietly
+requests `egress: evil.example.com` is *visible and rejected at review time*, not
+discovered post-breach.[^skills] The same floor governs everything extensible:
+skills are **data, not code** (they declare grants; they can never ship a script or
+self-install)[^skills], and MCP servers stay entirely host-side and gateway-gated, so
+they add tool reach without adding a boundary the sandbox can cross.[^mcp]
+
+## What this buys you, concretely
+
+Put the layers together and you get a property worth stating plainly. Even a
+**fully compromised agent**, one doing exactly what an attacker's injected prompt
+tells it to, cannot:
+
+- read another session's conversation data, or any at-rest plaintext;[^queues]
+- reach the host filesystem, or any network host that isn't on an
+  operator-approved egress allowlist;[^netnone]
+- obtain a host-held secret (the model API key, the queue keys, the API token), 
+  the model proxy injects the key into the outbound call host-side, so the key
+  never enters the sandbox;[^secrets]
+- change its own configuration or grant itself a new capability without a human
+  approving it at the gateway.[^gateway]
+
+That is the difference between "we asked the model nicely" and "the boundary holds
+even when the model is hostile." It's also why we publish a full
+[threat model](threat-model.md), adversaries, trust boundaries, a STRIDE pass per
+boundary, and an explicit list of what *is* and *isn't* a vulnerability, and version
+it with the code. A security claim you can't audit is a marketing claim.
+
+## Try the boundary yourself
+
+The fastest way to believe a security model is to watch it refuse something. The
+[quickstart](quickstart.md) walks you from a clean clone to **submitting a
+configuration change and watching it get held at the gateway** until you approve it, 
+no model key required, entirely on your machine. Five minutes, and the core invariant
+stops being a paragraph and becomes a command you ran.
+
+---
+
+### Accuracy notes (claim → source)
+
+Every claim above maps to a versioned source in the repository. This post makes **no**
+claim that is not backed by shipped code or the versioned threat model, so you can
+check each one for yourself.
+
+[^assume]: Core assumption and trust asymmetry, [threat model §1](threat-model.md).
+[^b1]: Trust boundaries B1-B5 and data-flow diagram, [threat model §3](threat-model.md).
+[^netnone]: `network=none`, host model-proxy socket, egress broker, deny-by-default allowlist, [threat model §3, §5 (B1/B4), §7](threat-model.md); [security posture](security.md).
+[^sealed]: Read-only rootfs, dropped caps, `no_new_privs`, non-root user namespace, compiled binary / no interpreter, [threat model §5 (B1, rows T and E)](threat-model.md); [security posture](security.md).
+[^queues]: Per-session encrypted SQLite queues, read-only inbound / append-only outbound, cross-session isolation, [threat model §5 (B2)](threat-model.md).
+[^escape]: gVisor (`runsc`) as the sandbox-escape mitigation for boundary B1 (row E), [threat model §5 (B1)](threat-model.md).
+[^platform]: gVisor is Linux-only; macOS falls back to runc-in-Docker, [README → Platform support](https://github.com/IronSecCo/ironclaw#platform-support); [quickstart security note](quickstart.md).
+[^gateway]: Mandatory human-approval gateway, `AlwaysRequireHuman` floor, agent cannot change its own config, [threat model §5-§6](threat-model.md); [security posture](security.md); [quickstart "Your first approved action"](quickstart.md).
+[^secrets]: Host-held secrets never enter the sandbox; model proxy injects the key host-side, [threat model §2, §5 (B1, row I), §6](threat-model.md).
+[^skills]: Skills are gateway-gated capability bundles, data-not-code, signature-verified, fail-closed, [threat model §12](threat-model.md); [skills](skills.md).
+[^mcp]: MCP servers are host-side, gateway-gated, deny-by-default, isolated, [threat model §13](threat-model.md).

--- a/docs/providers/.nav.yml
+++ b/docs/providers/.nav.yml
@@ -6,6 +6,7 @@
 # a nav line shared with other docs PRs, so provider PRs stop colliding.
 nav:
   - Choose your model provider: index.md
+  - Bring your own model (Ollama / Gemini / Vertex): ../bring-your-own-model.md
   - AWS Bedrock: bedrock.md
   - Azure OpenAI: azure.md
   - "*.md"

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -356,6 +356,7 @@ you the exact setup:
 ## See also
 
 - [Quickstart](../quickstart.md) — first working chat, then a real provider
+- [Bring your own model (Ollama / Gemini / Vertex)](../bring-your-own-model.md) — 5-minute setup per backend
 - [Run a 100% local model (Ollama)](../tutorials/local-model-ollama.md)
 - [Security and isolation](../security-isolation.md) — why keys stay host-side
 - [FAQ: which providers are supported?](../faq.md#which-model-providers-are-supported)

--- a/docs/security-isolation.md
+++ b/docs/security-isolation.md
@@ -34,6 +34,10 @@ your provider key, and the opt-in egress broker that is deny-by-default) plus th
 per-session encrypted queues (`inbound.db` bound read-only, `outbound.db`
 append-only).
 
+For the design rationale behind this posture, why the host is trusted and the agent
+is not, and what gVisor buys over a plain container, see
+[Why we run AI agents in gVisor](gvisor-deep-dive.md).
+
 ## What a compromised agent still cannot do
 
 We do not just assert the wall holds. We attack it. The


### PR DESCRIPTION
## What

Post-launch reach round 2 (IRO-290), in-repo deliverables.

**Two follow-up posts published** (drafts were gated on launch, IRO-118/IRO-213; launch blog now live via IRO-271):
- `docs/gvisor-deep-dive.md` — *Why we run AI agents in gVisor* (design rationale, complements the empirical *Breaking our own sandbox* post)
- `docs/bring-your-own-model.md` — *Ollama / Gemini / Vertex in 5 minutes*

**Wiring / cross-links:** mkdocs nav (Security & Trust, Model providers); cross-linked from `providers/index.md` and `security-isolation.md`.

**Metrics refresh:** new `community/adoption-metrics.md` snapshot (2026-07-03) with an honest delta readout vs the IRO-286 13-star baseline.

## Guardrails honored
- **No em/en-dashes** in either post (IRO-254). Draft `draft:`/gating frontmatter, internal `/IRO/` links, and the internal claims-matrix apparatus removed; claims re-pointed to shipped public sources (threat-model, benchmarks, containment gate).
- Provider claims limited to what ships on `main` (local, Gemini, Vertex, mock; full matrix linked).

## Verification
- `mkdocs build --strict` passes (both new pages build, nav + all internal links resolve; only pre-existing `social-proof.md#demo` INFO, unrelated).
- `grep -c '—|–'` = 0 on both posts.

## Not in this PR (owner-manual, out of agent scope)
Scope items 2 (engage Show HN / Reddit launch threads) and 3 (file 3 remaining directory submissions) require external accounts + identity guardrails and are owner-manual, tracked by IRO-271 (thread posting) and IRO-269 (submissions queue). Staged copy already exists in `community/launch-engagement-playbook.md` and `community/amplification-submissions-queue.md`. The metrics readout flags this as the round-2 bottleneck.