### PR TITLE
test(examples): release-readiness smoke matrix over every example dir (IRO-295)

### DIFF
--- a/.github/workflows/example-smoke.yml
+++ b/.github/workflows/example-smoke.yml
@@ -133,3 +133,30 @@ jobs:
       - name: Tear the demo down
         if: always()
         run: docker compose -f docker-compose.demo.yml down >/dev/null 2>&1 || true
+
+  smoke-matrix:
+    # RELEASE-READINESS smoke matrix (IRO-295): the single runner that exercises
+    # EVERY examples/*/ directory end-to-end against one offline control-plane and
+    # asserts real output. It extends the run-mock matrix above to also cover the
+    # config-recipe examples (setup.sh: channel-triage, keyword-watcher,
+    # multi-agent-team, personal-assistant) that the chat-only recipes cannot reach
+    # — those call `ironctl registry ...` against the live control-plane and are
+    # asserted to mint a real messaging-group id, so a broken CLI or registry route
+    # turns this job red. It rebuilds the demo image from the checkout first, which
+    # is what guards the IRO-278 class regression (a stale pre-fix image 500s with
+    # "UNIQUE constraint failed: messages_in.seq" under slack-triage's rapid sends).
+    #
+    # This is the `make smoke` target run in CI. Same additive/non-gating posture as
+    # the jobs above: NOT a required check, so it surfaces a broken first-run without
+    # ever blocking a release.
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Go (needed to build ironctl for the config recipes)
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Run the full example smoke matrix
+        run: examples/smoke-matrix.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build vet test fmt lint
+.PHONY: build vet test fmt lint smoke
 
 build:
 	go build ./...
@@ -14,3 +14,10 @@ fmt:
 
 lint:
 	go vet ./...
+
+# Release-readiness smoke matrix (IRO-295): build the demo images from the current
+# checkout, then run EVERY examples/*/ recipe end-to-end against one offline
+# control-plane and assert real output. Zero credentials (mock provider). Needs
+# Docker + jq. Exits non-zero on any empty/incorrect example output.
+smoke:
+	examples/smoke-matrix.sh

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,6 +34,26 @@ containment assertion fails. Same zero-credential path, no model key:
 examples/red-team-escape/run.sh       # build → up → attack → assert contained → tear down
 ```
 
+### Run the whole matrix in one command (release-readiness gate)
+
+[**`smoke-matrix.sh`**](smoke-matrix.sh) is the single release-readiness gate: it
+brings up one offline demo control-plane and runs **every** example directory
+end-to-end against it — the `hello-ironclaw` / `red-team-escape` round-trips, the
+three `run-mock.sh` reply recipes (each asserting a non-empty `.content` reply, the
+IRO-279 guard), and the four `setup.sh` config recipes (each asserting a real
+messaging-group id is minted) — then prints a PASS/FAIL/SKIP table and exits
+non-zero if any example produced empty or incorrect output. It rebuilds the demo
+image from the current checkout first, so it also catches control-plane regressions
+a stale image would hide. Zero credentials (mock provider); needs Docker + Go + jq:
+
+```sh
+make smoke                 # build images → up → run every example → assert → tear down
+examples/smoke-matrix.sh --attach   # against an already-running demo control-plane
+```
+
+It runs in CI as the `smoke-matrix` job in
+[`example-smoke.yml`](../.github/workflows/example-smoke.yml).
+
 ### Run a sandboxed agent in CI (GitHub Action)
 
 [**`ci-action/`**](ci-action/) documents the reusable

--- a/examples/smoke-matrix.sh
+++ b/examples/smoke-matrix.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# examples/smoke-matrix.sh — Release-readiness smoke matrix (IRO-295).
+#
+# Runs EVERY examples/*/ recipe end-to-end against ONE offline demo control-plane
+# and asserts the expected output is really produced, failing loudly on empty or
+# incorrect output. It is the developer-facing, single-command equivalent of the
+# CI jobs in .github/workflows/example-smoke.yml, EXTENDED to also exercise the
+# config-recipe examples (setup.sh) that the chat-only matrix cannot reach — so
+# every published example directory has a green (or explicitly-skipped) row.
+#
+# Zero credentials: every recipe drives the offline `mock` provider, which makes
+# no network call, so this needs nothing but Docker + Go + jq + curl.
+#
+# Why a fresh build matters: the inbound message-seq allocator is fixed in source
+# (IRO-278, single authoritative even-seq INSERT), but a STALE control-plane image
+# built before that fix will 500 with "UNIQUE constraint failed: messages_in.seq"
+# under the rapid multi-message sends in slack-triage. This runner therefore
+# rebuilds the demo image from the current checkout by default; pass SKIP_BUILD=1
+# only when you know your local images already match HEAD.
+#
+# Usage:
+#   examples/smoke-matrix.sh                # build images, bring demo up, run all, tear down
+#   SKIP_BUILD=1 examples/smoke-matrix.sh   # reuse existing images (faster; may be stale)
+#   examples/smoke-matrix.sh --attach       # use an already-running demo control-plane
+#   examples/smoke-matrix.sh --keep         # leave the demo running afterwards
+#
+# Exit status is 0 iff every non-skipped recipe passed.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+COMPOSE_FILE="$REPO_ROOT/docker-compose.demo.yml"
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+TOKEN="${IRONCLAW_API_TOKEN:-ironclaw-demo}"
+HEALTH_TIMEOUT="${IRONCLAW_HEALTH_TIMEOUT:-120}"
+
+ATTACH=0
+KEEP=0
+for arg in "$@"; do
+  case "$arg" in
+    --attach) ATTACH=1 ;;
+    --keep)   KEEP=1 ;;
+    -h|--help) sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+command -v jq   >/dev/null || { echo "smoke-matrix needs jq (https://jqlang.github.io/jq/)" >&2; exit 1; }
+command -v curl >/dev/null || { echo "smoke-matrix needs curl" >&2; exit 1; }
+
+compose() { docker compose -f "$COMPOSE_FILE" "$@"; }
+
+# --- results table ---------------------------------------------------------
+declare -a ROWS
+record() { ROWS+=("$1|$2|$3"); }   # dir | PASS/FAIL/SKIP | note
+
+# --- lifecycle -------------------------------------------------------------
+teardown() {
+  [ "$ATTACH" = 1 ] && return
+  if [ "$KEEP" = 1 ]; then
+    echo "==> leaving the demo running (--keep). Stop it with:"
+    echo "    docker compose -f docker-compose.demo.yml down"
+    return
+  fi
+  echo "==> tearing the demo down"
+  compose down >/dev/null 2>&1 || true
+}
+
+if [ "$ATTACH" = 0 ]; then
+  command -v docker >/dev/null || { echo "smoke-matrix needs Docker (or run with --attach)" >&2; exit 1; }
+  trap teardown EXIT
+  if [ "${SKIP_BUILD:-0}" != 1 ]; then
+    echo "==> building the sandbox image (container/build.sh)"
+    bash "$REPO_ROOT/container/build.sh" >/dev/null
+    echo "==> building the demo control-plane image from the current checkout"
+    compose build controlplane >/dev/null
+  fi
+  echo "==> starting the offline demo control-plane"
+  compose up -d >/dev/null
+fi
+
+echo -n "==> waiting for the control-plane to be ready (up to ${HEALTH_TIMEOUT}s)"
+ready=0
+for _ in $(seq 1 "$HEALTH_TIMEOUT"); do
+  if curl -fsS "$ADDR/healthz" >/dev/null 2>&1; then ready=1; break; fi
+  echo -n "."; sleep 1
+done
+echo
+if [ "$ready" != 1 ]; then
+  echo "FAIL: control-plane never became healthy at $ADDR" >&2
+  [ "$ATTACH" = 0 ] && compose logs --no-color 2>&1 | tail -40 >&2
+  exit 1
+fi
+
+# ironctl is needed by the setup.sh config recipes. Build it once from source so
+# the matrix runs on a clean checkout with no prior install.
+IRONCTL_BIN="$(command -v ironctl || true)"
+if [ -z "$IRONCTL_BIN" ]; then
+  echo "==> building ironctl for the config recipes"
+  tmpbin="$(mktemp -d)"
+  if go build -o "$tmpbin/ironctl" ./cmd/ironctl 2>/dev/null; then
+    IRONCTL_BIN="$tmpbin/ironctl"
+    export PATH="$tmpbin:$PATH"
+  else
+    echo "   (warning: could not build ironctl — setup.sh recipes will be SKIPped)" >&2
+  fi
+fi
+
+# --- runners ---------------------------------------------------------------
+
+# run.sh recipes (hello-ironclaw, red-team-escape) self-assert and support
+# --attach so they reuse the shared control-plane instead of managing their own.
+run_realpath_recipe() {
+  local dir="$1" name; name="$(basename "$dir")"
+  echo "::group::$name (run.sh --attach)"
+  if bash "$dir/run.sh" --attach; then record "$name" PASS "run.sh round-trip asserted"
+  else record "$name" FAIL "run.sh returned non-zero"; fi
+  echo "::endgroup::"
+}
+
+# run-mock.sh recipes self-assert a NON-EMPTY .content reply (the IRO-279 guard);
+# a bare non-zero exit is a real break (empty/wrong reply or broken round-trip).
+run_mock_recipe() {
+  local dir="$1" name; name="$(basename "$dir")"
+  echo "::group::$name (run-mock.sh)"
+  if IRONCLAW_ADDR="$ADDR" IRONCLAW_API_TOKEN="$TOKEN" bash "$dir/run-mock.sh"; then
+    record "$name" PASS "non-empty .content reply asserted"
+  else
+    record "$name" FAIL "empty/failed reply assertion"
+  fi
+  echo "::endgroup::"
+}
+
+# setup.sh recipes configure registry objects against the live control-plane.
+# They run under `set -euo pipefail`, so any ironctl error aborts non-zero — the
+# downstream wiring/destination calls fail loudly if an earlier create returned
+# an empty id. We additionally assert the recipe minted a real messaging-group id
+# so a silent null cannot pass.
+run_setup_recipe() {
+  local dir="$1" name; name="$(basename "$dir")"
+  echo "::group::$name (setup.sh)"
+  if [ -z "${IRONCTL_BIN:-}" ]; then
+    record "$name" SKIP "ironctl unavailable"; echo "::endgroup::"; return
+  fi
+  local out rc
+  out="$(IRONCLAW_ADDR="$ADDR" IRONCLAW_API_TOKEN="$TOKEN" bash "$dir/setup.sh" 2>&1)"; rc=$?
+  echo "$out"
+  if [ "$rc" -ne 0 ]; then
+    record "$name" FAIL "setup.sh exit=$rc"
+  elif printf '%s\n' "$out" | grep -qE 'messaging-group id: *(mg_[0-9a-f]+)'; then
+    record "$name" PASS "config applied, mg id minted"
+  else
+    record "$name" FAIL "no messaging-group id in output"
+  fi
+  echo "::endgroup::"
+}
+
+# --- dispatch every example directory --------------------------------------
+echo "==> running the example smoke matrix"
+for dir in "$REPO_ROOT"/examples/*/; do
+  dir="${dir%/}"
+  name="$(basename "$dir")"
+  if   [ -f "$dir/run.sh" ]      && grep -q -- '--attach' "$dir/run.sh"; then run_realpath_recipe "$dir"
+  elif [ -f "$dir/run-mock.sh" ]; then run_mock_recipe "$dir"
+  elif [ -f "$dir/setup.sh" ];    then run_setup_recipe "$dir"
+  else
+    # Doc-only recipe (e.g. ci-action, whose green run is proven by the
+    # reusable action in .github/workflows/ironclaw-action-example.yml).
+    record "$name" SKIP "doc-only; no runnable script"
+  fi
+done
+
+# --- report ----------------------------------------------------------------
+echo
+echo "================ example smoke matrix ================"
+fail=0 pass=0 skip=0
+for row in "${ROWS[@]}"; do
+  IFS='|' read -r n s note <<<"$row"
+  printf '  %-6s %-20s %s\n' "$s" "$n" "$note"
+  case "$s" in PASS) pass=$((pass+1));; FAIL) fail=$((fail+1));; SKIP) skip=$((skip+1));; esac
+done
+echo "-----------------------------------------------------"
+printf '  %d passed, %d failed, %d skipped\n' "$pass" "$fail" "$skip"
+echo "====================================================="
+
+[ "$fail" -eq 0 ] || { echo "SMOKE MATRIX RED: $fail example(s) failed" >&2; exit 1; }
+echo "SMOKE MATRIX GREEN"


### PR DESCRIPTION
## What

Release-readiness smoke matrix (IRO-295): one command runs **every** `examples/*/`
recipe end-to-end against a single offline demo control-plane and asserts real
output, failing loudly on empty/incorrect replies.

`examples/smoke-matrix.sh` classifies and drives each example dir:

| example | mode | assertion |
|---|---|---|
| hello-ironclaw | `run.sh --attach` | reply round-trips |
| red-team-escape | `run.sh --attach` | containment holds |
| scheduled-report | `run-mock.sh` | non-empty `.content` reply (IRO-279 guard) |
| slack-triage | `run-mock.sh` | non-empty `.content` reply |
| webhook-responder | `run-mock.sh` | non-empty `.content` reply |
| channel-triage | `setup.sh` | real messaging-group id minted |
| keyword-watcher | `setup.sh` | real messaging-group id minted |
| multi-agent-team | `setup.sh` | real messaging-group id minted |
| personal-assistant | `setup.sh` | real messaging-group id minted |
| ci-action | — | SKIP (doc-only; proven by `ironclaw-action-example.yml`) |

The four `setup.sh` config recipes are the coverage the chat-only matrix
(IRO-284, #307) never reached — they call `ironctl registry ...` against the live
control-plane, so a broken CLI or registry route now turns the gate red.

## Wire-up

- `make smoke` — the local one-command gate.
- `smoke-matrix` job in `example-smoke.yml` — same runner in CI (additive,
  non-gating), the green-on-clean-checkout proof.
- `examples/README.md` documents it.

The runner **rebuilds the demo image from the checkout first**, so it also catches
control-plane regressions a stale image would hide.

## Broken-example report

On a clean checkout of `origin/main` (b173e35, which includes the IRO-278/283
seq-allocator fix): **no example is broken** — all chat recipes round-trip and all
config recipes mint real ids.

One repro worth recording (a stale-image trap, not a source bug): running
`slack-triage/run-mock.sh` against a control-plane image built **before** the
IRO-278 fix 500s on its rapid multi-message sends:

```
POST /v1/ui/chat/send -> HTTP 500
host/router: write message_in: UNIQUE constraint failed: messages_in.seq
```

The single authoritative even-seq allocator (IRO-278, `internal/host/queue/queue.go`)
is on `origin/main`, so a fresh build is green. The matrix defaulting to a rebuild
is exactly what prevents this class of false-negative — and would catch a real
regression of that fix.

Coordinated with the IRO-279 `.content` fix (already merged): the `run-mock.sh`
recipes assert `.content`, so an IRO-279-class regression fails this gate.
