### PR TITLE
feat(provider): first-class Ollama zero-credential local provider (IRO-296)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,8 @@
 # permission denied", reddening the containment-report job for reasons unrelated to the
 # build. It is pure runtime state, never a build input, so exclude it from every context.
 .ironclaw-demo-state/
+.ironclaw-*-state/
+
+# Local dev / editor cruft that never belongs in the image either.
+site/
+*.log

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -111,6 +111,10 @@ func main() {
 		"OPT-IN: base URL of a LOCAL OpenAI-compatible model server — Ollama (http://localhost:11434/v1), LM Studio, vLLM, or llama.cpp. Allowlists its host, forwards to a loopback host over plain HTTP, and makes it the deployment-default model — no cloud credential. Empty disables local-model mode")
 	localModel := flag.String("local-model", os.Getenv("IRONCLAW_LOCAL_MODEL"),
 		"model id served by --local-model-url (e.g. llama3.2); required when --local-model-url is set")
+	ollama := flag.Bool("ollama", envBool("IRONCLAW_OLLAMA"),
+		"OPT-IN: enable the zero-credential Ollama provider. Reaches Ollama at OLLAMA_HOST (default localhost:11434) over plain HTTP, allowlists only that host, and makes it the deployment-default model — no cloud key. Ignored when --local-model-url is set")
+	ollamaModel := flag.String("ollama-model", envOr("IRONCLAW_OLLAMA_MODEL", "llama3.2"),
+		"model id served by Ollama when --ollama is set (must be pulled: `ollama pull <model>`)")
 	dev := flag.Bool("dev", false,
 		"seed the registry with a tiny dev owner/agent-group for local testing")
 	showVersion := flag.Bool("version", false, "print version and exit")
@@ -366,6 +370,31 @@ func main() {
 		}
 		localDefaultSel = session.ModelSelection{Provider: "local", Model: *localModel, Host: localModelHost}
 		logger.Info("local model enabled", "host", localModelHost, "model", *localModel, "scheme", parsed.Scheme, "credentialed", localKeyed)
+	}
+	// Ollama: the zero-credential, zero-config local path. Opt in with --ollama (or
+	// IRONCLAW_OLLAMA); the server is located at OLLAMA_HOST (default localhost:11434).
+	// Like the local block above it allowlists only that host, forwards over plain HTTP
+	// (Ollama serves no TLS on loopback), and makes it the deployment-default model so a
+	// provider-less agent group runs fully local with NO API key. A key is injected only
+	// if the operator set OLLAMA_API_KEY (an Ollama behind an authenticating reverse
+	// proxy). --local-model-url wins if both are set — it is the more explicit config.
+	if *ollama && localDefaultSel.Provider == "" {
+		ohost, oInsecure := ollamaHostPort(os.Getenv("OLLAMA_HOST"))
+		localModelHost = ohost
+		allowHosts = append(allowHosts, ohost)
+		if oInsecure {
+			localInsecure = append(localInsecure, ohost)
+		}
+		ollamaKeyed := false
+		if key := os.Getenv("OLLAMA_API_KEY"); key != "" {
+			injectors = append(injectors, modelproxy.OllamaInjector(ohost, key))
+			redactKeys = append(redactKeys, key)
+			ollamaKeyed = true
+		}
+		localDefaultSel = session.ModelSelection{Provider: "ollama", Model: *ollamaModel, Host: ohost}
+		logger.Info("ollama enabled", "host", ohost, "model", *ollamaModel, "insecure", oInsecure, "credentialed", ollamaKeyed)
+	} else if *ollama && *localModelURL != "" {
+		logger.Warn("--ollama ignored because --local-model-url is set (use one local provider at a time)")
 	}
 
 	credInjected := len(injectors) > 0
@@ -1178,6 +1207,49 @@ func envOr(key, def string) string {
 	return def
 }
 
+// envBool reports whether the environment variable key is set to a truthy value
+// ("1", "true", "yes", "on", case-insensitive). Anything else — including unset or
+// an explicit falsey value — is false. Used to default opt-in boolean flags from the
+// environment so a deployment can enable a feature without a command-line flag.
+func envBool(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// ollamaHostPort resolves the host:port to allowlist for the Ollama provider from an
+// OLLAMA_HOST value, reporting whether the upstream is plain HTTP (so the proxy
+// forwards without TLS). OLLAMA_HOST follows Ollama's own conventions: a bare
+// host:port ("127.0.0.1:11434"), a bare host ("localhost" — port 11434 assumed), or a
+// full URL ("http://host:11434", "https://ollama.example.com"). An empty value
+// resolves to the loopback default localhost:11434 over HTTP. https:// (a remote
+// Ollama behind TLS) resolves insecure=false; everything else is treated as plain HTTP
+// (loopback Ollama serves no TLS).
+func ollamaHostPort(env string) (hostPort string, insecure bool) {
+	env = strings.TrimSpace(env)
+	if env == "" {
+		return "localhost:11434", true
+	}
+	insecure = true
+	host := env
+	if strings.Contains(host, "://") {
+		u, err := url.Parse(host)
+		if err != nil || u.Host == "" {
+			return "localhost:11434", true
+		}
+		host = u.Host
+		insecure = u.Scheme != "https"
+	}
+	// Append Ollama's default port when the value carries a bare host with no port.
+	if _, _, err := net.SplitHostPort(host); err != nil {
+		host = net.JoinHostPort(host, "11434")
+	}
+	return strings.ToLower(host), insecure
+}
+
 // vertexAllowHost returns the Vertex AI host to allowlist for a region: the global
 // (region-less) endpoint for "global", otherwise the regional
 // {location}-aiplatform.googleapis.com. An unset location resolves to the same
@@ -1281,9 +1353,10 @@ func selectModelFromRegistry(reg *registry.MemRegistry, localDefault session.Mod
 			return def
 		}
 		sel := session.ModelSelection{Provider: g.Provider, Model: g.Model, Project: g.Project, Location: g.Location, APIVersion: g.APIVersion}
-		// A group pinned to the local provider but without its own host inherits the
-		// deployment's configured loopback host so it reaches the same local server.
-		if strings.EqualFold(sel.Provider, "local") && sel.Host == "" {
+		// A group pinned to the local or ollama provider but without its own host
+		// inherits the deployment's configured loopback host so it reaches the same
+		// local server the proxy allowlisted.
+		if (strings.EqualFold(sel.Provider, "local") || strings.EqualFold(sel.Provider, "ollama")) && sel.Host == "" {
 			sel.Host = localHost
 		}
 		// Likewise a bedrock-pinned group without its own host inherits the

--- a/cmd/controlplane/model_select_test.go
+++ b/cmd/controlplane/model_select_test.go
@@ -191,6 +191,66 @@ func TestSelectModel_LocalDefaultOverridesDevDefault(t *testing.T) {
 	}
 }
 
+// A group explicitly pinned to the ollama provider but carrying no host of its own
+// inherits the deployment's configured loopback host, exactly like the local provider
+// — so a provider-only pin reaches the same Ollama the proxy allowlisted.
+func TestSelectModel_OllamaGroupInheritsHost(t *testing.T) {
+	reg := registry.NewMemRegistry()
+	id := newSessionFor(t, reg, "ollama", "llama3.2")
+
+	sel := selectModelFromRegistry(reg, session.ModelSelection{}, "localhost:11434", "", "", "")(id)
+	if sel.Provider != "ollama" || sel.Host != "localhost:11434" {
+		t.Fatalf("ollama group must inherit the configured loopback host: got %+v", sel)
+	}
+}
+
+// ollamaHostPort resolves OLLAMA_HOST to the host:port the proxy allowlists, reporting
+// whether the upstream is plain HTTP. It must accept Ollama's own conventions: empty
+// (loopback default), bare host, host:port, and full http/https URLs — always matching
+// the host the sandbox provider addresses so the allowlist does not 403.
+func TestOllamaHostPort(t *testing.T) {
+	cases := []struct {
+		in           string
+		wantHost     string
+		wantInsecure bool
+	}{
+		{"", "localhost:11434", true},                                         // loopback default
+		{"127.0.0.1:11434", "127.0.0.1:11434", true},                          // bare host:port
+		{"localhost", "localhost:11434", true},                                // bare host, default port
+		{"http://localhost:11434", "localhost:11434", true},                   // explicit http URL
+		{"https://ollama.example.com", "ollama.example.com:11434", false},     // remote TLS, default port added
+		{"https://ollama.example.com:8443", "ollama.example.com:8443", false}, // remote TLS, explicit port
+		{"  http://192.168.1.9:11434  ", "192.168.1.9:11434", true},           // trimmed
+		{"HTTP://LocalHost:11434", "localhost:11434", true},                   // lowercased
+	}
+	for _, c := range cases {
+		gotHost, gotInsecure := ollamaHostPort(c.in)
+		if gotHost != c.wantHost || gotInsecure != c.wantInsecure {
+			t.Errorf("ollamaHostPort(%q) = (%q, %v), want (%q, %v)",
+				c.in, gotHost, gotInsecure, c.wantHost, c.wantInsecure)
+		}
+	}
+}
+
+// envBool defaults opt-in boolean flags (--ollama) from the environment. Only the
+// canonical truthy tokens enable; unset or anything else stays off.
+func TestEnvBool(t *testing.T) {
+	truthy := []string{"1", "true", "TRUE", "yes", "On", "  true  "}
+	falsy := []string{"", "0", "false", "no", "off", "maybe"}
+	for _, v := range truthy {
+		t.Setenv("IRONCLAW_ENVBOOL_T", v)
+		if !envBool("IRONCLAW_ENVBOOL_T") {
+			t.Errorf("envBool(%q) = false, want true", v)
+		}
+	}
+	for _, v := range falsy {
+		t.Setenv("IRONCLAW_ENVBOOL_F", v)
+		if envBool("IRONCLAW_ENVBOOL_F") {
+			t.Errorf("envBool(%q) = true, want false", v)
+		}
+	}
+}
+
 // A group explicitly pinned to the local provider but carrying no host of its own
 // inherits the deployment's configured loopback host.
 func TestSelectModel_LocalGroupInheritsHost(t *testing.T) {

--- a/cmd/sandbox/main.go
+++ b/cmd/sandbox/main.go
@@ -67,7 +67,7 @@ func run() error {
 		mcpSocket     = flag.String("mcp-socket", "", "host MCP-broker unix socket; when set, registers the agent's gateway-approved MCP-server tools (empty = no MCP surface)")
 		modelHost     = flag.String("model-host", "", "upstream model host the proxy allowlists (defaults to the provider's host)")
 		model         = flag.String("model", "", "model id override (defaults to the provider's default)")
-		modelKind     = flag.String("provider", "", "model provider: anthropic (default), openai, openrouter, codex, gemini, vertex, local (self-hosted OpenAI-compatible: Ollama/LM Studio/vLLM), or azure (Azure OpenAI); selected per agent group host-side")
+		modelKind     = flag.String("provider", "", "model provider: anthropic (default), openai, openrouter, codex, gemini, vertex, local (self-hosted OpenAI-compatible: LM Studio/vLLM), ollama (zero-credential local Ollama), or azure (Azure OpenAI); selected per agent group host-side")
 		modelProject  = flag.String("model-project", "", "Google Cloud project id for the vertex provider (rides in the request URL path)")
 		modelLocation = flag.String("model-location", "", "Google Cloud region for the vertex provider (empty = the provider's default region)")
 		modelAPIVer   = flag.String("model-api-version", "", "Azure OpenAI api-version query parameter (azure provider only; empty = the provider's default)")

--- a/docs/providers/.nav.yml
+++ b/docs/providers/.nav.yml
@@ -10,4 +10,5 @@ nav:
   - AWS Bedrock: bedrock.md
   - Azure OpenAI: azure.md
   - OpenRouter (100+ models): openrouter.md
+  - Ollama (zero-credential local): ollama.md
   - "*.md"

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -25,8 +25,9 @@ not change. This page helps you choose one, then links you straight to setup.
 
     No cloud, no key, nothing leaves the box.
 
-    → **`mock`** for a demo or CI, **`local`** (Ollama / LM Studio / vLLM) for a
-    real model on your own hardware.
+    → **`mock`** for a demo or CI, **`ollama`** for a real model on your own
+    hardware with zero setup, **`local`** for any other OpenAI-compatible server
+    (LM Studio / vLLM).
 
 -   :material-cloud-outline: __Hosted, fastest to first token__
 
@@ -217,7 +218,8 @@ export IRONCLAW_MODEL_GATEWAY_HOSTS=chatgpt.com</code></pre><button type="button
 | Provider | Kind | Auth method | Credential source (host-side) | Streaming | Best for | Setup |
 |---|---|---|---|---|---|---|
 | **Mock** | `mock` | none | none — offline, deterministic | n/a | Demos, e2e tests, first run | [Quickstart](../quickstart.md#a-working-chat-in-5-minutes-no-credentials) |
-| **Local / self-hosted** | `local` | none (optional key) | `IRONCLAW_LOCAL_MODEL_KEY` only if your server requires one | server-dependent | 100% local model, no data egress | [Ollama tutorial](../tutorials/local-model-ollama.md) |
+| **Ollama** | `ollama` | none (optional key) | none — `OLLAMA_API_KEY` only for an auth-gateway'd Ollama | yes (SSE) | Zero-credential local model, easiest quickstart | [Ollama provider](ollama.md) |
+| **Local / self-hosted** | `local` | none (optional key) | `IRONCLAW_LOCAL_MODEL_KEY` only if your server requires one | server-dependent | Any OpenAI-compatible server (LM Studio, vLLM, llama.cpp) | [Ollama tutorial](../tutorials/local-model-ollama.md) |
 | **Anthropic** _(default)_ | `anthropic` | API key | `ANTHROPIC_API_KEY` | yes (SSE) | Strongest default, tool use | [Quickstart](../quickstart.md#a-working-chat-in-5-minutes-no-credentials) |
 | **OpenAI** | `openai` | API key | `OPENAI_API_KEY` | yes (SSE) | GPT-class models | [Setup](#anthropic-openai-openrouter) |
 | **OpenRouter** | `openrouter` | API key | `OPENROUTER_API_KEY` | yes (SSE) | One key, many models | [Setup](#anthropic-openai-openrouter) |
@@ -238,9 +240,12 @@ export IRONCLAW_MODEL_GATEWAY_HOSTS=chatgpt.com</code></pre><button type="button
 
 - **Just want to see it work?** Start with **`mock`** — no key, no network. The
   [Quickstart](../quickstart.md) zero-credential demo replies in seconds.
-- **Privacy or air-gap is the constraint?** Run **`local`** against Ollama, LM
-  Studio, vLLM, or llama.cpp on your own box. Nothing leaves the machine, and no
-  cloud credential is required. See the [local model tutorial](../tutorials/local-model-ollama.md).
+- **Privacy or air-gap is the constraint?** Run a model on your own box — nothing
+  leaves the machine and no cloud credential is required. Use **`ollama`** for the
+  zero-config path (`--provider ollama` works with nothing else set; see the
+  [Ollama provider](ollama.md)), or **`local`** for any other OpenAI-compatible
+  server (LM Studio, vLLM, llama.cpp; see the
+  [local model tutorial](../tutorials/local-model-ollama.md)).
 - **You have an API key and want the best answer now?** Use **`anthropic`** (the
   default), **`openai`**, **`openrouter`**, or **`gemini`**. One environment
   variable and a restart.

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -1,0 +1,117 @@
+---
+title: "Ollama (zero-credential local model)"
+description: Run IronClaw against a model on your own machine with no cloud API key. First-class ollama provider, OLLAMA_HOST config, per-group setup, and how the credential-free path stays sealed.
+---
+
+# Ollama provider
+
+**`ollama`** is IronClaw's lowest-friction, **zero-credential** backend: point the
+sandbox at a model running on your own machine and there is **no cloud API key
+anywhere in the stack**. It is the easiest way to evaluate IronClaw, the natural fit
+for demos and CI, and the only provider where "where does the credential come from"
+has the answer *nowhere*.
+
+[Ollama](https://ollama.com) serves the **identical OpenAI Chat Completions wire
+format** (`POST /v1/chat/completions`) as the hosted `openai` provider, so IronClaw
+reuses the same request/streaming path. The `ollama` kind only adds the ergonomic
+defaults that make it zero-config.
+
+!!! abstract "The isolation invariant still holds"
+    Choosing `ollama` changes *where the model runs*, not *how the agent is sealed*.
+    The agent still runs in a per-session Docker sandbox and can reach the model only
+    through the host model-proxy allowlist. The difference from a cloud provider is
+    that there is no secret to hold host-side — see
+    [Choose your model provider](index.md) and
+    [Security and isolation](../security-isolation.md).
+
+## Quick start
+
+1. **Install Ollama and pull a model:**
+   ```sh
+   ollama pull llama3.2
+   ```
+2. **Start the control-plane with the ollama provider:**
+   ```sh
+   controlplane --ollama            # or: IRONCLAW_OLLAMA=1 controlplane
+   ```
+3. **Chat.** With `--ollama` set, ollama is the deployment-default model, so a
+   provider-less agent group runs fully local. To pin a specific group to it:
+   ```sh
+   ironctl agent create --yes --id local-helper --name "Local Helper" \
+     --provider ollama --model llama3.2
+   ```
+
+A complete runnable version — create the group, send a chat, print the reply — is in
+[`examples/ollama/`](https://github.com/IronSecCo/ironclaw/tree/main/examples/ollama).
+
+## Configuration
+
+| What | Flag / env | Default | Notes |
+|---|---|---|---|
+| Enable the provider | `--ollama` / `IRONCLAW_OLLAMA=1` | off | Opt in. Makes ollama the deployment default and allowlists its host. |
+| Deployment-default model | `--ollama-model` / `IRONCLAW_OLLAMA_MODEL` | `llama3.2` | Must be pulled (`ollama pull <model>`). |
+| Ollama location | `OLLAMA_HOST` | `localhost:11434` | Bare host, `host:port`, or a full `http(s)://` URL. `https://` forwards over TLS; everything else over plain HTTP. |
+| Optional gateway key | `OLLAMA_API_KEY` | unset | Only for an Ollama behind an authenticating reverse proxy. Injected **host-side**; never enters the sandbox. |
+
+`OLLAMA_HOST` follows Ollama's own conventions:
+
+```sh
+export OLLAMA_HOST=127.0.0.1:11500              # non-default port
+export OLLAMA_HOST=http://192.168.1.9:11434     # another machine, plain HTTP
+export OLLAMA_HOST=https://ollama.example.com   # remote Ollama behind TLS (port 11434 assumed)
+```
+
+The control-plane allowlists exactly that host on the model-proxy, so nothing else
+the sandbox tries to reach will resolve.
+
+### Per-group selection
+
+Any agent group can pin `--provider ollama` independently of the deployment default.
+A group pinned to `ollama` with no host of its own inherits the deployment's
+configured Ollama host, so a provider-only pin still reaches the right server.
+
+## How it stays credential-free
+
+- The **sandbox** builds a bare Chat Completions request with no `Authorization`
+  header. It holds no key because none exists.
+- The **host model-proxy** forwards to Ollama as-is. With no `OLLAMA_API_KEY` set the
+  injector is a no-op — the request goes out with no credential at all.
+- If you *do* set `OLLAMA_API_KEY` (an Ollama fronted by an auth gateway), the key is
+  stamped as a `Bearer` header **only on the allowlisted Ollama host** and never
+  crosses into the sandbox. It self-guards so it can never leak to another upstream.
+
+## `ollama` vs `local`
+
+Both run a self-hosted, OpenAI-compatible model with no cloud key. The difference is
+ergonomics:
+
+- **`ollama`** knows Ollama's defaults (`localhost:11434`, a common model), so
+  `--provider ollama` works with nothing else configured.
+- **`local`** (LM Studio, vLLM, llama.cpp) is the generic path: you supply the full
+  endpoint with `--local-model-url`. Use it for any other OpenAI-compatible server.
+  See the [100% local model tutorial](../tutorials/local-model-ollama.md).
+
+`--ollama` is ignored if `--local-model-url` is also set — run one local provider at a
+time; the explicit URL wins.
+
+## Docker / Compose
+
+When the control-plane runs in a container and Ollama runs on the host, point
+`OLLAMA_HOST` at the host gateway:
+
+```sh
+export OLLAMA_HOST=http://host.docker.internal:11434
+```
+
+That host is allowlisted the same way; the request still carries no credential.
+
+## Troubleshooting
+
+- **No reply / times out.** Confirm `ollama pull <model>` ran and `ollama list` shows
+  it, and that the control-plane logged `ollama enabled`. The first token is slow
+  while Ollama loads the model into memory.
+- **`--ollama` seems ignored.** It is skipped when `--local-model-url` is set, and it
+  does not override a group that pins a *different* explicit provider.
+- **Wrong host.** The proxy allowlists exactly the resolved `OLLAMA_HOST`; a mismatch
+  (e.g. `localhost` vs `127.0.0.1`, or a missing port) will not resolve. The log line
+  `ollama enabled host=...` shows the resolved value.

--- a/examples/README.md
+++ b/examples/README.md
@@ -83,6 +83,7 @@ docker compose -f docker-compose.demo.yml down            # tear down
 |--------|---------------|:--------------------:|
 | [`hello-ironclaw/`](hello-ironclaw/) | The full path working end-to-end, asserted — the smoke test + first "it works". | ✅ `run.sh` (self-contained) |
 | [`red-team-escape/`](red-team-escape/) | The sandbox **holding** under attack — network egress, host/socket escape, sibling breakout, and gateway-held self-modification, all asserted contained. | ✅ `run.sh` (self-contained) |
+| [`ollama/`](ollama/) | A real agent on a **local Ollama model** with **zero cloud API key** — the first-class `ollama` provider, create-group + chat + reply. | ✅ `setup.sh` (needs local Ollama) |
 | [`scheduled-report/`](scheduled-report/) | An agent that wakes itself on a schedule (`schedule_task`), summarizes, and posts to a channel. | ✅ `run-mock.sh` |
 | [`webhook-responder/`](webhook-responder/) | An inbound HTTP webhook routed to an agent that replies (poll or push-back via a `webhook` destination). | ✅ `run-mock.sh` |
 | [`slack-triage/`](slack-triage/) | A bot that classifies/labels **every** incoming Slack message. | ✅ `run-mock.sh` |

--- a/examples/ollama/README.md
+++ b/examples/ollama/README.md
@@ -1,0 +1,58 @@
+# Ollama (zero-credential local model)
+
+Run a real IronClaw agent against a model on **your own machine**, with **no cloud
+API key anywhere in the stack**. This is the lowest-friction path for OSS evaluators,
+demos, and CI: [Ollama](https://ollama.com) serves the OpenAI Chat Completions wire
+format, and IronClaw's first-class **`ollama`** provider points the sealed sandbox at
+it — the host model-proxy forwards to `localhost:11434` over plain HTTP with **no
+Authorization header**, because Ollama needs no credential.
+
+## What it configures
+
+- An agent group `local-helper` pinned to `--provider ollama --model llama3.2`.
+- Nothing else: no API key is set here or anywhere. The credential-free path is the
+  whole point.
+
+Then it sends the agent one chat and prints the reply, proving the round-trip runs
+end to end on a local model.
+
+## Prerequisites
+
+1. **Install Ollama and pull a model:**
+   ```sh
+   ollama pull llama3.2      # or any model; set OLLAMA_MODEL to match
+   ```
+2. **Start the control-plane with the ollama provider enabled:**
+   ```sh
+   controlplane --ollama       # or: IRONCLAW_OLLAMA=1 controlplane
+   ```
+   That allowlists `localhost:11434`, forwards over plain HTTP, and makes ollama the
+   deployment-default model. For a non-default port or a remote Ollama, set
+   `OLLAMA_HOST` first (e.g. `export OLLAMA_HOST=127.0.0.1:11500` or
+   `export OLLAMA_HOST=https://ollama.example.com`).
+
+## Try it
+
+```sh
+export IRONCLAW_API_TOKEN=<your control-plane API token>
+cd examples/ollama
+./setup.sh
+```
+
+Override the defaults with env vars: `OLLAMA_MODEL` (must be pulled) and `PROMPT`.
+
+## What to notice
+
+- **No credential, anywhere.** Unlike every cloud provider (`openai`, `bedrock`,
+  `azure`, ...), the `ollama` kind holds no key — the sandbox has none and the host
+  injects none. The one exception is an Ollama behind an authenticating reverse
+  proxy: set `OLLAMA_API_KEY` on the control-plane and it is injected host-side only,
+  never entering the sandbox.
+- **Same sealed path as any provider.** The agent still runs in a per-session Docker
+  sandbox and reaches the model only through the host model-proxy allowlist — the
+  isolation guarantees are identical to the hosted providers; only the credential
+  handling differs.
+- **`ollama` vs `local`.** The older `local` kind (LM Studio / vLLM / llama.cpp) needs
+  you to pass a full `--local-model-url`; `ollama` supplies Ollama's defaults
+  (`localhost:11434`, a common model) so `--provider ollama` works with nothing else
+  set. See [docs/providers/ollama.md](../../docs/providers/ollama.md).

--- a/examples/ollama/run-mock.sh
+++ b/examples/ollama/run-mock.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Credential-free end-to-end smoke for the Ollama recipe.
+#
+# The real recipe (setup.sh) points an agent group at your LOCAL Ollama, which CI
+# has no way to run. So the smoke instead drives the offline `mock-agent` seeded by
+# docker-compose.demo.yml and asserts a non-empty reply — proving the sealed
+# send/poll round-trip works with NO model, NO key, NO Ollama. Bring the demo up
+# first:
+#
+#   docker compose -f docker-compose.demo.yml up -d --build
+#
+# For the real zero-credential local run against Ollama, use setup.sh (see README).
+set -euo pipefail
+
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+TOKEN="${IRONCLAW_API_TOKEN:-ironclaw-demo}"
+AGENT="mock-agent"
+PROMPT="${PROMPT:-Say hello in one short sentence.}"
+
+command -v jq >/dev/null || { echo "this demo needs jq (https://jqlang.github.io/jq/)" >&2; exit 1; }
+
+echo "==> sending a chat to the offline mock-agent (stands in for your local Ollama): \"${PROMPT}\""
+curl -fsS -X POST "$ADDR/v1/ui/chat/send" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg a "$AGENT" --arg t "$PROMPT" '{agentGroupID:$a, text:$t}')" >/dev/null
+
+echo -n "==> waiting for the reply"
+# /messages is drain-on-read and the reply text is `.messages[].content` (NOT
+# `.text`, the /chat/send REQUEST field). Asserting a NON-EMPTY reply is the guard
+# that catches an IRO-279-class regression, so an empty reply FAILS the script.
+for _ in $(seq 1 30); do
+  out="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
+    -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.content // empty')"
+  if [ -n "$out" ]; then echo; printf '   -> %s\n' "$out"; exit 0; fi
+  echo -n "."; sleep 1
+done
+echo
+echo "FAIL: no reply within 30s — the .content round-trip returned empty." >&2
+echo "      is the demo control-plane up and the sandbox image built?" >&2
+exit 1

--- a/examples/ollama/setup.sh
+++ b/examples/ollama/setup.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Zero-credential local agent, powered by Ollama — see README.md.
+# Creates one agent group pinned to the first-class `ollama` provider so it runs
+# against a model on your own machine with NO cloud API key anywhere in the stack,
+# then sends it a chat and prints the reply.
+#
+# Prerequisites (see README.md):
+#   1. ollama pull llama3.2                 # or set OLLAMA_MODEL
+#   2. start the control-plane with --ollama (or IRONCLAW_OLLAMA=1)
+#      for a non-default port or a remote Ollama: export OLLAMA_HOST=host:port first
+set -euo pipefail
+
+# --- edit these for your setup ---------------------------------------------
+AGENT="local-helper"
+MODEL="${OLLAMA_MODEL:-llama3.2}"   # must be pulled first: `ollama pull llama3.2`
+PROMPT="${PROMPT:-Say hello in one short sentence.}"
+# ---------------------------------------------------------------------------
+
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+: "${IRONCLAW_API_TOKEN:?set IRONCLAW_API_TOKEN to your control-plane API token}"
+TOKEN="$IRONCLAW_API_TOKEN"
+ic() { ironctl --addr "$ADDR" "$@"; }   # ironctl reads IRONCLAW_API_TOKEN from the env
+
+# No API key is set here or anywhere else: the ollama provider needs none. The host
+# model-proxy reaches Ollama at OLLAMA_HOST (default localhost:11434) over plain HTTP
+# and forwards with no Authorization header. The sandbox never sees a secret because
+# there is none.
+echo "==> agent group pinned to the ollama provider (zero credential): ${AGENT}"
+ic agent create --yes \
+  --id "$AGENT" --name "Local Helper (Ollama)" \
+  --provider ollama --model "$MODEL"
+
+echo "==> sending a chat: \"${PROMPT}\""
+curl -fsS -X POST "$ADDR/v1/ui/chat/send" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg a "$AGENT" --arg t "$PROMPT" '{agentGroupID:$a, text:$t}')" >/dev/null
+
+echo -n "==> waiting for the local model's reply (up to 120s; first token is slow while Ollama loads the model)"
+reply=""
+for _ in $(seq 1 120); do
+  # /messages is drain-on-read: the reply text is `.messages[].content`; read it once.
+  got="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
+          -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.content // empty')"
+  if [ -n "$got" ]; then reply="$got"; break; fi
+  echo -n "."; sleep 1
+done
+echo
+
+if [ -z "$reply" ]; then
+  echo "FAIL: no reply — check that (1) 'ollama pull ${MODEL}' has been run and" >&2
+  echo "      (2) the control-plane was started with --ollama. See README.md." >&2
+  exit 1
+fi
+echo "==> reply from local '${MODEL}' (no credential used anywhere):"
+echo "    ${reply}"

--- a/internal/host/modelproxy/ollama.go
+++ b/internal/host/modelproxy/ollama.go
@@ -1,0 +1,18 @@
+package modelproxy
+
+// OllamaInjector returns an Injector for the Ollama provider. Ollama needs NO
+// credential — the whole point of the ollama backend is the zero-key local path — so
+// with an empty apiKey this is a no-op and the proxy forwards requests to Ollama with
+// no Authorization header. A non-empty key covers the rare case of an Ollama reached
+// through an authenticating reverse proxy (e.g. a shared/remote Ollama behind a
+// gateway that requires a Bearer token); the key then lives only on the host and never
+// enters the sandbox.
+//
+// Ollama is OpenAI-wire-compatible and authenticates (when it does at all) via the
+// same Bearer scheme, so this delegates to LocalInjector, which self-guards on the
+// exact upstream host and no-ops for every other provider — safe to compose through
+// MultiInjector. It is a named alias so the ollama provider's auth path is explicit
+// and greppable rather than piggybacking on "local".
+func OllamaInjector(host, apiKey string) Injector {
+	return LocalInjector(host, apiKey)
+}

--- a/internal/host/modelproxy/ollama_test.go
+++ b/internal/host/modelproxy/ollama_test.go
@@ -1,0 +1,34 @@
+package modelproxy
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestOllamaInjectorNoKey is the core credential-free guarantee: with no key (the
+// default and expected ollama path), the injector never stamps an Authorization
+// header, so the proxy forwards to Ollama with no credential at all.
+func TestOllamaInjectorNoKey(t *testing.T) {
+	req, _ := http.NewRequest("POST", "http://localhost:11434/v1/chat/completions", nil)
+	OllamaInjector("localhost:11434", "")("localhost:11434", req)
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("Authorization set with empty key: %q, want empty (ollama needs no credential)", got)
+	}
+}
+
+// TestOllamaInjectorOptionalKey covers the rare Ollama behind an authenticating
+// reverse proxy: a host-held key is stamped as Bearer on the matching host (bare host
+// also matches) but is never leaked to any other upstream.
+func TestOllamaInjectorOptionalKey(t *testing.T) {
+	req, _ := http.NewRequest("POST", "http://localhost:11434/v1/chat/completions", nil)
+	OllamaInjector("localhost:11434", "sk-gateway")("localhost", req)
+	if got := req.Header.Get("Authorization"); got != "Bearer sk-gateway" {
+		t.Errorf("Authorization = %q, want Bearer sk-gateway", got)
+	}
+	// Off-host: never leak the key to another upstream (e.g. a real cloud provider).
+	other, _ := http.NewRequest("POST", "http://api.openai.com/v1/chat/completions", nil)
+	OllamaInjector("localhost:11434", "sk-gateway")("api.openai.com", other)
+	if got := other.Header.Get("Authorization"); got != "" {
+		t.Errorf("ollama key leaked off-host: %q", got)
+	}
+}

--- a/internal/sandbox/provider/ollama.go
+++ b/internal/sandbox/provider/ollama.go
@@ -1,0 +1,64 @@
+// This file adds Ollama as a first-class, zero-credential provider so anyone can run
+// IronClaw against a model on their own machine with NO API key at all — the lowest-
+// friction path for OSS evaluators, demos, and CI. Ollama serves the IDENTICAL
+// OpenAI Chat Completions wire format (POST /v1/chat/completions) as KindOpenAI, so
+// this file does NOT fork the translation or streaming logic: NewOllama returns a
+// *OpenAIProvider whose only differences are ergonomic defaults —
+//
+//   - Host: defaults to the Ollama loopback default (localhost:11434) when cfg leaves
+//     it empty, so `--provider ollama` works with no other configuration. The
+//     control-plane overrides it from OLLAMA_HOST for a non-default port or a remote
+//     Ollama. The proxy reaches it over plain HTTP (Ollama serves no TLS on loopback)
+//     and allowlists only that host.
+//   - Model: defaults to a common small local model when cfg leaves it empty. Operators
+//     override it with --model (the model must be pulled: `ollama pull <model>`).
+//   - Auth: NONE. Ollama needs no credential; the sandbox holds none and the host
+//     model-proxy forwards with no Authorization header. An OPTIONAL key is injected
+//     host-side only for an Ollama behind an authenticating reverse proxy
+//     (modelproxy.OllamaInjector) — never by the sandbox.
+
+package provider
+
+// KindOllama routes to Ollama (https://ollama.com), the popular self-hosted model
+// runner, at its loopback default localhost:11434. It is the lowest-friction,
+// ZERO-CREDENTIAL path: no cloud key at all, ideal for OSS evaluators, demos, and CI.
+// Ollama serves the identical OpenAI Chat Completions wire format as KindOpenAI (POST
+// /v1/chat/completions), so it reuses OpenAIProvider; unlike KindLocal it supplies
+// zero-config defaults (the localhost:11434 host and a common local model) so
+// `--provider ollama` works with nothing else set. The control-plane backfills the
+// host from OLLAMA_HOST for a non-default port or a remote Ollama, allowlists only that
+// host, and forwards over plain HTTP. See NewOllama and modelproxy.OllamaInjector.
+const KindOllama = "ollama"
+
+func init() {
+	Register(KindOllama, func(cfg Config) (Provider, error) { return NewOllama(cfg), nil })
+}
+
+// defaultOllamaHost is the host:port the Ollama provider allowlists and dials when
+// cfg.UpstreamHost is empty. It is Ollama's own default bind address, so `--provider
+// ollama` with nothing else reaches a stock local Ollama. The control-plane backfills
+// a different host from OLLAMA_HOST.
+const defaultOllamaHost = "localhost:11434"
+
+// defaultOllamaModel is the model id used when cfg.Model is empty. It targets a small,
+// widely-pulled local model so the credential-free quickstart works after a single
+// `ollama pull`. Operators override it with --model.
+const defaultOllamaModel = "llama3.2"
+
+// NewOllama constructs an Ollama backend, reusing OpenAIProvider unchanged (the wire
+// format is identical) and only supplying Ollama's zero-config defaults: the
+// localhost:11434 loopback host and a common local model when cfg leaves them empty.
+// No credential is required or held — Ollama needs none; the host model-proxy forwards
+// over plain HTTP and injects a key only if the operator configured one for a guarded
+// reverse proxy. Callers usually go through New.
+func NewOllama(cfg Config) *OpenAIProvider {
+	if cfg.UpstreamHost == "" {
+		cfg.UpstreamHost = defaultOllamaHost
+	}
+	if cfg.Model == "" {
+		cfg.Model = defaultOllamaModel
+	}
+	// NewOpenAI fills the remaining defaults (socket, max tokens, timeout) and builds
+	// the http://<host>/v1/chat/completions URL that Ollama's OpenAI-compat API serves.
+	return NewOpenAI(cfg)
+}

--- a/internal/sandbox/provider/ollama_test.go
+++ b/internal/sandbox/provider/ollama_test.go
@@ -1,0 +1,97 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestOllamaQuerySuccess exercises the ollama provider (KindOllama) end to end against
+// a fake OpenAI-compatible server on a unix socket. Ollama serves the IDENTICAL Chat
+// Completions wire format, so this asserts the request keeps the standard path,
+// addresses the configured host (so the model-proxy allowlist matches), and carries NO
+// Authorization header — the whole point of the ollama backend is the zero-credential
+// local path: the sandbox holds no key and the host injects none by default.
+func TestOllamaQuerySuccess(t *testing.T) {
+	const ollamaHost = "localhost:11434"
+	var gotBody []byte
+	var gotPath, gotHost, gotAuth string
+	sock := serveUnix(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotHost = r.Host
+		gotAuth = r.Header.Get("Authorization")
+		gotBody, _ = io.ReadAll(r.Body)
+		writeSSE(w, chatHelloStream)
+	}))
+
+	p, err := New(Config{Kind: KindOllama, SocketPath: sock, UpstreamHost: ollamaHost, Model: "llama3.2"})
+	if err != nil {
+		t.Fatalf("New(ollama): %v", err)
+	}
+	out, err := p.Query(context.Background(), "hi there")
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if out != "hello world" {
+		t.Fatalf("Query output = %q, want %q", out, "hello world")
+	}
+	if gotPath != "/v1/chat/completions" {
+		t.Fatalf("path = %q, want /v1/chat/completions", gotPath)
+	}
+	if gotHost != ollamaHost {
+		t.Fatalf("Host = %q, want %q (proxy allowlists on Host)", gotHost, ollamaHost)
+	}
+	if gotAuth != "" {
+		t.Fatalf("Authorization = %q, want empty (ollama needs no credential)", gotAuth)
+	}
+
+	var req oaiChatRequest
+	if err := json.Unmarshal(gotBody, &req); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if req.Model != "llama3.2" {
+		t.Fatalf("model = %q, want %q", req.Model, "llama3.2")
+	}
+}
+
+// TestOllamaFactoryDefaults verifies the zero-config ergonomics that distinguish
+// KindOllama from KindLocal: with NO host and NO model set, the factory backfills
+// Ollama's loopback default (localhost:11434) and a common local model, and builds an
+// OpenAIProvider pointed at that loopback /v1/chat/completions URL. This is what makes
+// `--provider ollama` work with nothing else configured.
+func TestOllamaFactoryDefaults(t *testing.T) {
+	pv, err := New(Config{Kind: KindOllama})
+	if err != nil {
+		t.Fatalf("ollama with no host/model: want defaults, got error: %v", err)
+	}
+	op, ok := pv.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("ollama kind = %T, want *OpenAIProvider", pv)
+	}
+	if !strings.Contains(op.url, defaultOllamaHost+"/v1/chat/completions") {
+		t.Fatalf("ollama url = %q, want the %s loopback path", op.url, defaultOllamaHost)
+	}
+	if op.cfg.Model != defaultOllamaModel {
+		t.Fatalf("ollama default model = %q, want %q", op.cfg.Model, defaultOllamaModel)
+	}
+}
+
+// TestOllamaFactoryOverrides checks that explicit host/model win over the defaults
+// (a non-default port or a remote Ollama backfilled from OLLAMA_HOST by the control
+// plane), that the kind is case-insensitive, and that no credential is ever required.
+func TestOllamaFactoryOverrides(t *testing.T) {
+	pv, err := New(Config{Kind: "Ollama", UpstreamHost: "192.168.1.9:11434", Model: "qwen2.5"}) // case-insensitive
+	if err != nil {
+		t.Fatalf("ollama override: %v", err)
+	}
+	op := pv.(*OpenAIProvider)
+	if !strings.Contains(op.url, "192.168.1.9:11434/v1/chat/completions") {
+		t.Fatalf("ollama url = %q, want the overridden host path", op.url)
+	}
+	if op.cfg.Model != "qwen2.5" {
+		t.Fatalf("ollama model = %q, want overridden qwen2.5", op.cfg.Model)
+	}
+}

--- a/internal/sandbox/provider/provider.go
+++ b/internal/sandbox/provider/provider.go
@@ -58,9 +58,10 @@ const (
 // sealed single-provider posture is unchanged unless a group opts into another
 // backend. Its provider (AnthropicProvider) lives in this file and self-registers
 // in init below. Every OTHER kind is declared and registered in its own backend
-// file (openai.go, azure.go, ...) so adding a provider means adding ONE file that
-// touches no shared line here. Each kind maps to a model-proxy-allowlisted upstream
-// host that the host authenticates with its own credential (see internal/host/modelproxy).
+// file (openai.go, azure.go, ollama.go, ...) so adding a provider means adding ONE
+// file that touches no shared line here. Each kind maps to a model-proxy-allowlisted
+// upstream host that the host authenticates with its own credential (see
+// internal/host/modelproxy).
 const KindAnthropic = "anthropic"
 
 // Factory builds a Provider from cfg. A backend's Factory is responsible for
@@ -126,8 +127,8 @@ func New(cfg Config) (Provider, error) {
 // given backend ignores (e.g. DisableThinking for OpenAI) are simply unused.
 type Config struct {
 	// Kind selects the backend: "" / "anthropic" (default), "openai",
-	// "openrouter", "codex", "gemini", "vertex", "local", or "azure". See New. The
-	// kind is chosen per agent group host-side.
+	// "openrouter", "codex", "gemini", "vertex", "local", "azure", or "ollama". See
+	// New. The kind is chosen per agent group host-side.
 	Kind string
 	// Project and Location are the Google Cloud project id and region used by the
 	// Vertex AI backend (KindVertex); they ride in the request URL path. They are


### PR DESCRIPTION
## What

Adds **`ollama`** as a first-class, **zero-credential** model provider so anyone can run IronClaw against a model on their own machine with **no cloud API key anywhere in the stack** — the lowest-friction path for OSS evaluators, demos, and CI. Parallels the Azure (#310) / Bedrock (#300) provider structure.

Cloud providers broaden reach but each needs credentials, which is friction for evaluators. Ollama removes that entirely: local model, no key.

## How

Ollama serves the **identical OpenAI Chat Completions wire format**, so this does **not** fork the translation/streaming logic.

- **`KindOllama`** in the sandbox provider factory — reuses `OpenAIProvider` unchanged, only supplies Ollama's zero-config defaults (`localhost:11434`, a common local model) so `--provider ollama` works with nothing else set.
- **`modelproxy.OllamaInjector`** — no credential by default (true no-op → no `Authorization` header). An optional `OLLAMA_API_KEY` covers an Ollama behind an authenticating reverse proxy; injected **host-side only**, never enters the sandbox, self-guarded to the exact upstream host.
- **Control-plane wiring** — `--ollama` / `IRONCLAW_OLLAMA` opt-in; `OLLAMA_HOST` resolution (bare host, `host:port`, or full `http(s)://` URL; default `localhost:11434` over plain HTTP, `https://` over TLS); allowlists only that host; makes ollama the deployment default. Ollama groups inherit the configured loopback host like `local` groups. `--local-model-url` wins if both set.

## Deliverables (per IRO-296)

- [x] Provider Kind + host injector
- [x] Credential-free unit tests (8 new; no network, no credential) — provider query/no-auth/defaults/overrides, injector no-key + optional-key + off-host leak guard, `ollamaHostPort` resolution, `envBool`, ollama group host-inherit
- [x] `docs/providers/ollama.md` + provider matrix / decision-guide / nav updates
- [x] Runnable `examples/ollama/` (create group → chat → assert reply) + gallery entry

## Verification

- `go build ./...` clean
- `go vet` clean; `gofmt` clean
- Tests: 104 pass across `internal/sandbox/provider`, `internal/host/modelproxy`, `cmd/controlplane`; all 8 new ollama tests PASS
- `mkdocs build --strict` exit 0

## Isolation invariant

Choosing `ollama` changes *where the model runs*, not *how the agent is sealed*. Per-session Docker sandbox + host model-proxy allowlist are unchanged; the only difference from a cloud provider is there is no secret to hold host-side.

Closes IRO-296.