### PR TITLE
docs(providers): SEO provider-intent landing pages (IRO-310)

### DIFF
--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -179,6 +179,16 @@ group in explicitly. Two surfaces:
 Leaving the field blank keeps the sealed, single-provider default posture: only
 groups that opt in reach another backend.
 
+## Task-focused guides
+
+Prefer to start from what you want to run? These pages lead with the job and give
+you the exact setup:
+
+- [Run Claude in an isolated sandbox (AWS Bedrock)](run-claude-sandbox-bedrock.md)
+- [Run GPT securely (Azure OpenAI)](run-gpt-securely-azure-openai.md)
+- [Run Llama locally (Ollama)](run-llama-locally-ollama.md)
+- [Run any model (OpenRouter)](run-any-model-openrouter.md)
+
 ## See also
 
 - [Quickstart](../quickstart.md) — first working chat, then a real provider

--- a/docs/providers/run-any-model-openrouter.md
+++ b/docs/providers/run-any-model-openrouter.md
@@ -1,0 +1,69 @@
+---
+title: "Run any model securely with OpenRouter"
+description: Run any model through OpenRouter behind IronClaw, with one host-side key that never enters the agent container. Switch models without re-plumbing, and run every agent inside a sealed gVisor sandbox. Copy-paste setup.
+---
+
+# Run any model securely with OpenRouter
+
+You want the freedom to run **any model** and swap between them without re-plumbing,
+while every agent run stays isolated from your network and your key. IronClaw's
+`openrouter` provider gives you the full OpenRouter model catalog behind a single
+host-side key, called by an agent that runs inside a per-session **gVisor sandbox**
+with `network=none`.
+
+!!! abstract "Where your key lives"
+    The sandbox holds **no** credential. It reaches OpenRouter only through the host
+    **model-proxy** unix socket, which stamps each forwarded request with your
+    `OPENROUTER_API_KEY` on the way out. The key never enters the sandbox image, its
+    environment, or its filesystem. See [Security and isolation](../security-isolation.md).
+
+## 1. See it run with no credentials first
+
+Prove the sandbox loop end to end with the offline demo (one Docker command, no
+key) via the
+[zero-credential quickstart](../quickstart.md#a-working-chat-in-5-minutes-no-credentials),
+then point a group at OpenRouter below.
+
+## 2. Set your OpenRouter key host-side
+
+Set one key in the **control-plane** environment, never the sandbox:
+
+```bash
+export OPENROUTER_API_KEY=sk-or-…
+```
+
+## 3. Point an agent group at OpenRouter
+
+Opt a group in explicitly (a present key never forces any group to use it):
+
+- **Provider:** `openrouter`
+- **Model:** any OpenRouter model id (for example
+  `anthropic/claude-3.5-sonnet`, `openai/gpt-4o`, or `meta-llama/llama-3.1-70b-instruct`)
+
+Set it on the group's **Provider** and **Model** fields in the web console, or
+submit the change with `ironctl` and approve it at the human gateway so the switch
+lands on the [audit log](../observability.md). Because OpenRouter fronts many
+vendors, you can move a group between models by changing one field.
+
+## Why "securely" is the point
+
+OpenRouter gives you model choice. IronClaw makes each of those models safe to hand
+to an autonomous agent.
+
+- **gVisor per session.** Each conversation gets a fresh sandbox with a user-space
+  kernel and `network=none`. A compromised agent cannot reach your machine or the
+  internet.
+- **Least-privilege egress.** Only the OpenRouter host is allowlisted on the
+  model-proxy.
+- **Credential custody on the host.** The key is stamped in the proxy. The agent
+  sees a model reply, never the secret.
+
+See the [containment and isolation proof](../security-isolation.md) and the full
+[threat model](../threat-model.md).
+
+## See also
+
+- [Choose your model provider](index.md) - capability matrix and decision guide
+- [Run Claude in an isolated sandbox (AWS Bedrock)](run-claude-sandbox-bedrock.md)
+- [Run Llama locally (Ollama)](run-llama-locally-ollama.md)
+- [Security and isolation](../security-isolation.md) - why credentials stay host-side

--- a/docs/providers/run-claude-sandbox-bedrock.md
+++ b/docs/providers/run-claude-sandbox-bedrock.md
@@ -1,0 +1,82 @@
+---
+title: "Run Claude in an isolated sandbox (AWS Bedrock)"
+description: Run Anthropic Claude models through AWS Bedrock inside a sealed gVisor sandbox. Your AWS credentials stay host-side and never enter the agent container. Copy-paste setup and a link to the isolation proof.
+---
+
+# Run Claude in an isolated sandbox (AWS Bedrock)
+
+You want to run **Anthropic Claude** models, but your org only reaches foundation
+models through **AWS Bedrock**, and you want every agent run boxed off from your
+network and your credentials. That is exactly what IronClaw's `bedrock` provider
+does: it serves Claude (and any Bedrock model) to an agent that runs inside a
+per-session **gVisor sandbox** with `network=none`, while your AWS keys stay on the
+host.
+
+!!! abstract "Where your AWS credentials live"
+    The sandbox holds **no** AWS credential. It reaches Bedrock only through the host
+    **model-proxy** unix socket. The proxy is the sole authenticator: it signs each
+    forwarded request with **host-side SigV4** using your standard AWS environment
+    credentials. `AWS_SECRET_ACCESS_KEY` never enters the sandbox image, its
+    environment, or its filesystem. See [Security and isolation](../security-isolation.md)
+    for how that boundary is enforced and proved.
+
+!!! info "Bedrock is landing (beta)"
+    The `bedrock` provider is in review. Host-side SigV4 signing is validated against
+    AWS's reference vectors; requests use the non-stream `InvokeModel` API. This page
+    documents the shipping shape. For providers already merged, see the
+    [provider decision page](index.md).
+
+## 1. See it run with no credentials first
+
+Before you wire up Bedrock, prove the sandbox loop end to end with the offline
+demo (one Docker command, no key). Follow the
+[zero-credential quickstart](../quickstart.md#a-working-chat-in-5-minutes-no-credentials),
+then come back here to point a group at Claude on Bedrock.
+
+## 2. Set your AWS credentials host-side
+
+Set standard AWS credentials in the **control-plane** environment, never the
+sandbox. The region selects the regional
+`bedrock-runtime.{region}.amazonaws.com` host:
+
+```bash
+export AWS_ACCESS_KEY_ID=AKIA…
+export AWS_SECRET_ACCESS_KEY=…
+export AWS_SESSION_TOKEN=…                # optional, for temporary credentials
+export AWS_REGION=us-east-1               # or AWS_DEFAULT_REGION
+```
+
+## 3. Point an agent group at Claude
+
+Opt a group in explicitly (a present credential never forces any group to use it):
+
+- **Provider:** `bedrock`
+- **Model:** a Bedrock model id, for example a Claude model id such as
+  `anthropic.claude-3-5-sonnet-20241022-v2:0`
+
+Set it on the group's **Provider** and **Model** fields in the web console, or
+submit the change with `ironctl` and approve it at the human gateway so the switch
+lands on the [audit log](../observability.md) like any other change.
+
+## Why "in an isolated sandbox" is the point
+
+Bedrock gives you Claude behind your AWS controls. IronClaw adds the second half:
+the agent that calls Claude runs sealed.
+
+- **gVisor per session.** Each conversation gets a fresh sandbox with a
+  user-space kernel and `network=none`. A compromised agent cannot reach your VPC,
+  the metadata endpoint, or the public internet.
+- **Least-privilege egress.** Only your regional `bedrock-runtime` host is
+  allowlisted on the model-proxy. Nothing else is reachable.
+- **Credential custody on the host.** SigV4 signing happens in the proxy. The agent
+  sees a model reply, never the keys that paid for it.
+
+See the [containment and isolation proof](../security-isolation.md) and the full
+[threat model](../threat-model.md).
+
+## See also
+
+- [Choose your model provider](index.md) - full capability matrix and decision guide
+- [Run GPT securely (Azure OpenAI)](run-gpt-securely-azure-openai.md)
+- [Run any model (OpenRouter)](run-any-model-openrouter.md)
+- [Security and isolation](../security-isolation.md) - why credentials stay host-side

--- a/docs/providers/run-gpt-securely-azure-openai.md
+++ b/docs/providers/run-gpt-securely-azure-openai.md
@@ -1,0 +1,77 @@
+---
+title: "Run GPT securely with Azure OpenAI"
+description: Run GPT models through Azure OpenAI inside a sealed gVisor sandbox. Your Azure api-key or Entra token stays host-side and never enters the agent container. Copy-paste setup and a link to the isolation proof.
+---
+
+# Run GPT securely with Azure OpenAI
+
+You want to run **GPT** models, but your org reaches OpenAI only through **Azure
+OpenAI** (Azure AI Foundry), and you need every agent run isolated from your
+network and your subscription key. IronClaw's `azure` provider serves exactly that:
+GPT deployments on your Azure resource, called by an agent that runs inside a
+per-session **gVisor sandbox** with `network=none`, while your Azure credential
+stays on the host.
+
+!!! abstract "Where your Azure credential lives"
+    The sandbox holds **no** credential. It reaches Azure only through the host
+    **model-proxy** unix socket. The proxy stamps each forwarded request with your
+    **`api-key`** header or a Microsoft **Entra** bearer token on the way out. Your
+    `AZURE_OPENAI_API_KEY` never enters the sandbox image, its environment, or its
+    filesystem. See [Security and isolation](../security-isolation.md).
+
+## 1. See it run with no credentials first
+
+Prove the sandbox loop end to end with the offline demo (one Docker command, no
+key) via the
+[zero-credential quickstart](../quickstart.md#a-working-chat-in-5-minutes-no-credentials),
+then point a group at your Azure deployment below.
+
+## 2. Enable Azure OpenAI host-side
+
+Set your Azure OpenAI **endpoint** plus one credential in the **control-plane**
+environment, never the sandbox. A static api-key or a Microsoft Entra ID bearer
+token both work:
+
+```bash
+export AZURE_OPENAI_ENDPOINT=https://my-resource.openai.azure.com
+export AZURE_OPENAI_API_KEY=…                 # or AZURE_OPENAI_ACCESS_TOKEN for Entra
+export AZURE_OPENAI_API_VERSION=2024-10-21    # optional; provider default otherwise
+```
+
+Only `*.openai.azure.com` endpoints are accepted, so a misconfigured endpoint
+cannot silently widen egress to an arbitrary host.
+
+## 3. Point an agent group at Azure
+
+Azure routes by **deployment name**, not model id, so set the group's model to the
+name you gave the deployment in the Azure portal:
+
+- **Provider:** `azure`
+- **Model:** your Azure **deployment name** (for example `gpt-4o`)
+
+The host and api-version are inherited from the deployment, so you usually do not
+set them. For the full reference, including the failure table and Entra token
+handling, see the [Azure OpenAI guide](azure.md).
+
+## Why "securely" is the point
+
+Azure OpenAI gives you GPT behind your Azure controls. IronClaw adds the second
+half: the agent that calls GPT runs sealed.
+
+- **gVisor per session.** Each conversation gets a fresh sandbox with `network=none`.
+  A compromised agent cannot reach your tenant, other Azure services, or the public
+  internet.
+- **Least-privilege egress.** Only your `<resource>.openai.azure.com` host is
+  allowlisted on the model-proxy.
+- **Credential custody on the host.** The api-key or Entra token is stamped in the
+  proxy. The agent sees a model reply, never the secret.
+
+See the [containment and isolation proof](../security-isolation.md) and the full
+[threat model](../threat-model.md).
+
+## See also
+
+- [Azure OpenAI guide](azure.md) - full setup, deployment routing, and failures
+- [Choose your model provider](index.md) - capability matrix and decision guide
+- [Run Claude in an isolated sandbox (AWS Bedrock)](run-claude-sandbox-bedrock.md)
+- [Security and isolation](../security-isolation.md) - why credentials stay host-side

--- a/docs/providers/run-llama-locally-ollama.md
+++ b/docs/providers/run-llama-locally-ollama.md
@@ -1,0 +1,66 @@
+---
+title: "Run Llama locally with Ollama (zero cloud credentials)"
+description: Run Llama and other local models with Ollama behind IronClaw, entirely on your own machine with zero cloud API keys. The agent runs sealed and the model never leaves your box. Copy-paste setup.
+---
+
+# Run Llama locally with Ollama
+
+You want to run **Llama** (or any open model) with **no cloud provider and no API
+key**, and still run your agent boxed off from the rest of your machine. IronClaw's
+`local` provider points at any OpenAI-compatible endpoint, so you can serve Llama
+from **Ollama** on your own hardware and drive it through a sealed per-session
+sandbox. No credential exists anywhere in the stack.
+
+!!! abstract "Zero credential, still sealed"
+    Ollama serves the OpenAI-compatible API at `http://localhost:11434/v1`. The host
+    **model-proxy** allowlists that loopback host and forwards to it; the sandbox
+    stays `network=none` and reaches the model only through the proxy socket, exactly
+    as it does for a cloud provider. The difference is there is no key to hold. See
+    [Security and isolation](../security-isolation.md).
+
+The same steps work for **LM Studio**, **vLLM**, and **llama.cpp** - they all expose
+the OpenAI `/v1` Chat Completions API.
+
+## 1. Pull a model with Ollama
+
+```sh
+ollama pull llama3.2          # ~2 GB; any chat model works (qwen2.5, mistral, …)
+ollama serve &                # if it isn't already running as a service
+curl -s http://localhost:11434/v1/models   # sanity check: the OpenAI-compatible API is up
+```
+
+## 2. Point IronClaw at the local model host-side
+
+There is no `ANTHROPIC_API_KEY` in this posture. Set the local model URL and name in
+the **control-plane** environment:
+
+```sh
+export IRONCLAW_LOCAL_MODEL_URL=http://localhost:11434/v1   # the Ollama OpenAI endpoint
+export IRONCLAW_LOCAL_MODEL=llama3.2                        # the model you pulled
+```
+
+Then point an agent group at the `local` provider and send it a message. For the
+full end-to-end walkthrough (build, run, first reply), follow the
+[Run a 100% local model tutorial](../tutorials/local-model-ollama.md).
+
+## Why run it locally and still sandbox
+
+Running the model locally keeps your data on your box. IronClaw keeps a possibly
+compromised agent from touching the rest of it.
+
+- **gVisor per session.** Each conversation gets a fresh sandbox with a user-space
+  kernel and `network=none`. The agent cannot reach your files, your LAN, or the
+  internet.
+- **Least-privilege egress.** Only your loopback Ollama host is allowlisted on the
+  model-proxy.
+- **No data leaves the machine.** Model, control-plane, and sandbox all run locally.
+
+See the [containment and isolation proof](../security-isolation.md) and the full
+[threat model](../threat-model.md).
+
+## See also
+
+- [Run a 100% local model (Ollama) tutorial](../tutorials/local-model-ollama.md) - full walkthrough
+- [Choose your model provider](index.md) - capability matrix and decision guide
+- [Run any model (OpenRouter)](run-any-model-openrouter.md)
+- [Security and isolation](../security-isolation.md) - why the sandbox stays sealed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,10 @@ nav:
   - Model providers:
       - Choose your model provider: providers/index.md
       - Azure OpenAI: providers/azure.md
+      - Run Claude in a sandbox (AWS Bedrock): providers/run-claude-sandbox-bedrock.md
+      - Run GPT securely (Azure OpenAI): providers/run-gpt-securely-azure-openai.md
+      - Run Llama locally (Ollama): providers/run-llama-locally-ollama.md
+      - Run any model (OpenRouter): providers/run-any-model-openrouter.md
   - Tutorials:
       - Overview: tutorials/index.md
       - Your first sandboxed agent in 5 minutes: tutorials/first-agent.md


### PR DESCRIPTION
## What

Four compounding organic-discovery landing pages under `docs/providers/`, each targeting a real developer search intent and funneling into the sealed-sandbox story. Zero owner action required to go live (docs deploy on merge).

| Page | Search intent |
|---|---|
| `run-claude-sandbox-bedrock.md` | Run Claude in an isolated sandbox (AWS Bedrock) |
| `run-gpt-securely-azure-openai.md` | Run GPT securely (Azure OpenAI) |
| `run-llama-locally-ollama.md` | Run Llama locally (Ollama) |
| `run-any-model-openrouter.md` | Run any model (OpenRouter) |

Each page: SEO title + **unique** meta description, the exact quickstart pointer, the provider config snippet, and a link to the isolation/containment proof (`security-isolation.md` + threat model).

## Wiring
- Added to `mkdocs.yml` nav under **Model providers** (auto-included in `sitemap.xml`).
- Cross-linked from the provider decision page (IRO-285, `providers/index.md`) via a new **Task-focused guides** block.

## Accuracy (credibility over hype)
- **Bedrock** framed as beta/in-review (matches `index.md`; provider PR not yet merged) - no overclaim.
- **Ollama** uses the shipped `local` provider path (matches the existing tutorial), not the unmerged first-class `ollama` provider.
- **Azure** and **OpenRouter** are shipped; claims map to shipped capability.

## Verification
- `mkdocs build --strict` green; all four pages render and appear in the sitemap.
- Meta descriptions confirmed unique in rendered HTML.
- No em/en dashes in the new copy (IRO-254 standing rule), verified by scan.

Acceptance (IRO-310): 4 provider-intent pages live, unique meta descriptions, internal links from the decision page, strict build green, no em/en dashes. All met.