### PR TITLE
feat(provider): first-class OpenRouter provider docs, example, and model-select test (IRO-309)

### DIFF
--- a/cmd/controlplane/model_select_test.go
+++ b/cmd/controlplane/model_select_test.go
@@ -37,6 +37,21 @@ func TestSelectModel_ExplicitProviderWins(t *testing.T) {
 	}
 }
 
+// A group pinned to the openrouter provider carries its provider and a
+// vendor/model id through selection unchanged. OpenRouter has a single global host
+// (openrouter.ai) that the sandbox provider fills in, so — like openai — no host is
+// threaded here; the pin is all it takes for `agent create --provider openrouter` to
+// route to the OpenRouter backend.
+func TestSelectModel_OpenRouterExplicit(t *testing.T) {
+	reg := registry.NewMemRegistry()
+	id := newSessionFor(t, reg, "openrouter", "anthropic/claude-3.5-sonnet")
+
+	sel := selectModelFromRegistry(reg, session.ModelSelection{}, "", "", "", "")(id)
+	if sel.Provider != "openrouter" || sel.Model != "anthropic/claude-3.5-sonnet" {
+		t.Fatalf("openrouter selection must carry provider+vendor/model: got %+v", sel)
+	}
+}
+
 // Regression for the gateway-only 403: a group with NO provider must inherit the
 // deployment default (IRONCLAW_DEV_PROVIDER) rather than falling back to Anthropic,
 // whose host is not on the gateway-only allowlist.

--- a/docs/providers/.nav.yml
+++ b/docs/providers/.nav.yml
@@ -8,4 +8,5 @@ nav:
   - Choose your model provider: index.md
   - AWS Bedrock: bedrock.md
   - Azure OpenAI: azure.md
+  - OpenRouter (100+ models): openrouter.md
   - "*.md"

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -1,0 +1,109 @@
+---
+title: "OpenRouter (one key, 100+ models)"
+description: Run IronClaw against 100+ models — Claude, GPT, Llama, Mistral, Gemini — through a single OpenRouter key. First-class openrouter provider, vendor/model ids, per-group setup, and how the key stays host-side.
+---
+
+# OpenRouter provider
+
+**`openrouter`** is IronClaw's widest-reach backend: a single
+[OpenRouter](https://openrouter.ai) key unlocks **100+ models** across vendors —
+Claude, GPT, Llama, Mistral, Gemini, and more — behind one integration. Swap models
+by changing a `vendor/model` id; no new credential, host, or wiring per model.
+
+OpenRouter serves the **identical OpenAI Chat Completions wire format**
+(`POST /api/v1/chat/completions`) as the hosted `openai` provider, so IronClaw reuses
+the same request/streaming/tool-use path. The `openrouter` kind only changes the
+upstream host and the request path.
+
+!!! info "Where the credential lives"
+    As with every provider, the sandbox has `network=none` and holds **no** credential.
+    It reaches OpenRouter only through the host **model-proxy** unix socket. The proxy
+    is the sole authenticator: it stamps each forwarded request with your OpenRouter key
+    (`Authorization: Bearer`) on the way out. Your `OPENROUTER_API_KEY` never enters the
+    sandbox image, its environment, or its filesystem.
+
+## How it differs from the OpenAI provider
+
+Same wire format, a different gateway — all handled for you:
+
+| | OpenAI (`openai`) | OpenRouter (`openrouter`) |
+|---|---|---|
+| Host | `api.openai.com` | `openrouter.ai` |
+| Path | `/v1/chat/completions` | `/api/v1/chat/completions` |
+| Model id | `gpt-4o` | `vendor/model`, e.g. `anthropic/claude-3.5-sonnet` |
+| Auth | `Authorization: Bearer` (host-side) | `Authorization: Bearer` (host-side) |
+| Reach | OpenAI models | 100+ models across many vendors |
+
+OpenRouter routes by the **`vendor/model`** id in the request body — the vendor prefix
+selects the upstream provider OpenRouter fronts. The host is a single global endpoint,
+so — unlike Azure — no per-resource host is required.
+
+## 1. Enable OpenRouter on the control-plane
+
+Set your OpenRouter key in the **control-plane** environment (never the sandbox):
+
+```sh
+export OPENROUTER_API_KEY=sk-or-…
+```
+
+When `OPENROUTER_API_KEY` is set, the control-plane:
+
+- allowlists `openrouter.ai` on the model-proxy egress allowlist, and
+- installs the injector that stamps every forwarded OpenRouter request with your key as
+  an `Authorization: Bearer` header.
+
+The injector self-guards on the `openrouter.ai` host, so the key is stamped only on
+OpenRouter requests and can never leak to another upstream.
+
+## 2. Point an agent group at OpenRouter
+
+Pin a group to the `openrouter` provider and a `vendor/model` id:
+
+```sh
+ironctl agent create --yes --id router-helper --name "Router Helper" \
+  --provider openrouter --model anthropic/claude-3.5-sonnet
+```
+
+Or make OpenRouter the deployment default for provider-less groups:
+
+```sh
+export IRONCLAW_DEV_PROVIDER=openrouter
+export IRONCLAW_DEV_MODEL=anthropic/claude-3.5-sonnet
+```
+
+Browse available ids at [openrouter.ai/models](https://openrouter.ai/models); any
+`vendor/model` OpenRouter supports works — `openai/gpt-4o`, `meta-llama/llama-3.1-70b-instruct`,
+`mistralai/mistral-large`, `google/gemini-2.0-flash-001`, and so on.
+
+A complete runnable version — create the group, send a chat, print the reply — is in
+[`examples/openrouter/`](https://github.com/IronSecCo/ironclaw/tree/main/examples/openrouter).
+
+## 3. Verify
+
+Send the group a message. On success you get a normal reply; the model-proxy audit log
+records a `200` to `openrouter.ai`. Common failures:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `401 ... No auth credentials found` | missing/invalid `OPENROUTER_API_KEY` | set a valid key in the control-plane environment |
+| `404 ... No endpoints found for <id>` | the `vendor/model` id is wrong or unavailable | use an id listed at [openrouter.ai/models](https://openrouter.ai/models) |
+| `destination not on allowlist` | `OPENROUTER_API_KEY` was unset when the control-plane started | set the key and restart so `openrouter.ai` is allowlisted |
+| `402 ... insufficient credits` | the OpenRouter account is out of credit | top up the OpenRouter account |
+
+## Security notes
+
+- **Credential isolation.** The OpenRouter key stays on the host. The sandbox is
+  treated as potentially compromised and never receives it; the proxy self-guards on
+  the `openrouter.ai` host so the key is stamped only on OpenRouter requests.
+- **Least-privilege egress.** Only `openrouter.ai` is allowlisted. The sandbox cannot
+  reach any other host or the public internet — even though OpenRouter fronts many
+  vendors, egress from the box is one host.
+- **No plaintext secrets in logs.** The injector never logs credential material, and
+  the model-proxy redacts the key from any response body it forwards.
+
+## Try it credential-free first
+
+Not sure yet? The [`examples/openrouter/`](https://github.com/IronSecCo/ironclaw/tree/main/examples/openrouter)
+setup runs against the offline **`mock`** provider with `PROVIDER=mock`, proving the
+full sealed round-trip with **no key at all**, before you point it at a real
+OpenRouter model.

--- a/examples/openrouter/README.md
+++ b/examples/openrouter/README.md
@@ -1,0 +1,68 @@
+# OpenRouter (one key, 100+ models)
+
+Run a real IronClaw agent against **any of 100+ models** — Claude, GPT, Llama,
+Mistral, Gemini — through a **single** [OpenRouter](https://openrouter.ai) key. Change
+models by changing a `vendor/model` id; nothing else in the stack changes. OpenRouter
+serves the OpenAI Chat Completions wire format, and IronClaw's first-class
+**`openrouter`** provider points the sealed sandbox at it — the host model-proxy stamps
+your key host-side, so the sandbox never sees a secret.
+
+## What it configures
+
+- An agent group `router-helper` pinned to `--provider openrouter --model anthropic/claude-3.5-sonnet`.
+- Nothing else: the OpenRouter key lives only in the control-plane environment
+  (`OPENROUTER_API_KEY`), never in the script or the sandbox.
+
+Then it sends the agent one chat and prints the reply, proving the round-trip runs end
+to end through OpenRouter.
+
+## Try it credential-free first (mock)
+
+Prove the whole sealed path works with **no key at all**:
+
+```sh
+export IRONCLAW_API_TOKEN=<your control-plane API token>
+cd examples/openrouter
+PROVIDER=mock ./setup.sh
+```
+
+That pins the group to the offline `mock` provider — inbound → per-session Docker
+sandbox → encrypted queue → reply — with zero credentials, then prints the mock reply.
+
+## Try it against OpenRouter
+
+1. **Set your OpenRouter key on the control-plane** (never in the sandbox):
+   ```sh
+   export OPENROUTER_API_KEY=sk-or-…
+   ```
+   That allowlists `openrouter.ai` on the model-proxy and injects the key host-side.
+2. **Run it:**
+   ```sh
+   export IRONCLAW_API_TOKEN=<your control-plane API token>
+   cd examples/openrouter
+   ./setup.sh
+   ```
+
+Override the defaults with env vars: `MODEL` (any `vendor/model` at
+[openrouter.ai/models](https://openrouter.ai/models)) and `PROMPT`. For example:
+
+```sh
+MODEL=meta-llama/llama-3.1-70b-instruct ./setup.sh
+MODEL=openai/gpt-4o ./setup.sh
+```
+
+## What to notice
+
+- **One integration, many vendors.** The vendor prefix in the `vendor/model` id
+  (`anthropic/…`, `openai/…`, `meta-llama/…`) selects the upstream OpenRouter fronts.
+  No new host, credential, or wiring per model — just a different id.
+- **Key stays host-side.** Unlike the sandbox, which holds nothing, the OpenRouter key
+  lives only in the control-plane environment and is stamped onto requests by the
+  model-proxy. The injector self-guards on the `openrouter.ai` host, so it can never
+  leak to another upstream.
+- **Same sealed path as any provider.** The agent still runs in a per-session Docker
+  sandbox and reaches the model only through the host model-proxy allowlist — the
+  isolation guarantees are identical to every other provider; only the reach differs.
+
+See [docs/providers/openrouter.md](../../docs/providers/openrouter.md) for the full
+reference.

--- a/examples/openrouter/run-mock.sh
+++ b/examples/openrouter/run-mock.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Credential-free end-to-end smoke for the OpenRouter recipe.
+#
+# The real recipe (setup.sh) points an agent group at OpenRouter, which needs an
+# OPENROUTER_API_KEY on the control-plane that CI does not hold. So the smoke
+# instead drives the offline `mock-agent` seeded by docker-compose.demo.yml and
+# asserts a non-empty reply — proving the sealed send/poll round-trip works with
+# NO model, NO key. Bring the demo up first:
+#
+#   docker compose -f docker-compose.demo.yml up -d --build
+#
+# For the real run against OpenRouter, use setup.sh (see README), or run
+# `PROVIDER=mock ./setup.sh` for the credential-free full-recipe variant.
+set -euo pipefail
+
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+TOKEN="${IRONCLAW_API_TOKEN:-ironclaw-demo}"
+AGENT="mock-agent"
+PROMPT="${PROMPT:-Say hello in one short sentence.}"
+
+command -v jq >/dev/null || { echo "this demo needs jq (https://jqlang.github.io/jq/)" >&2; exit 1; }
+
+echo "==> sending a chat to the offline mock-agent (stands in for OpenRouter): \"${PROMPT}\""
+curl -fsS -X POST "$ADDR/v1/ui/chat/send" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg a "$AGENT" --arg t "$PROMPT" '{agentGroupID:$a, text:$t}')" >/dev/null
+
+echo -n "==> waiting for the reply"
+# /messages is drain-on-read and the reply text is `.messages[].content` (NOT
+# `.text`, the /chat/send REQUEST field). Asserting a NON-EMPTY reply is the guard
+# that catches an IRO-279-class regression, so an empty reply FAILS the script.
+for _ in $(seq 1 30); do
+  out="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
+    -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.content // empty')"
+  if [ -n "$out" ]; then echo; printf '   -> %s\n' "$out"; exit 0; fi
+  echo -n "."; sleep 1
+done
+echo
+echo "FAIL: no reply within 30s — the .content round-trip returned empty." >&2
+echo "      is the demo control-plane up and the sandbox image built?" >&2
+exit 1

--- a/examples/openrouter/setup.sh
+++ b/examples/openrouter/setup.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# One key, 100+ models, via OpenRouter — see README.md.
+# Creates one agent group pinned to the first-class `openrouter` provider (a single
+# key reaches Claude, GPT, Llama, Mistral, Gemini, ...), then sends it a chat and
+# prints the reply.
+#
+# Credential-free smoke: run `PROVIDER=mock ./setup.sh` to prove the full sealed
+# round-trip with NO key at all against the offline `mock` provider, before pointing
+# it at a real OpenRouter model.
+#
+# Prerequisites (see README.md):
+#   1. an OpenRouter key on the control-plane: export OPENROUTER_API_KEY=sk-or-...
+#      (skip for the PROVIDER=mock credential-free smoke)
+set -euo pipefail
+
+# --- edit these for your setup ---------------------------------------------
+AGENT="router-helper"
+PROVIDER="${PROVIDER:-openrouter}"                     # set PROVIDER=mock for a credential-free smoke
+MODEL="${MODEL:-anthropic/claude-3.5-sonnet}"          # any vendor/model at openrouter.ai/models
+PROMPT="${PROMPT:-Say hello in one short sentence.}"
+# ---------------------------------------------------------------------------
+
+# The mock provider needs no model id; pin nothing so the offline mock-agent answers.
+if [ "$PROVIDER" = "mock" ]; then MODEL=""; fi
+
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+: "${IRONCLAW_API_TOKEN:?set IRONCLAW_API_TOKEN to your control-plane API token}"
+TOKEN="$IRONCLAW_API_TOKEN"
+ic() { ironctl --addr "$ADDR" "$@"; }   # ironctl reads IRONCLAW_API_TOKEN from the env
+
+# No API key is set here or anywhere in this script: the OpenRouter key lives ONLY in
+# the control-plane environment (OPENROUTER_API_KEY) and is injected host-side into the
+# model-proxy. The sandbox never sees it.
+echo "==> agent group pinned to the ${PROVIDER} provider: ${AGENT}"
+ic agent create --yes \
+  --id "$AGENT" --name "Router Helper (OpenRouter)" \
+  --provider "$PROVIDER" ${MODEL:+--model "$MODEL"}
+
+echo "==> sending a chat: \"${PROMPT}\""
+curl -fsS -X POST "$ADDR/v1/ui/chat/send" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg a "$AGENT" --arg t "$PROMPT" '{agentGroupID:$a, text:$t}')" >/dev/null
+
+echo -n "==> waiting for the reply (up to 120s)"
+reply=""
+for _ in $(seq 1 120); do
+  # /messages is drain-on-read: the reply text is `.messages[].content`; read it once.
+  got="$(curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" \
+          -H "Authorization: Bearer $TOKEN" | jq -r '.messages[]?.content // empty')"
+  if [ -n "$got" ]; then reply="$got"; break; fi
+  echo -n "."; sleep 1
+done
+echo
+
+if [ -z "$reply" ]; then
+  echo "FAIL: no reply — for openrouter check that OPENROUTER_API_KEY is set on the" >&2
+  echo "      control-plane and the model id is valid; or run PROVIDER=mock ./setup.sh." >&2
+  echo "      See README.md." >&2
+  exit 1
+fi
+echo "==> reply from '${PROVIDER}${MODEL:+/$MODEL}':"
+echo "    ${reply}"


### PR DESCRIPTION
## Summary

Completes the **first-class** treatment of the `openrouter` model provider (IRO-309), matching the shipped **Ollama** (IRO-296) and **Azure** (IRO-282) pattern. One OpenRouter key reaches 100+ models (Claude, GPT, Llama, Mistral, Gemini) — the highest per-unit adoption-reach lever.

**Note:** OpenRouter's *code* path already shipped alongside the OpenAI provider — `KindOpenRouter`, `OpenAIProvider` reuse (`/api/v1/chat/completions`), host-side `OpenRouterInjector`, control-plane wiring (`OPENROUTER_API_KEY` -> allowlist `openrouter.ai` + inject), README rows, and the capability-matrix row. This PR fills the remaining first-class gaps.

## Changes

- **`docs/providers/openrouter.md`** — dedicated reference (one key / 100+ models, `vendor/model` ids, host-side key custody, verify table, security notes, credential-free mock path). Mirrors `azure.md`.
- **`mkdocs.yml`** — nav entry under Model providers.
- **`examples/openrouter/`** — `setup.sh` + `README.md`. `PROVIDER=mock ./setup.sh` runs the full sealed round-trip **credential-free**; default pins `--provider openrouter --model anthropic/claude-3.5-sonnet`.
- **`cmd/controlplane/model_select_test.go`** — a group pinned to `openrouter` carries provider + `vendor/model` through selection unchanged.

## Security lenses

- **Credential isolation / egress least-privilege.** No code path changed — the existing `OpenRouterInjector` self-guards on `openrouter.ai`; the sandbox holds no key.
- **No new secrets.** Placeholder keys only (`sk-or-...`); all tests credential-free.

## Verification

- `CGO_ENABLED=1 go test ./cmd/controlplane/ ./internal/sandbox/provider/ ./internal/host/modelproxy/` — green.
- `mkdocs build --strict` — clean.
- `bash -n examples/openrouter/setup.sh` — OK.

## Note on `docs/providers/index.md`

Deliberately left out: the shared working copy had **uncommitted concurrent work** (interactive provider picker, IRO-311). The capability matrix already lists the OpenRouter row, so acceptance holds without touching `index.md`.