### PR TITLE
docs(providers): interactive provider picker to copy-paste config + quickstart (IRO-311)

### DIFF
--- a/docs/javascripts/provider-picker.js
+++ b/docs/javascripts/provider-picker.js
@@ -1,0 +1,116 @@
+/* =============================================================================
+   Interactive provider picker (IRO-311) — progressive enhancement.
+
+   Two jobs, both optional:
+     1. Panel switching. Adds `.pp-js` to each picker so CSS hides all but the
+        selected panel, then swaps the active panel on radio change. Without this
+        file every panel is visible and the page still works.
+     2. Copy buttons. Reveals the per-snippet copy buttons and wires them to the
+        clipboard, with an execCommand fallback and an aria-live confirmation.
+
+   No framework, no build step: this ships as a plain static script that runs on
+   GitHub Pages.
+   ========================================================================== */
+(function () {
+  "use strict";
+
+  function ready(fn) {
+    if (document.readyState !== "loading") {
+      fn();
+    } else {
+      document.addEventListener("DOMContentLoaded", fn);
+    }
+  }
+
+  function legacyCopy(text) {
+    var ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "absolute";
+    ta.style.left = "-9999px";
+    document.body.appendChild(ta);
+    ta.select();
+    var ok = false;
+    try {
+      ok = document.execCommand("copy");
+    } catch (e) {
+      ok = false;
+    }
+    document.body.removeChild(ta);
+    return ok;
+  }
+
+  ready(function () {
+    var pickers = document.querySelectorAll(".pp");
+    if (!pickers.length) {
+      return;
+    }
+
+    pickers.forEach(function (pp) {
+      pp.classList.add("pp-js");
+
+      var live = pp.querySelector(".pp-live");
+      var announce = function (msg) {
+        if (live) {
+          live.textContent = "";
+          // Re-set on the next frame so repeated messages re-announce.
+          window.setTimeout(function () {
+            live.textContent = msg;
+          }, 30);
+        }
+      };
+
+      /* --- Panel switching --------------------------------------------- */
+      var radios = pp.querySelectorAll('input[type="radio"]');
+      var showPanel = function (id) {
+        pp.querySelectorAll(".pp-panel").forEach(function (panel) {
+          panel.classList.toggle("pp-active", panel.id === id);
+        });
+      };
+      var initial = null;
+      radios.forEach(function (r) {
+        if (r.checked) {
+          initial = r;
+        }
+        r.addEventListener("change", function () {
+          if (r.checked) {
+            showPanel(r.getAttribute("data-panel"));
+          }
+        });
+      });
+      showPanel(initial ? initial.getAttribute("data-panel") : radios[0] && radios[0].getAttribute("data-panel"));
+
+      /* --- Copy buttons ------------------------------------------------- */
+      pp.querySelectorAll(".pp-copy").forEach(function (btn) {
+        var label = btn.getAttribute("data-copy-label") || "snippet";
+        btn.setAttribute("aria-label", "Copy " + label);
+        btn.addEventListener("click", function () {
+          // Find the snippet by DOM position, not id: Material rewrites <pre> ids
+          // (prefixes them with "__code_"), so an id lookup would miss.
+          var container = btn.closest(".pp-code");
+          var target = container && container.querySelector("pre");
+          if (!target) {
+            return;
+          }
+          var text = target.innerText.replace(/\s+$/, "");
+          var finish = function (ok) {
+            btn.classList.toggle("pp-copied", ok);
+            announce(ok ? "Copied " + label : "Could not copy " + label);
+            window.clearTimeout(btn._resetTimer);
+            btn._resetTimer = window.setTimeout(function () {
+              btn.classList.remove("pp-copied");
+            }, 2000);
+          };
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(
+              function () { finish(true); },
+              function () { finish(legacyCopy(text)); }
+            );
+          } else {
+            finish(legacyCopy(text));
+          }
+        });
+      });
+    });
+  });
+})();

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -48,6 +48,170 @@ not change. This page helps you choose one, then links you straight to setup.
 
 </div>
 
+## Set up in three steps
+
+Pick a backend below. You get the exact host-side config, the `agent create` command, and a one-line isolation check, each ready to copy. Every provider follows the same shape: **set one credential, point a group at it, verify the seal.**
+
+<div class="pp">
+<div class="pp-live" aria-live="polite" role="status"></div>
+<div class="pp-chips" role="radiogroup" aria-label="Model provider">
+<p class="pp-cat">Local / offline</p>
+<label class="pp-chip"><input type="radio" name="pp-provider" value="mock" data-panel="pp-panel-mock" checked> Mock</label>
+<label class="pp-chip"><input type="radio" name="pp-provider" value="local" data-panel="pp-panel-local"> Local / Ollama</label>
+<p class="pp-cat">Hosted (API key)</p>
+<label class="pp-chip"><input type="radio" name="pp-provider" value="anthropic" data-panel="pp-panel-anthropic"> Anthropic</label>
+<label class="pp-chip"><input type="radio" name="pp-provider" value="openai" data-panel="pp-panel-openai"> OpenAI</label>
+<label class="pp-chip"><input type="radio" name="pp-provider" value="openrouter" data-panel="pp-panel-openrouter"> OpenRouter</label>
+<label class="pp-chip"><input type="radio" name="pp-provider" value="gemini" data-panel="pp-panel-gemini"> Gemini</label>
+<p class="pp-cat">Enterprise cloud (your billing / IAM)</p>
+<label class="pp-chip"><input type="radio" name="pp-provider" value="azure" data-panel="pp-panel-azure"> Azure</label>
+<label class="pp-chip"><input type="radio" name="pp-provider" value="bedrock" data-panel="pp-panel-bedrock"> Bedrock</label>
+<label class="pp-chip"><input type="radio" name="pp-provider" value="vertex" data-panel="pp-panel-vertex"> Vertex AI</label>
+<p class="pp-cat">Reuse a subscription</p>
+<label class="pp-chip"><input type="radio" name="pp-provider" value="codex" data-panel="pp-panel-codex"> ChatGPT / Codex</label>
+</div>
+<div class="pp-panels">
+<section class="pp-panel pp-active" id="pp-panel-mock" aria-label="Mock (offline, zero credential) setup">
+<h4>Mock (offline, zero credential)</h4>
+<p class="pp-panel-sub">Deterministic canned replies. No key, no network — the fastest way to see the full sandbox path.</p>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">1</span><span class="pp-step-title">Set the credential (host-side)</span></div>
+<div class="pp-code"><pre><code># no credential — the mock provider is fully offline</code></pre><button type="button" class="pp-copy" data-copy-label="the mock credential config"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Export in the control-plane's environment and restart it. This value stays host-side and never enters the sandbox.</p></div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">2</span><span class="pp-step-title">Create the agent</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl agent create --name &quot;Mock Bot&quot; --provider mock --model mock-1 --yes</code></pre><button type="button" class="pp-copy" data-copy-label="the mock agent-create command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+</div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">3</span><span class="pp-step-title">Verify the isolation</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl doctor</code></pre><button type="button" class="pp-copy" data-copy-label="the isolation-check command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Read-only preflight: confirms the gVisor sandbox and <code>network=none</code> egress before the first run. Then message the group in the console for a live reply.</p></div>
+</section>
+<section class="pp-panel" id="pp-panel-local" aria-label="Local model (Ollama, LM Studio, vLLM) setup">
+<h4>Local model (Ollama, LM Studio, vLLM)</h4>
+<p class="pp-panel-sub">Run a real model on your own hardware. Nothing leaves the box; most local servers need no key.</p>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">1</span><span class="pp-step-title">Set the credential (host-side)</span></div>
+<div class="pp-code"><pre><code>export IRONCLAW_LOCAL_MODEL_URL=http://localhost:11434/v1<span class="pp-comment">   # Ollama&#x27;s OpenAI-compatible endpoint</span></code></pre><button type="button" class="pp-copy" data-copy-label="the local credential config"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Export in the control-plane's environment and restart it. This value stays host-side and never enters the sandbox.</p></div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">2</span><span class="pp-step-title">Create the agent</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl agent create --name &quot;Local Bot&quot; --provider local --model llama3.2 --yes</code></pre><button type="button" class="pp-copy" data-copy-label="the local agent-create command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+</div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">3</span><span class="pp-step-title">Verify the isolation</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl doctor</code></pre><button type="button" class="pp-copy" data-copy-label="the isolation-check command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Read-only preflight: confirms the gVisor sandbox and <code>network=none</code> egress before the first run. Then message the group in the console for a live reply.</p></div>
+</section>
+<section class="pp-panel" id="pp-panel-anthropic" aria-label="Anthropic (default) setup">
+<h4>Anthropic (default)</h4>
+<p class="pp-panel-sub">The strongest default backend, with first-class tool use. One key and a restart.</p>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">1</span><span class="pp-step-title">Set the credential (host-side)</span></div>
+<div class="pp-code"><pre><code>export ANTHROPIC_API_KEY=sk-ant-...</code></pre><button type="button" class="pp-copy" data-copy-label="the anthropic credential config"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Export in the control-plane's environment and restart it. This value stays host-side and never enters the sandbox.</p></div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">2</span><span class="pp-step-title">Create the agent</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl agent create --name &quot;Research Bot&quot; --provider anthropic --model claude-sonnet-4-5 --yes</code></pre><button type="button" class="pp-copy" data-copy-label="the anthropic agent-create command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+</div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">3</span><span class="pp-step-title">Verify the isolation</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl doctor</code></pre><button type="button" class="pp-copy" data-copy-label="the isolation-check command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Read-only preflight: confirms the gVisor sandbox and <code>network=none</code> egress before the first run. Then message the group in the console for a live reply.</p></div>
+</section>
+<section class="pp-panel" id="pp-panel-openai" aria-label="OpenAI setup">
+<h4>OpenAI</h4>
+<p class="pp-panel-sub">GPT-class models over the OpenAI API.</p>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">1</span><span class="pp-step-title">Set the credential (host-side)</span></div>
+<div class="pp-code"><pre><code>export OPENAI_API_KEY=sk-...</code></pre><button type="button" class="pp-copy" data-copy-label="the openai credential config"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Export in the control-plane's environment and restart it. This value stays host-side and never enters the sandbox.</p></div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">2</span><span class="pp-step-title">Create the agent</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl agent create --name &quot;GPT Bot&quot; --provider openai --model gpt-4o --yes</code></pre><button type="button" class="pp-copy" data-copy-label="the openai agent-create command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+</div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">3</span><span class="pp-step-title">Verify the isolation</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl doctor</code></pre><button type="button" class="pp-copy" data-copy-label="the isolation-check command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Read-only preflight: confirms the gVisor sandbox and <code>network=none</code> egress before the first run. Then message the group in the console for a live reply.</p></div>
+</section>
+<section class="pp-panel" id="pp-panel-openrouter" aria-label="OpenRouter setup">
+<h4>OpenRouter</h4>
+<p class="pp-panel-sub">One key, many models — route to any model OpenRouter fronts.</p>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">1</span><span class="pp-step-title">Set the credential (host-side)</span></div>
+<div class="pp-code"><pre><code>export OPENROUTER_API_KEY=sk-or-...</code></pre><button type="button" class="pp-copy" data-copy-label="the openrouter credential config"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Export in the control-plane's environment and restart it. This value stays host-side and never enters the sandbox.</p></div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">2</span><span class="pp-step-title">Create the agent</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl agent create --name &quot;Router Bot&quot; --provider openrouter --model anthropic/claude-3.5-sonnet --yes</code></pre><button type="button" class="pp-copy" data-copy-label="the openrouter agent-create command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+</div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">3</span><span class="pp-step-title">Verify the isolation</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl doctor</code></pre><button type="button" class="pp-copy" data-copy-label="the isolation-check command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Read-only preflight: confirms the gVisor sandbox and <code>network=none</code> egress before the first run. Then message the group in the console for a live reply.</p></div>
+</section>
+<section class="pp-panel" id="pp-panel-gemini" aria-label="Google Gemini (AI Studio) setup">
+<h4>Google Gemini (AI Studio)</h4>
+<p class="pp-panel-sub">Hosted Google models with a generous free tier.</p>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">1</span><span class="pp-step-title">Set the credential (host-side)</span></div>
+<div class="pp-code"><pre><code>export GOOGLE_API_KEY=...<span class="pp-comment">   # GEMINI_API_KEY is honored as a fallback</span></code></pre><button type="button" class="pp-copy" data-copy-label="the gemini credential config"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Export in the control-plane's environment and restart it. This value stays host-side and never enters the sandbox.</p></div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">2</span><span class="pp-step-title">Create the agent</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl agent create --name &quot;Gemini Bot&quot; --provider gemini --model gemini-1.5-pro --yes</code></pre><button type="button" class="pp-copy" data-copy-label="the gemini agent-create command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+</div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">3</span><span class="pp-step-title">Verify the isolation</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl doctor</code></pre><button type="button" class="pp-copy" data-copy-label="the isolation-check command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Read-only preflight: confirms the gVisor sandbox and <code>network=none</code> egress before the first run. Then message the group in the console for a live reply.</p></div>
+</section>
+<section class="pp-panel" id="pp-panel-azure" aria-label="Azure OpenAI setup">
+<h4>Azure OpenAI</h4>
+<p class="pp-panel-sub">GPT-class models under your Azure billing and identity. Model = your deployment name.</p>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">1</span><span class="pp-step-title">Set the credential (host-side)</span></div>
+<div class="pp-code"><pre><code>export AZURE_OPENAI_ENDPOINT=https://my-resource.openai.azure.com
+export AZURE_OPENAI_API_KEY=...<span class="pp-comment">   # or AZURE_OPENAI_ACCESS_TOKEN for Entra</span></code></pre><button type="button" class="pp-copy" data-copy-label="the azure credential config"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Export in the control-plane's environment and restart it. This value stays host-side and never enters the sandbox.</p></div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">2</span><span class="pp-step-title">Create the agent</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl agent create --name &quot;Azure Bot&quot; --provider azure --model gpt-4o --yes</code></pre><button type="button" class="pp-copy" data-copy-label="the azure agent-create command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+</div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">3</span><span class="pp-step-title">Verify the isolation</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl doctor</code></pre><button type="button" class="pp-copy" data-copy-label="the isolation-check command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Read-only preflight: confirms the gVisor sandbox and <code>network=none</code> egress before the first run. Then message the group in the console for a live reply.</p></div>
+</section>
+<section class="pp-panel" id="pp-panel-bedrock" aria-label="AWS Bedrock setup">
+<h4>AWS Bedrock</h4>
+<p class="pp-panel-sub">Claude and others under your AWS billing and IAM, via host-side SigV4.</p>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">1</span><span class="pp-step-title">Set the credential (host-side)</span></div>
+<div class="pp-code"><pre><code>export AWS_ACCESS_KEY_ID=AKIA...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=us-east-1<span class="pp-comment">   # selects the bedrock-runtime.{region} host</span></code></pre><button type="button" class="pp-copy" data-copy-label="the bedrock credential config"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Export in the control-plane's environment and restart it. This value stays host-side and never enters the sandbox.</p></div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">2</span><span class="pp-step-title">Create the agent</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl agent create --name &quot;Bedrock Bot&quot; --provider bedrock --model anthropic.claude-3-5-sonnet-20240620-v1:0 --yes</code></pre><button type="button" class="pp-copy" data-copy-label="the bedrock agent-create command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+</div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">3</span><span class="pp-step-title">Verify the isolation</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl doctor</code></pre><button type="button" class="pp-copy" data-copy-label="the isolation-check command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Read-only preflight: confirms the gVisor sandbox and <code>network=none</code> egress before the first run. Then message the group in the console for a live reply.</p></div>
+</section>
+<section class="pp-panel" id="pp-panel-vertex" aria-label="Google Vertex AI setup">
+<h4>Google Vertex AI</h4>
+<p class="pp-panel-sub">Gemini under your GCP project, billing, and IAM. A project is required; region defaults when unset.</p>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">1</span><span class="pp-step-title">Set the credential (host-side)</span></div>
+<div class="pp-code"><pre><code>export GOOGLE_VERTEX_PROJECT=my-gcp-project<span class="pp-comment">   # or GOOGLE_CLOUD_PROJECT</span>
+export GOOGLE_VERTEX_USE_GCLOUD=1<span class="pp-comment">   # use gcloud Application Default Credentials</span></code></pre><button type="button" class="pp-copy" data-copy-label="the vertex credential config"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Export in the control-plane's environment and restart it. This value stays host-side and never enters the sandbox.</p></div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">2</span><span class="pp-step-title">Create the agent</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl agent create --name &quot;Vertex Bot&quot; --provider vertex --model gemini-1.5-pro --yes</code></pre><button type="button" class="pp-copy" data-copy-label="the vertex agent-create command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+</div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">3</span><span class="pp-step-title">Verify the isolation</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl doctor</code></pre><button type="button" class="pp-copy" data-copy-label="the isolation-check command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Read-only preflight: confirms the gVisor sandbox and <code>network=none</code> egress before the first run. Then message the group in the console for a live reply.</p></div>
+</section>
+<section class="pp-panel" id="pp-panel-codex" aria-label="ChatGPT / Codex (via credential gateway) setup">
+<h4>ChatGPT / Codex (via credential gateway)</h4>
+<p class="pp-panel-sub">Reuse a ChatGPT/Codex OAuth subscription fronted by a local gateway (e.g. OneCLI). The control-plane holds no model credential at all.</p>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">1</span><span class="pp-step-title">Set the credential (host-side)</span></div>
+<div class="pp-code"><pre><code>export IRONCLAW_MODEL_GATEWAY_URL=http://127.0.0.1:10255
+export IRONCLAW_MODEL_GATEWAY_HOSTS=chatgpt.com</code></pre><button type="button" class="pp-copy" data-copy-label="the codex credential config"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Export in the control-plane's environment and restart it. This value stays host-side and never enters the sandbox.</p></div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">2</span><span class="pp-step-title">Create the agent</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl agent create --name &quot;Codex Bot&quot; --provider codex --model gpt-4o --yes</code></pre><button type="button" class="pp-copy" data-copy-label="the codex agent-create command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+</div>
+<div class="pp-step"><div class="pp-step-head"><span class="pp-step-num" aria-hidden="true">3</span><span class="pp-step-title">Verify the isolation</span></div>
+<div class="pp-code"><pre><code>./bin/ironctl doctor</code></pre><button type="button" class="pp-copy" data-copy-label="the isolation-check command"><span class="pp-copy-idle">Copy</span><span class="pp-copy-done">Copied ✓</span></button></div>
+<p class="pp-step-note">Read-only preflight: confirms the gVisor sandbox and <code>network=none</code> egress before the first run. Then message the group in the console for a live reply.</p></div>
+</section>
+</div>
+</div>
+
+!!! tip "Prefer the console?"
+    You can also set a group's provider in the web console (**Agents** &rarr; edit a group &rarr; **Provider**), then approve the change through the human gateway so it lands on the [audit log](../observability.md). The commands above are the CLI equivalent.
+
 ## Capability matrix
 
 | Provider | Kind | Auth method | Credential source (host-side) | Streaming | Best for | Setup |

--- a/docs/stylesheets/provider-picker.css
+++ b/docs/stylesheets/provider-picker.css
@@ -1,0 +1,231 @@
+/* =============================================================================
+   Interactive provider picker (IRO-311).
+
+   A static, keyboard-accessible chooser on the model-provider decision page:
+   pick a backend, get the exact `agent create` command, the host-side config
+   snippet, and a one-line "verify isolation" step, each with a copy button.
+
+   Design notes
+   - Native radios inside a role="radiogroup": arrow-key navigation, focus ring,
+     and label association come free (Recognition over Recall; Jakob's Law).
+   - Progressive enhancement: without JS every panel is visible and its code is
+     selectable, so the page still works. `provider-picker.js` adds the `.pp-js`
+     class, which is the ONLY thing that hides non-selected panels — no JS, no
+     hidden content.
+   - Colors/spacing reuse the brand tokens from brand.css (steel scale).
+   ========================================================================== */
+
+.pp {
+  --pp-gap: 0.75rem;
+  margin: 1.25rem 0 2rem;
+}
+
+/* ---- Chip radiogroup ---------------------------------------------------- */
+
+.pp-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+/* Category separators between chip clusters (Chunking / Common Region). */
+.pp-cat {
+  flex: 1 0 100%;
+  margin: 0.6rem 0 0.1rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--md-default-fg-color--light);
+}
+.pp-cat:first-child { margin-top: 0; }
+
+.pp-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  /* Fitts's Law: comfortable target, >=32px tall. */
+  min-height: 2rem;
+  padding: 0.4rem 0.75rem;
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  line-height: 1.1;
+  color: var(--md-default-fg-color);
+  background: var(--md-default-bg-color);
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+.pp-chip:hover { border-color: var(--iro-steel-500); }
+
+/* Native radio kept visible for a11y; sized to sit inside the chip. */
+.pp-chip input[type="radio"] {
+  width: 0.85rem;
+  height: 0.85rem;
+  margin: 0;
+  accent-color: var(--iro-steel-600);
+  flex: none;
+}
+
+/* Checked chip: filled steel, white text (Von Restorff — the active choice pops). */
+.pp-chip:has(input:checked) {
+  background: var(--iro-steel-600);
+  border-color: var(--iro-steel-600);
+  color: #ffffff;
+}
+[data-md-color-scheme="slate"] .pp-chip:has(input:checked) {
+  background: var(--iro-steel-500);
+  border-color: var(--iro-steel-500);
+  color: #0b1124;
+}
+
+/* Keyboard focus ring on the chip that owns the focused radio. */
+.pp-chip:has(input:focus-visible) {
+  outline: 2px solid var(--iro-steel-500);
+  outline-offset: 2px;
+}
+
+/* ---- Panels ------------------------------------------------------------- */
+
+.pp-panels { margin-top: 1rem; }
+
+.pp-panel {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.5rem;
+  padding: 1rem 1.1rem 1.2rem;
+  background: var(--md-code-bg-color);
+}
+
+/* Enhanced mode: JS present -> show only the selected panel. */
+.pp-js .pp-panel { display: none; }
+.pp-js .pp-panel.pp-active { display: block; }
+
+/* No-JS separator so stacked panels stay visually distinct. */
+.pp-panel + .pp-panel { margin-top: 1rem; }
+.pp-js .pp-panel + .pp-panel { margin-top: 0; }
+
+.pp-panel > h4 {
+  margin: 0 0 0.15rem;
+  font-size: 1rem;
+}
+.pp-panel-sub {
+  margin: 0 0 1rem;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.85rem;
+}
+
+/* ---- Steps -------------------------------------------------------------- */
+
+.pp-step { margin-top: 1.1rem; }
+.pp-step:first-of-type { margin-top: 0; }
+
+.pp-step-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+.pp-step-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.35rem;
+  height: 1.35rem;
+  flex: none;
+  border-radius: 999px;
+  background: var(--iro-steel-600);
+  color: #ffffff;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+.pp-step-title {
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+.pp-step-note {
+  margin: 0.3rem 0 0;
+  font-size: 0.78rem;
+  color: var(--md-default-fg-color--light);
+}
+
+/* ---- Code + copy button ------------------------------------------------- */
+
+.pp-code {
+  position: relative;
+}
+.pp-code pre {
+  margin: 0;
+  padding: 0.75rem 3.2rem 0.75rem 0.9rem; /* right room reserves space for the copy button */
+  border-radius: 0.35rem;
+  background: var(--md-default-bg-color);
+  border: 1px solid var(--md-default-fg-color--lightest);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+.pp-code pre code {
+  font-family: var(--md-code-font-family, monospace);
+  /* Wrap long commands instead of scrolling: no horizontal scroll on mobile, and
+     the text never runs under the top-right copy button. The Copy button always
+     copies the exact single-line source regardless of visual wrapping. */
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: none;
+  padding: 0;
+}
+.pp-comment { color: var(--md-default-fg-color--light); }
+
+/* Copy button — hidden until JS reveals it (nothing to click without a handler). */
+.pp-copy {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+  display: none;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.28rem 0.55rem;
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 0.3rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+.pp-js .pp-copy { display: inline-flex; }
+.pp-copy:hover { border-color: var(--iro-steel-500); }
+.pp-copy:focus-visible {
+  outline: 2px solid var(--iro-steel-500);
+  outline-offset: 2px;
+}
+.pp-copy .pp-copy-done { display: none; }
+.pp-copy.pp-copied { border-color: var(--iro-steel-600); color: var(--iro-steel-700); }
+[data-md-color-scheme="slate"] .pp-copy.pp-copied { color: var(--iro-steel-300); }
+.pp-copy.pp-copied .pp-copy-idle { display: none; }
+.pp-copy.pp-copied .pp-copy-done { display: inline; }
+
+/* Screen-reader-only live region for copy confirmations. */
+.pp-live {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ---- Reduced motion ----------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .pp-chip,
+  .pp-copy {
+    transition: none;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,12 +59,16 @@ extra_css:
   - stylesheets/brand.css
   # Landing-page styles, scoped under `.iro-landing` (home template only).
   - stylesheets/landing.css
+  # Interactive provider picker on the model-provider decision page (IRO-311).
+  - stylesheets/provider-picker.css
 
 extra_javascript:
   # Render the bare <div class="mermaid"> blocks (see superfences config below).
   # Loaded as an ES module so it can `import` the pinned Mermaid build.
   - path: javascripts/mermaid-init.js
     type: module
+  # Provider picker: panel switching + copy buttons (progressive enhancement).
+  - javascripts/provider-picker.js
 
 plugins:
   - search


### PR DESCRIPTION
## What

Adds an **interactive provider picker** to the model-provider decision page (`docs/providers/index.md`, from IRO-285). The visitor selects a backend and instantly gets three copy-paste blocks:

1. **Set the credential (host-side)** — the exact env var(s)
2. **Create the agent** — the exact `ironctl agent create --provider … --model …` command
3. **Verify the isolation** — a one-line `ironctl doctor` preflight

Each block has a copy button. Goal: collapse the path from *"which provider"* to *"first sandboxed run."*

Covers **every shipped provider**: `mock`, `local` (Ollama / LM Studio / vLLM), `anthropic`, `openai`, `openrouter`, `gemini`, `azure`, `bedrock`, `vertex`, `codex` — chunked into Local / Hosted / Enterprise / Subscription (matches the existing "Pick in 15 seconds" IA).

## How it's built

- **Static, GitHub-Pages safe.** No server. Native radios in a `role="radiogroup"` — arrow-key navigation, focus ring, and label association come for free.
- **Progressive enhancement.** `provider-picker.js` adds panel switching and reveals the copy buttons. **Without JS, every panel is visible and its code is selectable**, so the page degrades gracefully (the `.pp-js` class is the only thing that hides non-selected panels).
- **Copy** always yields the exact single-line source; falls back to `execCommand` and announces success through an `aria-live` region.
- **Long commands wrap** — no horizontal scroll on mobile. Reduced-motion safe. Reuses `brand.css` steel tokens (no new color system).

## Files

- `docs/providers/index.md` — new "Set up in three steps" section with the picker
- `docs/stylesheets/provider-picker.css`, `docs/javascripts/provider-picker.js`
- `mkdocs.yml` — wire the new CSS/JS

## Verification (visual-truth gate)

Rendered the built site at real viewports:

- **Desktop 1440×900** (light + dark): grouped chips, active-chip Von Restorff highlight, numbered 3-step panel.
- **Mobile 390×844**: commands wrap, no horizontal overflow, copy buttons don't overlap text.
- **Interaction**: panel switch verified (only selected panel shown); copy handler captures the exact command, toggles `pp-copied`, and announces via the live region.
- **A11y**: radiogroup labeled "Model provider", 10-radio single keyboard group, every panel `aria-label`led, live region `role=status aria-live=polite`.
- **`mkdocs build --strict` green.**

## Acceptance

- [x] Picker renders on the decision page covering every shipped provider
- [x] Copy buttons work
- [x] a11y pass (keyboard + labels)
- [x] mkdocs build green on desktop + mobile widths