### PR TITLE
refactor(provider): self-registering provider registry (IRO-314)

### DIFF
--- a/internal/sandbox/provider/azure.go
+++ b/internal/sandbox/provider/azure.go
@@ -31,6 +31,20 @@ import (
 // deployment requires it.
 const defaultAzureAPIVersion = "2024-10-21"
 
+// KindAzure routes to Azure OpenAI (Azure AI Foundry) at the per-resource
+// {resource}.openai.azure.com host. It reuses OpenAIProvider (identical wire
+// format); only the transport envelope differs — the model is selected by a
+// DEPLOYMENT NAME in the URL path (cfg.Model) plus an api-version query param
+// (cfg.APIVersion), and auth is the `api-key` header or a Microsoft Entra ID bearer
+// token injected host-side (modelproxy.AzureKeyInjector / AzureTokenInjector), not
+// the Bearer key OpenAI uses. There is no safe default host or deployment, so both
+// are required — see NewAzure, which the factory below delegates to.
+const KindAzure = "azure"
+
+func init() {
+	Register(KindAzure, func(cfg Config) (Provider, error) { return NewAzure(cfg) })
+}
+
 // NewAzure constructs an Azure OpenAI backend, reusing OpenAIProvider unchanged (the
 // wire format is identical) and overriding only the request URL so the deployment
 // name and api-version ride in it. Unlike the single-global-host cloud providers,

--- a/internal/sandbox/provider/codex.go
+++ b/internal/sandbox/provider/codex.go
@@ -26,6 +26,16 @@ import (
 	"strings"
 )
 
+// KindCodex routes to the ChatGPT Codex Responses API (chatgpt.com), powered by a
+// ChatGPT/Codex OAuth credential injected host-side (e.g. via OneCLI). NewCodex
+// applies this backend's default host and model, so the registered factory just
+// delegates.
+const KindCodex = "codex"
+
+func init() {
+	Register(KindCodex, func(cfg Config) (Provider, error) { return NewCodex(cfg), nil })
+}
+
 // Codex backend constants. The model defaults to the current ChatGPT-account
 // Codex model; the upstream host is what the model-proxy allowlists and the
 // credential gateway matches to inject the Codex token.

--- a/internal/sandbox/provider/gemini.go
+++ b/internal/sandbox/provider/gemini.go
@@ -28,6 +28,17 @@ import (
 	"strings"
 )
 
+// KindGemini routes to the Google Generative Language API
+// (generativelanguage.googleapis.com) — Google AI Studio with a host-held API key,
+// or the Gemini CLI's OAuth credential injected via the credential gateway. NewGemini
+// applies this backend's default host and model, so the registered factory just
+// delegates.
+const KindGemini = "gemini"
+
+func init() {
+	Register(KindGemini, func(cfg Config) (Provider, error) { return NewGemini(cfg), nil })
+}
+
 const (
 	geminiUpstreamHost = "generativelanguage.googleapis.com"
 	defaultGeminiModel = "gemini-2.5-pro"

--- a/internal/sandbox/provider/local.go
+++ b/internal/sandbox/provider/local.go
@@ -1,0 +1,31 @@
+// This file wires KindLocal: a LOCAL, self-hosted OpenAI-compatible model server —
+// Ollama (http://localhost:11434/v1), LM Studio, vLLM, or llama.cpp — running on
+// the operator's own machine. It speaks the identical Chat Completions wire format
+// as KindOpenAI (the same /v1/chat/completions path), so it reuses OpenAIProvider;
+// the only differences are that the upstream is the operator's loopback host (set
+// host-side; there is no sensible default) and that NO cloud credential is required —
+// the host model-proxy forwards to the local server over plain HTTP and injects a
+// key only if the operator configured one. This is the "100% local, zero cloud
+// credential" path: the model runs on the same box, so no data leaves it. See
+// modelproxy.WithInsecureUpstreams.
+//
+// Because there is no default loopback host, the factory requires cfg.UpstreamHost
+// rather than silently falling back to api.openai.com (which would send "local"
+// traffic to the cloud). Colocated here so adding the local backend touches no
+// shared line in provider.go.
+
+package provider
+
+import "fmt"
+
+// KindLocal selects a local, self-hosted OpenAI-compatible model server.
+const KindLocal = "local"
+
+func init() {
+	Register(KindLocal, func(cfg Config) (Provider, error) {
+		if cfg.UpstreamHost == "" {
+			return nil, fmt.Errorf("sandbox/provider: local provider requires an upstream host (set --model-host, e.g. localhost:11434)")
+		}
+		return NewOpenAI(cfg), nil
+	})
+}

--- a/internal/sandbox/provider/mock.go
+++ b/internal/sandbox/provider/mock.go
@@ -25,6 +25,14 @@ import (
 // with no credential.
 type MockProvider struct{}
 
+// KindMock is a deterministic, offline backend (no network, no credential) for
+// local demos and end-to-end tests. See MockProvider.
+const KindMock = "mock"
+
+func init() {
+	Register(KindMock, func(cfg Config) (Provider, error) { return NewMock(cfg), nil })
+}
+
 // NewMock constructs a MockProvider. cfg is accepted for signature parity with
 // the other constructors; every field is ignored (the mock has no network,
 // model, or socket to configure).

--- a/internal/sandbox/provider/openai.go
+++ b/internal/sandbox/provider/openai.go
@@ -22,6 +22,19 @@ import (
 	"strings"
 )
 
+// KindOpenAI selects the OpenAI Chat Completions backend. Its kind constant and
+// default upstream host/model live here (not in provider.go) so this backend is
+// self-contained; it self-registers below.
+const (
+	KindOpenAI         = "openai"
+	openAIUpstreamHost = "api.openai.com"
+	defaultOpenAIModel = "gpt-4o"
+)
+
+func init() {
+	Register(KindOpenAI, func(cfg Config) (Provider, error) { return NewOpenAI(cfg), nil })
+}
+
 // OpenAIProvider talks to an OpenAI-compatible Chat Completions API via the host
 // model-proxy socket. It serves both OpenAI and OpenRouter (an OpenAI-compatible
 // gateway); the only difference is the upstream host, model id, and request path.

--- a/internal/sandbox/provider/openrouter.go
+++ b/internal/sandbox/provider/openrouter.go
@@ -1,0 +1,32 @@
+// This file wires OpenRouter (https://openrouter.ai) as a first-class provider
+// kind. OpenRouter is an OpenAI-wire-compatible aggregator: it serves chat
+// completions under /api/v1, so it reuses OpenAIProvider unchanged — NewOpenAI
+// detects the openrouter.ai host and selects the /api/v1 path. The only thing this
+// backend contributes over the raw OpenAI path is OpenRouter's distinct default
+// upstream host and model, applied in the registered factory below before
+// delegating to NewOpenAI.
+//
+// It lives in its own file (kind constant + defaults + registration all here) so
+// OpenRouter can be added or changed without touching a shared region of
+// provider.go — the whole point of the provider registry.
+
+package provider
+
+// KindOpenRouter selects the OpenRouter aggregator backend.
+const (
+	KindOpenRouter         = "openrouter"
+	openRouterUpstreamHost = "openrouter.ai"
+	defaultOpenRouterModel = "openai/gpt-4o"
+)
+
+func init() {
+	Register(KindOpenRouter, func(cfg Config) (Provider, error) {
+		if cfg.UpstreamHost == "" {
+			cfg.UpstreamHost = openRouterUpstreamHost
+		}
+		if cfg.Model == "" {
+			cfg.Model = defaultOpenRouterModel
+		}
+		return NewOpenAI(cfg), nil
+	})
+}

--- a/internal/sandbox/provider/provider.go
+++ b/internal/sandbox/provider/provider.go
@@ -54,120 +54,72 @@ const (
 	anthropicVersion    = "2023-06-01"
 )
 
-// Provider kinds selectable per agent group. The default (empty) is Anthropic, so
-// the sealed single-provider posture is unchanged unless a group opts into another
-// backend. Each kind maps to a model-proxy-allowlisted upstream host that the host
-// authenticates with its own credential (see internal/host/modelproxy).
-const (
-	KindAnthropic  = "anthropic"
-	KindOpenAI     = "openai"
-	KindOpenRouter = "openrouter"
-	// KindCodex routes to the ChatGPT Codex Responses API (chatgpt.com), powered
-	// by a ChatGPT/Codex OAuth credential injected host-side (e.g. via OneCLI).
-	KindCodex = "codex"
-	// KindGemini routes to the Google Generative Language API
-	// (generativelanguage.googleapis.com) — Google AI Studio with a host-held API
-	// key, or the Gemini CLI's OAuth credential injected via the credential gateway.
-	KindGemini = "gemini"
-	// KindVertex routes to Google Cloud Vertex AI
-	// ({location}-aiplatform.googleapis.com). It speaks the identical Gemini wire
-	// format — only the transport envelope differs: the GCP project and location ride
-	// in the URL path, and auth is an OAuth2 bearer (gcloud ADC / service account)
-	// injected host-side, not a static API key. See NewVertex.
-	KindVertex = "vertex"
-	// KindLocal routes to a LOCAL, self-hosted OpenAI-compatible model server —
-	// Ollama (http://localhost:11434/v1), LM Studio, vLLM, or llama.cpp — running on
-	// the operator's own machine. It speaks the identical Chat Completions wire
-	// format as KindOpenAI (the same /v1/chat/completions path), so it reuses
-	// OpenAIProvider; the only difference is that the upstream is the operator's
-	// loopback host (set host-side; there is no sensible default) and that NO cloud
-	// credential is required — the host model-proxy forwards to the local server over
-	// plain HTTP and injects a key only if the operator configured one. This is the
-	// "100% local, zero cloud credential" path: the model runs on the same box, so no
-	// data leaves it. See New (requires UpstreamHost) and modelproxy.WithInsecureUpstreams.
-	KindLocal = "local"
-	// KindAzure routes to Azure OpenAI (Azure AI Foundry) at the per-resource
-	// {resource}.openai.azure.com host. It speaks the identical OpenAI Chat
-	// Completions wire format as KindOpenAI, so it reuses OpenAIProvider; only the
-	// transport envelope differs — the model is selected by a DEPLOYMENT NAME in the
-	// URL path (cfg.Model) plus an api-version query param (cfg.APIVersion), and auth
-	// is the `api-key` header or a Microsoft Entra ID bearer token injected host-side
-	// (modelproxy.AzureKeyInjector / AzureTokenInjector), not the Bearer key OpenAI
-	// uses. There is no safe default host or deployment, so both are required. See NewAzure.
-	KindAzure = "azure"
-	// KindMock is a deterministic, offline backend (no network, no credential)
-	// for local demos and end-to-end tests. See MockProvider.
-	KindMock = "mock"
+// KindAnthropic is the default backend: an empty cfg.Kind resolves to it, so the
+// sealed single-provider posture is unchanged unless a group opts into another
+// backend. Its provider (AnthropicProvider) lives in this file and self-registers
+// in init below. Every OTHER kind is declared and registered in its own backend
+// file (openai.go, azure.go, ...) so adding a provider means adding ONE file that
+// touches no shared line here. Each kind maps to a model-proxy-allowlisted upstream
+// host that the host authenticates with its own credential (see internal/host/modelproxy).
+const KindAnthropic = "anthropic"
 
-	openAIUpstreamHost     = "api.openai.com"
-	openRouterUpstreamHost = "openrouter.ai"
+// Factory builds a Provider from cfg. A backend's Factory is responsible for
+// applying that backend's own default upstream host and model when cfg leaves them
+// zero (colocated with the backend, not here), so New stays a pure lookup. Backends
+// register their Factory for their kind via Register, called from an init() in the
+// backend's own file.
+type Factory func(cfg Config) (Provider, error)
 
-	defaultOpenAIModel     = "gpt-4o"
-	defaultOpenRouterModel = "openai/gpt-4o"
-)
+// registry maps a normalized (lowercased, trimmed) provider kind to its Factory.
+// It is written ONLY by Register, which runs exclusively from package init()
+// functions — before main starts and before any New call — so it is never mutated
+// concurrently with the reads New performs. New does a single keyed lookup and
+// never ranges the map, so provider selection has no map-iteration-order dependence
+// and is race-free.
+var registry = map[string]Factory{}
 
-// New builds the Provider for cfg.Kind, applying that kind's default upstream host
-// and model when cfg leaves them zero. An empty kind selects Anthropic. The
-// returned Provider always reaches the network only through the host model-proxy
-// unix socket (cfg.SocketPath) — the sandbox has network=none — and holds no
-// credentials; the proxy authenticates per provider and enforces the egress
-// allowlist. An unknown kind is an error.
+// Register wires a Factory for kind. Call it from a backend file's init(). It
+// panics on an empty kind, a nil factory, or a duplicate registration: all three
+// are init-time programming errors, and a silent overwrite could mask a backend
+// whose defaults changed. The kind is normalized (lowercased, trimmed) to match the
+// lookup New performs.
+func Register(kind string, f Factory) {
+	kind = strings.ToLower(strings.TrimSpace(kind))
+	if kind == "" {
+		panic("sandbox/provider: Register called with empty kind")
+	}
+	if f == nil {
+		panic("sandbox/provider: Register called with nil factory for kind " + kind)
+	}
+	if _, dup := registry[kind]; dup {
+		panic("sandbox/provider: duplicate provider registration for kind " + kind)
+	}
+	registry[kind] = f
+}
+
+func init() {
+	// Anthropic is the default backend; its provider lives in this file, so it is
+	// registered here rather than in a separate backend file.
+	Register(KindAnthropic, func(cfg Config) (Provider, error) { return NewAnthropic(cfg), nil })
+}
+
+// New builds the Provider for cfg.Kind by looking up its registered Factory and
+// delegating (the Factory applies that kind's default host/model). An empty kind
+// selects Anthropic, the sealed default. The lookup is case-insensitive and trims
+// surrounding whitespace. The returned Provider always reaches the network only
+// through the host model-proxy unix socket (cfg.SocketPath) — the sandbox has
+// network=none — and holds no credentials; the proxy authenticates per provider and
+// enforces the egress allowlist. An unknown kind is an error.
 func New(cfg Config) (Provider, error) {
-	switch strings.ToLower(strings.TrimSpace(cfg.Kind)) {
-	case "", KindAnthropic:
-		return NewAnthropic(cfg), nil
-	case KindOpenAI:
-		if cfg.UpstreamHost == "" {
-			cfg.UpstreamHost = openAIUpstreamHost
-		}
-		if cfg.Model == "" {
-			cfg.Model = defaultOpenAIModel
-		}
-		return NewOpenAI(cfg), nil
-	case KindOpenRouter:
-		if cfg.UpstreamHost == "" {
-			cfg.UpstreamHost = openRouterUpstreamHost
-		}
-		if cfg.Model == "" {
-			cfg.Model = defaultOpenRouterModel
-		}
-		return NewOpenAI(cfg), nil
-	case KindCodex:
-		// NewCodex applies the chatgpt.com upstream host and the default Codex
-		// model when cfg leaves them zero.
-		return NewCodex(cfg), nil
-	case KindGemini:
-		// NewGemini applies the generativelanguage.googleapis.com upstream host and
-		// the default Gemini model when cfg leaves them zero.
-		return NewGemini(cfg), nil
-	case KindVertex:
-		// NewVertex reuses GeminiProvider (identical wire format) but builds the
-		// Vertex URL from cfg.Project/cfg.Location and derives the regional
-		// {location}-aiplatform.googleapis.com host when cfg leaves them zero.
-		return NewVertex(cfg), nil
-	case KindLocal:
-		// Local, self-hosted OpenAI-compatible server (Ollama, LM Studio, vLLM,
-		// llama.cpp). It is OpenAI wire-compatible, so it reuses OpenAIProvider — but
-		// there is no default loopback host, so require one explicitly rather than
-		// silently falling back to api.openai.com (which would send "local" traffic to
-		// the cloud). The operator always passes the model id too; NewOpenAI keeps its
-		// own default only as a last resort.
-		if cfg.UpstreamHost == "" {
-			return nil, fmt.Errorf("sandbox/provider: local provider requires an upstream host (set --model-host, e.g. localhost:11434)")
-		}
-		return NewOpenAI(cfg), nil
-	case KindAzure:
-		// NewAzure reuses OpenAIProvider (identical wire format) but builds the Azure
-		// deployment URL from cfg.UpstreamHost/cfg.Model/cfg.APIVersion. Azure is
-		// per-resource with no global default host and routes by deployment, so both
-		// the host and the deployment (cfg.Model) are required — see NewAzure.
-		return NewAzure(cfg)
-	case KindMock:
-		// Deterministic offline backend; ignores host/model/socket entirely.
-		return NewMock(cfg), nil
-	default:
+	kind := strings.ToLower(strings.TrimSpace(cfg.Kind))
+	if kind == "" {
+		kind = KindAnthropic
+	}
+	f, ok := registry[kind]
+	if !ok {
 		return nil, fmt.Errorf("sandbox/provider: unknown provider kind %q", cfg.Kind)
 	}
+	return f(cfg)
 }
 
 // Config configures a Provider. The same struct serves every backend; fields a

--- a/internal/sandbox/provider/registry_test.go
+++ b/internal/sandbox/provider/registry_test.go
@@ -1,0 +1,73 @@
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// stubProvider is a minimal Provider used to prove the registry wires a brand-new
+// backend without any edit to provider.go.
+type stubProvider struct{ cfg Config }
+
+func (s stubProvider) Query(context.Context, string) (string, error) { return "stub", nil }
+
+// TestRegistryExtensibility demonstrates the acceptance criterion: a hypothetical
+// new provider is added purely by calling Register (as a backend file's init would),
+// touching no shared region of provider.go, and New then resolves it — including the
+// case-insensitive, whitespace-trimmed lookup and the factory-applied default.
+func TestRegistryExtensibility(t *testing.T) {
+	const kind = "iro314-demo"
+	Register(kind, func(cfg Config) (Provider, error) {
+		if cfg.Model == "" {
+			cfg.Model = "demo-default" // per-kind default colocated in the factory
+		}
+		return stubProvider{cfg: cfg}, nil
+	})
+
+	pv, err := New(Config{Kind: "  IRO314-Demo  "}) // mixed case + surrounding space
+	if err != nil {
+		t.Fatalf("New(demo): %v", err)
+	}
+	sp, ok := pv.(stubProvider)
+	if !ok {
+		t.Fatalf("New(demo) = %T, want stubProvider", pv)
+	}
+	if sp.cfg.Model != "demo-default" {
+		t.Fatalf("factory default not applied: model = %q", sp.cfg.Model)
+	}
+}
+
+// TestRegisterRejectsDuplicate proves a duplicate registration panics rather than
+// silently overwriting a backend (which could mask changed defaults / a wire fork).
+func TestRegisterRejectsDuplicate(t *testing.T) {
+	const kind = "iro314-dup"
+	Register(kind, func(cfg Config) (Provider, error) { return stubProvider{}, nil })
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("duplicate Register: want panic, got none")
+		}
+		if !strings.Contains(strings.ToLower(r.(string)), "duplicate") {
+			t.Fatalf("panic = %v, want it to mention a duplicate registration", r)
+		}
+	}()
+	Register(kind, func(cfg Config) (Provider, error) { return stubProvider{}, nil })
+}
+
+// TestRegisterRejectsEmptyAndNil guards the other two init-time programming errors.
+func TestRegisterRejectsEmptyAndNil(t *testing.T) {
+	assertPanics(t, "empty kind", func() { Register("   ", func(Config) (Provider, error) { return nil, nil }) })
+	assertPanics(t, "nil factory", func() { Register("iro314-nil", nil) })
+}
+
+func assertPanics(t *testing.T, name string, f func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("%s: want panic, got none", name)
+		}
+	}()
+	f()
+}

--- a/internal/sandbox/provider/vertex.go
+++ b/internal/sandbox/provider/vertex.go
@@ -20,6 +20,18 @@ package provider
 
 import "strings"
 
+// KindVertex routes to Google Cloud Vertex AI ({location}-aiplatform.googleapis.com).
+// It reuses GeminiProvider (identical wire format); only the transport envelope
+// differs — the GCP project and location ride in the URL path, and auth is an OAuth2
+// bearer (gcloud ADC / service account) injected host-side, not a static API key.
+// NewVertex derives the regional host from cfg.Project/cfg.Location, so the registered
+// factory just delegates.
+const KindVertex = "vertex"
+
+func init() {
+	Register(KindVertex, func(cfg Config) (Provider, error) { return NewVertex(cfg), nil })
+}
+
 const (
 	// defaultVertexModel matches the AI Studio default; Vertex serves the same
 	// Gemini models under publishers/google/models/{model}.


### PR DESCRIPTION
## What
Refactor sandbox provider selection from a shared `Kind*` const block + monolithic `switch` in `New()` into a **self-registering registry**, so concurrent provider PRs stop conflicting on the same lines of `provider.go`. Closes IRO-314.

## Why (our #1 throughput tax)
Every new provider today edits two shared regions of `internal/sandbox/provider/provider.go` (the `Kind*` const block and the `switch cfg.Kind` factory). Both are adjacent-line edits, so any two in-flight provider PRs (Azure/Bedrock/OpenRouter/Ollama) textually conflict; merging one forces every other to rebase, and those rebases have already produced RED provider-registration collisions (IRO-312, IRO-292). This makes the merge queue slow.

## What changed
- **Registry core (`provider.go`)**: `Factory` type, a `registry map[string]Factory`, and `Register(kind, factory)` guarded against empty kind, nil factory, and duplicate keys. `New(cfg)` is now a pure lookup — normalize kind, empty selects Anthropic, look up factory, delegate. Each factory applies its own default host/model. Unknown kind returns the same error as before.
- **Backends self-register in their own files** via `init()`: `openai.go`, `azure.go`, `codex.go`, `gemini.go`, `vertex.go`, `mock.go`, plus new `openrouter.go` and `local.go`. Anthropic (the default) registers in `provider.go` where its provider lives.

## Adding a new provider now = ONE new file, zero shared-line edits
A new backend adds a file with an `init()` that calls `Register(KindX, NewX)` and touches no shared region of `provider.go`. `registry_test.go` demonstrates exactly this (registers a hypothetical kind at runtime with zero `provider.go` edits) and guards the duplicate/empty/nil panics.

## Acceptance
- All 50 existing provider tests pass **unchanged** (behavior-preserving refactor).
- `-race` clean. Registry is written only from `init()` and read (single keyed lookup, never ranged) from `New`, so provider selection is race-free with no map-iteration-order dependence.
- Wire formats, defaults, sealed-runtime posture unchanged.

## Verification
```
CGO_ENABLED=1 go build ./...            # ok
CGO_ENABLED=1 go test -race ./internal/sandbox/provider/   # ok, 53 tests
gofmt -l internal/sandbox/provider/*.go # clean
```

## Security lenses
Touches **trust boundary / sealed-runtime posture** only insofar as it preserves them: no wire-format, default, or egress change; the sandbox still holds no credentials and reaches the network only through the host model-proxy socket. Behavior-preserving refactor — routes to CEO for trust-model review before merge.

Unblocks faster, conflict-free provider merges (IRO-292 regression guard depends on this landing cleanly).