### PR TITLE
docs: assemble nav from per-directory fragments (IRO-315)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,29 @@ Changing it requires:
 | Shared frozen seam | `internal/contract/**` (see above) |
 | Behavioral parity suite | `test/parity/**` (shared — add specs, don't rewrite others') |
 
+## Documentation
+
+The docs site (MkDocs Material, under [`docs/`](docs/)) has **no shared `nav:`
+block** in `mkdocs.yml`. The navigation is assembled at build time from
+per-directory `.nav.yml` fragment files, so two docs PRs almost never touch the
+same nav line and no longer conflict on merge.
+
+**To add a page:**
+
+1. Drop the `.md` file in the right directory with a top-level `# H1` (its title).
+2. For the churn-heavy sections — `providers/`, `tutorials/`, `integrations/` —
+   that is **all you need**: the directory's `.nav.yml` ends with a `"*.md"`
+   glob that auto-includes any new page (titled from its H1), appended after the
+   explicitly listed ones. Add an explicit `- My Label: my-page.md` line to that
+   directory's `.nav.yml` only if you want a custom label or a specific position.
+3. For a page in another section, add one line to the matching section in
+   [`docs/.nav.yml`](docs/.nav.yml) (the root fragment).
+
+`mkdocs build --strict` must stay green (`pip install -r docs/requirements.txt`
+then `mkdocs build --strict`). The assembler fails the build loudly if a
+fragment points at a missing page, so a typo can never silently drop a page.
+See the top of [`docs/hooks.py`](docs/hooks.py) for the fragment format.
+
 ## Pull requests
 
 - Branch from `main`, make your change, and open a PR against `main`.

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -1,0 +1,49 @@
+# Root navigation fragment for the IronClaw docs site.
+#
+# This is the canonical source of the site `nav`. It is assembled at build time
+# by docs/hooks.py (there is deliberately NO `nav:` block in mkdocs.yml). Churn-
+# heavy directories (providers/, tutorials/, integrations/) are referenced by
+# name and resolve to their own `.nav.yml` fragment, so adding a page there
+# never edits a line shared with unrelated docs PRs.
+#
+# Item forms (see docs/hooks.py `_resolve_items`):
+#   - "Title: page.md"   a page
+#   - "Title: subdir"    a section pulled from subdir/.nav.yml
+#   - "Title:" + list    an inline nested section
+#   - "*.md"             every remaining page in this dir, auto-titled from its H1
+nav:
+  - Home: index.md
+  - Why IronClaw: comparison.md
+  - Get Started:
+      - Quickstart: quickstart.md
+      - Building from source: building.md
+      - Production deployment: deployment.md
+      - Observability (metrics): observability.md
+      - Troubleshooting: troubleshooting.md
+      - FAQ: faq.md
+  - Model providers: providers
+  - Tutorials: tutorials
+  - Examples & use cases: examples.md
+  - Concepts:
+      - IronClaw, Explained: ironclaw-explained.md
+      - Architecture: architecture.md
+      - The frozen contract: contract.md
+      - MCP servers: mcp.md
+  - Channels:
+      - Channel adapters: channels.md
+      - Writing a channel adapter: writing-a-channel-adapter.md
+  - Skills: skills.md
+  - Integrations: integrations
+  - Social proof: social-proof.md
+  - Security & Trust:
+      - Overview: security.md
+      - Isolation, proven: security-isolation.md
+      - Credential vault: vault.md
+      - Breaking our own sandbox: breaking-our-own-sandbox.md
+      - Threat model: threat-model.md
+      - Performance & footprint: benchmarks.md
+  - Reference:
+      - API (OpenAPI): reference/api.md
+      - Release runbook: release-runbook.md
+      - PR review & reviewer identity: pr-review-process.md
+      - Roadmap: roadmap.md

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,12 +1,18 @@
 """MkDocs build hooks for the IronClaw docs site.
 
-Two jobs, both reproducible and run identically in local builds and in CI:
+Three jobs, all reproducible and run identically in local builds and in CI:
 
-1. Copy the canonical OpenAPI spec (``api/openapi.yaml``, the single source of
+1. Assemble the site ``nav`` from per-directory ``.nav.yml`` fragment files
+   instead of one shared ``nav:`` block in ``mkdocs.yml``. A single shared nav
+   line is a merge-collision magnet: every docs/provider PR edits it, so merging
+   one flips all the siblings to CONFLICTING and forces serial rebase-then-merge.
+   Splitting the nav into per-directory fragments means N docs PRs merge in any
+   order without touching a shared line. See ``_assemble_nav`` for the format.
+2. Copy the canonical OpenAPI spec (``api/openapi.yaml``, the single source of
    truth) into ``docs/reference/openapi.yaml`` so the API reference page renders
    a same-origin, vendored copy — no committed duplicate, no runtime fetch from
    an external host.
-2. Stamp the site with the release version derived the same way the release
+3. Stamp the site with the release version derived the same way the release
    pipeline derives it (``v0.1.<commit-count>``), so every published site is
    tied to the source commit it was built from. CI passes the version via
    ``IRONCLAW_DOCS_VERSION``; locally we fall back to ``git rev-list --count``.
@@ -19,9 +25,17 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import yaml
+
 # repo_root/docs/hooks.py -> repo_root
 REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs"
 BASE_VERSION = "0.1"
+
+# The per-directory nav fragment filename. A dotfile on purpose: MkDocs ignores
+# dotfiles when collecting the doc tree, so these fragments never leak into the
+# built site, while this hook reads them straight off disk.
+NAV_FILE = ".nav.yml"
 
 
 def _derive_version() -> str:
@@ -39,7 +53,131 @@ def _derive_version() -> str:
         return f"v{BASE_VERSION}.dev"
 
 
+class NavError(Exception):
+    """Raised when a nav fragment is missing, malformed, or points at a file
+    that does not exist. We fail the build loudly rather than let MkDocs fall
+    back to an auto-generated nav that silently drops or reorders pages."""
+
+
+def _read_fragment(frag_path: Path) -> list:
+    """Load a ``.nav.yml`` fragment and return its ``nav:`` list."""
+    if not frag_path.exists():
+        raise NavError(f"nav fragment not found: {frag_path.relative_to(REPO_ROOT)}")
+    data = yaml.safe_load(frag_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict) or "nav" not in data:
+        raise NavError(
+            f"nav fragment {frag_path.relative_to(REPO_ROOT)} must contain a top-level 'nav:' list"
+        )
+    nav = data["nav"]
+    if not isinstance(nav, list):
+        raise NavError(
+            f"'nav:' in {frag_path.relative_to(REPO_ROOT)} must be a list, got {type(nav).__name__}"
+        )
+    return nav
+
+
+def _rel(path: Path) -> str:
+    """docs-dir-relative POSIX path, the form MkDocs expects in nav."""
+    return path.relative_to(DOCS_DIR).as_posix()
+
+
+def _check_page(base: Path, filename: str) -> str:
+    page = (base / filename).resolve()
+    if not page.exists():
+        raise NavError(
+            f"nav references missing page: {_rel(base)}/{filename}".lstrip("/")
+        )
+    return _rel(page)
+
+
+def _resolve_items(items: list, base: Path) -> list:
+    """Resolve one fragment's item list into a MkDocs nav list.
+
+    ``base`` is the directory the fragment lives in; every relative path in the
+    fragment is resolved against it. Supported item forms:
+
+      - ``Title: page.md``      -> a page (path relative to this fragment's dir)
+      - ``Title: subdir``       -> a section whose children come from
+                                    ``subdir/.nav.yml`` (title from the key)
+      - ``Title: [ ... ]``      -> an inline nested section
+      - ``"*.md"`` (any glob)   -> every matching file in this fragment's dir not
+                                    already listed above, sorted, auto-titled by
+                                    MkDocs from each page's H1 (zero-edit adds)
+      - ``page.md``             -> a page, auto-titled
+    """
+    resolved: list = []
+    listed: set[str] = set()  # filenames explicitly named in this fragment's dir
+
+    for item in items:
+        if isinstance(item, str):
+            if any(ch in item for ch in "*?[") :
+                # Glob: expand later, once we know everything explicitly listed.
+                resolved.append(("__glob__", item))
+                continue
+            resolved.append(_check_page(base, item))
+            listed.add(item)
+            continue
+
+        if not isinstance(item, dict) or len(item) != 1:
+            raise NavError(
+                f"nav item in {_rel(base) or 'docs'} must be a single-key mapping or string, got: {item!r}"
+            )
+
+        (title, value), = item.items()
+
+        if isinstance(value, list):
+            resolved.append({title: _resolve_items(value, base)})
+        elif isinstance(value, str) and value.endswith(".md"):
+            resolved.append({title: _check_page(base, value)})
+            listed.add(value)
+        elif isinstance(value, str):
+            # Directory reference: pull the subdirectory's own fragment.
+            subdir = (base / value).resolve()
+            if not subdir.is_dir():
+                raise NavError(
+                    f"nav references '{value}' as a directory under {_rel(base) or 'docs'}, "
+                    "but it is not a directory"
+                )
+            children = _resolve_items(_read_fragment(subdir / NAV_FILE), subdir)
+            resolved.append({title: children})
+        else:
+            raise NavError(
+                f"nav item {title!r} in {_rel(base) or 'docs'} has unsupported value: {value!r}"
+            )
+
+    # Expand any glob tokens against files not already named in this fragment.
+    out: list = []
+    for entry in resolved:
+        if isinstance(entry, tuple) and entry[0] == "__glob__":
+            pattern = entry[1]
+            for match in sorted(base.glob(pattern)):
+                if match.name.startswith(".") or match.name in listed:
+                    continue
+                out.append(_rel(match))  # bare path -> MkDocs titles it from the H1
+        else:
+            out.append(entry)
+    return out
+
+
+def _assemble_nav(config) -> None:
+    """Build ``config['nav']`` from the per-directory ``.nav.yml`` fragments.
+
+    Canonical source of the site nav is ``docs/.nav.yml`` (the root fragment),
+    which references churn-heavy directories (providers/, tutorials/,
+    integrations/) by name so they resolve to their own fragments. Adding a page
+    to one of those directories touches only that directory's fragment — never a
+    line shared with unrelated docs PRs.
+    """
+    root = _read_fragment(DOCS_DIR / NAV_FILE)
+    nav = _resolve_items(root, DOCS_DIR)
+    if not nav:
+        raise NavError("assembled nav is empty — refusing to build with no navigation")
+    config["nav"] = nav
+
+
 def on_config(config, **kwargs):
+    _assemble_nav(config)
+
     version = _derive_version()
     # Surfaced in the footer copyright and available to templates via extra.version.
     config.setdefault("extra", {})

--- a/docs/integrations/.nav.yml
+++ b/docs/integrations/.nav.yml
@@ -1,0 +1,9 @@
+# Navigation for the "Integrations" section. New integration guide: drop the
+# file; the `*.md` glob auto-includes it (titled from its H1). List it explicitly
+# only to override the label or ordering.
+nav:
+  - CI (GitHub Action): ci.md
+  - LangChain: langchain.md
+  - OpenAI SDK: openai-sdk.md
+  - CrewAI: crewai.md
+  - "*.md"

--- a/docs/providers/.nav.yml
+++ b/docs/providers/.nav.yml
@@ -1,0 +1,11 @@
+# Navigation for the "Model providers" section.
+#
+# Adding a provider page: drop `providers/<name>.md` with an H1 title. The `*.md`
+# glob below auto-includes it (titled from its H1) with ZERO edit here. Add an
+# explicit line only to control its label or ordering. Either way you never touch
+# a nav line shared with other docs PRs, so provider PRs stop colliding.
+nav:
+  - Choose your model provider: index.md
+  - AWS Bedrock: bedrock.md
+  - Azure OpenAI: azure.md
+  - "*.md"

--- a/docs/tutorials/.nav.yml
+++ b/docs/tutorials/.nav.yml
@@ -1,0 +1,10 @@
+# Navigation for the "Tutorials" section. New tutorial: drop the file; the `*.md`
+# glob auto-includes it (titled from its H1). List it explicitly only to override
+# the label or ordering.
+nav:
+  - Overview: index.md
+  - Your first sandboxed agent in 5 minutes: first-agent.md
+  - Run a 100% local model (Ollama): local-model-ollama.md
+  - Connect IronClaw to Slack: connect-slack.md
+  - Write a custom channel adapter: custom-channel-adapter.md
+  - "*.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,51 +102,9 @@ markdown_extensions:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
-nav:
-  - Home: index.md
-  - Why IronClaw: comparison.md
-  - Get Started:
-      - Quickstart: quickstart.md
-      - Building from source: building.md
-      - Production deployment: deployment.md
-      - Observability (metrics): observability.md
-      - Troubleshooting: troubleshooting.md
-      - FAQ: faq.md
-  - Model providers:
-      - Choose your model provider: providers/index.md
-      - AWS Bedrock: providers/bedrock.md
-      - Azure OpenAI: providers/azure.md
-  - Tutorials:
-      - Overview: tutorials/index.md
-      - Your first sandboxed agent in 5 minutes: tutorials/first-agent.md
-      - Run a 100% local model (Ollama): tutorials/local-model-ollama.md
-      - Connect IronClaw to Slack: tutorials/connect-slack.md
-      - Write a custom channel adapter: tutorials/custom-channel-adapter.md
-  - Examples & use cases: examples.md
-  - Concepts:
-      - IronClaw, Explained: ironclaw-explained.md
-      - Architecture: architecture.md
-      - The frozen contract: contract.md
-      - MCP servers: mcp.md
-  - Channels:
-      - Channel adapters: channels.md
-      - Writing a channel adapter: writing-a-channel-adapter.md
-  - Skills: skills.md
-  - Integrations:
-      - CI (GitHub Action): integrations/ci.md
-      - LangChain: integrations/langchain.md
-      - OpenAI SDK: integrations/openai-sdk.md
-      - CrewAI: integrations/crewai.md
-  - Social proof: social-proof.md
-  - Security & Trust:
-      - Overview: security.md
-      - Isolation, proven: security-isolation.md
-      - Credential vault: vault.md
-      - Breaking our own sandbox: breaking-our-own-sandbox.md
-      - Threat model: threat-model.md
-      - Performance & footprint: benchmarks.md
-  - Reference:
-      - API (OpenAPI): reference/api.md
-      - Release runbook: release-runbook.md
-      - PR review & reviewer identity: pr-review-process.md
-      - Roadmap: roadmap.md
+# The site navigation is assembled at build time from per-directory `.nav.yml`
+# fragment files by docs/hooks.py (`_assemble_nav`). There is intentionally no
+# `nav:` block here: a single shared nav line is a merge-collision magnet (every
+# docs/provider PR edited it). The canonical nav source is docs/.nav.yml, which
+# delegates churn-heavy sections to providers/.nav.yml, tutorials/.nav.yml, and
+# integrations/.nav.yml. See docs/CONTRIBUTING or the top of docs/hooks.py.


### PR DESCRIPTION
## What
Kills the mkdocs.yml `nav:` merge-collision tax (IRO-315). Every docs/provider PR edited the single shared `nav:` block, so merging one flipped all siblings to CONFLICTING and forced serial rebase-then-merge (just merging #300 flipped #316/#317/#318/#319). Docs-side twin of IRO-314 (provider.go registry).

## How
- Remove the shared `nav:` block from `mkdocs.yml`.
- `docs/hooks.py` `_assemble_nav` builds `config['nav']` at build time from per-directory `.nav.yml` fragment files.
- Root fragment `docs/.nav.yml` delegates churn-heavy sections to `providers/.nav.yml`, `tutorials/.nav.yml`, `integrations/.nav.yml`.
- Those fragments end with a `"*.md"` glob → **adding a page is zero shared-line edits**: drop the file, it is auto-included and titled from its H1. Add an explicit line only to override label/order.
- `docs/CONTRIBUTING` note on how to add a page.

## Design notes (supply-chain lenses)
- **No new dependency.** Pure hook — the hash-locked `docs/requirements.txt` (`--require-hashes`, regen only in a linux/py3.12 container) is untouched. No third-party plugin added to the docs path. Fully auditable (our code).
- **Fail-closed.** The assembler raises and fails the build if a fragment points at a missing page, instead of letting MkDocs silently fall back to an auto-generated nav that could drop/reorder pages.
- `.nav.yml` are dotfiles → MkDocs ignores them in the doc tree; they never leak into the built site (verified).

## Acceptance
- [x] New page added by dropping a file (+ optional per-dir entry), **no shared-line edit** — proven: dropped `providers/zzz-cohere.md`, appeared in nav via glob, zero nav edit.
- [x] `mkdocs build --strict` green (EXIT=0).
- [x] Existing nav order + labels unchanged — assembled nav is **byte-identical** to the old block (structural deep-compare).
- [x] Short `docs/CONTRIBUTING` note.
- [x] Fail-loud verified: a missing-page reference raises `NavError` and fails the build.

Closes IRO-315.