### PR TITLE
ci(providers): credential-free provider regression guard (IRO-292)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,30 @@ jobs:
             ./internal/host/delivery/ \
             ./test/parity/
 
+  # Credential-free provider regression guard (IRO-292). We ship model providers
+  # fast (Gemini, Vertex, Bedrock, Azure, OpenRouter, ...); this job stops config
+  # drift from rotting them. scripts/provider-smoke-guard.sh parses the Kind*
+  # constants from internal/sandbox/provider/provider.go (the factory's source of
+  # truth) and fails, by name, if any provider kind lacks a credential-free factory
+  # test — or, for a dedicated-injector provider (vertex/bedrock/azure/local), a
+  # host-injector test — then re-runs those two test packages with EVERY provider
+  # credential scrubbed from the env, proving the credential-free path is green with
+  # no secrets present. Unlike the umbrella `go test ./...` in `build`, this is a
+  # dedicated, visible check: a provider shipped without a credential-free path
+  # turns THIS job red with a clear message, instead of silently having no coverage.
+  # Mirrors the additive posture of example-smoke.yml (IRO-284).
+  provider-smoke:
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: "1"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.23.12"
+      - name: provider smoke guard (credential-free factory + injector coverage)
+        run: scripts/provider-smoke-guard.sh
+
   # Short bounded native-fuzz run over the highest-risk untrusted-input parsers
   # (skill manifest YAML, minisign signature/key blobs, name/version/asset path
   # validation). This is a regression smoke test, not an exhaustive campaign: each

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -59,7 +59,7 @@ not change. This page helps you choose one, then links you straight to setup.
 | **OpenRouter** | `openrouter` | API key | `OPENROUTER_API_KEY` | yes (SSE) | One key, many models | [Setup](#anthropic-openai-openrouter) |
 | **Google Gemini** | `gemini` | API key | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) | yes (SSE) | Hosted Google models, generous free tier | [Setup](#gemini-google-ai-studio) |
 | **Google Vertex AI** | `vertex` | OAuth2 bearer | gcloud ADC (`GOOGLE_VERTEX_USE_GCLOUD=1`) or `GOOGLE_VERTEX_ACCESS_TOKEN`; `GOOGLE_VERTEX_PROJECT` required | yes (SSE) | Gemini under GCP billing / IAM | [Setup](#vertex-ai-google-cloud) |
-| **AWS Bedrock** | `bedrock` | AWS SigV4 | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (+ `AWS_SESSION_TOKEN`), `AWS_REGION` | no (InvokeModel) | Claude/others under AWS billing / IAM | [Setup](#aws-bedrock-beta) |
+| **AWS Bedrock** | `bedrock` | AWS SigV4 | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (+ `AWS_SESSION_TOKEN`), `AWS_REGION` | no (InvokeModel) | Claude/others under AWS billing / IAM | [Setup](#aws-bedrock) |
 | **ChatGPT / Codex** | `codex` | OAuth via gateway | credential gateway (`IRONCLAW_MODEL_GATEWAY_URL`, e.g. OneCLI) | yes (SSE) | Reuse a ChatGPT/Codex subscription | [Setup](#codex-chatgpt-via-a-credential-gateway) |
 | **Azure OpenAI** | `azure` | api-key or Entra token | `AZURE_OPENAI_API_KEY` (or `AZURE_OPENAI_ACCESS_TOKEN`) + `AZURE_OPENAI_ENDPOINT` | yes (SSE) | GPT-class models under Azure billing / IAM | [Azure OpenAI](azure.md) |
 
@@ -122,7 +122,7 @@ export GOOGLE_VERTEX_USE_GCLOUD=1             # use gcloud Application Default C
 # export GOOGLE_VERTEX_ACCESS_TOKEN=ya29.…
 ```
 
-### AWS Bedrock (beta)
+### AWS Bedrock
 
 For orgs that consume models only through Bedrock. Credentials come from the
 standard AWS environment; the region selects the regional
@@ -135,10 +135,10 @@ export AWS_SESSION_TOKEN=…                # optional, for temporary credential
 export AWS_REGION=us-east-1               # or AWS_DEFAULT_REGION
 ```
 
-!!! info "Bedrock is landing"
-    The `bedrock` provider is in review ([IRO-273](https://github.com/IronSecCo/ironclaw/issues)).
+!!! note "How Bedrock auth works"
     Host-side SigV4 signing is validated against AWS's reference vectors; requests
-    use the non-stream `InvokeModel` API. This section documents the shipping shape.
+    use the non-stream `InvokeModel` API. The signature is region-bound, so
+    `AWS_REGION` is required and no static credential ever enters the sandbox.
 
 ### Codex (ChatGPT) via a credential gateway
 

--- a/scripts/provider-smoke-guard.sh
+++ b/scripts/provider-smoke-guard.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Provider regression guard (IRO-292).
+#
+# Every first-class model provider must have a CREDENTIAL-FREE unit/smoke path so
+# config drift (a renamed env var, a broken factory default, a dropped host
+# injector) is caught in CI instead of shipping. We ship providers fast (Gemini,
+# Vertex, Bedrock, Azure, OpenRouter, ...); this script is the anti-rot gate.
+#
+# It does two things, both credential-free (no provider secret is ever read):
+#
+#   1. COVERAGE: parses the authoritative Kind* constants from
+#      internal/sandbox/provider/provider.go (the factory's source of truth) and
+#      asserts every provider kind is referenced by at least one _test.go in the
+#      factory package AND — for kinds whose host-side auth needs a dedicated
+#      injector — in the model-proxy package. Add a provider without a
+#      credential-free test and this fails, by name, listing the gap.
+#
+#   2. HERMETIC RUN: runs the factory + host-injector test packages with every
+#      known provider credential SCRUBBED from the environment, proving the
+#      credential-free path actually passes with no secrets present. A test that
+#      silently depends on a real key turns this red here.
+#
+# Mirrors the additive, visible posture of example-smoke.yml (IRO-284): a
+# dedicated, named check rather than coverage folded invisibly into `go test ./...`.
+#
+# Usage: scripts/provider-smoke-guard.sh
+# Exit 0 = every first-class provider has credential-free coverage and it passes.
+
+set -euo pipefail
+
+# Resolve the repo root from this script's location so it runs from anywhere.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PROVIDER_PKG="internal/sandbox/provider"
+INJECTOR_PKG="internal/host/modelproxy"
+PROVIDER_GO="$PROVIDER_PKG/provider.go"
+
+# Kinds whose host-side authentication is injected by a DEDICATED model-proxy
+# injector (as opposed to the generic bearer/API-key path shared by
+# anthropic/openai/openrouter/gemini/codex). Each of these must additionally have
+# a credential-free injector test. (A plain case, not an associative array, so the
+# script runs on macOS's bash 3.2 as well as CI's bash 4+.)
+#   vertex  — OAuth2 bearer (gcloud ADC / service account)
+#   bedrock — AWS SigV4 signing
+#   azure   — api-key header or Microsoft Entra bearer
+#   local   — optional-key loopback (WithInsecureUpstreams)
+needs_injector_test() {
+  case "$1" in
+    vertex|bedrock|azure|local) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+fail=0
+note() { printf '  %s\n' "$*"; }
+
+echo "==> Provider regression guard (IRO-292)"
+echo "    factory source of truth: $PROVIDER_GO"
+echo
+
+# --- 1. COVERAGE ------------------------------------------------------------
+# Extract "KindXxx = \"value\"" pairs. The identifier is what tests reference;
+# the value is the wire kind string and the injector key. (while-read, not
+# mapfile, so this runs on bash 3.2.)
+KIND_LINES="$(grep -oE 'Kind[A-Za-z]+[[:space:]]*=[[:space:]]*"[a-z]+"' "$PROVIDER_GO")"
+
+if [ -z "$KIND_LINES" ]; then
+  echo "FAIL: no Kind* constants found in $PROVIDER_GO — did the factory move?" >&2
+  exit 1
+fi
+
+echo "==> Coverage: every provider kind has a credential-free test"
+while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  ident="$(printf '%s' "$line" | grep -oE '^Kind[A-Za-z]+')"  # KindAzure
+  val="$(printf '%s' "$line" | grep -oE '"[a-z]+"' | tr -d '"')"  # azure
+
+  # Factory-side coverage: a factory test must CONSTRUCT this kind through New,
+  # i.e. contain `Kind: KindXxx` or `Kind: "value"` (case-insensitive, since the
+  # factory lower-cases and tests exercise mixed case on purpose).
+  if grep -riqE "Kind:[[:space:]]*(\"?${val}\"?|${ident})" "$PROVIDER_PKG"/*_test.go 2>/dev/null; then
+    factory="ok"
+  else
+    factory="MISSING"
+    fail=1
+  fi
+
+  # Injector-side coverage (only for kinds with a dedicated injector). Match the
+  # kind name case-insensitively in the model-proxy tests (e.g. AzureKeyInjector).
+  inj="n/a"
+  if needs_injector_test "$val"; then
+    if grep -riql -- "$val" "$INJECTOR_PKG"/*_test.go 2>/dev/null; then
+      inj="ok"
+    else
+      inj="MISSING"
+      fail=1
+    fi
+  fi
+
+  printf '    %-14s (%-10s) factory=%-7s injector=%s\n' "$ident" "\"$val\"" "$factory" "$inj"
+done <<EOF
+$KIND_LINES
+EOF
+
+if [ "$fail" -ne 0 ]; then
+  echo >&2
+  echo "FAIL: a provider kind has no credential-free test (see MISSING above)." >&2
+  echo "      Add a factory test in $PROVIDER_PKG and, for a dedicated-injector" >&2
+  echo "      provider, an injector test in $INJECTOR_PKG before shipping it." >&2
+  exit 1
+fi
+echo "    all provider kinds covered."
+echo
+
+# --- 2. HERMETIC RUN --------------------------------------------------------
+# Run the credential-free factory + injector tests with EVERY known provider
+# credential unset, so a test that leaks a dependency on a real secret fails here
+# rather than passing on a developer box that happens to have keys exported.
+echo "==> Hermetic run: factory + injector tests with all provider creds scrubbed"
+SCRUB=(
+  ANTHROPIC_API_KEY OPENAI_API_KEY OPENROUTER_API_KEY
+  GOOGLE_API_KEY GEMINI_API_KEY
+  GOOGLE_VERTEX_ACCESS_TOKEN GOOGLE_VERTEX_PROJECT GOOGLE_VERTEX_LOCATION GOOGLE_VERTEX_USE_GCLOUD
+  AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_REGION AWS_DEFAULT_REGION
+  AZURE_OPENAI_API_KEY AZURE_OPENAI_ACCESS_TOKEN AZURE_OPENAI_ENDPOINT AZURE_OPENAI_API_VERSION
+  IRONCLAW_LOCAL_MODEL_KEY IRONCLAW_MODEL_GATEWAY_URL
+)
+unset_args=()
+for v in "${SCRUB[@]}"; do unset_args+=(-u "$v"); done
+
+# -count=1 disables the test cache so the scrubbed environment is actually exercised.
+env "${unset_args[@]}" go test -count=1 "./$PROVIDER_PKG/..." "./$INJECTOR_PKG/..."
+
+echo
+echo "==> Provider smoke guard passed: all first-class providers have a"
+echo "    credential-free path and it is green with no secrets present."


### PR DESCRIPTION
## What

Anti-rot guard so every first-class model provider keeps a **credential-free** unit/smoke path and an accurate capability-matrix row as we ship providers fast (Gemini, Vertex, Bedrock, Azure, OpenRouter, ...). Closes IRO-292 (unblocked now that Azure IRO-282 #310 and Bedrock IRO-273 #300 are on `main`).

## Changes

1. **`scripts/provider-smoke-guard.sh`** — parses the `Kind*` constants from `internal/sandbox/provider/provider.go` (the factory's source of truth) and fails, **by name**, if any provider kind lacks a credential-free **factory** test — or, for a dedicated-injector provider (`vertex`/`bedrock`/`azure`/`local`), a host-**injector** test. Then re-runs `internal/sandbox/provider/...` + `internal/host/modelproxy/...` with every known provider credential **scrubbed** from the env, proving the credential-free path is green with no secrets present. bash 3.2-compatible (runs on macOS + CI).
2. **`.github/workflows/ci.yml`** — new dedicated, visible **`provider-smoke`** job runs the guard on every push/PR (additive, mirrors `example-smoke.yml` from IRO-284). A provider shipped without a credential-free path now turns this job red with a clear message, instead of silently having no coverage under the umbrella `go test ./...`.
3. **`docs/providers/index.md`** — flip the **AWS Bedrock** capability-matrix row from beta/"in review" to **shipped** (IRO-273 is on main): drop the `(beta)` header + "Bedrock is landing" admonition, fix the in-page setup anchor (`#aws-bedrock`). Azure already reads as shipped.

## Verification

- Guard: all **10** first-class kinds covered (anthropic, openai, openrouter, codex, gemini, vertex, local, bedrock, azure, mock); hermetic test packages green with creds scrubbed.
- **Negative control**: injected a fake `KindFoo` → guard fails as expected (`factory=MISSING`, exit non-zero), then reverted.
- `mkdocs build --strict` → exit 0 (decision-guide + FAQ cross-links resolve).
- `python -c yaml.safe_load` on ci.yml → valid, jobs: build, race, provider-smoke, fuzz, glibc-floor.

## Acceptance (IRO-292)

- [x] CI smoke covers all first-class providers credential-free (dedicated `provider-smoke` job)
- [x] Capability-matrix rows for Azure + Bedrock verified/corrected
- [x] `mkdocs --strict` green