### PR TITLE
ci: exclude .ironclaw-demo-state from Docker build context (IRO-316)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Build-context excludes (IRO-316).
+#
+# Both image builds use the repository ROOT as their Docker build context:
+#   - container/build.sh          -> docker build -f container/Dockerfile <repo root>
+#   - docker-compose.demo.yml     -> controlplane: build.context = "."
+# so this .dockerignore governs what the BuildKit context sender transfers for both.
+
+# Runtime state the demo control-plane writes as a HOST bind (docker-compose.demo.yml:
+# IRONCLAW_DOCKER_BINDS / ./.ironclaw-demo-state). In CI the control-plane runs as root
+# and writes .ironclaw-demo-state/changes root-owned; a later `compose up --build` then
+# fails loading the context with "error from sender: open .../.ironclaw-demo-state/changes:
+# permission denied", reddening the containment-report job for reasons unrelated to the
+# build. It is pure runtime state, never a build input, so exclude it from every context.
+.ironclaw-demo-state/

--- a/.github/workflows/ironclaw-action-example.yml
+++ b/.github/workflows/ironclaw-action-example.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - ".github/actions/ironclaw/**"
       - ".github/workflows/ironclaw-action-example.yml"
+      - ".dockerignore"
       - "docker-compose.demo.yml"
       - "container/**"
       - "cmd/sandbox/**"
@@ -27,6 +28,7 @@ on:
     paths:
       - ".github/actions/ironclaw/**"
       - ".github/workflows/ironclaw-action-example.yml"
+      - ".dockerignore"
       - "docker-compose.demo.yml"
       - "container/**"
       - "cmd/sandbox/**"


### PR DESCRIPTION
## What

Add a repo-root `.dockerignore` excluding `.ironclaw-demo-state/`.

## Why

The `containment-report` job (`ironclaw-action-example.yml`) recurrently flakes with:

```
#7 [internal] load build context
#7 ERROR: error from sender: open /home/runner/work/ironclaw/ironclaw/.ironclaw-demo-state/changes: permission denied
```

(seen on PR #300, run 28655496983). Both image builds use the **repo root** as their
Docker build context:

- `container/build.sh` -> `docker build -f container/Dockerfile <repo root>`
- `docker-compose.demo.yml` controlplane -> `build.context: "."`

The demo control-plane writes `.ironclaw-demo-state/` there as a host bind. In CI it runs
as **root**, so `.ironclaw-demo-state/changes` is root-owned; a later `compose up --build`
in the same job cannot read it during context load and the whole build fails, reddening
`containment-report` even when `sandbox-containment` and `red-team-escape` pass. Forces
admin-merge and erodes the "green means green" signal on the containment gate.

## Fix

Fix option (1) from the issue — the SSOT fix. BuildKit prunes `.dockerignore` matches
before the context sender opens them, so the root-owned file is never read. Portable
(no `sudo`, works local + CI) and covers **both** repo-root build contexts.

Fix (2) (`rm -rf` in `run-agent.sh`) was rejected: the file is root-owned so a non-sudo
`rm` fails, and adding `sudo rm` to a human-facing script harms local UX. `.dockerignore`
resolves the root cause for every build path.

Bonus: both Dockerfiles do `COPY . .`, so before this the ephemeral runtime state was also
being copied **into** the image layer. Excluding it removes a nondeterministic input from
the image -> **reproducibility** win.

## Lenses

- **Reproducibility** — removes nondeterministic runtime state from the image context.
- **Fail loud, fail closed** — no gate weakened; the containment gate still fails on a real
  regression, it just stops reddening on unrelated build-context noise.

## Verification

Docker unavailable in the authoring env; the live proof is this PR's own `containment-report`
job going green. `.dockerignore` pattern is standard BuildKit directory exclusion.

Closes IRO-316.