### PR TITLE
fix(ci): exact ref probe for rolling brew branch (IRO-318)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -761,7 +761,16 @@ jobs:
           # if it already exists (leftover from a prior release whose PR is still open,
           # or was merged without deleting the branch). Force-reset is what keeps the
           # PR rebased and conflict-free — never a plain create-if-missing.
-          if gh api "repos/${REPO}/git/refs/heads/${branch}" >/dev/null 2>&1; then
+          #
+          # Use the SINGULAR git/ref/heads/<branch> endpoint for the existence probe,
+          # NOT the plural git/refs/heads/<branch>. The plural endpoint does PREFIX
+          # matching and returns a 200 array whenever any ref merely starts with the
+          # query, so a stale per-tag leftover like brew/track-v0.1.143 makes the probe
+          # falsely report that the exact rolling branch brew/track exists. The code
+          # then PATCHes brew/track, which does not exist, and the release job dies with
+          # "gh: Reference does not exist (HTTP 422)" (IRO-318). The singular endpoint
+          # matches the ref exactly and 404s when brew/track is truly absent.
+          if gh api "repos/${REPO}/git/ref/heads/${branch}" >/dev/null 2>&1; then
             gh api -X PATCH "repos/${REPO}/git/refs/heads/${branch}" \
               -f "sha=${base_sha}" -F "force=true"
           else


### PR DESCRIPTION
## IRO-318 — Release build failing after merge to main

### Root cause
The Release workflow `formula` job died with:
```
gh: Reference does not exist (HTTP 422)
{"message":"Reference does not exist",..."status":"422"}
```
on the `PATCH git/refs/heads/brew/track` call, reddening every release after merge to main.

The existence probe used the **plural** `GET git/refs/heads/<branch>` endpoint, which does **prefix matching** and returns a 200 array when any ref merely *starts with* the query. 17 stale per-tag leftover branches from the old pre-IRO-270 flow (`brew/track-v0.1.101` … `brew/track-v0.1.143`) all share the `brew/track` prefix, so the probe falsely reported the exact rolling `brew/track` branch existed. The job then took the update (PATCH) path against a ref that was actually absent → 422.

### Fix
- Swap the probe to the **singular** `GET git/ref/heads/<branch>` endpoint, which matches the ref exactly and 404s when `brew/track` is truly absent, so the create (POST) path runs instead.
- Deleted all 17 stale `brew/track-v0.1.x` leftover branches (no open PRs on any of them) — removes the prefix-match trigger and the accumulated cruft.

### Verification
- Singular `git/ref/heads/brew/track` → 404 (correct); plural → 200 array (the bug). Confirmed against live API.
- `release.yml` YAML validates.
- No untrusted input in the changed `run:` block (fixed `${branch}` literal only).

Merge to publish; the push trigger ignores `Formula/ironclaw.rb` so the merge does not cut another release.