### PR TITLE
docs(providers): re-wire provider-picker CSS/JS dropped by nav-fragment merge (IRO-311)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,12 +59,16 @@ extra_css:
   - stylesheets/brand.css
   # Landing-page styles, scoped under `.iro-landing` (home template only).
   - stylesheets/landing.css
+  # Interactive provider picker on the model-provider decision page (IRO-311).
+  - stylesheets/provider-picker.css
 
 extra_javascript:
   # Render the bare <div class="mermaid"> blocks (see superfences config below).
   # Loaded as an ES module so it can `import` the pinned Mermaid build.
   - path: javascripts/mermaid-init.js
     type: module
+  # Provider picker: panel switching + copy buttons (progressive enhancement).
+  - javascripts/provider-picker.js
 
 plugins:
   - search


### PR DESCRIPTION
## Regression

PR #319 shipped the interactive provider picker (HTML in `docs/providers/index.md` + `provider-picker.css`/`.js`) and wired the two assets into `mkdocs.yml`.

PR #321 (IRO-315 nav-fragments) branched off a **pre-#319** base, rewrote the `extra_css`/`extra_javascript` blocks to drop the `nav:` machinery, and in doing so **dropped the two picker lines** on merge. Net effect on `main`: the picker markup and assets are present, but nothing loads the CSS/JS — so the decision page renders **raw unstyled HTML with no panel switching and no copy buttons**.

## Fix

Re-add the two entries:
- `extra_css: - stylesheets/provider-picker.css`
- `extra_javascript: - javascripts/provider-picker.js`

## Verification

- `mkdocs build --strict` green.
- Built `providers/index.html` now references both `provider-picker.css` and `provider-picker.js`; both assets emitted to the site dir.

Closes the last gap on IRO-311 (picker fully functional on the live docs).