### PR TITLE
docs(growth): organic SEO cluster for AI-agent sandboxing wedge (IRO-321)

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -24,6 +24,7 @@ nav:
   - Model providers: providers
   - Tutorials: tutorials
   - Examples & use cases: examples.md
+  - Learn (agent security): learn
   - Concepts:
       - IronClaw, Explained: ironclaw-explained.md
       - Architecture: architecture.md

--- a/docs/gvisor-deep-dive.md
+++ b/docs/gvisor-deep-dive.md
@@ -143,6 +143,13 @@ configuration change and watching it get held at the gateway** until you approve
 no model key required, entirely on your machine. Five minutes, and the core invariant
 stops being a paragraph and becomes a command you ran.
 
+For the practical, task-oriented versions of the ideas above, see the
+[agent security and sandboxing guide](learn/index.md): how to
+[sandbox an AI agent](learn/how-to-sandbox-an-ai-agent.md),
+[run untrusted LLM-generated code safely](learn/run-untrusted-llm-code-safely.md),
+[prevent prompt-injection escape](learn/prevent-ai-agent-prompt-injection-escape.md), and
+[gVisor vs containers for AI isolation](learn/gvisor-vs-container-ai-isolation.md).
+
 ---
 
 ### Accuracy notes (claim → source)

--- a/docs/learn/.nav.yml
+++ b/docs/learn/.nav.yml
@@ -1,0 +1,14 @@
+# Navigation for the "Learn: agent security" section.
+#
+# Search-intent SEO cluster targeting the sandboxing / untrusted-agent wedge
+# (IRO-321). Adding a page: drop `learn/<slug>.md` with an H1 and front-matter
+# title/description. The `*.md` glob below auto-includes it (titled from its H1)
+# with ZERO edit here. Add an explicit line only to control label or ordering.
+nav:
+  - AI agent security and sandboxing: index.md
+  - How to sandbox an AI agent: how-to-sandbox-an-ai-agent.md
+  - Run untrusted LLM code safely: run-untrusted-llm-code-safely.md
+  - Prevent prompt-injection escape: prevent-ai-agent-prompt-injection-escape.md
+  - AI agent security best practices: ai-agent-security-best-practices.md
+  - gVisor vs containers for AI isolation: gvisor-vs-container-ai-isolation.md
+  - "*.md"

--- a/docs/learn/ai-agent-security-best-practices.md
+++ b/docs/learn/ai-agent-security-best-practices.md
@@ -1,0 +1,88 @@
+---
+title: "AI agent security best practices"
+description: "A practical checklist for securing autonomous AI agents: assume compromise, seal the sandbox, allowlist egress, keep secrets host-side, gate config changes, and make every claim auditable."
+---
+
+# AI agent security best practices
+
+Most agent-security advice stops at "validate inputs" and "use a good system prompt."
+Neither survives contact with a real prompt-injection attack. The practices below start
+from a harder assumption and work down to controls you can actually verify. They apply
+to any agent stack; where IronClaw ships a control by default, it is called out.
+
+## 1. Assume the agent is already compromised
+
+Design backwards from "an attacker controls the model's actions" rather than "the model
+is basically trustworthy." Every control below earns its place by holding *even when the
+model is hostile*. If a mitigation only works when the model behaves, it is not a
+security control, it is a hope.
+
+## 2. Isolate before you execute
+
+Run each agent session in its own sandbox with, at minimum: no network namespace
+(`network=none`), a read-only root filesystem with `nosuid,nodev,noexec` mounts, dropped
+capabilities, `no_new_privs`, and a non-root user namespace. On Linux, add a second
+kernel (gVisor `runsc`) so a kernel bug is not automatically a host escape. Details:
+[How to sandbox an AI agent](how-to-sandbox-an-ai-agent.md) and
+[gVisor vs containers](gvisor-vs-container-ai-isolation.md).
+
+## 3. Make egress an allowlist, not a default
+
+A compromised agent that cannot open a socket cannot exfiltrate. Route model and API
+traffic through host-owned sockets and enforce a deny-by-default destination allowlist,
+so reaching a new host is an operator decision, not the agent's.
+
+## 4. Keep secrets out of the sandbox
+
+The model API key, queue keys, and tokens should live host-side and be injected into
+outbound calls *outside* the box. If the secret never enters the environment the agent
+runs in, a leaked env dump leaks nothing.
+
+## 5. Isolate session state
+
+Give each session its own encrypted store (in IronClaw, per-session SQLite queues with
+their own 256-bit key, read-only inbound and append-only outbound). One session then
+physically cannot read another's data, and nothing sits in plaintext on disk.
+
+## 6. Gate every configuration change behind a human
+
+An agent that can grant itself a new tool, egress host, mount, or persona has escalated
+without escaping the sandbox. Hold every capability change at a deterministic approval
+gateway: the agent may *ask*, only a human may *grant*, and no change kind may skip the
+floor. This also catches a trojaned skill that quietly requests
+`egress: evil.example.com`, it is visible and rejected at review time, not discovered
+post-breach.
+
+## 7. Make skills data, not code
+
+Extensions (skills) should declare the grants they need and never ship an executable
+script or self-install. MCP servers should stay host-side and gateway-gated so they add
+tool reach without adding a boundary the sandbox can cross. See [MCP servers](../mcp.md)
+and [skills](../skills.md).
+
+## 8. Make every claim auditable
+
+A security property you cannot verify is a marketing claim. Publish a versioned threat
+model, exercise the boundary in CI, and let anyone reproduce the escape attempts.
+IronClaw ships a [threat model](../threat-model.md) versioned with the code, a red-team
+containment gate that runs on every push, and a
+[Breaking our own sandbox](../breaking-our-own-sandbox.md) writeup you can rerun.
+
+## Check the floor in one command
+
+```bash
+docker compose -f docker-compose.demo.yml up --build -d
+./bin/ironctl doctor                                  # read-only preflight
+
+# The non-negotiable invariant: an agent cannot change its own config
+./bin/ironctl change submit --kind persona --group dev-agent --by alice
+./bin/ironctl change approve <change-id> --by alice   # only a human grants
+```
+
+## Where to go next
+
+- The reasoning behind the runtime: [Why we run AI agents in gVisor](../gvisor-deep-dive.md).
+- Contain a successful injection: [Prevent AI agent prompt-injection escape](prevent-ai-agent-prompt-injection-escape.md).
+- Run untrusted model output: [Run untrusted LLM-generated code safely](run-untrusted-llm-code-safely.md).
+- Run it with your model: [model providers](../providers/index.md).
+- How IronClaw compares: [comparison](../comparison.md).

--- a/docs/learn/gvisor-vs-container-ai-isolation.md
+++ b/docs/learn/gvisor-vs-container-ai-isolation.md
@@ -1,0 +1,73 @@
+---
+title: "gVisor vs containers for AI agent isolation"
+description: "What a user-space kernel (gVisor runsc) buys you over a standard container when isolating untrusted AI agents, what it does not, and why to run it as a second wall rather than the only one."
+---
+
+# gVisor vs containers for AI agent isolation
+
+If you are sandboxing an AI agent you assume can be compromised, the interesting
+question about your container is: **what happens the moment the agent gets code
+execution inside it?** That is where the difference between a standard container and a
+gVisor-backed one stops being academic.
+
+## The shared-kernel problem
+
+A normal container is process isolation on top of the host kernel. Namespaces and
+cgroups fence off what the process can *see*, but every syscall it makes runs against
+the real host kernel directly. So the isolation is only as strong as the millions of
+lines of syscall-handling code in that kernel: one kernel-level vulnerability is a
+container-escape vulnerability. For a workload you are actively assuming is hostile, that
+is a large, shared attack surface sitting right under the box.
+
+## What gVisor changes
+
+gVisor (`runsc`) interposes a user-space kernel, written in Go, between the sandboxed
+process and the host. The agent's syscalls hit gVisor's reimplementation of the Linux
+ABI, not the host kernel directly. The host kernel surface the agent can actually reach
+shrinks to a small, audited interface. For the specific threat we care about, "the agent
+breaks out of its box and onto the host," an attacker now has to defeat a **second
+independent kernel** after they have already defeated the model. That is exactly the
+right place to spend defense.
+
+## Two honest caveats
+
+Overclaiming is its own security smell, so:
+
+- **gVisor is not a VM, and it has its own attack surface.** It is a strong additional
+  isolation layer, not a magic one. Treat it as one wall among several, never the only
+  one.
+- **gVisor is Linux-only.** The production sandbox runtime `runsc` runs on Linux. On
+  macOS the host side runs natively but a real agent sandbox falls back to runc inside
+  Docker Desktop's Linux VM, a weaker, kernel-shared boundary. The laptop demo is for
+  seeing it work; the sealed production posture is Linux plus gVisor.
+
+## Defense in depth, not a single wall
+
+This is the key design point: gVisor is not a substitute for the other controls, it is
+an addition *underneath* them. In IronClaw the sandbox keeps `network=none`, a read-only
+sealed rootfs, dropped capabilities, and host-side secrets in place, and gVisor is the
+second kernel wall behind all of that. If any one layer fails, the others still hold. A
+container-plus-LLM setup that relies on the shared host kernel alone has no such second
+line. See [How to sandbox an AI agent](how-to-sandbox-an-ai-agent.md) for the full set of
+edges, and [Why we run AI agents in gVisor](../gvisor-deep-dive.md) for the deep dive.
+
+## Verify the overhead, do not guess it
+
+A second kernel is not free, so the cost should be measured, not asserted. IronClaw runs
+`runsc` overhead benchmarks on Linux CI and publishes the numbers in
+[Performance and footprint](../benchmarks.md), and the isolation boundary itself is
+exercised on every push by a red-team containment gate. You can start the runtime and
+confirm the posture locally:
+
+```bash
+docker compose -f docker-compose.demo.yml up --build -d
+./bin/ironctl doctor   # reports the sandbox runtime and isolation posture
+```
+
+## Where to go next
+
+- The full isolation model: [Why we run AI agents in gVisor](../gvisor-deep-dive.md).
+- The controls that sit under gVisor: [How to sandbox an AI agent](how-to-sandbox-an-ai-agent.md).
+- The measured cost: [Performance and footprint](../benchmarks.md).
+- How IronClaw compares to raw container glue: [comparison](../comparison.md).
+- Run it with your model: [model providers](../providers/index.md).

--- a/docs/learn/how-to-sandbox-an-ai-agent.md
+++ b/docs/learn/how-to-sandbox-an-ai-agent.md
@@ -1,0 +1,83 @@
+---
+title: "How to sandbox an AI agent"
+description: "A practical guide to sandboxing an autonomous AI agent: no network, read-only filesystem, dropped capabilities, a second kernel, and no path to host secrets. With runnable IronClaw commands."
+---
+
+# How to sandbox an AI agent
+
+An AI agent with tools is an execution engine that takes instructions from untrusted
+input. The moment its inbox, a web page, or a tool result can carry an injected
+instruction, "what the agent can do" becomes "what an attacker can do." Sandboxing is
+how you make that a bounded problem instead of an open one.
+
+This page is the concrete version: the specific edges you seal, why each one matters,
+and how to turn the whole posture on with IronClaw.
+
+## The five edges that matter
+
+A useful agent sandbox seals a small number of deliberately boring boundaries. Skip
+any one and the others leak around it.
+
+1. **Network.** The strongest control on this list. If the sandbox has no network
+   namespace at all (`network=none`), a compromised agent cannot exfiltrate data or
+   phone home, because there is no socket to open. Reach the model and approved APIs
+   through host-owned sockets instead, so every byte that leaves crosses a choke point
+   you control.
+2. **Filesystem.** A read-only root filesystem with `nosuid,nodev,noexec` mounts means
+   the agent cannot rewrite its own runtime or drop a persistent implant. Ship a
+   compiled binary with no interpreter and no source in the box, and there is nothing
+   to modify.
+3. **Privileges.** Drop Linux capabilities, set `no_new_privs`, and run in a non-root
+   user namespace so a process that gets code execution still cannot escalate.
+4. **Kernel.** A normal container shares the host kernel, so one kernel bug is a host
+   escape. Interposing a user-space kernel (gVisor `runsc`) shrinks the host syscall
+   surface the agent can touch. See [gVisor vs containers](gvisor-vs-container-ai-isolation.md).
+5. **Secrets and configuration.** The agent should never hold the model API key (inject
+   it host-side, outside the box) and should never be able to change its own
+   configuration to grant itself new reach. Route every capability change through a
+   human approval gateway.
+
+For the full trust-boundary walkthrough with a STRIDE pass per edge, see
+[Why we run AI agents in gVisor](../gvisor-deep-dive.md) and the
+[threat model](../threat-model.md).
+
+## Turn it on with IronClaw
+
+In IronClaw every agent session runs in its own sealed sandbox by default; you do not
+assemble the controls above by hand. The production `docker compose up` is the hardened
+posture (network-namespaceless sandbox, read-only rootfs, gVisor on Linux, host-side
+secret injection). The demo control-plane starts the same machinery locally:
+
+```bash
+# Start the control-plane (demo posture, no model key required)
+docker compose -f docker-compose.demo.yml up --build -d
+
+# Point the admin CLI at it and diagnose the setup
+./bin/ironctl doctor
+```
+
+The single most important property to verify is that **the agent cannot change its own
+configuration.** Every capability change is held at a gateway for a human decision:
+
+```bash
+# An agent (or you) proposes a change; it is HELD, not applied
+./bin/ironctl change submit --kind persona --group dev-agent --by alice
+
+# A human reviews and approves it, only now does it take effect
+./bin/ironctl change pending
+./bin/ironctl change approve <change-id> --by alice
+```
+
+That deny-by-default floor is the difference between "we asked the model nicely" and "a
+compromised agent still cannot grant itself new reach."
+
+## Where to go next
+
+- Running model output you did not write? See
+  [Run untrusted LLM-generated code safely](run-untrusted-llm-code-safely.md).
+- Worried about the injection itself? See
+  [Prevent AI agent prompt-injection escape](prevent-ai-agent-prompt-injection-escape.md).
+- Want the full checklist? See
+  [AI agent security best practices](ai-agent-security-best-practices.md).
+- Picking a model backend? See [model providers](../providers/index.md).
+- Weighing IronClaw against alternatives? See the [comparison](../comparison.md).

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -1,0 +1,43 @@
+---
+title: "AI agent security and sandboxing: a practical guide"
+description: "How to run AI agents and untrusted LLM-generated code safely. Sandboxing, prompt-injection containment, and isolation best practices, with runnable IronClaw examples."
+---
+
+# AI agent security and sandboxing
+
+Give an AI agent tools and you have given it a way to act on the world: read files,
+call APIs, spend money, send messages. Give it an inbox, a web page, or a tool result
+and you have given an **attacker** a way to steer those actions. Prompt injection is
+not a corner case for an autonomous agent; it is the normal operating condition.
+
+This guide is a practical, vendor-honest walk through the problem and the controls
+that actually hold. Every claim links to shipped code or a versioned threat model, and
+every page carries a runnable IronClaw snippet so you can watch the boundary work
+instead of taking our word for it.
+
+## Start here
+
+- [How to sandbox an AI agent](how-to-sandbox-an-ai-agent.md) - the concrete controls
+  (network, filesystem, kernel, secrets) and how to turn them on.
+- [Run untrusted LLM-generated code safely](run-untrusted-llm-code-safely.md) - the
+  pattern for executing model output you did not write.
+- [Prevent AI agent prompt-injection escape](prevent-ai-agent-prompt-injection-escape.md)
+  - why filtering fails and where the real boundary lives.
+- [AI agent security best practices](ai-agent-security-best-practices.md) - a checklist
+  you can apply to any agent stack, ours or not.
+- [gVisor vs containers for AI isolation](gvisor-vs-container-ai-isolation.md) - what a
+  second kernel buys you, and what it does not.
+
+## Why IronClaw
+
+IronClaw is a self-hosted agent runtime built on one uncomfortable assumption: **treat
+every agent as already compromised, and design the boundary so it holds anyway.** If
+you are weighing options, the [comparison page](../comparison.md) is an evidence-backed
+look at IronClaw against hosted platforms, raw container-plus-LLM glue, and other
+self-hosted runtimes. To run it with your own model, see the
+[model providers](../providers/index.md) guide, and the
+[quickstart](../quickstart.md) takes you from a clean clone to watching a
+configuration change get held at the approval gateway in about five minutes.
+
+For the deep dive on the runtime itself, read
+[Why we run AI agents in gVisor](../gvisor-deep-dive.md).

--- a/docs/learn/prevent-ai-agent-prompt-injection-escape.md
+++ b/docs/learn/prevent-ai-agent-prompt-injection-escape.md
@@ -1,0 +1,75 @@
+---
+title: "Prevent AI agent prompt-injection escape"
+description: "Why prompt-injection filtering fails and where the real boundary lives. Contain a compromised agent with isolation, host-side secrets, and a human approval gateway, not with better prompts."
+---
+
+# Prevent AI agent prompt-injection escape
+
+Prompt injection is when text the model reads, an email, a web page, a tool result,
+carries instructions the model then follows as if you had given them. For an autonomous
+agent with tools, a successful injection does not just produce a bad answer; it produces
+a bad **action**: reading `~/.ssh`, POSTing your environment variables somewhere, or
+spending money. The agent did not "go rogue," it did exactly what the injected
+instructions said, with exactly the privileges you handed it.
+
+## Why you cannot filter your way out
+
+The tempting fix is to detect the injection: scan inputs for "ignore previous
+instructions," add a system prompt that says "never exfiltrate secrets," fine-tune for
+refusals. These help at the margin, but none is a boundary:
+
+- Injection payloads are open-ended natural language. Any classifier you build, an
+  attacker rephrases around.
+- A system prompt is a request the model can be argued out of, not a wall it cannot
+  cross.
+- The threat is not the words; it is the **capability**. If a compromised agent can
+  reach the network and the network can reach your secrets, the injection had somewhere
+  to go.
+
+So the durable question is not "how do I stop the injection?" but "**when an injection
+succeeds, what can the agent actually do?**" Design so the answer is "nothing that
+matters."
+
+## Contain the blast radius
+
+The boundary has to live below the model, where its output cannot reach:
+
+- **No network to escape through.** A sandbox with no network namespace
+  (`network=none`) has no socket to open. The injected "exfiltrate this" command has
+  nowhere to send. See [How to sandbox an AI agent](how-to-sandbox-an-ai-agent.md).
+- **No secret to steal.** The model key, queue keys, and tokens stay host-side and are
+  injected into outbound calls outside the sandbox, so they never enter the box the
+  agent runs in.
+- **No self-escalation.** A compromised agent that can grant itself a new tool, egress
+  host, or mount has escalated without ever leaving the sandbox. So configuration
+  changes never pass through the model's hands: every one is held at a deterministic
+  approval gateway for a human decision. The agent can *ask*; only a human can *grant*.
+
+The agent can be fully hostile and still cannot read another session's data, reach an
+unapproved host, obtain a host secret, or widen its own permissions. That is
+containment, not detection, and it holds against payloads nobody has seen yet.
+
+## See it hold with IronClaw
+
+The fastest way to trust a boundary is to watch it refuse something. In IronClaw, an
+agent proposing a configuration change gets **held at the gateway** until a human
+approves, no matter what any injected prompt told it to do:
+
+```bash
+docker compose -f docker-compose.demo.yml up --build -d
+
+# Whatever the agent was told, a config change is HELD, never auto-applied
+./bin/ironctl change submit --kind persona --group dev-agent --by alice
+./bin/ironctl change pending                          # shows it waiting for a human
+./bin/ironctl change approve <change-id> --by alice   # only a human can grant
+```
+
+Run that and the core invariant stops being a paragraph and becomes a command you ran.
+
+## Where to go next
+
+- The isolation internals: [Why we run AI agents in gVisor](../gvisor-deep-dive.md).
+- Running model output safely: [Run untrusted LLM-generated code safely](run-untrusted-llm-code-safely.md).
+- The full checklist: [AI agent security best practices](ai-agent-security-best-practices.md).
+- The versioned adversary model: [threat model](../threat-model.md).
+- How this compares to hosted platforms: [comparison](../comparison.md).

--- a/docs/learn/run-untrusted-llm-code-safely.md
+++ b/docs/learn/run-untrusted-llm-code-safely.md
@@ -1,0 +1,68 @@
+---
+title: "Run untrusted LLM-generated code safely"
+description: "How to execute LLM-generated code and agent tool-calls without trusting them. The containment pattern: isolate first, allowlist egress, keep secrets host-side, and gate every config change."
+---
+
+# Run untrusted LLM-generated code safely
+
+An LLM writes a shell command, a Python snippet, or a tool-call, and something in your
+stack runs it. That output was shaped by whatever went into the model's context: a
+document, a web page, a prior tool result, any of which an attacker may control. So the
+honest framing is not "is this code malicious?" but "**assume it is, and make it not
+matter.**"
+
+You cannot solve this by reviewing the code, because at agent speed nobody is reviewing
+every command, and you cannot solve it by asking the model to behave, because a system
+prompt is a request, not a boundary. The fix lives *below* the model, in the runtime
+that executes its output.
+
+## The containment pattern
+
+Whether you build this yourself or use IronClaw, the shape is the same:
+
+- **Isolate before you execute.** Run the code in a sandbox with no network namespace,
+  a read-only root filesystem, dropped capabilities, and (on Linux) a second kernel
+  under it. See [How to sandbox an AI agent](how-to-sandbox-an-ai-agent.md) for the
+  specific edges.
+- **Make egress an allowlist, not a default.** Untrusted code that cannot open a socket
+  cannot exfiltrate. Reach approved APIs only through a host-owned egress broker that
+  enforces a deny-by-default destination allowlist, so a snippet that tries to POST your
+  environment to `evil.example.com` simply has nowhere to send it.
+- **Keep secrets out of the box.** The model API key, queue keys, and tokens live
+  host-side. Inject credentials into the outbound call *outside* the sandbox so the key
+  never enters the environment the untrusted code runs in. Then a leaked env dump leaks
+  nothing.
+- **Gate every capability change.** Untrusted code must not be able to widen its own
+  permissions. New tools, new egress hosts, new mounts, all held for human approval.
+
+## Do it with IronClaw
+
+IronClaw runs every agent session, and therefore every piece of model-generated
+tool-call, inside a sealed sandbox by default. You do not opt code into isolation; it is
+the floor. Start the runtime and drive it entirely over its local API, no model key
+required for the demo posture:
+
+```bash
+# Start the sealed control-plane
+docker compose -f docker-compose.demo.yml up --build -d
+
+# Send a message to an agent; its work runs inside the sandbox, not on your host
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' \
+  -H 'content-type: application/json' \
+  -d '{"group":"dev-agent","text":"summarize the open issues"}'
+```
+
+Whatever the model decides to do in response executes behind `network=none`, a
+read-only rootfs, and (on Linux) gVisor, and it cannot reach a secret or a network host
+that an operator has not approved. That boundary is exercised on every push by a
+red-team containment gate and you can reproduce the escape attempts yourself; see
+[Breaking our own sandbox](../breaking-our-own-sandbox.md).
+
+## Where to go next
+
+- The isolation internals: [Why we run AI agents in gVisor](../gvisor-deep-dive.md).
+- Stopping the injection upstream: [Prevent AI agent prompt-injection escape](prevent-ai-agent-prompt-injection-escape.md).
+- The full checklist: [AI agent security best practices](ai-agent-security-best-practices.md).
+- Run it with your model: [model providers](../providers/index.md).
+- How this compares to raw container-plus-LLM glue: [comparison](../comparison.md).


### PR DESCRIPTION
## What

Ships a durable, **non-owner-gated** organic-search growth channel (IRO-321): a 5-page search-intent content cluster targeting IronClaw's unique wedge, sandboxing / containment of untrusted AI agents. Distinct from provider landing pages (IRO-310) and the SEO audit (IRO-277).

New under `docs/learn/` (hub + 5 articles):

| Page | Target query |
|---|---|
| `how-to-sandbox-an-ai-agent` | how to sandbox an AI agent |
| `run-untrusted-llm-code-safely` | run untrusted LLM-generated code safely |
| `prevent-ai-agent-prompt-injection-escape` | prevent AI agent prompt-injection escape |
| `ai-agent-security-best-practices` | AI agent security best practices |
| `gvisor-vs-container-ai-isolation` | gVisor vs container for AI isolation |

## Acceptance criteria

- [x] `mkdocs build --strict` passes (exit 0)
- [x] Wired via per-dir `docs/learn/.nav.yml` (IRO-315; `*.md` glob auto-includes future pages) + referenced from root nav
- [x] Sitemap auto-updated with all 5 pages
- [x] Each page: unique title/meta description (6 distinct verified)
- [x] Each page: one runnable IronClaw CLI/API snippet
- [x] Internal-link graph connects cluster to money pages (comparison, providers, quickstart) + threat model + benchmarks
- [x] Existing gVisor deep-dive (IRO-290) cross-linked into the cluster
- [x] No em/en-dashes (IRO-254)

## Credibility

Every claim maps to shipped code or the versioned threat model (network=none, read-only sealed rootfs, dropped caps, gVisor runsc on Linux, host-side secret injection, per-session encrypted queues, deny-by-default approval gateway). No vaporware.

Ships WITHOUT any owner action. Merge when green.

Closes IRO-321.