### PR TITLE
feat(landing): hero star CTA + value-prop one-liner for view->star conversion (IRO-323)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ read, write, schedule, and reply.
 > change is held at a gateway for a human decision. The full design is in the
 > [architecture overview](docs/architecture.md) and the [threat model](docs/threat-model.md).
 
+**If a safer way to run agents is worth having, [star the repo](https://github.com/IronSecCo/ironclaw)** to follow along and help others find it. Then try the zero-credential [quickstart](docs/quickstart.md).
+
 <div align="center">
 
 <img src="docs/assets/demo.svg" width="800" alt="Zero-credential chat demo terminal session: one command (docker compose -f docker-compose.demo.yml up -d) starts the offline mock-agent control-plane with no API key; a chat message engages the agent, which launches a real per-session sandbox container (ic-sbx-…); the reply flows back through the encrypted per-session queue.">

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,12 +17,12 @@ hide:
 
 # Security-first AI agents you actually run yourself.
 
-IronClaw runs autonomous AI assistants on infrastructure you control — reachable from the chat
-apps you already use. Every agent runs sealed off from the network (`network=none` in a gVisor
-sandbox) and cannot change its own configuration without a human approving it. Isolation you can
-prove, not just promise.
+A sandboxed runtime for untrusted AI agents. IronClaw runs autonomous AI assistants on
+infrastructure you control, reachable from the chat apps you already use. Every agent runs sealed
+off from the network (`network=none` in a gVisor sandbox) and cannot change its own configuration
+without a human approving it. Isolation you can prove, not just promise.
 
 - **[Run the zero-credential demo](quickstart.md)** — one command, no model key, no account.
+- **[Star it on GitHub](https://github.com/IronSecCo/ironclaw)**, if the threat model earns it.
 - **[Why IronClaw / vs. alternatives](comparison.md)** — how it compares, honestly.
 - **[Security posture](security.md)** and **[threat model](threat-model.md)** — the trust story.
-- **[Star it on GitHub](https://github.com/IronSecCo/ironclaw)**.

--- a/docs/stylesheets/landing.css
+++ b/docs/stylesheets/landing.css
@@ -198,10 +198,40 @@
 .iro-section .iro-btn--ghost:hover {
   background: var(--md-accent-fg-color--transparent);
 }
+/* GitHub star CTA — first-class secondary action in the hero. Distinct from the
+   ghost button so the star ask reads as its own affordance, not a repeat link. */
+.iro-btn--github {
+  background: rgba(143, 180, 255, 0.10);
+  border-color: rgba(143, 180, 255, 0.55);
+  color: #eaf2ff;
+}
+.iro-btn--github:hover {
+  background: rgba(143, 180, 255, 0.20);
+  border-color: #8fb4ff;
+  transform: translateY(-1px);
+}
+.iro-btn__star { color: #ffd257; font-size: 1.05em; line-height: 1; }
 .iro-btn:focus-visible {
   outline: 3px solid #8fb4ff;
   outline-offset: 2px;
 }
+
+/* Honest, low-key star nudge directly under the hero CTAs. */
+.iro-hero__proof {
+  margin: calc(-1 * var(--s-4)) 0 var(--s-6);
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: #aebfe0;
+  max-width: 62ch;
+}
+.iro-hero__proof a {
+  color: #8fb4ff;
+  font-weight: 600;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(143, 180, 255, 0.4);
+}
+.iro-hero__proof a:hover { border-bottom-color: #8fb4ff; }
+.iro-hero__proof a:focus-visible { outline: 3px solid #8fb4ff; outline-offset: 2px; border-radius: 2px; }
 
 /* ----- copyable demo block ----------------------------------------------- */
 .iro-code {

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -20,24 +20,30 @@
   {# ===== 1. HERO ===== #}
   <section class="iro-section iro-hero" aria-labelledby="hero-title">
     <div class="iro-wrap">
-      <span class="iro-eyebrow">Open source · AGPLv3 + commercial · self-hosted</span>
+      <span class="iro-eyebrow">A sandboxed runtime for untrusted AI agents</span>
       <h1 class="iro-hero__title" id="hero-title">Security-first AI agents you actually run yourself.</h1>
       <p class="iro-hero__sub">
-        IronClaw runs autonomous AI assistants on infrastructure you control — reachable from the
-        chat apps you already use. The difference is the threat model: every agent runs sealed off
-        from the network and <strong>cannot change its own configuration without a human approving
-        it.</strong> Isolation you can prove, not just promise.
+        Run autonomous AI assistants on infrastructure you control, reachable from the chat apps you
+        already use. Every agent runs sealed off from the network and <strong>cannot change its own
+        configuration without a human approving it.</strong> Isolation you can prove, not just promise.
       </p>
 
       <div class="iro-cta-row">
         <a class="iro-btn iro-btn--primary" href="https://ironsecco.github.io/ironclaw/quickstart/">Run the quickstart demo
           <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
         </a>
-        <a class="iro-btn iro-btn--ghost" href="https://ironsecco.github.io/ironclaw/examples/">
-          <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
-          Browse the examples
+        <a class="iro-btn iro-btn--github" href="https://github.com/IronSecCo/ironclaw" rel="noopener">
+          <svg width="17" height="17" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49 0-.24-.01-.87-.01-1.71-2.78.62-3.37-1.37-3.37-1.37-.46-1.18-1.11-1.5-1.11-1.5-.9-.63.07-.62.07-.62 1 .07 1.53 1.05 1.53 1.05.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.37-2.22-.26-4.55-1.14-4.55-5.06 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.28 2.75 1.05a9.35 9.35 0 0 1 5 0c1.91-1.33 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.93-2.34 4.79-4.57 5.05.36.32.68.94.68 1.9 0 1.37-.01 2.48-.01 2.82 0 .27.18.6.69.49A10.26 10.26 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
+          Star on GitHub
+          <span class="iro-btn__star" aria-hidden="true">★</span>
         </a>
       </div>
+
+      <p class="iro-hero__proof">
+        Open source, self-hosted, and built to be verified. If the threat model earns it,
+        <a href="https://github.com/IronSecCo/ironclaw" rel="noopener">give it a star</a> or
+        <a href="https://ironsecco.github.io/ironclaw/examples/">browse the examples</a>.
+      </p>
 
       {# Above-the-fold copyable, zero-credential demo line #}
       <div class="iro-code">
@@ -55,6 +61,7 @@
 
       {# Live trust badges — Best Practices "passing" gets first / priority slot #}
       <div class="iro-badges">
+        <a href="https://github.com/IronSecCo/ironclaw/stargazers" rel="noopener" title="Star IronClaw on GitHub"><img src="https://img.shields.io/github/stars/IronSecCo/ironclaw?style=flat&logo=github&label=stars&color=2563eb" alt="GitHub stars" loading="lazy"></a>
         <a href="https://www.bestpractices.dev/projects/13348" rel="noopener" title="OpenSSF Best Practices (passing)"><img src="https://www.bestpractices.dev/projects/13348/badge" alt="OpenSSF Best Practices: passing" loading="lazy"></a>
         <a href="https://scorecard.dev/viewer/?uri=github.com/IronSecCo/ironclaw" rel="noopener" title="OpenSSF Scorecard"><img src="https://api.securityscorecards.dev/projects/github.com/IronSecCo/ironclaw/badge" alt="OpenSSF Scorecard score" loading="lazy"></a>
         <a href="https://github.com/IronSecCo/ironclaw/actions/workflows/codeql.yml" rel="noopener" title="CodeQL analysis"><img src="https://github.com/IronSecCo/ironclaw/actions/workflows/codeql.yml/badge.svg" alt="CodeQL workflow status" loading="lazy"></a>
@@ -120,6 +127,8 @@
       <p class="iro-aside">
         <strong>Talk to it where you already work</strong> — 12 channel adapters
         (<a href="https://ironsecco.github.io/ironclaw/channels/">Slack, Discord, Telegram, and more</a>).
+        <strong>Bring your own model:</strong> Anthropic, OpenAI, Bedrock, Azure, Gemini, Vertex,
+        OpenRouter, and local <a href="https://ironsecco.github.io/ironclaw/providers/">Ollama</a>.
       </p>
     </div>
   </section>


### PR DESCRIPTION
## IRO-323 — Landing conversion + star-CTA audit

Audits the landing home (`overrides/home.html` + `docs/index.md`) and README top-fold as a
view -> star / view -> quickstart funnel, and ships the high-impact fixes. Non-gated; `mkdocs
--strict` green.

### Funnel audit (current state + gaps)

CEO baseline: ~2% view -> star (13 stars / ~543 views / 56 uniques / 14d).

| # | Gap found | Impact | Fix shipped |
|---|-----------|--------|-------------|
| 1 | **Star ask buried.** Only appeared in the page-bottom final CTA and the Material header repo widget. The whole conversion goal (a star) had no affordance in the hero. | High | First-class `Star on GitHub` button in the hero CTA row. |
| 2 | **Zero star affordance on mobile above the fold.** Material collapses the header repo widget (the `★13`) on small screens, so mobile visitors saw no star option in the first viewport at all. | High | Same hero star button stacks under the primary CTA on mobile, in-viewport. |
| 3 | **Value prop not the one-liner.** The prime eyebrow slot carried licensing metadata ("Open source · AGPLv3 + commercial · self-hosted"); the category ("sandboxed runtime for untrusted AI agents") was buried inside a dense 3-sentence sub. | High | Eyebrow now reads "A sandboxed runtime for untrusted AI agents"; sub tightened. |
| 4 | **No social proof / honest star signal near the hero.** IRO-241 wall lived in the footer only. | Med | Live GitHub stars badge added to the trust cluster; low-key proof line under the CTAs. |
| 5 | **Provider breadth invisible.** A key "works with my stack" trust signal was absent from the fold and the differentiators. | Med | Bring-your-own-model line (Anthropic/OpenAI/Bedrock/Azure/Gemini/Vertex/OpenRouter/Ollama) added to the "what it is" aside. |

Quickstart friction was already low (primary CTA -> quickstart, plus a copyable zero-cred command
in the hero); left intact. The primary action stays "Run the quickstart demo" (the thing that
earns the star); the star is the visible secondary.

### Before / after (first viewport)

Verified by rendering the built site and screenshotting at 1440x900 and 390x844:

- **Desktop before:** eyebrow = licensing meta; two CTAs (quickstart + "Browse the examples"); no star button; star only as tiny `★13` in the header.
- **Desktop after:** eyebrow = "A SANDBOXED RUNTIME FOR UNTRUSTED AI AGENTS"; CTAs = "Run the quickstart demo" + "Star on GitHub ★"; honest proof line beneath.
- **Mobile before:** header repo widget collapsed -> no star affordance anywhere in the first viewport.
- **Mobile after:** "Star on GitHub ★" button in-viewport directly under the primary CTA, plus a "give it a star" text link.

### Constraints held

- **WCAG-AA (IRO-176):** star button is an `<a>` with visible text ("Star on GitHub"); icon and star glyph are `aria-hidden`; reuses the existing `:focus-visible` ring token; touch target >= 44px.
- **No em/en-dashes (IRO-254)** in any new copy (scanned).
- **`mkdocs --strict` green** (built standalone off `main`).
- **Growth (SEO cluster) coordination:** no changes to the `learn/` cluster or nav; the hero's "browse the examples" and provider links point at existing shipped pages, so internal links stay consistent.

### Files

- `overrides/home.html` — hero eyebrow, star CTA button, proof line, stars badge, provider aside.
- `docs/stylesheets/landing.css` — `.iro-btn--github`, `.iro-btn__star`, `.iro-hero__proof`.
- `docs/index.md` — text-mirror synced (value prop + star prominence).
- `README.md` — concise honest star CTA after the one-line security model.

PR to `main`. Ship when green.
