### PR TITLE
feat(examples): one-command live-containment demo + recording + README CTA (IRO-322)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,19 @@ read, write, schedule, and reply.
 > change is held at a gateway for a human decision. The full design is in the
 > [architecture overview](docs/architecture.md) and the [threat model](docs/threat-model.md).
 
+**If a safer way to run agents is worth having, [star the repo](https://github.com/IronSecCo/ironclaw)** to follow along and help others find it. Then try the zero-credential [quickstart](docs/quickstart.md).
+
 <div align="center">
 
 <img src="docs/assets/demo.svg" width="800" alt="Zero-credential chat demo terminal session: one command (docker compose -f docker-compose.demo.yml up -d) starts the offline mock-agent control-plane with no API key; a chat message engages the agent, which launches a real per-session sandbox container (ic-sbx-…); the reply flows back through the encrypted per-session queue.">
 
 <sub><b>Zero credentials, one command.</b> The offline <code>mock-agent</code> runs the full chat → per-session sandbox → reply path with no API key — production seals each sandbox with gVisor and <code>network=none</code>. <a href="docs/quickstart.md">Quickstart</a></sub>
+
+<br><br>
+
+<img src="docs/assets/containment.svg" width="800" alt="live-containment demo (final frame): one command engages a real per-session sandbox, then a fully-jailbroken agent tries three escapes from inside the box and each is BLOCKED — exfiltrating to the attacker is denied because network=none leaves only the loopback interface and DNS fails; reading the operator's host filesystem is denied because the host root is outside the sandbox mount namespace; seizing the host via the Docker Engine socket is denied because the socket is never mounted in and there is no docker client — ending with a containment summary that 3 of 3 escape attempts were denied and the box held.">
+
+<sub><b>…now watch it catch a real escape.</b> <a href="examples/live-containment/"><code>examples/live-containment/run.sh</code></a> engages a real sandbox and lets a fully-jailbroken agent <b>try to break out</b> — network exfil, host-filesystem breakout, host takeover via the Docker socket — while your terminal shows each attempt <b>denied</b>, then prints a containment summary. Zero credentials; reduced-motion friendly (static final frame).</sub>
 
 </div>
 
@@ -601,9 +609,15 @@ just Docker. Copy one line and watch it work:
 
 <br><br>
 
+<img src="docs/assets/containment.svg" width="760" alt="live-containment terminal demo (final frame): a fully-jailbroken agent tries three escapes from inside the sandbox and each is BLOCKED — network exfil denied by network=none (only loopback), host filesystem read denied by the mount namespace, host takeover via the Docker Engine socket denied because the socket is never mounted in — ending with a containment summary that 3 of 3 escape attempts were denied and the box held.">
+
+<sub><b><a href="examples/live-containment/">live-containment</a> — watch it catch a real escape.</b> The 60-second security aha: one command engages a real sandbox, a fully-jailbroken agent <b>tries to break out</b> (network exfil, host-filesystem breakout, host takeover via the Docker socket), and your terminal shows each attempt <b>denied</b> plus a containment summary. The curated cut of <code>red-team-escape</code>. Zero credentials.</sub>
+
+<br><br>
+
 <img src="docs/assets/redteam.svg" width="760" alt="red-team-escape terminal demo: assuming a fully jailbroken agent, the harness runs an escape battery from inside the sandbox and prints a PASS table — network egress blocked (interfaces: lo), Docker socket absent, no sibling orchestration, host root not mounted, self-modification held at the gateway, host master and sibling keys unreachable — then reports every core containment assertion held.">
 
-<sub><b><a href="examples/red-team-escape/">red-team-escape</a> — isolation you can prove.</b> Assumes a fully jailbroken agent and <b>tries to break out</b> — network egress, host escape via the Docker socket, sibling breakout, self-modification — then asserts every attack is contained. Zero credentials.</sub>
+<sub><b><a href="examples/red-team-escape/">red-team-escape</a> — isolation you can prove.</b> The full six-assertion battery behind <code>live-containment</code>: adds sibling-breakout and cross-session key-custody probes and emits a <b>signed, versioned containment report</b>; runs as the CI containment gate on every push. Zero credentials.</sub>
 
 </div>
 

--- a/docs/assets/containment.svg
+++ b/docs/assets/containment.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="556" viewBox="0 0 820 556" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace" role="img" aria-labelledby="lc-title lc-desc">
+  <title id="lc-title">IronClaw live-containment demo: a jailbroken agent's escape attempts are all blocked</title>
+  <desc id="lc-desc">Terminal recording (final frame) of examples/live-containment/run.sh. One command starts the offline demo control-plane with no API key and engages a real per-session sandbox. A fully-jailbroken agent then tries three escapes from inside the box and each is denied: (1) exfiltrate to the attacker via getent hosts api.anthropic.com is blocked because network=none leaves only the loopback interface and DNS fails; (2) reading the operator's host filesystem via cat /host/etc/shadow is blocked because the host root is outside the sandbox mount namespace; (3) seizing the host via the Docker Engine socket is blocked because the socket is never mounted in and there is no docker client. The run ends with a containment summary: 3 of 3 escape attempts denied, the box held.</desc>
+  <rect width="820" height="556" rx="9" fill="#0d1117" stroke="#30363d" stroke-width="1"/>
+  <!-- title bar -->
+  <rect width="820" height="40" rx="9" fill="#161b22"/>
+  <rect y="20" width="820" height="20" fill="#161b22"/>
+  <circle cx="24" cy="20" r="6" fill="#ff5f58"/>
+  <circle cx="44" cy="20" r="6" fill="#ffbd2e"/>
+  <circle cx="64" cy="20" r="6" fill="#18c132"/>
+  <text x="410" y="25" text-anchor="middle" font-size="12.5" fill="#8b949e">IronClaw — live containment</text>
+
+  <g font-size="14">
+    <!-- setup -->
+    <text x="28" y="70"><tspan fill="#58a6ff">$</tspan><tspan fill="#e6edf3"> examples/live-containment/run.sh</tspan></text>
+    <text x="28" y="92" fill="#8b949e">==&gt; offline demo control-plane up (no API key, no channel tokens)</text>
+    <text x="28" y="114" fill="#8b949e">==&gt; live sandbox engaged: ic-sbx-ses_a771…  (runc, laptop demo)</text>
+
+    <text x="28" y="148" fill="#e6edf3" font-weight="bold">A fully-jailbroken agent tries to break out:</text>
+
+    <!-- 1 -->
+    <text x="28" y="182" fill="#58a6ff" font-weight="bold">[1/3] Exfiltrate stolen data to the attacker</text>
+    <text x="52" y="204" fill="#f85149">$ getent hosts api.anthropic.com   <tspan fill="#6e7681"># resolve C2, exfil</tspan></text>
+    <g transform="translate(52,215)">
+      <rect x="0" y="0" width="82" height="20" rx="4" fill="#238636"/>
+      <text x="41" y="14.5" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">BLOCKED</text>
+      <text x="94" y="15" fill="#3fb950">network=none: only <tspan font-style="italic">lo</tspan> exists, DNS fails.</text>
+    </g>
+
+    <!-- 2 -->
+    <text x="28" y="266" fill="#58a6ff" font-weight="bold">[2/3] Read the operator's host filesystem</text>
+    <text x="52" y="288" fill="#f85149">$ cat /host/etc/shadow   <tspan fill="#6e7681"># steal host secrets</tspan></text>
+    <g transform="translate(52,299)">
+      <rect x="0" y="0" width="82" height="20" rx="4" fill="#238636"/>
+      <text x="41" y="14.5" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">BLOCKED</text>
+      <text x="94" y="15" fill="#3fb950">host root is outside the sandbox mount namespace.</text>
+    </g>
+
+    <!-- 3 -->
+    <text x="28" y="350" fill="#58a6ff" font-weight="bold">[3/3] Seize the host via the Docker Engine socket</text>
+    <text x="52" y="372" fill="#f85149">$ docker -H /var/run/docker.sock run --privileged …</text>
+    <g transform="translate(52,383)">
+      <rect x="0" y="0" width="82" height="20" rx="4" fill="#238636"/>
+      <text x="41" y="14.5" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">BLOCKED</text>
+      <text x="94" y="15" fill="#3fb950">Engine socket never mounted; no docker client.</text>
+    </g>
+
+    <!-- summary -->
+    <rect x="28" y="432" width="764" height="94" rx="7" fill="#0f2417" stroke="#238636" stroke-width="1.5"/>
+    <text x="48" y="466" font-size="15" font-weight="bold" fill="#3fb950">CONTAINMENT SUMMARY: 3/3 escape attempts DENIED. The box held.</text>
+    <text x="48" y="492" fill="#8b949e">A compromised agent could not phone home, read the host, or seize the Engine.</text>
+    <text x="48" y="512" fill="#e6edf3">Isolation you can prove, not just promise.</text>
+  </g>
+</svg>

--- a/examples/live-containment/README.md
+++ b/examples/live-containment/README.md
@@ -1,0 +1,62 @@
+# live-containment — watch IronClaw catch a real escape, in under a minute
+
+This is the 60-second **aha**. One command stands up the offline demo control-plane,
+engages a real per-session sandbox, and then plays out a **fully-jailbroken agent trying
+to escape** while your terminal shows each attempt being denied at the isolation boundary.
+It ends with a containment summary.
+
+No model key. No channel tokens. The same zero-credential path as
+[`docker-compose.demo.yml`](../../docker-compose.demo.yml).
+
+```bash
+examples/live-containment/run.sh
+```
+
+<div align="center">
+<img src="../../docs/assets/containment.svg" width="760"
+     alt="live-containment terminal demo: a fully-jailbroken agent tries three escapes from inside the sandbox and each is BLOCKED — network exfil denied by network=none (only loopback), host filesystem read denied by the mount namespace, and host takeover via the Docker Engine socket denied because the socket is never mounted in — ending with a containment summary that 3 of 3 escape attempts were denied.">
+</div>
+
+## What you see
+
+A fully-compromised agent — assume prompt-injection defences, model alignment, and tool
+allow-listing have **all** failed — running arbitrary code as the sandbox's own user, and
+three escapes each hitting a wall:
+
+| The agent tries to…                                  | …and hits                                              |
+|------------------------------------------------------|--------------------------------------------------------|
+| **Exfiltrate** stolen data to an attacker (DNS/HTTP) | `network=none`: no NIC but `lo`, so a lookup has nowhere to go |
+| **Read the host** filesystem (`/host`, host secrets) | the host root is outside the sandbox mount namespace   |
+| **Seize the host** via the Docker Engine socket      | the socket is never mounted in, and there is no docker client |
+
+Then: `CONTAINMENT SUMMARY: 3/3 escape attempts DENIED. The box held.`
+
+## How the test is honest
+
+Each attempt runs **inside the live sandbox container** as its own uid (`65532`) via
+`docker exec` — exactly the privilege a jailbroken agent has. The question this answers is
+not "can the model be tricked" (prompt injection is a different layer) but: **when it is,
+does the isolation boundary still hold?** A test that only pokes the agent through its
+polite tool API proves the tools are polite; it does not prove the *box* is a box.
+
+## Flags
+
+```bash
+examples/live-containment/run.sh            # build + up + demo + tear down
+examples/live-containment/run.sh --keep     # leave the demo running afterwards
+examples/live-containment/run.sh --attach   # use an already-running demo control-plane
+```
+
+It exits non-zero if **any** escape is not contained, so it doubles as a smoke/CI
+assertion — [`examples/smoke-matrix.sh`](../smoke-matrix.sh) drives it with `--attach`.
+
+## Where to go deeper
+
+This is a curated, three-escape cut. For the full picture:
+
+- [`examples/red-team-escape/`](../red-team-escape/) — the complete **six-assertion** battery
+  (adds sibling-breakout and cross-session key-custody probes) plus a **signed, versioned
+  containment report**, and the CI gate that re-proves it on every push.
+- [`docs/breaking-our-own-sandbox.md`](../../docs/breaking-our-own-sandbox.md) — the write-up.
+- The **runc fallback** used by this laptop demo is deliberately weaker than the production
+  posture: each session is sealed with **gVisor** and `network=none` in production.

--- a/examples/live-containment/run.sh
+++ b/examples/live-containment/run.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# live-containment — watch IronClaw catch a real sandbox escape, in under a minute.
+#
+# This is the 60-second "aha": one command brings up the offline demo control-plane
+# (the same zero-credential path as docker-compose.demo.yml — no model key, no channel
+# tokens), engages a real per-session sandbox, and then plays out a fully-jailbroken
+# agent TRYING TO ESCAPE from inside that box while the terminal shows each attempt
+# being denied at the isolation boundary. It ends with a containment summary.
+#
+# It is a curated, narration-forward cut of examples/red-team-escape (which runs the
+# full six-assertion battery and doubles as the CI containment gate). Same threat model,
+# same probe technique (a shell INSIDE the live sandbox, as its own uid 65532 — exactly
+# the privilege a jailbroken agent would have), fewer probes, told as a story.
+#
+# THREAT MODEL. We assume the worst: prompt-injection defences, model alignment and tool
+# allow-listing have ALL failed, and the attacker is now running arbitrary code as the
+# sandbox's own user, inside the box. The question is not "can the model be tricked"
+# (that is a different layer) but: WHEN it is, does the isolation boundary still hold?
+#
+#   examples/live-containment/run.sh            # build + up + demo + tear down
+#   examples/live-containment/run.sh --keep     # leave the demo running afterwards
+#   examples/live-containment/run.sh --attach   # use an already-running demo control-plane
+#
+# Env overrides (all optional):
+#   IRONCLAW_ADDR        control-plane base URL   (default http://127.0.0.1:8787)
+#   IRONCLAW_API_TOKEN   API bearer token         (default ironclaw-demo)
+#   IRONCLAW_DEMO_AGENT  agent group id           (default mock-agent)
+#   SKIP_BUILD=1         skip the sandbox image build (assume it exists)
+#   NO_COLOR=1           disable ANSI colour (also auto-off when stdout is not a TTY)
+#   IRONCLAW_HEALTH_TIMEOUT  seconds to wait for /healthz   (default 90)
+#   IRONCLAW_ENGAGE_TIMEOUT  seconds to wait for the sandbox to launch (default 180)
+#
+# Exits non-zero if ANY escape is NOT contained, so it doubles as a smoke/CI assertion
+# (examples/smoke-matrix.sh drives it with --attach).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+TOKEN="${IRONCLAW_API_TOKEN:-ironclaw-demo}"
+AGENT="${IRONCLAW_DEMO_AGENT:-mock-agent}"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.demo.yml"
+
+HEALTH_TIMEOUT="${IRONCLAW_HEALTH_TIMEOUT:-90}"
+ENGAGE_TIMEOUT="${IRONCLAW_ENGAGE_TIMEOUT:-180}"
+
+# A hostname the demo sandbox has NO business resolving — the exfil-egress probe target.
+EGRESS_HOST="${IRONCLAW_EGRESS_PROBE_HOST:-api.anthropic.com}"
+
+KEEP=0        # --keep: don't tear the demo down on exit
+ATTACH=0      # --attach: talk to an already-running control-plane, manage nothing
+for arg in "$@"; do
+  case "$arg" in
+    --keep)   KEEP=1 ;;
+    --attach) ATTACH=1 ;;
+    -h|--help) sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown flag: $arg (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+command -v jq   >/dev/null || { echo "this demo needs jq (https://jqlang.github.io/jq/)" >&2; exit 1; }
+command -v curl >/dev/null || { echo "this demo needs curl" >&2; exit 1; }
+command -v docker >/dev/null || { echo "this demo needs Docker" >&2; exit 1; }
+
+# --- colour ----------------------------------------------------------------
+# On when stdout is a TTY and NO_COLOR is unset; off otherwise (CI logs stay clean).
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  BOLD=$'\033[1m'; DIM=$'\033[2m'; RED=$'\033[31m'; GREEN=$'\033[32m'
+  YELLOW=$'\033[33m'; CYAN=$'\033[36m'; RESET=$'\033[0m'
+else
+  BOLD=''; DIM=''; RED=''; GREEN=''; YELLOW=''; CYAN=''; RESET=''
+fi
+
+# --- demo lifecycle --------------------------------------------------------
+compose() { docker compose -f "$COMPOSE_FILE" "$@"; }
+
+# shellcheck disable=SC2329  # invoked indirectly via `trap teardown EXIT`
+teardown() {
+  [ "$KEEP" = 1 ]   && { echo; echo "==> leaving the demo running (--keep). Stop it with:"; \
+                         echo "    docker compose -f docker-compose.demo.yml down"; return; }
+  [ "$ATTACH" = 1 ] && return
+  echo; echo "==> tearing the demo down"
+  compose down >/dev/null 2>&1 || true
+}
+
+if [ "$ATTACH" = 0 ]; then
+  trap teardown EXIT
+  if [ "${SKIP_BUILD:-0}" != 1 ]; then
+    echo "==> building the sandbox image (ironclaw-sandbox:latest) — first run is ~1-2 min"
+    bash "$REPO_ROOT/container/build.sh" >/dev/null
+  fi
+  echo "==> starting the offline demo control-plane (no API key, no channel tokens)"
+  compose up --build -d >/dev/null
+fi
+
+# --- wait for /healthz -----------------------------------------------------
+echo -n "==> waiting for the control-plane to be ready (up to ${HEALTH_TIMEOUT}s)"
+ready=0
+for _ in $(seq 1 "$HEALTH_TIMEOUT"); do
+  if curl -fsS "$ADDR/healthz" >/dev/null 2>&1; then ready=1; break; fi
+  echo -n "."; sleep 1
+done
+echo
+[ "$ready" = 1 ] || { echo "FAIL: control-plane never became healthy at $ADDR within ${HEALTH_TIMEOUT}s" >&2; exit 1; }
+
+# --- engage a real sandbox --------------------------------------------------
+# A chat message to the mock-agent makes the router launch that conversation's
+# per-session sandbox as a sibling container (ic-sbx-*). The reply proves it is up.
+MARKER="live-containment $$"
+echo "==> engaging a live sandbox: chatting to '$AGENT' so its per-session container launches"
+curl -fsS -X POST "$ADDR/v1/ui/chat/send" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg a "$AGENT" --arg t "$MARKER" '{agentGroupID:$a, text:$t}')" >/dev/null
+
+echo -n "==> waiting for the sandbox to come up (up to ${ENGAGE_TIMEOUT}s)"
+SBX=""
+for _ in $(seq 1 "$ENGAGE_TIMEOUT"); do
+  curl -fsS "$ADDR/v1/ui/chat/$AGENT/messages" -H "Authorization: Bearer $TOKEN" >/dev/null 2>&1 || true
+  SBX="$(docker ps --filter 'label=ironclaw.session' --filter 'name=ic-sbx-' \
+         --filter 'status=running' --format '{{.Names}}' 2>/dev/null | head -n1)"
+  if [ -n "$SBX" ]; then break; fi
+  echo -n "."; sleep 1
+done
+echo
+[ -n "$SBX" ] || { echo "FAIL: no running sandbox container (ic-sbx-*) appeared within ${ENGAGE_TIMEOUT}s" >&2; \
+                   [ "$ATTACH" = 0 ] && compose logs --no-color 2>&1 | tail -40 >&2; exit 1; }
+
+# --- the story -------------------------------------------------------------
+# sbx runs a probe inside the live sandbox as its own uid (65532), the exact privilege
+# a jailbroken agent has. It never aborts the demo: output + exit code feed the verdict.
+sbx() { docker exec -u 65532:65532 "$SBX" sh -c "$1" 2>&1; }
+set +e   # a contained attack returns non-zero — that is the point, not a failure
+
+CONTAINED=0 ESCAPED=0
+step=0
+
+# scene <title> <what-the-agent-runs>  — narrate one escape attempt.
+scene() {
+  step=$((step + 1))
+  echo
+  echo "${BOLD}${CYAN}[$step/3] $1${RESET}"
+  echo "${DIM}    agent (inside the box, uid 65532) runs:${RESET} ${YELLOW}$2${RESET}"
+}
+blocked() { echo "    ${GREEN}${BOLD}⛔ BLOCKED${RESET}${GREEN} — $1${RESET}"; CONTAINED=$((CONTAINED + 1)); }
+leaked()  { echo "    ${RED}${BOLD}✗ ESCAPED${RESET}${RED} — $1${RESET}";    ESCAPED=$((ESCAPED + 1)); }
+
+echo
+echo "=============================================================================="
+echo " ${BOLD}IronClaw live containment${RESET} — a fully-jailbroken agent tries to break out"
+echo " sandbox under test: ${BOLD}$SBX${RESET}   (runc fallback for the laptop demo)"
+echo "=============================================================================="
+
+# 1) NETWORK EXFIL — the agent tries to phone home and exfiltrate. network=none means
+#    the box has NO network interface but lo, so a name lookup has nowhere to go.
+scene "Exfiltrate stolen data to the attacker" "getent hosts $EGRESS_HOST   # resolve C2, then POST the loot"
+ifaces="$(sbx 'ls -1 /sys/class/net 2>/dev/null | tr "\n" " " | sed "s/ *$//"')"
+sbx "getent hosts $EGRESS_HOST" >/dev/null 2>&1; dns_rc=$?
+if [ "$ifaces" = "lo" ] && [ "$dns_rc" != "0" ]; then
+  blocked "no network namespace: only \`lo\` exists (interfaces: $ifaces), DNS resolution fails. network=none."
+else
+  leaked  "reached the network — interfaces: [$ifaces], DNS exit: $dns_rc"
+fi
+
+# 2) HOST FILESYSTEM BREAKOUT — the agent tries to read the operator's host. The host
+#    root fs is simply not in the sandbox's mount namespace, so it is not there to read.
+scene "Read the operator's host filesystem" "cat /host/etc/shadow /etc/ironclaw-host-marker   # steal host secrets"
+hostfs="$(sbx 'if [ -e /host ] || [ -r /etc/ironclaw-host-marker ]; then echo EXPOSED; else echo CONTAINED; fi')"
+if [ "$hostfs" = "CONTAINED" ]; then
+  blocked "host root is outside the sandbox mount namespace: the paths do not exist in the box."
+else
+  leaked  "host paths are reachable from inside the sandbox ($hostfs)"
+fi
+
+# 3) HOST TAKEOVER via the Docker socket — the crown jewel. Whoever holds the Engine
+#    socket owns every sibling container AND the host. It is never mounted into the box.
+scene "Seize the host via the Docker Engine socket" "docker -H unix:///var/run/docker.sock run --privileged ...   # own the host"
+socket="$(sbx 'if [ -S /var/run/docker.sock ] || [ -S /run/docker.sock ]; then echo PRESENT; else echo ABSENT; fi')"
+cli="$(sbx 'command -v docker >/dev/null 2>&1 && echo PRESENT || echo ABSENT')"
+if [ "$socket" = "ABSENT" ] && [ "$cli" = "ABSENT" ]; then
+  blocked "the Engine socket is never mounted in and there is no docker client: nothing to seize."
+else
+  leaked  "the sandbox can reach the Docker Engine (socket:$socket client:$cli)"
+fi
+
+# --- containment summary ----------------------------------------------------
+echo
+echo "=============================================================================="
+if [ "$ESCAPED" = 0 ]; then
+  echo " ${GREEN}${BOLD}CONTAINMENT SUMMARY: $CONTAINED/3 escape attempts DENIED. The box held.${RESET}"
+  echo "=============================================================================="
+  echo " A fully-compromised agent could not phone home, could not read the host, and"
+  echo " could not seize the Engine. That is ${BOLD}isolation you can prove, not just promise.${RESET}"
+  echo
+  echo " Next: the full six-assertion battery + signed containment report ->"
+  echo "   ${BOLD}examples/red-team-escape/run.sh${RESET}"
+  echo "   Production seals each session with gVisor and network=none (docs/breaking-our-own-sandbox.md)."
+  exit 0
+fi
+echo " ${RED}${BOLD}CONTAINMENT SUMMARY: $ESCAPED of 3 escapes SUCCEEDED — the sandbox did NOT hold.${RESET}"
+echo "=============================================================================="
+echo " ${RED}This is a real security regression. Do not ship until every row is BLOCKED.${RESET}" >&2
+exit 1


### PR DESCRIPTION
## What

The 60-second **aha** that lands the security wedge for the visitors we already get. One command engages a real per-session sandbox, then a fully-jailbroken agent tries three escapes from inside the box and the terminal shows each **BLOCKED**, ending with a containment summary.

```bash
examples/live-containment/run.sh
```

![live-containment](https://raw.githubusercontent.com/IronSecCo/ironclaw/relay/iro-322-live-containment/docs/assets/containment.svg)

## Changes

- **`examples/live-containment/run.sh`** — curated, narration-forward cut of `red-team-escape`. Offline mock provider, zero credentials, same `docker-compose.demo.yml` path. Three escapes probed inside the live sandbox as uid 65532 (exactly a jailbroken agent's privilege): network exfil (`network=none`), host-filesystem breakout (mount namespace), host takeover via the Docker Engine socket. Each shown denied, then a `3/3 DENIED` summary. `--keep` / `--attach`; exits non-zero if any escape is not contained.
- **`docs/assets/containment.svg`** — recorded final frame of a verified run; static + reduced-motion friendly (IRO-291 pattern).
- **`README.md`** — hero card + examples-section card wired to the demo; reframed `red-team-escape` as the deeper six-assertion battery behind it.

## Acceptance criteria

- [x] Command runs clean on fresh Docker (colima ok) and DEMONSTRABLY shows escape attempts denied + containment summary — **verified end-to-end on colima (Docker 29.5.2): 3/3 BLOCKED, exit 0, clean teardown**
- [x] Recording committed (`docs/assets/containment.svg`)
- [x] README/landing CTA wired (hero + examples cards)
- [x] smoke-matrix covers the new dir — **auto-covered: `run.sh` has `--attach` + self-asserts, so `examples/smoke-matrix.sh` picks it up with no matrix edit (IRO-295 pattern)**
- [x] shellcheck clean, SVG well-formed

## Reuse (per scope)

Reuses IRO-257 `network=none`, IRO-267 containment posture, and the `docker exec` probe technique from `red-team-escape` — no net-new sandbox work.

## Boundary

The docs-site hero (`overrides/home.html`) is owned by the in-flight landing-conversion task (IRO-323); `containment.svg` is available for it to reference. Kept out of this PR to avoid a collision on that surface (the two tasks share a working checkout).

IRO-322. No owner gate (conversion infra); needs a reviewer to clear branch protection.