### PR TITLE
docs(compare): comparison-intent SEO cluster (IRO-330)

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -25,6 +25,7 @@ nav:
   - Tutorials: tutorials
   - Examples & use cases: examples.md
   - Learn (agent security): learn
+  - Compare: compare
   - Concepts:
       - IronClaw, Explained: ironclaw-explained.md
       - Architecture: architecture.md

--- a/docs/compare/.nav.yml
+++ b/docs/compare/.nav.yml
@@ -1,0 +1,15 @@
+# Navigation for the "Compare" section.
+#
+# Comparison-intent SEO cluster (IRO-330). Comparison search converts best, so
+# each page answers a real "IronClaw vs X" evaluation question with an honest
+# table, a when-to-use box, and a try-it link. Adding a page: drop
+# `compare/<slug>.md` with an H1 and front-matter title/description. The `*.md`
+# glob below auto-includes it (titled from its H1) with ZERO edit here. Add an
+# explicit line only to control label or ordering.
+nav:
+  - Compare IronClaw: index.md
+  - vs running agents unsandboxed: ironclaw-vs-unsandboxed-ai-agents.md
+  - vs raw Docker: ironclaw-vs-docker-agent-sandbox.md
+  - vs gVisor alone: ironclaw-vs-gvisor-alone.md
+  - vs hosted sandboxes (E2B): ironclaw-vs-e2b-hosted-sandboxes.md
+  - "*.md"

--- a/docs/compare/index.md
+++ b/docs/compare/index.md
@@ -1,0 +1,44 @@
+---
+title: "Compare IronClaw: sandboxing options for AI agents"
+description: "How IronClaw compares to running agents unsandboxed, raw Docker, gVisor alone, and hosted sandboxes like E2B. Honest tables, when-to-use guidance, and runnable examples."
+---
+
+# Compare IronClaw
+
+Deciding where to run an autonomous AI agent is really a decision about one thing:
+**what stops the agent when it turns hostile.** Prompt injection, a poisoned tool
+result, or a compromised dependency can all steer an agent that has real tools. These
+pages compare IronClaw against the options teams actually weigh, honestly and with the
+security boundary front and center.
+
+Every IronClaw claim on these pages links to shipped code, a versioned threat model,
+or a runnable example. We describe the *architectural pattern* of each alternative and
+do not assert specific capabilities of any named third-party project, because those
+change and you should verify them against that project's own docs.
+
+## Pick the comparison that matches your question
+
+- [IronClaw vs running AI agents unsandboxed](ironclaw-vs-unsandboxed-ai-agents.md) -
+  the core risk: what a tool-enabled agent can do with no boundary at all, and the
+  smallest set of controls that changes the outcome.
+- [IronClaw vs raw Docker for agent isolation](ironclaw-vs-docker-agent-sandbox.md) -
+  why a plain container is a good first step but a shared-kernel boundary, and what you
+  still have to build on top of it.
+- [IronClaw vs gVisor alone](ironclaw-vs-gvisor-alone.md) - a user-space kernel is a
+  strong wall, but a wall is not a runtime. What the rest of the agent lifecycle needs.
+- [IronClaw vs hosted agent sandboxes (E2B and similar)](ironclaw-vs-e2b-hosted-sandboxes.md) -
+  the self-hosted vs managed trade: who holds your keys and data, and when each side wins.
+
+## The short version
+
+IronClaw is a **security-first, self-hosted runtime for autonomous AI agents.** It
+assumes the agent could be compromised and builds a boundary you can verify: a
+gVisor-backed sandbox with `network=none`, a read-only rootfs, dropped capabilities, a
+host-side proxy so provider keys never enter the box, and a human-approval gateway for
+capability changes. If that threat model matches how you think about giving an LLM the
+ability to act, IronClaw is built for you.
+
+For the full evidence-backed rundown across all alternatives, see the main
+[Why IronClaw comparison page](../comparison.md). To run it yourself, the
+[quickstart](../quickstart.md) goes from a clean clone to a held approval in about
+five minutes.

--- a/docs/compare/ironclaw-vs-docker-agent-sandbox.md
+++ b/docs/compare/ironclaw-vs-docker-agent-sandbox.md
@@ -1,0 +1,62 @@
+---
+title: "IronClaw vs raw Docker for AI agent isolation"
+description: "A plain Docker container is a good first boundary for an AI agent but it shares the host kernel and stops short of egress, credential, and approval control. What IronClaw adds on top."
+---
+
+# IronClaw vs raw Docker for agent isolation
+
+Putting the agent in a container is the right instinct. It is a real boundary and a big
+improvement over running the model's tools directly on your host. The gap is that a
+container is process isolation on a **shared kernel**, and an agent runtime needs more
+than process isolation.
+
+## Where a plain container stops
+
+`docker run` fences off what a process can see with namespaces and cgroups, but every
+syscall the agent makes still runs against the real host kernel. So the isolation is
+only as strong as the host's syscall-handling code: one kernel-level vulnerability is a
+container-escape vulnerability. For a workload you are actively assuming is hostile,
+that is a large shared attack surface sitting right under the box. And a bare container
+says nothing about egress, where your keys live, or who approves a new capability. Those
+are the parts you would still have to design and maintain yourself.
+
+## What you build vs what ships
+
+| Concern | Raw Docker + LLM glue | IronClaw |
+| --- | --- | --- |
+| Kernel isolation | Shared host kernel | gVisor (`runsc`) second kernel wall on Linux, container underneath |
+| Network egress | Open by default, you lock it down | `network=none` on the sandbox by default |
+| Filesystem | You configure mounts and read-only flags | Read-only sealed rootfs, one sandbox per conversation |
+| Provider key | Usually passed in as an env var | Never enters the box, injected host-side over a Unix socket |
+| Capability changes | Agent acts directly | Held at a human-approval gateway, no bypass path |
+| Proof it holds | Your own review | Red-team containment gate on every push, published threat model |
+| Supply chain of the runtime | Your image, your provenance | cosign signatures, SLSA provenance, SPDX + CycloneDX SBOMs |
+
+## When raw Docker is the right call
+
+If you want full control of every layer and are willing to own the security boundary,
+DIY container plus LLM glue is a legitimate path. Teams pick it when they have the
+security engineering time to design egress, secrets, and isolation themselves and want
+no framework opinion in the way. IronClaw is not trying to talk you out of that; it is
+what you would end up building if you kept hardening that container for agent workloads.
+
+## When to reach for IronClaw
+
+Reach for IronClaw when you want the hardened result without assembling and maintaining
+it: a kernel-level sandbox, egress and credential control, and an approval gateway that
+ship as the default and are exercised in CI. You keep the self-hosted, own-your-stack
+posture of raw Docker and skip the part where a missed flag becomes a host compromise.
+
+## Try it against your own container mental model
+
+```bash
+docker compose -f docker-compose.demo.yml up --build -d
+./bin/ironctl doctor   # reports the sandbox runtime and isolation posture
+```
+
+## Where to go next
+
+- The kernel angle in depth: [gVisor vs containers for AI isolation](../learn/gvisor-vs-container-ai-isolation.md).
+- The full control set: [How to sandbox an AI agent](../learn/how-to-sandbox-an-ai-agent.md).
+- The evidence-backed rundown: [Why IronClaw](../comparison.md).
+- Run it with your model: [model providers](../providers/index.md).

--- a/docs/compare/ironclaw-vs-e2b-hosted-sandboxes.md
+++ b/docs/compare/ironclaw-vs-e2b-hosted-sandboxes.md
@@ -1,0 +1,60 @@
+---
+title: "IronClaw vs hosted agent sandboxes (E2B and similar)"
+description: "Hosted agent sandboxes trade ops for a third party holding your keys and data. IronClaw is the self-hosted alternative that keeps both on your infrastructure. When each side wins."
+---
+
+# IronClaw vs hosted agent sandboxes
+
+Hosted agent sandboxes (E2B and similar managed platforms) solve a real problem well:
+you sign up, call an API, and someone else runs the isolated environment. No cluster to
+operate, no runtime to patch. The trade is architectural, not a knock on any product:
+in a hosted model, a third party runs the sandbox and, in most agent setups, holds the
+keys and data flowing through it. IronClaw is the self-hosted answer to the same job.
+
+We describe the common hosted pattern here and do not assert the specifics of any named
+platform; verify those against that platform's own docs. This is about the
+managed-vs-self-hosted trade, so you can pick the side that fits your constraints.
+
+## The trade, honestly
+
+| Axis | Hosted sandbox (managed) | IronClaw (self-hosted) |
+| --- | --- | --- |
+| Ops burden | None, the vendor runs it | You run it, self-hosted |
+| Where your data lives | On the vendor's infrastructure | On yours |
+| Where provider keys live | Commonly with the vendor or passed through it | Host-side on your box, never inside the sandbox |
+| Isolation you can inspect | Vendor internal detail | gVisor + `network=none` + read-only rootfs, open source |
+| Data residency and compliance | Depends on the vendor's regions and terms | Fully under your control |
+| Approval gateway for capability changes | Varies by platform | Built in, no bypass path |
+| Cost model | Usage-based, per sandbox | Your infrastructure, AGPLv3 + commercial |
+| Lock-in | Vendor API and runtime | Own the stack, portable |
+
+## When a hosted sandbox wins
+
+Pick a managed sandbox when time-to-value and zero ops matter most, your data and keys
+are comfortable living with a third party, and elastic usage-based scaling beats owning
+infrastructure. For prototyping, spiky workloads, or teams with no platform engineers, a
+hosted sandbox is often the faster and cheaper call. That is a legitimate choice and
+IronClaw does not compete for it.
+
+## When to reach for IronClaw
+
+Reach for IronClaw when the answer to "who holds our keys and data" has to be "we do":
+regulated data, strict residency requirements, secrets that cannot leave your network,
+or a security team that needs to inspect and prove the isolation rather than trust a
+vendor's description of it. IronClaw keeps the whole path on infrastructure you control,
+with a boundary that is open source and re-tested by a red-team containment gate on
+every push.
+
+## Run the self-hosted path in minutes
+
+```bash
+docker compose -f docker-compose.demo.yml up --build -d
+./bin/ironctl doctor   # reports the sandbox runtime and isolation posture
+```
+
+## Where to go next
+
+- The full alternative rundown, including hosted platforms: [Why IronClaw](../comparison.md).
+- What self-hosting buys you at the boundary: [How to sandbox an AI agent](../learn/how-to-sandbox-an-ai-agent.md).
+- Bring your own model, local or cloud: [model providers](../providers/index.md).
+- From clone to held approval: [quickstart](../quickstart.md).

--- a/docs/compare/ironclaw-vs-gvisor-alone.md
+++ b/docs/compare/ironclaw-vs-gvisor-alone.md
@@ -1,0 +1,73 @@
+---
+title: "IronClaw vs gVisor alone for AI agents"
+description: "gVisor (runsc) is a strong syscall-level wall, but a wall is not a runtime. What the rest of the agent lifecycle needs: egress control, host-side keys, an approval gateway, and proof."
+---
+
+# IronClaw vs gVisor alone
+
+gVisor is excellent, and IronClaw uses it. `runsc` interposes a user-space kernel
+between a sandboxed process and the host, so the agent's syscalls hit gVisor's
+reimplementation of the Linux ABI instead of the real kernel. That shrinks the host
+attack surface to a small audited interface. If you have already reached for gVisor to
+run untrusted agents, you have made a good call. The question this page answers is what
+sits around that wall.
+
+## A wall is not a runtime
+
+gVisor gives you one thing very well: a strong kernel boundary for a process. An agent
+runtime has to answer several more questions that `runsc` on its own does not:
+
+- **Egress.** gVisor sandboxes the process; it does not decide the agent should have no
+  network. You still have to enforce `network=none` and the rest of the network policy.
+- **Credentials.** The provider API key has to reach the model somehow. If it lives
+  inside the sandbox as an env var, a compromised agent can read it, gVisor or not.
+- **Approval.** Nothing in `runsc` holds a new capability, tool, or egress rule for a
+  human to approve before it takes effect.
+- **Lifecycle.** One sandbox per conversation, sealed compiled-binary runtime, the chat
+  and channel plumbing, provider routing. That is the runtime, not the wall.
+- **Proof.** A boundary you cannot re-test on every change is a boundary you are hoping
+  still holds.
+
+## gVisor alone vs the full stack
+
+| Layer | gVisor (`runsc`) alone | IronClaw |
+| --- | --- | --- |
+| Kernel isolation | Yes, this is exactly what it does | Yes, IronClaw runs on gVisor |
+| `network=none` enforced by default | You configure it | Default on the sandbox |
+| Provider key kept out of the box | Not addressed | Host-side proxy injects the key over a Unix socket |
+| Human-approval gateway for capability changes | Not addressed | Built in, no bypass path |
+| Per-conversation sandbox and sealed runtime | You build it | Default |
+| Continuous proof the boundary holds | You script it | Red-team containment gate on every push |
+| Supply-chain attestation of the runtime | Your responsibility | cosign, SLSA provenance, SBOMs |
+
+## When gVisor alone is enough
+
+If you are running a single well-understood workload and you have already built egress,
+secrets, approval, and lifecycle around it, gVisor by itself may be all you need. The
+wall is genuinely strong, and adding a runtime you do not need is its own cost.
+
+## When to reach for IronClaw
+
+Reach for IronClaw when you want gVisor as the second kernel wall *plus* the rest of the
+agent runtime designed to the same standard, so you are not hand-rolling egress,
+credential handling, approvals, and containment tests around a bare `runsc`. IronClaw
+treats gVisor as one wall among several, never the only one, and keeps `network=none`, a
+read-only rootfs, dropped capabilities, and host-side secrets in place behind it.
+
+## Confirm the posture locally
+
+```bash
+docker compose -f docker-compose.demo.yml up --build -d
+./bin/ironctl doctor   # reports the sandbox runtime and isolation posture
+```
+
+Note gVisor is Linux-only. On macOS the host runs natively but the sandbox falls back to
+runc inside Docker Desktop's Linux VM, a weaker kernel-shared boundary. The sealed
+production posture is Linux plus gVisor.
+
+## Where to go next
+
+- The deep dive: [Why we run AI agents in gVisor](../gvisor-deep-dive.md).
+- Wall vs container: [gVisor vs containers for AI isolation](../learn/gvisor-vs-container-ai-isolation.md).
+- The measured overhead: [Performance and footprint](../benchmarks.md).
+- Run it with your model: [model providers](../providers/index.md).

--- a/docs/compare/ironclaw-vs-unsandboxed-ai-agents.md
+++ b/docs/compare/ironclaw-vs-unsandboxed-ai-agents.md
@@ -1,0 +1,63 @@
+---
+title: "IronClaw vs running AI agents unsandboxed"
+description: "What a tool-enabled AI agent can actually do when it runs with no sandbox, why prompt injection makes that the default risk, and the controls that change the outcome."
+---
+
+# IronClaw vs running AI agents unsandboxed
+
+The most common way to run an autonomous agent today is the least safe: an LLM SDK in
+a normal process, with tools wired straight to the host, holding your API keys as
+environment variables. It works on the happy path. The question is what happens on the
+unhappy one.
+
+## The risk is the default, not the edge case
+
+An agent with tools can read files, call APIs, spend money, and send messages. The
+moment it also reads an inbox, a web page, or a tool result, an **attacker** can put
+instructions in that content and steer those same tools. Prompt injection is not a rare
+failure for an autonomous agent; it is the normal operating condition. Run that agent
+unsandboxed and a single injected instruction has your filesystem, your network, and
+your credentials.
+
+## What each setup actually stops
+
+| Question | Unsandboxed agent | IronClaw |
+| --- | --- | --- |
+| Compromised agent reaches the host filesystem? | Yes, full user access | No. Read-only sealed rootfs, per-conversation sandbox |
+| Agent can open arbitrary network connections? | Yes | No. Sandbox runs `network=none` |
+| Provider API key exfiltratable by the agent? | Yes, it is in the process env | No. Key stays host-side, injected by a proxy over a Unix socket |
+| Capability change (new tool, new egress) needs approval? | No, agent just acts | Yes. Held at a human-approval gateway with no bypass |
+| Kernel-level second boundary if the process is popped? | No, shared host kernel | Yes, gVisor (`runsc`) user-space kernel on Linux |
+| Isolation you can prove, not just assert? | You wrote it, you audit it | Red-team containment gate runs on every push |
+
+## When running unsandboxed is fine
+
+Be honest about your own threat model. Running an agent with no sandbox is a reasonable
+choice when **all** of these hold: the agent has no tools that touch anything you care
+about, it never ingests untrusted content, and it holds no credential worth stealing. A
+read-only chat summarizer over public data is not the same risk as an agent with shell
+access and your cloud keys.
+
+## When to reach for IronClaw
+
+The moment an agent has real tools **and** can see content you do not control, the
+boundary stops being optional. IronClaw's design starts from "treat every agent as
+already compromised, and make the boundary hold anyway," so the controls above are the
+baseline, not an add-on you remember to configure later.
+
+## See it hold
+
+You do not have to take the table on trust. The zero-credential offline demo drives the
+full chat to sandbox to reply path locally:
+
+```bash
+docker compose -f docker-compose.demo.yml up --build -d
+./bin/ironctl doctor   # reports the sandbox runtime and isolation posture
+```
+
+## Where to go next
+
+- The controls in detail: [How to sandbox an AI agent](../learn/how-to-sandbox-an-ai-agent.md).
+- Why filtering is not the boundary: [Prevent prompt-injection escape](../learn/prevent-ai-agent-prompt-injection-escape.md).
+- The full alternative-by-alternative rundown: [Why IronClaw](../comparison.md).
+- Run it with your model: [model providers](../providers/index.md).


### PR DESCRIPTION
## What

New `docs/compare/` comparison-intent SEO cluster (IRO-330, workstream A). Comparison search converts best, so each page answers a real "IronClaw vs X" evaluation question.

Pages:
- **vs running AI agents unsandboxed** - the core risk narrative
- **vs raw Docker** for agent isolation
- **vs gVisor alone**
- **vs hosted sandboxes (E2B and similar)** - self-hosted vs managed trade

Each page: honest comparison table, when-to-use guidance for *both* sides (no disparagement), runnable try-it snippet, cross-links to the learn/ cluster and comparison.md.

## Pattern (IRO-321)
- Own `docs/compare/.nav.yml` fragment with `*.md` glob + single root nav ref (`Compare: compare`)
- Unique front-matter title/description per page
- `mkdocs --strict` green (verified locally, exit 0, all 5 pages rendered)

## Accuracy
Every IronClaw claim maps to shipped capability and reuses the sources cited in `comparison.md`: gVisor `runsc`, `network=none`, read-only rootfs, host-side key injection, approval gateway, red-team containment gate, cosign/SLSA/SBOM. No specific third-party capabilities asserted. No em/en-dashes per IRO-254.

Ref IRO-330.