### PR TITLE
feat(devcontainer): zero-install Try IronClaw via Codespaces (IRO-329)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,75 @@
+# Try IronClaw with zero install (GitHub Codespaces)
+
+This `.devcontainer/` lets a visitor go from **Open in Codespaces** to a **running,
+sandboxed IronClaw agent** in the browser with no local install and no API key.
+
+## What you get
+
+Open the repo in a Codespace ([one-click button in the README](../README.md#want-to-see-it-work-first--no-api-key-no-signup)).
+On first create it:
+
+1. Installs `jq` + `curl` and a nested Docker daemon (`docker-in-docker`).
+2. Runs [`examples/hello-ironclaw/run.sh --keep`](../examples/hello-ironclaw/README.md),
+   which builds the sandbox image and the demo control-plane, then **asserts** a real
+   chat -> per-session sandbox -> encrypted queue -> reply round-trip with the offline
+   `mock` provider.
+3. Leaves the demo running on port **8787**, which Codespaces forwards to your browser.
+
+Open the forwarded **8787** port, add **`/ui/`** to the URL, pick **Mock Agent (offline)**
+in the Chat tab, and say hi. If prompted for a token, paste **`ironclaw-demo`**.
+
+Then watch containment for real:
+
+```sh
+examples/live-containment/run.sh
+```
+
+A fully jailbroken agent tries three escapes (network exfil, host-filesystem breakout,
+host takeover via the Docker socket) and each is **denied**.
+
+## Why docker-in-docker (not the host socket)
+
+The demo launches each agent sandbox as a **sibling container** and binds the session's
+encrypted-queue + key files at the **same absolute path** inside both the control-plane
+and the sandbox (`IRONCLAW_DOCKER_BINDS` in
+[`docker-compose.demo.yml`](../docker-compose.demo.yml)). That path alignment is
+load-bearing for the queue handshake, and it only holds when the Docker daemon shares
+this container's filesystem — which `docker-in-docker` provides. A mounted host Docker
+socket (docker-outside-of-docker) would resolve `${PWD}` against a **different**
+filesystem and break the handshake, so we deliberately do not use it here.
+
+## Security note — this is the demo posture, not production
+
+The Codespace runs the **same relaxed demo posture** as the local zero-credential demo:
+no gVisor, `runc` (shared host kernel), the control-plane runs as root and reaches the
+nested Docker daemon. What stays intact even here:
+
+- **`network=none`** on every sandbox sibling (no egress; the
+  [`live-containment`](../examples/live-containment/README.md) demo proves it),
+- the **mandatory human-approval gateway**,
+- the **encrypted per-session queues**, and
+- **host-side model-credential custody** (no key ever enters a sandbox).
+
+This is a trial box, not a deployment. The hardened production posture (gVisor +
+`network=none` + host model-proxy) is the default
+[`docker-compose.yml`](../docker-compose.yml) / [deployment guide](../docs/deployment.md).
+
+## Known constraints
+
+- **First create is ~2-3 min** while the sandbox and control-plane images build. This is
+  prebuild-cacheable.
+- **gVisor is not available in Codespaces**, so the sandbox seal is `runc`, exactly like
+  the local laptop demo. `network=none`, the approval gateway, and the encrypted queues
+  are unchanged, so the containment story (what the `live-containment` demo shows) still
+  holds; only the kernel-isolation layer is relaxed. For a true gVisor seal, run on a
+  Linux host per the [deployment guide](../docs/deployment.md).
+- The demo control-plane binds **loopback only** (`127.0.0.1:8787`); Codespaces forwards
+  that to you privately. No public `0.0.0.0` port is opened inside the box.
+
+## Files
+
+| File | Role |
+|------|------|
+| `devcontainer.json` | image, `docker-in-docker` + Go features, port 8787, lifecycle hooks |
+| `post-create.sh` | the single post-create command: build + run the demo end to end, leave it up |
+| `welcome.sh` | post-attach banner (how to open the console / run live-containment) |

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,50 @@
+{
+  // Zero-install "Try IronClaw" in GitHub Codespaces (IRO-329).
+  //
+  // Open this repo in a Codespace and, with no local install, you get a running
+  // sandboxed agent: the post-create step builds the sandbox image, brings up the
+  // offline mock-agent control-plane, ASSERTS a real chat -> per-session sandbox ->
+  // encrypted-queue -> reply round-trip, and leaves the demo running on port 8787.
+  //
+  // Why docker-in-docker (not the host Docker socket): the demo launches each agent
+  // sandbox as a sibling container and binds the session's queue + key files at the
+  // SAME absolute path in both the control-plane and the sandbox (docker-compose.demo.yml,
+  // IRONCLAW_DOCKER_BINDS). That path alignment only holds when the Docker daemon shares
+  // this container's filesystem, which docker-in-docker gives us. A mounted host socket
+  // (docker-outside-of-docker) would resolve ${PWD} against a different filesystem and
+  // break the queue handshake. See .devcontainer/README.md for the security note.
+  "name": "IronClaw — zero-install try",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    // Nested Docker daemon so the demo can build the sandbox image and launch
+    // per-session sandbox siblings entirely inside this Codespace.
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    // Go toolchain matching the repo (go.mod: go 1.23) so contributors can also
+    // `make build/vet/test` from the same Codespace. Not needed for the demo itself
+    // (the control-plane and sandbox are built inside Docker), only for local dev.
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.23"
+    }
+  },
+  // curl + jq are what the demo check needs on the host side; the images build in Docker.
+  "onCreateCommand": "sudo apt-get update -y && sudo apt-get install -y --no-install-recommends jq curl",
+  // The single post-create command that runs the demo end to end and leaves it up.
+  "postCreateCommand": ".devcontainer/post-create.sh",
+  // Re-print the "what now" banner every time you attach to the Codespace.
+  "postAttachCommand": ".devcontainer/welcome.sh",
+  // The demo control-plane listens on 127.0.0.1:8787; Codespaces forwards it so the
+  // web console at /ui/ opens in your browser. Loopback-only binding is intentional
+  // (same posture as production) — no public 0.0.0.0 port is opened inside the box.
+  "forwardPorts": [8787],
+  "portsAttributes": {
+    "8787": {
+      "label": "IronClaw control-plane (web console at /ui/)",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["golang.go"]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Codespaces post-create: run the IronClaw zero-credential demo end to end and
+# leave it running so a fresh visitor can chat with a real sandboxed agent in the
+# browser — no local install, no API key (IRO-329).
+#
+# What it does (via examples/hello-ironclaw/run.sh --keep):
+#   1. builds the sandbox image (container/build.sh) and the demo control-plane image
+#   2. brings up the offline mock-agent control-plane (docker-compose.demo.yml)
+#   3. sends a chat message and ASSERTS the reply comes back through the real
+#      engage -> per-session sandbox -> encrypted queue -> delivery path
+#   4. leaves the demo running on 127.0.0.1:8787 (Codespaces forwards it)
+#
+# The demo relaxes the sandbox seal to run without gVisor (runc, shared host kernel);
+# the approval gateway, encrypted per-session queues, and network=none per sandbox are
+# unchanged. See .devcontainer/README.md and examples/hello-ironclaw/README.md.
+#
+# We do NOT hard-fail the Codespace on a demo error: the container should still open
+# so the visitor can read the diagnostics and retry. run.sh already fails loud and
+# dumps control-plane + sandbox logs on a broken round-trip.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "======================================================================"
+echo " IronClaw — building and starting the zero-credential demo"
+echo " First run builds the sandbox + control-plane images (~2-3 min)."
+echo "======================================================================"
+
+if bash examples/hello-ironclaw/run.sh --keep; then
+  cat <<'EOF'
+
+======================================================================
+ IronClaw is running. Zero install, zero credentials.
+======================================================================
+
+ Open the web console:
+   - Click the forwarded port 8787 (PORTS tab) and open it in your browser,
+     then add /ui/ to the URL.
+   - In the Chat tab pick "Mock Agent (offline)" and say hi.
+   - If it asks for an API token, paste:  ironclaw-demo
+
+ Now watch it catch a real escape (a jailbroken agent tries to break out
+ of the sandbox and every attempt is denied):
+
+   examples/live-containment/run.sh
+
+ Stop the demo:
+   docker compose -f docker-compose.demo.yml down
+
+ Rerun this whole demo:
+   .devcontainer/post-create.sh
+======================================================================
+EOF
+else
+  cat <<'EOF'
+
+======================================================================
+ The demo did not come up cleanly.
+======================================================================
+ The Codespace is still usable. Common causes: the nested Docker daemon
+ was still starting, or the first image build timed out.
+
+ Retry with:
+   .devcontainer/post-create.sh
+
+ Or run the pieces by hand:
+   bash container/build.sh
+   docker compose -f docker-compose.demo.yml up --build -d
+   examples/hello-ironclaw/run.sh --attach
+======================================================================
+EOF
+fi
+
+# Always exit 0 so a demo hiccup doesn't mark Codespace creation as failed.
+exit 0

--- a/.devcontainer/welcome.sh
+++ b/.devcontainer/welcome.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Codespaces post-attach banner: shown every time you open/attach to the Codespace.
+# Kept lightweight (no Docker calls) so attaching stays fast. IRO-329.
+set -uo pipefail
+
+cat <<'EOF'
+
+  IronClaw — zero-install try (Codespaces)
+
+  The demo control-plane is set up to run on port 8787 (offline mock-agent,
+  zero credentials). Open the forwarded port 8787 and add /ui/ to chat;
+  paste the token  ironclaw-demo  if prompted.
+
+  Start / restart the demo:   .devcontainer/post-create.sh
+  Watch a real escape denied:  examples/live-containment/run.sh
+  Stop the demo:              docker compose -f docker-compose.demo.yml down
+
+EOF

--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ browser first? Run [`hello-ironclaw`](examples/hello-ironclaw/) or the
 [zero-credential quickstart](docs/quickstart.md). Production seals each sandbox with gVisor and
 `network=none`.
 
+> **No Docker, nothing to install? Try it in your browser.**
+> Open the repo in a GitHub Codespace and it builds and starts the same offline demo for
+> you, then leaves a real sandboxed agent running on the forwarded port **8787**. Chat with
+> it at **`/ui/`** (token `ironclaw-demo`). Zero install, zero credentials.
+>
+> [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/IronSecCo/ironclaw?quickstart=1)
+>
+> Codespaces has no gVisor, so the sandbox seal is `runc` (same as the laptop demo), but
+> `network=none`, the approval gateway, and the encrypted queues are unchanged — so you can
+> still run `examples/live-containment/run.sh` and watch an escape get denied. Details in
+> [`.devcontainer/`](.devcontainer/README.md).
+
 > [!WARNING]
 > **Alpha software, work in progress. Please read before relying on it.**
 >


### PR DESCRIPTION
## What / why (IRO-329)

Kill the biggest friction for a security tool: local setup. Give a visitor a **zero-install** path to a **running sandboxed agent** so they experience containment before deciding to star.

Open the repo in a GitHub Codespace and, with no local install and no API key, you get a running IronClaw demo:

1. On create: install `jq`/`curl` + a nested Docker daemon (`docker-in-docker`).
2. Run the already CI-gated `examples/hello-ironclaw/run.sh --keep`: build the sandbox + demo control-plane images, **assert** a real `chat -> per-session sandbox -> encrypted queue -> reply` round-trip (offline `mock` provider), and leave the demo running.
3. Codespaces forwards port **8787**; open `/ui/`, pick **Mock Agent (offline)**, chat (token `ironclaw-demo`).

Then `examples/live-containment/run.sh` shows a jailbroken agent try three escapes, each **denied**.

## Files
- `.devcontainer/devcontainer.json` — base image, `docker-in-docker` + Go 1.23 features, forward 8787, lifecycle hooks
- `.devcontainer/post-create.sh` — the single post-create command: build + run the demo end to end, leave it up (never hard-fails the Codespace)
- `.devcontainer/welcome.sh` — post-attach banner
- `.devcontainer/README.md` — how it works + the security note + known constraints
- `README.md` — "Open in GitHub Codespaces" button in the zero-credential callout

## Why docker-in-docker (not the host socket)
The demo binds each session's queue/key files at the **same absolute path** in the control-plane and the sandbox sibling (`IRONCLAW_DOCKER_BINDS`). That alignment only holds when the Docker daemon shares this container's filesystem, which `docker-in-docker` gives. A mounted host socket would resolve `${PWD}` against a different filesystem and break the queue handshake.

## Security posture (unchanged trust model)
Codespaces has **no gVisor**, so the seal is `runc` — the **same relaxed posture as the existing laptop demo** (`docker-compose.demo.yml`). What stays intact: `network=none` per sandbox, the mandatory approval gateway, the encrypted per-session queues, host-side credential custody. The control-plane binds **loopback only** (`127.0.0.1:8787`); Codespaces forwards it privately, no public port. This is a trial box, not production. Documented clearly in `.devcontainer/README.md`.

## Verification
- `bash -n` clean on both scripts; `devcontainer.json` parses.
- The wrapped command (`examples/hello-ironclaw/run.sh`) is CI-gated on every push by `.github/workflows/example-smoke.yml`, so the demo round-trip is proven green on `main`.
- **Remaining (needs a human):** launch a real Codespace from this branch and confirm the browser flow end to end (docker-in-docker build + `/ui/` chat + `live-containment`). I cannot open a Codespace from the agent environment; requesting the CEO run the one-click verification.

Standing rule IRO-254: no em/en-dashes in the README public copy addition.