### PR TITLE
feat(landing): fill hero right-column void with containment.svg + compact trust strip (IRO-334)

### DIFF
--- a/docs/stylesheets/landing.css
+++ b/docs/stylesheets/landing.css
@@ -148,6 +148,44 @@
   font-weight: 700;
 }
 
+/* ----- hero 2-col layout (R1) -------------------------------------------
+   Base: single column. The copy renders full-width and the containment still
+   stacks BELOW it, so the mobile layout is unchanged (copy order untouched).
+   The 2-col split only engages at >=1024px (see responsive block), where it
+   fills the right-column void the left-aligned copy would otherwise leave. */
+.iro-hero__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--s-6);
+  align-items: center;
+}
+.iro-hero__media {
+  min-width: 0;
+}
+.iro-hero__media img {
+  display: block;
+  width: 100%;
+  max-width: 560px;
+  height: auto;
+  margin-inline: auto;
+  border: 1px solid rgba(143, 180, 255, 0.20);
+  border-radius: var(--iro-radius);
+  box-shadow: 0 1.2rem 3rem rgba(3, 8, 22, 0.45);
+}
+
+/* ----- compact trust strip (R4) -----------------------------------------
+   A 2-3 badge subset kept next to the CTAs so >=1 supply-chain signal is
+   visible above the fold. Not a duplicate of the full .iro-badges wall. */
+.iro-trust-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: calc(-1 * var(--s-4)) 0 var(--s-6);
+}
+.iro-trust-strip img { height: 20px; display: block; }
+.iro-trust-strip a:focus-visible { outline: 3px solid #8fb4ff; outline-offset: 3px; border-radius: 3px; }
+
 /* ----- CTA buttons ------------------------------------------------------- */
 .iro-cta-row {
   display: flex;
@@ -626,6 +664,16 @@
 }
 @media (min-width: 960px) {
   .iro-section { padding-inline: 2rem; }
+}
+/* >=1024px: split the hero into copy (left) + containment still (right) so the
+   left-aligned copy no longer leaves the right ~50% as dark void (R1). Below
+   this width the grid stays single-column and the still stacks under the copy. */
+@media (min-width: 1024px) {
+  .iro-hero__grid {
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.85fr);
+    gap: var(--s-8, 3rem);
+  }
+  .iro-hero__media img { max-width: 100%; }
 }
 
 /* =============================================================================

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -19,7 +19,8 @@
 
   {# ===== 1. HERO ===== #}
   <section class="iro-section iro-hero" aria-labelledby="hero-title">
-    <div class="iro-wrap">
+    <div class="iro-wrap iro-hero__grid">
+     <div class="iro-hero__copy">
       <span class="iro-eyebrow">A sandboxed runtime for untrusted AI agents</span>
       <h1 class="iro-hero__title" id="hero-title">Security-first AI agents you actually run yourself.</h1>
       <p class="iro-hero__sub">
@@ -37,6 +38,14 @@
           Star on GitHub
           <span class="iro-btn__star" aria-hidden="true">★</span>
         </a>
+      </div>
+
+      {# Compact trust strip — keep >=1 supply-chain signal above the fold with the
+         CTAs (R4). A 3-badge subset of the full .iro-badges wall below; not a dup. #}
+      <div class="iro-trust-strip" aria-label="Security trust signals">
+        <a href="https://www.bestpractices.dev/projects/13348" rel="noopener" title="OpenSSF Best Practices (passing)"><img src="https://www.bestpractices.dev/projects/13348/badge" alt="OpenSSF Best Practices: passing" loading="lazy"></a>
+        <a href="https://scorecard.dev/viewer/?uri=github.com/IronSecCo/ironclaw" rel="noopener" title="OpenSSF Scorecard"><img src="https://api.securityscorecards.dev/projects/github.com/IronSecCo/ironclaw/badge" alt="OpenSSF Scorecard score" loading="lazy"></a>
+        <a href="https://ironsecco.github.io/ironclaw/security/" title="cosign-signed releases"><img src="https://img.shields.io/badge/releases-cosign%20signed-2563eb.svg" alt="Releases: cosign signed" loading="lazy"></a>
       </div>
 
       <p class="iro-hero__proof">
@@ -73,6 +82,14 @@
           Alpha software — the gVisor seal is Linux-only.
           <a href="https://ironsecco.github.io/ironclaw/roadmap/">See project status →</a>
         </p>
+      </div>
+     </div>{# /.iro-hero__copy #}
+
+      {# Fill the >=1024px right-column void with the shipped, static, reduced-motion
+         safe live-containment still (R1). Stacks below the copy on mobile. #}
+      <div class="iro-hero__media" aria-hidden="false">
+        <img src="{{ base_url }}/assets/containment.svg" loading="lazy" decoding="async" width="820" height="556"
+             alt="IronClaw live-containment demo (final terminal frame): a jailbroken agent's three escape attempts — reaching the network, reading a host secret, and breaking out of the sandbox — are each blocked, and the run ends CONTAINED.">
       </div>
     </div>
   </section>


### PR DESCRIPTION
## What

Docs landing hero conversion fixes from the IRO-331 visual audit (IRO-334, R1/R4).

**R1 [HIGH] — fill the empty hero right-column.** At >=1024px the hero left-aligns all copy and left the right ~50% as dark void. Add a 2-col hero grid (`.iro-hero__grid`) with the **existing, shipped** `docs/assets/containment.svg` (4.3K, static, reduced-motion safe) in a right-column `.iro-hero__media`. No new asset. This surfaces the shipped "catch a real escape" aha above the fold.

**R4 [MED] — compact trust strip.** Add a 3-badge trust line (OpenSSF passing + Scorecard + cosign) directly under the CTA row so >=1 supply-chain signal is visible with the CTAs. Subset of the full `.iro-badges` wall, not a duplicate.

## Mobile

Below 1024px the grid stays single-column; the still stacks **below** the copy and the copy order is untouched, so the mobile layout is unchanged.

## Files
- `overrides/home.html` — hero markup (copy wrapper + media column + trust strip)
- `docs/stylesheets/landing.css` — `.iro-hero__grid` / `.iro-hero__media` / `.iro-trust-strip` + >=1024px 2-col rule

## Verification
- `mkdocs build --strict` — clean.
- Rendered the built site and screenshotted both viewports:
  - **1440x900**: right column shows containment.svg (no void); trust strip visible beside CTAs.
  - **390x844**: single-column, copy order matches current mobile; compact trust strip present, still below copy.

## Lenses
Docs/landing only — no build, signing, attestation, required-check, or installer-verification surface touched. No trust-model change.

Closes IRO-334.