### PR TITLE
docs(readme): hero conversion pass — stars-first badges, containment-first visuals, trim above-fold density (IRO-333)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,15 @@
 
 Each one runs sealed in a sandbox that provably cannot phone home, read your host, or rewrite its own rules.
 
-<!-- Security & supply-chain trust cluster — lead with what makes this project different -->
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/IronSecCo/ironclaw/badge)](https://scorecard.dev/viewer/?uri=github.com/IronSecCo/ironclaw)
+<!-- One curated row, stars first. The supply-chain trust badges (Scorecard, cosign, SBOM, SLSA) live beside the release-verification story below, where they carry more weight. -->
+[![GitHub stars](https://img.shields.io/github/stars/IronSecCo/ironclaw?style=social)](https://github.com/IronSecCo/ironclaw/stargazers)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13348/badge)](https://www.bestpractices.dev/projects/13348)
 [![CodeQL](https://github.com/IronSecCo/ironclaw/actions/workflows/codeql.yml/badge.svg)](https://github.com/IronSecCo/ironclaw/actions/workflows/codeql.yml)
-[![Signed releases (cosign)](https://img.shields.io/badge/releases-cosign%20signed-0a7bbb.svg)](#verifying-a-release)
-[![SBOM: SPDX + CycloneDX](https://img.shields.io/badge/SBOM-SPDX%20%2B%20CycloneDX-44883e.svg)](#verifying-a-release)
-[![SLSA provenance](https://img.shields.io/badge/SLSA-build%20provenance-44883e.svg)](#verifying-a-release)
-
-[![Documentation](https://img.shields.io/badge/docs-ironsecco.github.io-0a7bbb.svg)](https://ironsecco.github.io/ironclaw/)
-[![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#project-status)
 [![Latest release](https://img.shields.io/github/v/release/IronSecCo/ironclaw?sort=semver)](https://github.com/IronSecCo/ironclaw/releases/latest)
-[![Go Reference](https://pkg.go.dev/badge/github.com/IronSecCo/ironclaw.svg)](https://pkg.go.dev/github.com/IronSecCo/ironclaw)
 [![License: AGPLv3 + Commercial](https://img.shields.io/badge/License-AGPLv3%20%2B%20Commercial-blue.svg)](LICENSING.md)
-[![GitHub Discussions](https://img.shields.io/github/discussions/IronSecCo/ironclaw?logo=github&label=discussions)](https://github.com/IronSecCo/ironclaw/discussions)
-[![Good first issues](https://img.shields.io/github/issues/IronSecCo/ironclaw/good%20first%20issue?label=good%20first%20issues)](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-[![GitHub stars](https://img.shields.io/github/stars/IronSecCo/ironclaw?style=social)](https://github.com/IronSecCo/ironclaw/stargazers)
+[![Documentation](https://img.shields.io/badge/docs-ironsecco.github.io-0a7bbb.svg)](https://ironsecco.github.io/ironclaw/)
+
+**If a safer way to run agents is worth having, [star the repo](https://github.com/IronSecCo/ironclaw)** to follow along and help others find it. Then try the zero-credential [quickstart](docs/quickstart.md).
 
 </div>
 
@@ -357,6 +350,9 @@ around.
 
 ## Project status
 
+[![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#project-status)
+[![Go Reference](https://pkg.go.dev/badge/github.com/IronSecCo/ironclaw.svg)](https://pkg.go.dev/github.com/IronSecCo/ironclaw)
+
 **Alpha.** The architecture is settled and the full control-plane and sandbox pipelines are
 implemented and tested. The encrypted-queue binding is now wired:
 
@@ -475,6 +471,11 @@ Releases are **signed and attested** — a keyless [cosign](https://docs.sigstor
 signature over `SHA256SUMS`, an **SBOM** (SPDX + CycloneDX), and build-provenance attestations for
 every archive and the container image. For how releases are cut, verified, and yanked, see the
 [release runbook](docs/release-runbook.md).
+
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/IronSecCo/ironclaw/badge)](https://scorecard.dev/viewer/?uri=github.com/IronSecCo/ironclaw)
+[![Signed releases (cosign)](https://img.shields.io/badge/releases-cosign%20signed-0a7bbb.svg)](#verifying-a-release)
+[![SBOM: SPDX + CycloneDX](https://img.shields.io/badge/SBOM-SPDX%20%2B%20CycloneDX-44883e.svg)](#verifying-a-release)
+[![SLSA provenance](https://img.shields.io/badge/SLSA-build%20provenance-44883e.svg)](#verifying-a-release)
 
 <details>
 <summary>Verifying a signed release</summary>
@@ -978,6 +979,9 @@ To report a vulnerability, please open a private security advisory rather than a
 - [x] Gateway auto-approval policy + RBAC — implemented as a verifier/approver, but **inert by default**: the mandatory-human floor is the only active path until an operator opts in
 
 ## Community
+
+[![GitHub Discussions](https://img.shields.io/github/discussions/IronSecCo/ironclaw?logo=github&label=discussions)](https://github.com/IronSecCo/ironclaw/discussions)
+[![Good first issues](https://img.shields.io/github/issues/IronSecCo/ironclaw/good%20first%20issue?label=good%20first%20issues)](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 
 Questions, ideas, "is this a bug or am I holding it wrong?" — bring them to
 **[GitHub Discussions](https://github.com/IronSecCo/ironclaw/discussions)**. It's the project's


### PR DESCRIPTION
## IRO-333 — README hero conversion fixes (from the IRO-331 visual audit)

Applied against `main`. No copy claims changed; changes are curation, ordering, and placement.

### R2 [HIGH] One curated badge row, stars first
- Hero cut from **14 badges over 3 rows → one row of 6**, stars **first**: stars, OpenSSF Best Practices, CodeQL, release, AGPLv3, docs.
- Supply-chain badges (Scorecard, cosign, SBOM, SLSA) moved down next to **Verifying a release**, where they carry the trust story with more weight.
- Remaining badges relocated to natural homes: alpha + Go Reference → **Project status**; Discussions + good-first-issues → **Community**. Every original badge is preserved exactly once.
- The **star-the-repo CTA** now sits immediately under the badge row.

### R3 [MED] Containment-first hero visuals
- Lead with `containment.svg` (**"watch it catch a real escape"**) then `demo.svg` (**"it replies"**). Both images and captions kept; the containment caption's orphaned leading ellipsis dropped now that it leads.

### R5 [LOW] Trim above-the-fold density
- The full alpha **WARNING** admonition is replaced in the hero by a **one-line inline alpha note** and relocated below the first demo images (just above "The whole journey").

### Verification
- Hero badge row = 6, stars first; all 14 original badges present exactly once across the file; WARNING appears once; visual order containment→demo confirmed.
- Docs-only change (no Go build impact). Verify by viewing the rendered README on GitHub at desktop width.

Parent: IRO-331 (conversion visual audit).