### PR TITLE
fix(demo): surface silent dead chat + auto-build sandbox image (IRO-335)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -755,6 +755,19 @@ func main() {
 	if broker != nil && *vaultEndpoint != "" {
 		egressProvisioner = broker
 	}
+
+	// Channel adapters + the in-process webchat buffer are created here (ahead of the
+	// SessionManager) so the manager's OnLaunchError hook can deliver a user-visible
+	// "sandbox couldn't start" chat message through the same adapter the normal reply
+	// path uses (IRO-335). Concrete platform adapters register when configured; the
+	// inbound Router is wired below, once the manager exists.
+	channelReg := channels.NewRegistry()
+	registerChannelAdapters(channelReg, logger)
+	webchat := channels.NewWebchatAdapter("webchat")
+	if err := channelReg.Register(webchat); err != nil {
+		logger.Error("register webchat adapter", "error", err)
+	}
+
 	manager, err := session.New(session.Config{
 		Factory:          factory,
 		Keys:             custodian,
@@ -773,6 +786,7 @@ func main() {
 		KeyDir:           filepath.Join(*stateDir, "keys"),
 		WorkspaceRoot:    filepath.Join(*stateDir, "workspaces"),
 		OnLaunch:         m.SandboxLaunches.Inc,
+		OnLaunchError:    launchErrorReporter(reg, channelReg, logger, *sandboxImage),
 	})
 	if err != nil {
 		logger.Error("session manager", "error", err)
@@ -788,22 +802,14 @@ func main() {
 	// affected group's running sessions so the grant takes effect immediately.
 	respawnApplier.SetRespawner(manager)
 
-	// Delivery: poll per-session outbound queues and deliver via channel adapters,
-	// re-authorizing privileged system actions through the gateway. Concrete
-	// platform adapters register when their bot token is configured.
-	channelReg := channels.NewRegistry()
-	registerChannelAdapters(channelReg, logger)
-
-	// Chat playground: register an in-process webchat adapter so the
-	// delivery loop routes an agent's "webchat" replies back to it for the browser
-	// to poll, and instantiate the inbound Router (registry + the SessionManager's
-	// inbound-writer factory + waker) so the API can feed a browser message into
-	// the normal engage/route/deliver path. Additive — no existing adapter calls
-	// the router, so the inbound posture is unchanged for them.
-	webchat := channels.NewWebchatAdapter("webchat")
-	if err := channelReg.Register(webchat); err != nil {
-		logger.Error("register webchat adapter", "error", err)
-	}
+	// Delivery: poll per-session outbound queues and deliver via channel adapters
+	// (channelReg + the in-process webchat buffer created above), re-authorizing
+	// privileged system actions through the gateway.
+	//
+	// Chat playground: instantiate the inbound Router (registry + the SessionManager's
+	// inbound-writer factory + waker) so the API can feed a browser message into the
+	// normal engage/route/deliver path. Additive — no existing adapter calls the
+	// router, so the inbound posture is unchanged for them.
 	chatRouter := router.New(reg, manager.InboundWriter, manager)
 	server = server.WithChat(chatRouter, webchat)
 
@@ -1067,6 +1073,65 @@ func registerChannelAdapters(reg *channels.Registry, logger *obs.Logger) {
 	})
 	reqExtra("imessage", runtime.GOOS == "darwin" && os.Getenv("IRONCLAW_IMESSAGE_ENABLE") == "1",
 		func() channels.Adapter { return channels.NewIMessageAdapter("imessage") })
+}
+
+// launchErrorReporter builds the session manager's OnLaunchError hook: when a
+// sandbox launch fails and the session is left un-launched, it delivers a
+// user-visible chat message to the conversation that triggered it, so a fresh
+// visitor sees an actionable error instead of an eternally silent empty reply
+// (IRO-335). It resolves the session's own messaging group and delivers through the
+// SAME channel adapter the normal reply path uses, so the message shows up wherever
+// the visitor is chatting (the web console, Slack, etc.). Best-effort: any
+// unresolved session/group/adapter is a no-op, and delivery runs out-of-band on a
+// bounded context so it never blocks the Wake path.
+func launchErrorReporter(reg registry.Registry, channelReg *channels.Registry, logger *obs.Logger, sandboxImage string) func(contract.SessionID, error) {
+	return func(id contract.SessionID, launchErr error) {
+		sess, ok := reg.GetSession(id)
+		if !ok {
+			return
+		}
+		mg, ok := reg.GetMessagingGroup(sess.MessagingGroupID)
+		if !ok {
+			return
+		}
+		adapter, ok := channelReg.Get(mg.ChannelType)
+		if !ok {
+			return
+		}
+		var content string
+		if isolation.IsImageMissing(launchErr) {
+			img := sandboxImage
+			if img == "" {
+				img = "ironclaw-sandbox:latest"
+			}
+			content = fmt.Sprintf("The IronClaw sandbox could not start: its container image %q is missing.\n\n"+
+				"Build it once, then resend your message:\n"+
+				"    bash container/build.sh\n\n"+
+				"(The demo compose file builds it for you: docker compose -f docker-compose.demo.yml up --build)", img)
+		} else {
+			content = "The IronClaw sandbox could not start due to a host error. " +
+				"Check the control-plane logs for details, then resend your message."
+		}
+		channelType := mg.ChannelType
+		platformID := mg.PlatformID
+		msg := contract.MessageOut{
+			ID:          contract.MessageID("launcherr_" + string(id)),
+			Timestamp:   time.Now().UTC(),
+			Kind:        contract.KindChat,
+			ChannelType: &channelType,
+			PlatformID:  &platformID,
+			Content:     content,
+		}
+		// Deliver out-of-band: platform adapters make network calls, and this runs
+		// inline on the Wake path. Bound it so a slow adapter cannot wedge a launch.
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if _, err := adapter.Deliver(ctx, msg); err != nil {
+				logger.Warn("surface launch error to chat", "session", id, "channel", channelType, "error", err)
+			}
+		}()
+	}
 }
 
 // defaultStateDir returns a per-user state directory under the OS state/cache

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,10 +1,14 @@
 # IronClaw — zero-credential local chat demo (a working "it works" in one command).
 #
-#   bash container/build.sh                              # build the sandbox image once
-#   docker compose -f docker-compose.demo.yml up --build # start the demo control-plane
+#   docker compose -f docker-compose.demo.yml up --build # build BOTH images + start the demo
 #   open http://127.0.0.1:8787/ui/                       # Chat → "Mock Agent (offline)" → say hi
 #                                                         # (if it asks for an API token, paste: ironclaw-demo)
 #   docker compose -f docker-compose.demo.yml down       # tear it down
+#
+# One command: `up --build` builds the control-plane image AND the per-session sandbox
+# image (ironclaw-sandbox:latest, via the sandbox-image helper service below), so you no
+# longer need a separate `bash container/build.sh` first. If you skip --build on a clean
+# machine, compose still builds both images because neither tag exists locally yet.
 #
 # This is a STANDALONE compose file (run it with -f, NOT alongside docker-compose.yml).
 # It brings up a single control-plane wired for an offline chat: it seeds the `mock-agent`
@@ -29,6 +33,14 @@ services:
       dockerfile: container/controlplane.Dockerfile
     # First run builds the image (pass --build); later `up`s reuse it. The tag is
     # local-only, so compose builds it rather than pulling from a registry.
+    # Wait for the sandbox image to be built + tagged into the host daemon before
+    # starting, so the two-build requirement can't be half-satisfied: a launch would
+    # otherwise 404 ("No such image: ironclaw-sandbox:latest") and the chat would sit
+    # silent (IRO-335). service_completed_successfully = the build-only helper below
+    # ran and exited 0.
+    depends_on:
+      sandbox-image:
+        condition: service_completed_successfully
     # Run as root so the process can reach the bind-mounted Docker socket (root:docker).
     user: "0:0"
     environment:
@@ -76,3 +88,22 @@ services:
       retries: 5
       start_period: 10s
     stop_grace_period: 20s
+
+  # Build-only helper: compiles + tags the PER-SESSION sandbox image
+  # (ironclaw-sandbox:latest) into the SAME host Docker daemon the control-plane
+  # launches siblings through (they share /var/run/docker.sock). This makes the demo
+  # self-sufficient: `docker compose -f docker-compose.demo.yml up --build` now builds
+  # BOTH images, so a visitor no longer has to remember the separate
+  # `bash container/build.sh` step (the top drop-off in the try-it path, IRO-335).
+  #
+  # It is NOT a long-running service: compose builds the `image:` tag from `build:`,
+  # then this container overrides the entrypoint to a no-op that exits 0. The
+  # control-plane's depends_on ... service_completed_successfully gates on that exit.
+  # `restart: "no"` keeps it from re-running after it completes.
+  sandbox-image:
+    image: ironclaw-sandbox:latest
+    build:
+      context: .
+      dockerfile: container/Dockerfile
+    entrypoint: ["true"]
+    restart: "no"

--- a/internal/host/isolation/launch_error.go
+++ b/internal/host/isolation/launch_error.go
@@ -1,0 +1,30 @@
+package isolation
+
+import "strings"
+
+// IsImageMissing reports whether a launch error was caused by the sandbox
+// container image not being present. It is a best-effort string classifier over
+// the errors the concrete isolators return: the Docker Engine API answers a create
+// against an absent image with a 404 "No such image: <ref>", and the containerd/OCI
+// path surfaces "not found"/"manifest unknown" when the image was never pulled.
+//
+// The daemon uses it (via session.Config.OnLaunchError) to turn a launch failure
+// into a specific, actionable chat message ("build the sandbox image") rather than a
+// silent empty reply (IRO-335). A false result means "some other launch fault", for
+// which the caller shows a generic message.
+func IsImageMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "no such image"):
+		return true
+	case strings.Contains(msg, "manifest unknown"):
+		return true
+	case strings.Contains(msg, "image") && strings.Contains(msg, "not found"):
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/host/isolation/launch_error_test.go
+++ b/internal/host/isolation/launch_error_test.go
@@ -1,0 +1,32 @@
+package isolation
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsImageMissing(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"docker 404 no such image", errors.New(
+			"host/isolation: docker create ic-sbx-ses_1: docker api POST /containers/create?name=ic-sbx-ses_1: 404 Not Found: {\"message\":\"No such image: ironclaw-sandbox:latest\"}"), true},
+		{"wrapped no such image", fmt.Errorf("launch: %w", errors.New("No such image: foo")), true},
+		{"containerd manifest unknown", errors.New("failed to pull: manifest unknown"), true},
+		{"image not found", errors.New("image ironclaw-sandbox:latest not found in store"), true},
+		{"unrelated start failure", errors.New("host/isolation: docker start ic-sbx-ses_1: 500 Internal Server Error"), false},
+		{"rootfs error", errors.New("rootfs not provisioned"), false},
+		{"plain not found without image", errors.New("container not found"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsImageMissing(c.err); got != c.want {
+				t.Fatalf("IsImageMissing(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/host/session/manager.go
+++ b/internal/host/session/manager.go
@@ -123,6 +123,14 @@ type Config struct {
 	// counter, mirroring the SandboxKills increment on the kill path. Nil is a
 	// no-op. It must not block — it runs inline on the Wake path.
 	OnLaunch func()
+
+	// OnLaunchError is an optional hook fired when a sandbox launch fails and the
+	// session is left un-launched (the trigger message is already queued). The daemon
+	// wires it to surface a user-visible chat message ("the sandbox couldn't start")
+	// instead of leaving the visitor with a silent, empty reply forever (IRO-335).
+	// Nil is a no-op. It must not block — it runs inline on the Wake path, so the
+	// wiring does its own bounded, out-of-band delivery.
+	OnLaunchError func(id contract.SessionID, launchErr error)
 }
 
 // defaultEarlyExitGrace is the post-launch wait before probing for an early exit.
@@ -467,6 +475,11 @@ func (m *Manager) Wake(id contract.SessionID) error {
 		// Best-effort: the message is already queued. Log and leave the session
 		// un-launched so a later Wake retries once the environment can run it.
 		m.cfg.Logger.Printf("host/session: launch %s deferred: %v", id, err)
+		// Surface the failure to the user's chat (IRO-335) so a missing sandbox image
+		// or other launch fault is not an eternally silent empty reply. Best-effort.
+		if m.cfg.OnLaunchError != nil {
+			m.cfg.OnLaunchError(id, err)
+		}
 		return nil
 	}
 

--- a/internal/host/session/manager_test.go
+++ b/internal/host/session/manager_test.go
@@ -166,6 +166,60 @@ func TestManagerWakeBestEffortOnLaunchFailure(t *testing.T) {
 	}
 }
 
+// TestManagerWakeReportsLaunchError asserts a failed launch fires OnLaunchError with
+// the session id and the underlying error, so the daemon can surface a user-visible
+// chat message instead of a silent empty reply (IRO-335). The hook runs inline on the
+// Wake path, so it has fired by the time Wake returns.
+func TestManagerWakeReportsLaunchError(t *testing.T) {
+	iso := &fakeIsolator{failWith: errors.New(
+		"host/isolation: docker create ic-sbx-ses_noimg: docker api POST /containers/create: 404 Not Found: No such image: ironclaw-sandbox:latest")}
+	cust, err := keys.New([32]byte{})
+	if err != nil {
+		t.Fatalf("keys.New: %v", err)
+	}
+	var (
+		mu     sync.Mutex
+		called int
+		gotID  contract.SessionID
+		gotErr error
+	)
+	m, err := New(Config{
+		Factory:       queue.NewFactory(t.TempDir()),
+		Keys:          cust,
+		Isolator:      iso,
+		Registry:      registry.NewMemRegistry(),
+		KeyDir:        t.TempDir(),
+		WorkspaceRoot: t.TempDir(),
+		OnLaunchError: func(id contract.SessionID, e error) {
+			mu.Lock()
+			defer mu.Unlock()
+			called++
+			gotID = id
+			gotErr = e
+		},
+	})
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+
+	const id contract.SessionID = "ses_noimg"
+	if err := m.Wake(id); err != nil {
+		t.Fatalf("Wake should not propagate launch failure: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if called != 1 {
+		t.Fatalf("OnLaunchError called %d times, want 1", called)
+	}
+	if gotID != id {
+		t.Fatalf("OnLaunchError session id = %q, want %q", gotID, id)
+	}
+	if !isolation.IsImageMissing(gotErr) {
+		t.Fatalf("OnLaunchError err = %v, want classified image-missing", gotErr)
+	}
+}
+
 func TestManagerKillStopsAndUntracks(t *testing.T) {
 	iso := &fakeIsolator{}
 	m := newTestManager(t, iso)


### PR DESCRIPTION
## Problem (IRO-335, found in IRO-332 funnel audit)

A fresh visitor whose per-session sandbox launch fails — most commonly because `ironclaw-sandbox:latest` was never built (`bash container/build.sh` skipped or silently failed) — gets an empty `{"messages":[]}` reply **forever**. The only signal is buried in the control-plane log (`404 No such image`). Highest drop-off risk on the primary try-it path.

## Fix (both suggested remedies)

**1. Surface the failure to chat.** New `session.Config.OnLaunchError` fires when a launch is deferred; the daemon wires it to deliver a user-visible message through the **same channel adapter the normal reply path uses**, to the session's **own origin chat**:
- missing image -> actionable: `bash container/build.sh` + the compose one-liner
- any other fault -> generic "check the control-plane logs" (deliberately does NOT echo the raw host error, so no path leakage)

`isolation.IsImageMissing` classifies the launch error across the docker/OCI paths.

**2. Compose builds the sandbox image.** `docker-compose.demo.yml` gains a build-only `sandbox-image` helper that compiles + tags `ironclaw-sandbox:latest` into the **same host Docker daemon** the control-plane launches siblings through, then exits 0. The control-plane `depends_on` it with `service_completed_successfully`, so `up --build` now builds BOTH images in one command — the separate `build.sh` step is no longer required on the demo path.

## Security review

Touches host->channel emission but NOT the trust model:
- **Trust boundary**: message is host-synthesized (sandbox never ran); delivered only to the session's own origin messaging group — no destination escalation; sandbox capabilities unchanged.
- **Info leakage**: generic branch does not echo the raw error; image name is the configured non-secret sandbox tag.
- **Gateway / isolation / egress / encryption**: unchanged. `network=none` and per-session binds untouched; compose fix builds a local image, no new sandbox network path.

Requesting CEO review per the security bar (demo/release-relevant, host->user path).

## Verification
- `CGO_ENABLED=1 go build ./...` — OK
- `CGO_ENABLED=1 go test ./internal/host/session/ ./internal/host/isolation/` — 97 pass (new `TestManagerWakeReportsLaunchError`, `TestIsImageMissing`)
- `go vet` on changed packages — clean
- `docker compose -f docker-compose.demo.yml config` — valid (live `up` not run: no Docker daemon in this env)

Closes IRO-335.