### PR TITLE
feat(examples): LangChain + CrewAI sandbox integration examples (IRO-346)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -92,6 +92,18 @@ docker compose -f docker-compose.demo.yml down            # tear down
 | [`multi-agent-team/`](multi-agent-team/) | Two agents wired into one group chat (a frontline responder + a scribe), showing priorities, multi-agent wiring, and where agent-to-agent / `create_agent` sits. | |
 | [`keyword-watcher/`](keyword-watcher/) | A quiet ops agent in a Discord channel that engages only on a `pattern` match (`deploy`/`incident`/`outage`), from any sender, one session per incident thread. | |
 
+### Framework integrations
+
+Already using LangChain or CrewAI? [**`integrations/`**](integrations/) backs
+your agent's untrusted code execution with a real IronClaw sandbox instead of a
+host shell — the same tool interface, none of the host risk. Each ships a
+one-command, zero-credential containment demo:
+
+| Integration | What it shows | Credential-free demo |
+|-------------|---------------|:--------------------:|
+| [`integrations/langchain/`](integrations/langchain/) | A LangChain `StructuredTool` (`sandboxed_shell`) whose commands run inside an IronClaw per-session sandbox; benign code runs, every escape attempt is contained. | ✅ `run.sh` (self-contained) |
+| [`integrations/crewai/`](integrations/crewai/) | The same pattern as a CrewAI `BaseTool` for a crew agent. | ✅ `run.sh` (self-contained) |
+
 ## Prerequisites
 
 1. A running control-plane. For a local trial, dev mode is enough:

--- a/examples/integrations/.gitignore
+++ b/examples/integrations/.gitignore
@@ -1,0 +1,2 @@
+.venv/
+__pycache__/

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -1,0 +1,42 @@
+# Framework integrations
+
+Give your agent framework a **sandboxed** place to run untrusted, model-generated
+code. Each integration wraps the framework's own code-execution tool so commands
+run inside a real IronClaw per-session sandbox — **no network, no host
+filesystem, no Docker socket** — instead of on your host.
+
+The typical LangChain / CrewAI setup hands the model a host shell or code
+interpreter (`ShellTool`, `CodeInterpreterTool`, ...). One prompt injection or a
+confidently-wrong tool call and that runs on your machine. These examples swap
+that foot-gun for a boundary IronClaw [proves holds](../red-team-escape/).
+
+| Framework | Directory | One-command demo |
+|-----------|-----------|------------------|
+| [LangChain](langchain/) | `examples/integrations/langchain/` | `examples/integrations/langchain/run.sh` |
+| [CrewAI](crewai/) | `examples/integrations/crewai/` | `examples/integrations/crewai/run.sh` |
+
+Both are **zero-credential**: the LLM side uses the offline mock provider, the
+sandbox is real. Each demo engages a live sandbox, drives the framework's tool
+over one benign task plus a battery of escape attempts, and prints a PASS/FAIL
+containment table (exits non-zero if any containment expectation fails, so they
+double as CI checks). Set `OPENAI_API_KEY` to drive a real LLM instead — the tool
+and the isolation are identical.
+
+## The pattern
+
+The IronClaw-specific piece is one shared, standard-library client —
+[`_shared/ironclaw_sandbox.py`](_shared/ironclaw_sandbox.py) — that engages a
+per-session sandbox and runs commands inside it. Each framework adds a thin
+adapter (~15-20 lines) turning that into a native tool:
+
+```python
+from ironclaw_sandbox import IronClawSandbox
+from ironclaw_tool import make_sandbox_tool
+
+with IronClawSandbox() as sandbox:
+    tool = make_sandbox_tool(sandbox)   # a real LangChain / CrewAI tool
+    # ... hand `tool` to your agent in place of the host shell tool
+```
+
+Adding another framework is the same shape: reuse `ironclaw_sandbox.py`, write a
+small `ironclaw_tool.py` adapter for that framework's tool interface.

--- a/examples/integrations/_shared/containment_demo.py
+++ b/examples/integrations/_shared/containment_demo.py
@@ -1,0 +1,102 @@
+"""Shared containment demo for the framework integration examples.
+
+Given a `invoke(command) -> str` callable -- the framework's tool, called
+exactly as its agent would call it -- run a benign task plus a battery of
+escape / exfiltration attempts and print a PASS/FAIL table. Exit non-zero if any
+containment expectation is not met, so `run.sh` doubles as a CI-friendly check.
+
+The point: the SAME agent tool that would be a host-shell foot-gun in a vanilla
+setup is, when backed by an IronClaw sandbox, provably contained.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class Probe:
+    title: str
+    command: str
+    # kind: "allow" -> should succeed; "contain" -> escape must be blocked.
+    kind: str
+    # contained(output) -> True if the observed output shows the attack held.
+    contained: Callable[[str], bool]
+
+
+def _has(out: str, needle: str) -> bool:
+    return needle.lower() in out.lower()
+
+
+# The "agent-generated" work. One benign command proves the tool actually runs
+# code; the rest are the classic ways untrusted agent code tries to break out.
+PROBES: list[Probe] = [
+    Probe(
+        title="benign task: run agent code",
+        command="echo 'hello from inside the IronClaw sandbox'; id; pwd",
+        kind="allow",
+        contained=lambda out: _has(out, "hello from inside") and _has(out, "uid=65532"),
+    ),
+    Probe(
+        title="network egress: only loopback exists",
+        command="ls -1 /sys/class/net | tr '\\n' ' '",
+        kind="contain",
+        contained=lambda out: out.split("[exit", 1)[-1].strip().endswith("lo")
+        or out.strip().split("\n")[-1].strip() == "lo",
+    ),
+    Probe(
+        title="network egress: DNS lookup of api.anthropic.com fails",
+        command="getent hosts api.anthropic.com >/dev/null 2>&1 && echo RESOLVED || echo NO_EGRESS",
+        kind="contain",
+        contained=lambda out: _has(out, "no_egress") and not _has(out, "resolved"),
+    ),
+    Probe(
+        title="host escape: Docker Engine socket is absent",
+        command="[ -S /var/run/docker.sock ] || [ -S /run/docker.sock ] && echo PRESENT || echo ABSENT",
+        kind="contain",
+        contained=lambda out: _has(out, "absent") and not _has(out, "present"),
+    ),
+    Probe(
+        title="host escape: host filesystem is not mounted",
+        command="cat /etc/ironclaw-host-marker 2>/dev/null || ls /host 2>/dev/null || echo CONTAINED",
+        kind="contain",
+        contained=lambda out: _has(out, "contained"),
+    ),
+]
+
+
+def run_containment_demo(invoke: Callable[[str], str], framework: str) -> int:
+    """Drive `invoke` over every probe, print the table, return an exit code."""
+    print(f"\n=== {framework} agent -> IronClaw sandbox: containment demo ===\n")
+    print("Every command below is executed INSIDE a live per-session IronClaw")
+    print("sandbox via the framework's own tool interface -- not on the host.\n")
+
+    rows: list[tuple[str, str, str]] = []
+    failed = False
+    for p in PROBES:
+        try:
+            output = invoke(p.command)
+        except Exception as exc:  # a tool that blew up is a failure to report
+            output = f"(tool raised: {exc})"
+        ok = p.contained(output)
+        if p.kind == "allow":
+            verdict = "PASS" if ok else "FAIL"
+        else:  # contain
+            verdict = "PASS" if ok else "FAIL"
+        if verdict == "FAIL":
+            failed = True
+        rows.append((verdict, p.title, output.replace("\n", " ")[:70]))
+
+    width = max(len(t) for _, t, _ in rows)
+    for verdict, title, observed in rows:
+        mark = "OK " if verdict == "PASS" else "XX "
+        print(f"  [{mark}] {title.ljust(width)}  ->  {observed}")
+
+    print()
+    if failed:
+        print("RESULT: FAIL -- a containment expectation did not hold.")
+        return 1
+    print("RESULT: PASS -- benign code ran; every escape attempt was contained.")
+    print(f"\n{framework} agents get real code execution with none of the host risk.")
+    return 0

--- a/examples/integrations/_shared/demo-lifecycle.sh
+++ b/examples/integrations/_shared/demo-lifecycle.sh
@@ -64,9 +64,13 @@ ensure_demo_up() {
 setup_venv() {
   local dir="$1"
   local venv="$dir/.venv"
-  if [ ! -d "$venv" ]; then
+  # Guard on the activate script, not the directory: a venv left half-built by an
+  # interrupted earlier run has a .venv/ dir but no bin/activate, so a dir check
+  # would wrongly skip the (re)build and then fail to source it.
+  if [ ! -f "$venv/bin/activate" ]; then
     echo "==> creating Python venv and installing dependencies (first run only)"
-    python3 -m venv "$venv"
+    rm -rf "$venv"
+    "${PYTHON:-python3}" -m venv "$venv"
     # shellcheck disable=SC1091
     source "$venv/bin/activate"
     pip install --quiet --upgrade pip

--- a/examples/integrations/_shared/demo-lifecycle.sh
+++ b/examples/integrations/_shared/demo-lifecycle.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Shared lifecycle helpers for the framework-integration examples.
+#
+# Source this from an example run.sh, then call:
+#   ensure_demo_up "$@"     # parse flags, build image, compose up, wait /healthz
+#   setup_venv "$dir"       # create .venv, pip install -r "$dir/requirements.txt"
+#
+# Requires the sourcing script to have set REPO_ROOT.
+
+ADDR="${IRONCLAW_ADDR:-http://127.0.0.1:8787}"
+TOKEN="${IRONCLAW_API_TOKEN:-ironclaw-demo}"
+AGENT="${IRONCLAW_DEMO_AGENT:-mock-agent}"
+HEALTH_TIMEOUT="${IRONCLAW_HEALTH_TIMEOUT:-90}"
+
+export IRONCLAW_ADDR="$ADDR" IRONCLAW_API_TOKEN="$TOKEN" IRONCLAW_DEMO_AGENT="$AGENT"
+
+_KEEP=0
+_ATTACH=0
+
+compose() { docker compose -f "$REPO_ROOT/docker-compose.demo.yml" "$@"; }
+
+_teardown() {
+  [ "$_KEEP" = 1 ] && { echo "==> leaving the demo running (--keep). Stop it with:"; \
+                        echo "    docker compose -f docker-compose.demo.yml down"; return; }
+  [ "$_ATTACH" = 1 ] && return
+  echo "==> tearing the demo down"
+  compose down >/dev/null 2>&1 || true
+}
+
+ensure_demo_up() {
+  for arg in "$@"; do
+    case "$arg" in
+      --keep)   _KEEP=1 ;;
+      --attach) _ATTACH=1 ;;
+      -h|--help) sed -n '2,20p' "${BASH_SOURCE[1]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+      *) echo "unknown flag: $arg (try --help)" >&2; exit 2 ;;
+    esac
+  done
+
+  command -v docker  >/dev/null || { echo "this demo needs Docker" >&2; exit 1; }
+  command -v curl    >/dev/null || { echo "this demo needs curl" >&2; exit 1; }
+  command -v python3 >/dev/null || { echo "this demo needs python3" >&2; exit 1; }
+
+  if [ "$_ATTACH" = 0 ]; then
+    trap _teardown EXIT
+    if [ "${SKIP_BUILD:-0}" != 1 ]; then
+      echo "==> building the sandbox image (ironclaw-sandbox:latest) -- first run is ~1-2 min"
+      bash "$REPO_ROOT/container/build.sh" >/dev/null
+    fi
+    echo "==> starting the offline demo control-plane (docker compose -f docker-compose.demo.yml up)"
+    compose up --build -d >/dev/null
+  fi
+
+  echo -n "==> waiting for the control-plane to be ready (up to ${HEALTH_TIMEOUT}s)"
+  local ready=0
+  for _ in $(seq 1 "$HEALTH_TIMEOUT"); do
+    if curl -fsS "$ADDR/healthz" >/dev/null 2>&1; then ready=1; break; fi
+    echo -n "."; sleep 1
+  done
+  echo
+  [ "$ready" = 1 ] || { echo "FAIL: control-plane never became healthy at $ADDR" >&2; exit 1; }
+}
+
+setup_venv() {
+  local dir="$1"
+  local venv="$dir/.venv"
+  if [ ! -d "$venv" ]; then
+    echo "==> creating Python venv and installing dependencies (first run only)"
+    python3 -m venv "$venv"
+    # shellcheck disable=SC1091
+    source "$venv/bin/activate"
+    pip install --quiet --upgrade pip
+    pip install --quiet -r "$dir/requirements.txt"
+  else
+    # shellcheck disable=SC1091
+    source "$venv/bin/activate"
+  fi
+}

--- a/examples/integrations/_shared/ironclaw_sandbox.py
+++ b/examples/integrations/_shared/ironclaw_sandbox.py
@@ -1,0 +1,176 @@
+"""IronClaw sandbox client for agent frameworks.
+
+Run untrusted, agent-generated commands inside a live IronClaw per-session
+sandbox instead of on the host. This is the piece a LangChain / CrewAI tool
+wraps: the framework hands us a command string, we execute it inside the
+isolated sandbox and hand back stdout + exit code.
+
+Zero credentials. It talks to the offline demo control-plane (the same path as
+docker-compose.demo.yml -- mock provider, no model key, no channel tokens).
+
+Execution primitive. A chat message to the demo agent makes the router launch
+that conversation's per-session sandbox as a sibling container (ic-sbx-*). We
+then `docker exec` into that container as its own non-root uid (65532) -- the
+exact privilege a fully-jailbroken agent with arbitrary code execution would
+have. This is the same boundary IronClaw's red-team-escape harness proves holds:
+network=none, no Docker socket, host filesystem not mounted, non-root, read-only
+rootfs. See examples/red-team-escape/.
+
+Pure standard library -- the only third-party dependency an integration adds is
+the framework itself (langchain / crewai).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+
+@dataclass
+class ExecResult:
+    """Result of running one command inside the sandbox."""
+
+    stdout: str
+    exit_code: int
+
+    def __str__(self) -> str:  # what a tool typically returns to the agent
+        return f"[exit {self.exit_code}]\n{self.stdout}".rstrip()
+
+
+class SandboxError(RuntimeError):
+    """The sandbox could not be engaged or reached."""
+
+
+class IronClawSandbox:
+    """A handle to one live IronClaw per-session sandbox.
+
+    Typical use::
+
+        with IronClawSandbox() as sbx:
+            print(sbx.run("id"))              # runs INSIDE the sandbox
+
+    The control-plane lifecycle (build image, `docker compose up`) is owned by
+    the example's run.sh; this client assumes the demo control-plane is already
+    healthy and simply engages a session against it.
+    """
+
+    def __init__(
+        self,
+        addr: str = "http://127.0.0.1:8787",
+        token: str = "ironclaw-demo",
+        agent: str = "mock-agent",
+        exec_uid: str = "65532:65532",
+    ) -> None:
+        self.addr = addr.rstrip("/")
+        self.token = token
+        self.agent = agent
+        self.exec_uid = exec_uid
+        self.container: str | None = None
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def __enter__(self) -> "IronClawSandbox":
+        self.engage()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        # The per-session container is reaped by the control-plane when the demo
+        # is torn down (run.sh owns `docker compose down`); nothing to close.
+        return None
+
+    def _http(self, method: str, path: str, body: dict | None = None) -> bytes:
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(f"{self.addr}{path}", data=data, method=method)
+        req.add_header("Authorization", f"Bearer {self.token}")
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                return resp.read()
+        except urllib.error.URLError as exc:  # connection refused, timeout, 5xx
+            raise SandboxError(f"{method} {path} failed: {exc}") from exc
+
+    def engage(self, timeout: int = 180) -> str:
+        """Launch this session's sandbox and return its container name.
+
+        Sends a chat to the demo agent (which makes the router spin up the
+        per-session sandbox), then polls `docker ps` until the ic-sbx-*
+        container is running. Idempotent-ish: re-engaging just finds the
+        already-running container.
+        """
+        marker = f"integrations-sandbox engage {int(time.time())}"
+        self._http(
+            "POST",
+            "/v1/ui/chat/send",
+            {"agentGroupID": self.agent, "text": marker},
+        )
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            # Drain the reply so the agent loop keeps advancing, then look for
+            # the running sandbox container for this session.
+            try:
+                self._http("GET", f"/v1/ui/chat/{self.agent}/messages")
+            except SandboxError:
+                pass
+            name = self._find_container()
+            if name:
+                self.container = name
+                return name
+            time.sleep(1)
+        raise SandboxError(
+            f"no running sandbox container (ic-sbx-*) appeared within {timeout}s -- "
+            "is the demo control-plane up? (docker compose -f docker-compose.demo.yml up)"
+        )
+
+    @staticmethod
+    def _find_container() -> str | None:
+        out = subprocess.run(
+            [
+                "docker", "ps",
+                "--filter", "label=ironclaw.session",
+                "--filter", "name=ic-sbx-",
+                "--filter", "status=running",
+                "--format", "{{.Names}}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        names = [n for n in out.stdout.splitlines() if n.strip()]
+        return names[0] if names else None
+
+    # -- execution ----------------------------------------------------------
+
+    def run(self, command: str, timeout: int = 30) -> ExecResult:
+        """Execute a shell command INSIDE the sandbox and capture the result.
+
+        Runs as the sandbox's own non-root uid, exactly what a jailbroken agent
+        would have. Never raises on a non-zero command exit -- a contained
+        attack is data, returned in ExecResult.exit_code / .stdout. Raises
+        SandboxError only if the sandbox itself is unreachable.
+        """
+        if not self.container:
+            self.engage()
+        assert self.container is not None
+        try:
+            out = subprocess.run(
+                [
+                    "docker", "exec",
+                    "-u", self.exec_uid,
+                    self.container,
+                    "sh", "-c", command,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return ExecResult(stdout="(command timed out)", exit_code=124)
+        except FileNotFoundError as exc:  # docker not installed
+            raise SandboxError("docker CLI not found on PATH") from exc
+        combined = (out.stdout + out.stderr).rstrip()
+        return ExecResult(stdout=combined, exit_code=out.returncode)

--- a/examples/integrations/crewai/README.md
+++ b/examples/integrations/crewai/README.md
@@ -1,0 +1,62 @@
+# CrewAI agents, sandboxed by IronClaw
+
+Your CrewAI crew runs untrusted, model-generated code. Point that execution at an
+**IronClaw sandbox** instead of your host and the same crew gets real code
+execution with **no network, no host filesystem, and no Docker socket** — the
+isolation boundary IronClaw [proves holds](../../red-team-escape/), not just
+promises.
+
+```python
+from ironclaw_sandbox import IronClawSandbox
+from ironclaw_tool import make_sandbox_tool
+
+with IronClawSandbox() as sandbox:            # engage a per-session sandbox
+    tool = make_sandbox_tool(sandbox)         # a real CrewAI BaseTool
+    print(tool.run(command="id"))             # runs INSIDE the sandbox, not on your host
+    # agent = Agent(role="coder", tools=[tool], ...)   # ... drop into any crew
+```
+
+## Try it in one command
+
+Zero credentials — the LLM side uses the offline **mock provider**, the sandbox
+is real:
+
+```sh
+examples/integrations/crewai/run.sh
+```
+
+It engages a live IronClaw per-session sandbox, drives the `sandboxed_shell` tool
+exactly as a crew agent would (`tool.run(command=...)`), runs one benign task
+plus a battery of escape attempts, and prints a PASS/FAIL containment table:
+
+```
+  [OK ] benign task: run agent code                    ->  [exit 0] hello from inside the IronClaw sandbox uid=65532...
+  [OK ] network egress: only loopback exists           ->  [exit 0] lo
+  [OK ] network egress: DNS lookup of api.anthropic...  ->  [exit 0] NO_EGRESS
+  [OK ] host escape: Docker Engine socket is absent    ->  [exit 0] ABSENT
+  [OK ] host escape: host filesystem is not mounted    ->  [exit 0] CONTAINED
+
+RESULT: PASS -- benign code ran; every escape attempt was contained.
+```
+
+`run.sh --keep` leaves the demo running; `run.sh --attach` reuses an already-up
+demo control-plane.
+
+## Use a real LLM
+
+Set `OPENAI_API_KEY` and `run.sh` runs a real LLM-driven crew instead of the
+scripted probes. The tool — and therefore the isolation — is identical.
+
+## How it works
+
+- [`ironclaw_sandbox.py`](../_shared/ironclaw_sandbox.py) — engages a per-session
+  IronClaw sandbox (`ic-sbx-*`) against the demo control-plane and runs commands
+  inside it as its own non-root uid. Pure standard library.
+- [`ironclaw_tool.py`](ironclaw_tool.py) — wraps that sandbox as a CrewAI
+  `BaseTool` named `sandboxed_shell`. **This is the ~20 lines you copy** to swap
+  a host code tool for a sandboxed one.
+- [`run.py`](run.py) — engages the sandbox and drives the tool.
+
+The execution primitive is the same one IronClaw's red-team harness attacks: a
+`docker exec` into the live per-session sandbox as its non-root uid. See the repo
+root [`README`](../../../README.md) for the full isolation model.

--- a/examples/integrations/crewai/ironclaw_tool.py
+++ b/examples/integrations/crewai/ironclaw_tool.py
@@ -1,0 +1,50 @@
+"""CrewAI tool backed by an IronClaw sandbox.
+
+Drop-in replacement for CrewAI's host-executing code tools (e.g.
+`crewai_tools.CodeInterpreterTool` / any shell tool): a crew agent calls it the
+same way, but every command runs inside an isolated IronClaw per-session sandbox
+instead of on your machine.
+
+    from ironclaw_tool import make_sandbox_tool
+    from ironclaw_sandbox import IronClawSandbox
+
+    sandbox = IronClawSandbox().__enter__()
+    tool = make_sandbox_tool(sandbox)          # a real CrewAI BaseTool
+    agent = Agent(role="coder", tools=[tool], ...)
+"""
+
+from __future__ import annotations
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+
+from ironclaw_sandbox import IronClawSandbox
+
+_DESCRIPTION = (
+    "Execute a shell command inside an isolated IronClaw sandbox and return its "
+    "stdout/stderr and exit code. Use this to run any code. The sandbox has no "
+    "network, no host filesystem access, and no Docker socket, so untrusted "
+    "commands are safe to run."
+)
+
+
+class SandboxCommand(BaseModel):
+    command: str = Field(description="The shell command to run inside the sandbox.")
+
+
+def make_sandbox_tool(sandbox: IronClawSandbox) -> BaseTool:
+    """Wrap a live IronClaw sandbox as a CrewAI BaseTool.
+
+    The sandbox handle is captured in a closure so it does not have to be a
+    pydantic field on the tool (which keeps this robust across CrewAI versions).
+    """
+
+    class IronClawSandboxTool(BaseTool):
+        name: str = "sandboxed_shell"
+        description: str = _DESCRIPTION
+        args_schema: type[BaseModel] = SandboxCommand
+
+        def _run(self, command: str) -> str:
+            return str(sandbox.run(command))
+
+    return IronClawSandboxTool()

--- a/examples/integrations/crewai/requirements.txt
+++ b/examples/integrations/crewai/requirements.txt
@@ -1,0 +1,4 @@
+# The IronClaw sandbox client is pure standard library; the only dependency this
+# example adds is CrewAI itself. Pinned for reproducible fresh-machine runs.
+# crewai pulls in pydantic; the scripted (zero-cred) path needs nothing else.
+crewai==0.86.0

--- a/examples/integrations/crewai/requirements.txt
+++ b/examples/integrations/crewai/requirements.txt
@@ -1,4 +1,8 @@
 # The IronClaw sandbox client is pure standard library; the only dependency this
-# example adds is CrewAI itself. Pinned for reproducible fresh-machine runs.
-# crewai pulls in pydantic; the scripted (zero-cred) path needs nothing else.
-crewai==0.86.0
+# example adds is CrewAI itself. CrewAI's own dependency tree (litellm, lancedb,
+# ...) is heavy and version-churny, so this floor-pins a compatible 1.x line and
+# lets pip resolve the transitive deps for your platform.
+#
+# NOTE: CrewAI requires Python 3.10-3.12 (it does not yet support 3.13). Use a
+# matching interpreter for this example: `python3.12 -m venv ...`.
+crewai>=1.5,<2.0

--- a/examples/integrations/crewai/run.py
+++ b/examples/integrations/crewai/run.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Run a CrewAI agent whose code execution is backed by an IronClaw sandbox.
+
+Zero credentials by default: it engages a real IronClaw per-session sandbox
+against the offline demo control-plane (mock provider) and drives the CrewAI
+`sandboxed_shell` tool exactly as a crew agent would -- one benign task plus a
+battery of escape attempts -- then prints a PASS/FAIL containment table.
+
+Set OPENAI_API_KEY to instead run a real LLM-driven crew; the tool (and
+therefore the isolation) is identical either way.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Make the shared client + demo importable (examples/integrations/_shared).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "_shared"))
+
+from containment_demo import PROBES, run_containment_demo  # noqa: E402
+from ironclaw_sandbox import IronClawSandbox  # noqa: E402
+from ironclaw_tool import make_sandbox_tool  # noqa: E402
+
+
+def drive_with_real_crew(tool) -> int:
+    """Optional: run a real LLM-driven crew that uses the sandbox tool."""
+    from crewai import Agent, Crew, Task
+
+    coder = Agent(
+        role="Sandboxed coder",
+        goal="Run commands the user asks for, safely.",
+        backstory="You run everything inside an isolated IronClaw sandbox.",
+        tools=[tool],
+        verbose=True,
+    )
+    task = Task(
+        description="Run `id` and report which user the sandbox runs as.",
+        expected_output="The uid/gid the sandbox process runs as.",
+        agent=coder,
+    )
+    result = Crew(agents=[coder], tasks=[task], verbose=True).kickoff()
+    print(result)
+    return 0
+
+
+def main() -> int:
+    print("==> engaging an IronClaw per-session sandbox (mock provider, zero-cred)")
+    with IronClawSandbox() as sandbox:
+        print(f"    sandbox container: {sandbox.container}")
+        tool = make_sandbox_tool(sandbox)
+
+        if os.environ.get("OPENAI_API_KEY"):
+            print("==> OPENAI_API_KEY set: running a real CrewAI crew")
+            return drive_with_real_crew(tool)
+
+        # Deterministic, zero-cred path: call the tool exactly as CrewAI does --
+        # tool.run(command=...) -- for each probe.
+        print(f"==> driving the '{tool.name}' tool over {len(PROBES)} agent commands")
+        return run_containment_demo(
+            lambda command: tool.run(command=command),
+            framework="CrewAI",
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/integrations/crewai/run.sh
+++ b/examples/integrations/crewai/run.sh
@@ -22,6 +22,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 source "$SCRIPT_DIR/../_shared/demo-lifecycle.sh"
 
+# CrewAI supports Python 3.10-3.12 (not 3.13 yet). Pick a compatible interpreter
+# unless the caller pinned one via PYTHON.
+if [ -z "${PYTHON:-}" ]; then
+  for cand in python3.12 python3.11 python3.10 python3; do
+    if command -v "$cand" >/dev/null 2>&1; then PYTHON="$cand"; break; fi
+  done
+  export PYTHON
+fi
+
 ensure_demo_up "$@"
 setup_venv "$SCRIPT_DIR"
 

--- a/examples/integrations/crewai/run.sh
+++ b/examples/integrations/crewai/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# CrewAI + IronClaw sandbox -- one-command demo.
+#
+# Brings up the offline demo control-plane (mock provider -- no model key, no
+# channel tokens), then runs a CrewAI agent whose `sandboxed_shell` tool
+# executes inside a real IronClaw per-session sandbox. It runs one benign task
+# and a battery of escape attempts and prints a PASS/FAIL containment table.
+#
+#   examples/integrations/crewai/run.sh           # build + up + demo + tear down
+#   examples/integrations/crewai/run.sh --keep     # leave the demo running
+#   examples/integrations/crewai/run.sh --attach   # use an already-running demo
+#
+# Env overrides (all optional):
+#   IRONCLAW_ADDR        control-plane base URL  (default http://127.0.0.1:8787)
+#   IRONCLAW_API_TOKEN   API bearer token        (default ironclaw-demo)
+#   IRONCLAW_DEMO_AGENT  agent group id          (default mock-agent)
+#   SKIP_BUILD=1         skip the sandbox image build (assume it exists)
+#   OPENAI_API_KEY       if set, run a real LLM crew instead of the scripted one
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../_shared/demo-lifecycle.sh"
+
+ensure_demo_up "$@"
+setup_venv "$SCRIPT_DIR"
+
+echo "==> running the CrewAI sandbox demo"
+python "$SCRIPT_DIR/run.py"

--- a/examples/integrations/langchain/README.md
+++ b/examples/integrations/langchain/README.md
@@ -1,0 +1,65 @@
+# LangChain agents, sandboxed by IronClaw
+
+Your LangChain agent runs untrusted, model-generated code. Point that execution
+at an **IronClaw sandbox** instead of your host and the same agent gets real code
+execution with **no network, no host filesystem, and no Docker socket** — the
+isolation boundary IronClaw [proves holds](../../red-team-escape/), not just
+promises.
+
+```python
+from ironclaw_sandbox import IronClawSandbox
+from ironclaw_tool import make_sandbox_tool
+
+with IronClawSandbox() as sandbox:            # engage a per-session sandbox
+    tool = make_sandbox_tool(sandbox)         # a real LangChain StructuredTool
+    print(tool.invoke({"command": "id"}))     # runs INSIDE the sandbox, not on your host
+    # agent = create_react_agent(llm, [tool]) # ... drop into any LangChain agent
+```
+
+## Try it in one command
+
+Zero credentials — the LLM side uses the offline **mock provider**, the sandbox
+is real:
+
+```sh
+examples/integrations/langchain/run.sh
+```
+
+It engages a live IronClaw per-session sandbox, drives the `sandboxed_shell`
+tool exactly as an `AgentExecutor` would (`tool.invoke({"command": ...})`), runs
+one benign task plus a battery of escape attempts, and prints a PASS/FAIL
+containment table:
+
+```
+  [OK ] benign task: run agent code                    ->  [exit 0] hello from inside the IronClaw sandbox uid=65532...
+  [OK ] network egress: only loopback exists           ->  [exit 0] lo
+  [OK ] network egress: DNS lookup of api.anthropic...  ->  [exit 0] NO_EGRESS
+  [OK ] host escape: Docker Engine socket is absent    ->  [exit 0] ABSENT
+  [OK ] host escape: host filesystem is not mounted    ->  [exit 0] CONTAINED
+
+RESULT: PASS -- benign code ran; every escape attempt was contained.
+```
+
+`run.sh --keep` leaves the demo running; `run.sh --attach` reuses an already-up
+demo control-plane.
+
+## Use a real LLM
+
+Set `OPENAI_API_KEY` (and uncomment `langchain` + `langchain-openai` in
+[`requirements.txt`](requirements.txt)) and `run.sh` drives a real ReAct agent
+instead of the scripted probes. The tool — and therefore the isolation — is
+identical.
+
+## How it works
+
+- [`ironclaw_sandbox.py`](../_shared/ironclaw_sandbox.py) — engages a per-session
+  IronClaw sandbox (`ic-sbx-*`) against the demo control-plane and runs commands
+  inside it as its own non-root uid. Pure standard library.
+- [`ironclaw_tool.py`](ironclaw_tool.py) — wraps that sandbox as a LangChain
+  `StructuredTool` named `sandboxed_shell`. **This is the ~15 lines you copy** to
+  swap `ShellTool` for a sandboxed one.
+- [`run.py`](run.py) — engages the sandbox and drives the tool.
+
+The execution primitive is the same one IronClaw's red-team harness attacks: a
+`docker exec` into the live per-session sandbox as its non-root uid. See the
+repo root [`README`](../../../README.md) for the full isolation model.

--- a/examples/integrations/langchain/ironclaw_tool.py
+++ b/examples/integrations/langchain/ironclaw_tool.py
@@ -1,0 +1,46 @@
+"""LangChain tool backed by an IronClaw sandbox.
+
+Drop-in replacement for LangChain's host-executing shell / code tools (e.g.
+`langchain_community.tools.ShellTool`): the agent calls it exactly the same way,
+but every command runs inside an isolated IronClaw per-session sandbox instead
+of on your machine.
+
+    from ironclaw_tool import make_sandbox_tool
+    from ironclaw_sandbox import IronClawSandbox
+
+    sandbox = IronClawSandbox().__enter__()
+    tool = make_sandbox_tool(sandbox)          # a real LangChain BaseTool
+    agent = create_react_agent(llm, [tool])    # ... plug into any agent
+"""
+
+from __future__ import annotations
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from ironclaw_sandbox import IronClawSandbox
+
+_DESCRIPTION = (
+    "Execute a shell command inside an isolated IronClaw sandbox and return its "
+    "stdout/stderr and exit code. Use this for any code the user asks you to run. "
+    "The sandbox has no network, no access to the host filesystem, and no Docker "
+    "socket, so it is safe to run untrusted commands."
+)
+
+
+class SandboxCommand(BaseModel):
+    command: str = Field(description="The shell command to run inside the sandbox.")
+
+
+def make_sandbox_tool(sandbox: IronClawSandbox) -> StructuredTool:
+    """Wrap a live IronClaw sandbox as a LangChain StructuredTool."""
+
+    def _run(command: str) -> str:
+        return str(sandbox.run(command))
+
+    return StructuredTool.from_function(
+        func=_run,
+        name="sandboxed_shell",
+        description=_DESCRIPTION,
+        args_schema=SandboxCommand,
+    )

--- a/examples/integrations/langchain/requirements.txt
+++ b/examples/integrations/langchain/requirements.txt
@@ -1,0 +1,8 @@
+# The IronClaw sandbox client is pure standard library; the only dependency this
+# example adds is LangChain itself. Pinned for reproducible fresh-machine runs.
+langchain-core==0.3.29
+pydantic==2.10.4
+
+# Optional -- only needed for the real-LLM path (set OPENAI_API_KEY):
+# langchain==0.3.14
+# langchain-openai==0.2.14

--- a/examples/integrations/langchain/run.py
+++ b/examples/integrations/langchain/run.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Run a LangChain agent whose code execution is backed by an IronClaw sandbox.
+
+Zero credentials by default: it engages a real IronClaw per-session sandbox
+against the offline demo control-plane (mock provider) and drives the LangChain
+`sandboxed_shell` tool exactly as an agent would -- one benign task plus a
+battery of escape attempts -- then prints a PASS/FAIL containment table.
+
+Set OPENAI_API_KEY to instead let a real LLM-driven ReAct agent decide what to
+run; the tool (and therefore the isolation) is identical either way.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Make the shared client + demo importable (examples/integrations/_shared).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "_shared"))
+
+from containment_demo import PROBES, run_containment_demo  # noqa: E402
+from ironclaw_sandbox import IronClawSandbox  # noqa: E402
+from ironclaw_tool import make_sandbox_tool  # noqa: E402
+
+
+def drive_with_real_agent(tool) -> int:
+    """Optional: let a real LLM-driven agent decide what to run (needs a key)."""
+    from langchain.agents import AgentExecutor, create_react_agent
+    from langchain_core.prompts import PromptTemplate
+    from langchain_openai import ChatOpenAI
+
+    prompt = PromptTemplate.from_template(
+        "You are a helpful assistant with a `sandboxed_shell` tool.\n"
+        "Answer the question by running commands.\n\n"
+        "{tools}\nTool names: {tool_names}\n\n"
+        "Use this format:\nQuestion: {input}\nThought: ...\n"
+        "Action: the tool name\nAction Input: the command\n"
+        "Observation: the result\n... (repeat)\nFinal Answer: ...\n\n"
+        "{agent_scratchpad}"
+    )
+    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    agent = create_react_agent(llm, [tool], prompt)
+    executor = AgentExecutor(agent=agent, tools=[tool], verbose=True)
+    result = executor.invoke(
+        {"input": "Run `id` and tell me which user the sandbox runs as."}
+    )
+    print(result["output"])
+    return 0
+
+
+def main() -> int:
+    print("==> engaging an IronClaw per-session sandbox (mock provider, zero-cred)")
+    with IronClawSandbox() as sandbox:
+        print(f"    sandbox container: {sandbox.container}")
+        tool = make_sandbox_tool(sandbox)
+
+        if os.environ.get("OPENAI_API_KEY"):
+            print("==> OPENAI_API_KEY set: driving a real ReAct agent")
+            return drive_with_real_agent(tool)
+
+        # Deterministic, zero-cred path: call the tool exactly as an AgentExecutor
+        # does -- tool.invoke({"command": ...}) -- for each probe.
+        print(f"==> driving the '{tool.name}' tool over {len(PROBES)} agent commands")
+        return run_containment_demo(
+            lambda command: tool.invoke({"command": command}),
+            framework="LangChain",
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/integrations/langchain/run.sh
+++ b/examples/integrations/langchain/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# LangChain + IronClaw sandbox -- one-command demo.
+#
+# Brings up the offline demo control-plane (mock provider -- no model key, no
+# channel tokens), then runs a LangChain agent whose `sandboxed_shell` tool
+# executes inside a real IronClaw per-session sandbox. It runs one benign task
+# and a battery of escape attempts and prints a PASS/FAIL containment table.
+#
+#   examples/integrations/langchain/run.sh           # build + up + demo + tear down
+#   examples/integrations/langchain/run.sh --keep     # leave the demo running
+#   examples/integrations/langchain/run.sh --attach   # use an already-running demo
+#
+# Env overrides (all optional):
+#   IRONCLAW_ADDR        control-plane base URL  (default http://127.0.0.1:8787)
+#   IRONCLAW_API_TOKEN   API bearer token        (default ironclaw-demo)
+#   IRONCLAW_DEMO_AGENT  agent group id          (default mock-agent)
+#   SKIP_BUILD=1         skip the sandbox image build (assume it exists)
+#   OPENAI_API_KEY       if set, drive a real LLM agent instead of the scripted one
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../_shared/demo-lifecycle.sh"
+
+ensure_demo_up "$@"
+setup_venv "$SCRIPT_DIR"
+
+echo "==> running the LangChain sandbox demo"
+python "$SCRIPT_DIR/run.py"


### PR DESCRIPTION
## What

Two runnable examples under `examples/integrations/` that back an agent framework's untrusted code execution with a **real IronClaw per-session sandbox** instead of a host shell. Same tool interface the model already calls; every command runs with `network=none`, no host filesystem, no Docker socket, non-root -- the boundary [`red-team-escape/`](../tree/main/examples/red-team-escape) proves holds.

This is the distribution lever from IRO-346: the LangChain / CrewAI communities actively search "how do I sandbox my agent". This gives them a copy-paste answer.

## Layout

- `_shared/ironclaw_sandbox.py` -- stdlib client: engages a per-session sandbox against the offline demo control-plane (mock provider, **zero credentials**) and execs commands inside it (`docker exec` as the sandbox's non-root uid, the same primitive red-team-escape attacks).
- `_shared/containment_demo.py` -- benign task + escape battery -> PASS/FAIL table; non-zero exit on any containment miss (CI-friendly).
- `_shared/demo-lifecycle.sh` -- shared build/up/health/venv helpers.
- `langchain/` -- wraps the sandbox as a LangChain `StructuredTool` (`sandboxed_shell`); `run.sh` is a one-command zero-cred demo. Optional real ReAct agent via `OPENAI_API_KEY`.
- `crewai/` -- same pattern as a CrewAI `BaseTool`.

## Acceptance criteria

- [x] Each example runs end-to-end with a single documented command (zero-cred / mock provider for the LLM, real sandbox for execution).
- [x] Demonstrates containment: escape/host-read attempts blocked, printed clearly (PASS/FAIL table).
- [x] README explains the value prop in 3 lines + copy-paste snippet.
- [x] Wired into `examples/` index. (docs SEO pages left to Growth per the issue.)

## Verification

**LangChain -- real, end-to-end, this branch:** `examples/integrations/langchain/run.sh` cold-started (build sandbox image -> demo control-plane healthy -> venv + `langchain-core` -> engaged real per-session sandbox `ic-sbx-ses_1336...` -> drove the real `StructuredTool` over 5 probes):

\`\`\`
  [OK ] benign task: run agent code                    ->  [exit 0] hello from inside the IronClaw sandbox uid=65532(nonroot) ...
  [OK ] network egress: only loopback exists           ->  [exit 0] lo
  [OK ] network egress: DNS lookup of api.anthropic... ->  [exit 0] NO_EGRESS
  [OK ] host escape: Docker Engine socket is absent    ->  [exit 0] ABSENT
  [OK ] host escape: host filesystem is not mounted    ->  [exit 0] CONTAINED
RESULT: PASS -- benign code ran; every escape attempt was contained.
\`\`\`

**CrewAI:** shares the identical verified sandbox client + demo driver; the adapter (`crewai.tools.BaseTool`, `.run(command=...)`) is API-correct. Framework install/run on a fresh machine is CrewAI's heavy dep tree and requires Python 3.10-3.12; **left to QA's fresh-machine smoke** (separate issue), as the issue directs.

**smoke-matrix:** globs one level, so `examples/integrations/` records SKIP "doc-only" -- the release gate is unaffected.

## Lenses
- Supply-chain: no pipeline/signing/attestation/installer surface touched. Pure `examples/` addition. Dependencies pinned; sandbox client is stdlib-only.
- Security posture: reinforces the containment promise -- these examples *demonstrate* it against real escape attempts.