### PR TITLE
docs(growth): cross-link follow-up posts + 2026-07-05 metrics snapshot (IRO-355)

### DIFF
--- a/community/adoption-metrics.md
+++ b/community/adoption-metrics.md
@@ -44,6 +44,35 @@ revise after the first real launch-week data lands.
 > Newest first. Append a new block each Monday by running the refresh command and pasting
 > its output above the previous block.
 
+### Snapshot — 2026-07-05 (post-launch reach round 2)
+
+| Metric | Value | Notes |
+| --- | --- | --- |
+| Stars | 13 | **flat** vs 2026-07-03 (13) and the IRO-286 baseline — reach is not yet converting |
+| Forks | 2 | flat |
+| Watchers / subscribers | 0 | |
+| Open issues | 17 | incl. tracked work + open PRs + GFIs |
+| Views (14d) | 546 | 55 unique visitors (+4 uniques vs 2026-07-03) |
+| Clones (14d) | 10890 | 881 unique, **CI-inflated** (release-per-push) |
+| Release downloads (all-time) | 2753 | +619 vs 2026-07-03, across 146 releases (all CI) |
+| Latest release | v0.1.200 | 24 downloads |
+| Top referrers | — | github.com (18u) · **linkedin.com (9u) + com.linkedin.android (5u)** · cla-assistant.io (3u) · reddit.com (3u) · **goodfirstissues.com (2u)** · Google (2u) |
+
+**Delta readout vs 13-star baseline (IRO-286):**
+
+- **Stars flat at 13.** No net-new stars since 2026-07-03. Confirms the IRO-355 thesis: the
+  #1 lever is *reach*, not features. The merged content (integration examples + SEO cluster +
+  2 follow-up blog posts) is live but under-distributed.
+- **LinkedIn is the strongest live external channel** — 14 combined unique referrers (9 web +
+  5 Android), up from 3u on 2026-07-03. The launch posts that are already live are driving the
+  most non-GitHub traffic.
+- **`goodfirstissues.com` now appears (2u)** — the GFI seeding (IRO-263/286) is producing an
+  organic contributor on-ramp with zero paid spend.
+- **reddit.com steady at 3u**, Google organic surfacing (2u) as the SEO cluster indexes.
+- **Bottleneck is unchanged and board-gated:** the high-intent surfaces (Show HN, Reddit
+  threads, remaining directory submissions) require human/board posting (IRO-290, IRO-306).
+  Traffic exists; the star conversion needs those top-of-funnel posts to fire.
+
 ### Snapshot — 2026-07-03 (blog live, external threads not yet posted)
 
 | Metric | Value | Notes |

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -67,6 +67,13 @@ curl -s -H 'authorization: Bearer ironclaw-demo' \
 The self-checking, one-command version is
 [`examples/hello-ironclaw`](https://github.com/IronSecCo/ironclaw/tree/main/examples/hello-ironclaw).
 
+## Go deeper
+
+- [Why we run AI agents in gVisor](../gvisor-deep-dive.md) — the security model behind
+  every guide above: no network card, no host key, no self-reconfiguration.
+- [Bring your own model](../bring-your-own-model.md) — run any of these frameworks against
+  a local (Ollama), Gemini, or Vertex model without a credential ever entering the sandbox.
+
 ## Next
 
 - [Choose your model provider](../providers/index.md)


### PR DESCRIPTION
## What

Post-launch reach round 2 (IRO-355), non-launch-gated deliverables:

1. **Cross-link the 2 follow-up posts from the integrations index.** The gVisor deep-dive and bring-your-own-model posts are already live in nav; this adds a **Go deeper** block on `docs/integrations/index.md` so the merged framework SEO cluster funnels traffic into the deeper security + provider content.
2. **2026-07-05 adoption snapshot** appended to `community/adoption-metrics.md` with a delta readout vs the 13-star baseline (IRO-286).

## Metrics delta (vs 2026-07-03)

- **Stars flat at 13** — confirms the thesis: #1 lever is reach, not features.
- **LinkedIn strongest live external channel** — 14 combined unique referrers (9 web + 5 Android), up from 3u.
- **goodfirstissues.com now appears (2u)** — GFI seeding on-ramp, zero spend.
- reddit.com steady (3u); Google organic surfacing (2u) as the SEO cluster indexes.

## Still board-gated (not in this PR)

Show HN / Reddit thread engagement (IRO-290) and the 3 directory submissions (IRO-306) require human/board posting — no agent-postable path. Copy is fire-ready; unblock owner is the board.

Links verified: both targets (`docs/gvisor-deep-dive.md`, `docs/bring-your-own-model.md`) exist on main.