### PR TITLE
fix(examples): run integration demo compose from repo root (IRO-361)

### DIFF
--- a/examples/integrations/_shared/demo-lifecycle.sh
+++ b/examples/integrations/_shared/demo-lifecycle.sh
@@ -17,7 +17,13 @@ export IRONCLAW_ADDR="$ADDR" IRONCLAW_API_TOKEN="$TOKEN" IRONCLAW_DEMO_AGENT="$A
 _KEEP=0
 _ATTACH=0
 
-compose() { docker compose -f "$REPO_ROOT/docker-compose.demo.yml" "$@"; }
+# Run compose from the repo root so ${PWD} inside docker-compose.demo.yml (the
+# state bind, IRONCLAW_DOCKER_BINDS) resolves to the repo root regardless of the
+# caller's cwd. Compose resolves ${PWD} from the invocation cwd, not the -f
+# directory, so `bash /abs/path/run.sh` from a stranger's cwd would otherwise
+# hand sandboxes a nonexistent state path and every session would exit 1
+# ("read session key ...: is a directory"). See IRO-361.
+compose() { ( cd "$REPO_ROOT" && docker compose -f docker-compose.demo.yml "$@" ); }
 
 _teardown() {
   [ "$_KEEP" = 1 ] && { echo "==> leaving the demo running (--keep). Stop it with:"; \


### PR DESCRIPTION
## Problem (IRO-361)

Running any integration example `run.sh` from a cwd other than the repo root made every sandbox exit 1 with a cryptic `read session key ".../session.key": is a directory`, which printed as an all-`FAIL` containment table and read as a containment breach.

**Root cause:** `_shared/demo-lifecycle.sh` invoked compose with an absolute `-f` path, but `docker-compose.demo.yml` interpolates `${PWD}` for the state bind (`IRONCLAW_DOCKER_BINDS`). Compose resolves `${PWD}` from the invocation cwd, not the `-f` directory, so a stranger's cwd leaked into the sandbox state-bind path, pointing at a nonexistent dir.

## Fix

One line: wrap the `compose()` helper in a subshell that `cd`s to `$REPO_ROOT` before running compose with a relative `-f`, so `${PWD}` always resolves to the repo root. Fixes all 4 integration examples (they share this helper).

## Verification

`docker compose config` from a non-repo cwd (`/tmp/stranger-cwd`):

| | `IRONCLAW_DOCKER_BINDS` source |
|---|---|
| before | `/tmp/stranger-cwd/.ironclaw-demo-state` (wrong, nonexistent) |
| after | `$REPO_ROOT/.ironclaw-demo-state` (correct) |

## Security lens

No trust-boundary change. Makes the host-side demo state-bind path deterministic (repo-root anchored) instead of cwd-dependent. Isolation / gateway / encryption / egress untouched.