### PR TITLE
feat(mcp): ship IronClaw as an MCP server via `ironctl mcp serve` (sandbox_exec) (IRO-366)

### DIFF
--- a/cmd/ironctl/main.go
+++ b/cmd/ironctl/main.go
@@ -576,6 +576,7 @@ func printReference(w io.Writer) {
   ironctl [--addr URL] [--token T] skill add <name>@<version> --group <id> [--by <user>]
   ironctl [--addr URL] [--token T] skill list
   ironctl [--addr URL] [--token T] skill remove <name>[@<version>]
+  ironctl mcp serve [--http :ADDR] [--image IMG] [--docker BIN] [--timeout SECONDS]
   ironctl [--addr URL] [--token T] mcp list
   ironctl [--addr URL] [--token T] mcp add <name> (--command C [--arg A]... | --url U) [--image I] [--env K=V]... [--header K=V]...
   ironctl [--addr URL] [--token T] mcp probe <name>

--- a/cmd/ironctl/mcp.go
+++ b/cmd/ironctl/mcp.go
@@ -16,9 +16,13 @@ import (
 // is a thin client — the daemon (with --mcp-catalog set) owns the broker + verifier.
 func cmdMCP(addr string, args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("expected: mcp <list|add|remove|probe|grant>")
+		return fmt.Errorf("expected: mcp <serve|list|add|remove|probe|grant>")
 	}
 	switch args[0] {
+	case "serve":
+		// serve runs IronClaw ITSELF as an MCP server (sandbox_exec tool); it is
+		// standalone (no control-plane API), so it ignores addr.
+		return cmdMCPServe(args[1:])
 	case "list", "ls":
 		return cmdMCPList(addr)
 	case "add", "put":
@@ -30,7 +34,7 @@ func cmdMCP(addr string, args []string) error {
 	case "grant":
 		return cmdMCPGrant(addr, args[1:])
 	default:
-		return fmt.Errorf("unknown mcp subcommand %q (want list|add|remove|probe|grant)", args[0])
+		return fmt.Errorf("unknown mcp subcommand %q (want serve|list|add|remove|probe|grant)", args[0])
 	}
 }
 

--- a/cmd/ironctl/mcp_serve.go
+++ b/cmd/ironctl/mcp_serve.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -15,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/IronSecCo/ironclaw/internal/host/isolation"
 	"github.com/IronSecCo/ironclaw/internal/host/mcp"
 	"github.com/IronSecCo/ironclaw/internal/version"
 )
@@ -25,29 +28,46 @@ import (
 // broker (list/add/remove/probe/grant), which makes IronClaw a CLIENT of external
 // servers; here IronClaw is the server exposing a `sandbox_exec` tool.
 //
-//	ironctl mcp serve                 # stdio (what MCP clients spawn)
-//	ironctl mcp serve --http :9000    # streamable HTTP transport
+//	ironctl mcp serve                      # stdio (what MCP clients spawn)
+//	ironctl mcp serve --http :9000         # HTTP transport, loopback-only by default
+//	ironctl mcp serve --http 0.0.0.0:9000 --auth-token $TOK   # world-bound requires auth
 //	ironctl mcp serve --image IMG --timeout 30 --docker /path/to/docker
+//	ironctl mcp serve --runtime runc       # explicit, LABELLED runc fallback (NOT gVisor)
 //
 // The server holds no credentials and makes no model calls: `sandbox_exec` shells
-// a HARDENED `docker run` (network=none, drop-all-caps, non-root, read-only rootfs,
-// no-new-privs, pids/mem/cpu caps) into an ephemeral ic-sbx-mcp-* box, captures
-// stdout/stderr + exit code, and returns them with an explicit containment status.
+// a HARDENED `docker run` under gVisor (runsc) with network=none, drop-all-caps,
+// non-root, read-only rootfs, no-new-privileges, a restrictive seccomp profile, and
+// pids/mem/cpu caps into an ephemeral ic-sbx-mcp-* box, captures stdout/stderr +
+// exit code, and returns them with an explicit containment status.
 func cmdMCPServe(args []string) error {
 	fs := flag.NewFlagSet("mcp serve", flag.ContinueOnError)
-	httpAddr := fs.String("http", "", "serve over streamable HTTP on this address (e.g. :9000) instead of stdio")
+	httpAddr := fs.String("http", "", "serve over streamable HTTP on this address (e.g. :9000); host defaults to loopback (127.0.0.1)")
 	image := fs.String("image", defaultSandboxImage, "container image for the ephemeral sandbox box")
 	dockerBin := fs.String("docker", "docker", "container runtime binary (docker/podman) used to launch the box")
+	runtime := fs.String("runtime", isolation.DefaultRuntimeBinary, "OCI runtime for the box; default is gVisor (runsc). Any other value is an explicit, LABELLED fallback that does NOT provide gVisor's syscall interception")
+	authToken := fs.String("auth-token", os.Getenv("IRONCLAW_MCP_AUTH_TOKEN"), "bearer token required for HTTP clients; REQUIRED for any non-loopback --http bind (env: IRONCLAW_MCP_AUTH_TOKEN)")
 	timeout := fs.Int("timeout", 30, "default per-exec timeout in seconds (bounds a runaway command)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
+	// Materialize IronClaw's restrictive default seccomp profile to a temp file so
+	// the container runtime can enforce it (--security-opt seccomp=<file>). Matches
+	// the DockerIsolator/OCI path (internal/host/isolation/seccomp.go); without it a
+	// box would get only the runtime's default profile.
+	seccompPath, cleanup, err := writeSeccompProfile()
+	if err != nil {
+		return fmt.Errorf("mcp serve: could not stage seccomp profile: %w", err)
+	}
+	defer cleanup()
+
 	cfg := sandboxExecConfig{
-		image:      *image,
-		dockerBin:  *dockerBin,
-		timeoutSec: *timeout,
-		run:        dockerExecRunner,
+		image:       *image,
+		dockerBin:   *dockerBin,
+		runtime:     *runtime,
+		seccompPath: seccompPath,
+		timeoutSec:  *timeout,
+		run:         dockerExecRunner,
 	}
 	srv := newSandboxMCPServer(cfg)
 
@@ -55,14 +75,32 @@ func cmdMCPServe(args []string) error {
 	defer stop()
 
 	if *httpAddr != "" {
+		addr, loopback, err := normalizeHTTPAddr(*httpAddr)
+		if err != nil {
+			return fmt.Errorf("mcp serve: %w", err)
+		}
+		// Fail closed: never expose arbitrary sandbox_exec to the network without
+		// authentication. A non-loopback bind is only allowed with a bearer token.
+		if !loopback && *authToken == "" {
+			return fmt.Errorf("mcp serve: refusing to bind %s without authentication: "+
+				"set --auth-token (or IRONCLAW_MCP_AUTH_TOKEN), or bind a loopback address", addr)
+		}
+		var handler http.Handler = srv.Handler()
+		if *authToken != "" {
+			handler = bearerAuth(*authToken, handler)
+		}
 		mux := http.NewServeMux()
-		mux.Handle("/", srv.Handler())
-		httpServer := &http.Server{Addr: *httpAddr, Handler: mux}
+		mux.Handle("/", handler)
+		httpServer := &http.Server{Addr: addr, Handler: mux}
 		go func() {
 			<-ctx.Done()
 			_ = httpServer.Close()
 		}()
-		fmt.Fprintf(os.Stderr, "ironctl mcp serve: MCP over HTTP at %s (image=%s)\n", *httpAddr, *image)
+		authNote := "no auth (loopback)"
+		if *authToken != "" {
+			authNote = "bearer-auth required"
+		}
+		fmt.Fprintf(os.Stderr, "ironctl mcp serve: MCP over HTTP at %s (%s, runtime=%s image=%s)\n", addr, authNote, *runtime, *image)
 		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			return err
 		}
@@ -72,7 +110,7 @@ func cmdMCPServe(args []string) error {
 	// stdio is the default: MCP clients spawn `ironctl mcp serve` and speak
 	// newline-delimited JSON-RPC over the child's stdin/stdout. Diagnostics go to
 	// stderr so they never corrupt the protocol stream.
-	fmt.Fprintf(os.Stderr, "ironctl mcp serve: MCP over stdio (image=%s)\n", *image)
+	fmt.Fprintf(os.Stderr, "ironctl mcp serve: MCP over stdio (runtime=%s image=%s)\n", *runtime, *image)
 	if err := srv.ServeStdio(ctx, os.Stdin, os.Stdout); err != nil && ctx.Err() == nil {
 		return err
 	}
@@ -88,10 +126,19 @@ const defaultSandboxImage = "docker.io/library/alpine:3.20"
 // run field is a seam: production uses dockerExecRunner; tests substitute a fake so
 // the hardened arg construction and result formatting are verified without Docker.
 type sandboxExecConfig struct {
-	image      string
-	dockerBin  string
-	timeoutSec int
-	run        execRunner
+	image       string
+	dockerBin   string
+	runtime     string // OCI runtime: "runsc" (gVisor) by default; anything else is a labelled fallback
+	seccompPath string // path to the seccomp profile JSON; empty omits the flag (tests)
+	timeoutSec  int
+	run         execRunner
+}
+
+// usesGVisor reports whether the configured runtime is gVisor (runsc), which is the
+// only runtime that gives syscall-interception containment. Anything else runs under
+// the shared host kernel and must be labelled as a fallback, not as gVisor.
+func (cfg sandboxExecConfig) usesGVisor() bool {
+	return cfg.runtime == isolation.DefaultRuntimeBinary
 }
 
 // execRunner launches a fully-formed argv and returns the combined stdout, stderr,
@@ -105,10 +152,12 @@ func newSandboxMCPServer(cfg sandboxExecConfig) *mcp.Server {
 		Name: "sandbox_exec",
 		Description: "Run a shell command (or code snippet via `sh -c`) inside an ephemeral, " +
 			"hardened IronClaw sandbox box and return its stdout, stderr, exit code, and " +
-			"containment status. The box has NO network (egress is impossible), drops all " +
-			"Linux capabilities, runs as a non-root user with a read-only root filesystem and " +
-			"no-new-privileges, and is bounded by cpu/memory/pids caps. It is torn down after " +
-			"the command completes. Use this to execute untrusted or model-generated code safely.",
+			"containment status. By default the box runs under gVisor (runsc), which intercepts " +
+			"syscalls in a user-space guest kernel; it has NO network (egress is impossible), drops " +
+			"all Linux capabilities, runs as a non-root user with a read-only root filesystem, " +
+			"no-new-privileges, a restrictive seccomp profile, and is bounded by cpu/memory/pids " +
+			"caps. It is torn down after the command completes. Use this to execute untrusted or " +
+			"model-generated code safely.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{` +
 			`"command":{"type":"string","description":"Command to run inside the sandbox, executed via sh -c."},` +
 			`"image":{"type":"string","description":"Optional container image override (default: the server's configured image)."},` +
@@ -136,6 +185,14 @@ func (cfg sandboxExecConfig) toolFunc() mcp.ToolFunc {
 		if strings.TrimSpace(in.Image) != "" {
 			image = in.Image
 		}
+		// Argument-injection guard: the image is placed in the docker argv. A value
+		// like "--volume=/:/host" or "--user=0:0" would otherwise be parsed by docker
+		// as a flag and could relax the sandbox. Reject a leading '-'; the "--"
+		// end-of-options separator in the argv (see hardenedDockerArgs) is the second
+		// layer of defense.
+		if err := validateImageRef(image); err != nil {
+			return mcp.ToolResult{}, fmt.Errorf("sandbox_exec: %w", err)
+		}
 		timeoutSec := cfg.timeoutSec
 		if in.Timeout > 0 {
 			timeoutSec = in.Timeout
@@ -144,7 +201,7 @@ func (cfg sandboxExecConfig) toolFunc() mcp.ToolFunc {
 		// Deterministic, unique box name per call from the RPC deadline-free clock.
 		// We derive it from the runner start so the ephemeral box is always ic-sbx-mcp-*.
 		boxName := "ic-sbx-mcp-" + sandboxBoxSuffix(ctx)
-		argv := hardenedDockerArgs(boxName, image, in.Command)
+		argv := hardenedDockerArgs(cfg, boxName, image, in.Command)
 
 		runCtx := ctx
 		if timeoutSec > 0 {
@@ -155,58 +212,176 @@ func (cfg sandboxExecConfig) toolFunc() mcp.ToolFunc {
 
 		stdout, stderr, exitCode, err := cfg.run(runCtx, cfg.dockerBin, argv)
 		if err != nil {
-			// A launch failure (docker missing, image pull denied, timeout) is a tool
-			// error, not a protocol error: report it as text with IsError so the client
-			// surfaces it to the user/model rather than tearing down the session.
+			// A launch failure (docker missing, image pull denied, runsc absent,
+			// timeout) is a tool error, not a protocol error: report it as text with
+			// IsError so the client surfaces it to the user/model rather than tearing
+			// down the session.
+			hint := ""
+			if cfg.usesGVisor() {
+				hint = "\n(if the runtime %q is not registered with your engine, install gVisor/runsc " +
+					"or re-run with an explicit --runtime fallback; the fallback is NOT gVisor-equivalent)"
+				hint = fmt.Sprintf(hint, cfg.runtime)
+			}
 			return mcp.ToolResult{
 				Content: []mcp.Content{{Type: "text", Text: fmt.Sprintf(
-					"sandbox_exec: launch failed: %v\n(runtime=%s image=%s)\ncontainment: box never gained network or host access.",
-					err, cfg.dockerBin, image)}},
+					"sandbox_exec: launch failed: %v\n(runtime=%s engine=%s image=%s)%s\ncontainment: box never gained network or host access.",
+					err, cfg.runtime, cfg.dockerBin, image, hint)}},
 				IsError: true,
 			}, nil
 		}
 
-		result := formatExecResult(image, exitCode, stdout, stderr)
+		result := formatExecResult(cfg, image, exitCode, stdout, stderr)
 		return mcp.TextResult(result), nil
 	}
 }
 
+// validateImageRef rejects an image reference that docker would parse as a flag. A
+// leading '-' (e.g. "--volume=/:/host") is the injection vector; everything else is
+// left to docker's own reference parsing (the "--" separator handles the rest).
+func validateImageRef(image string) error {
+	image = strings.TrimSpace(image)
+	if image == "" {
+		return fmt.Errorf("image is required")
+	}
+	if strings.HasPrefix(image, "-") {
+		return fmt.Errorf("invalid image %q: must not start with '-' (would be parsed as a docker flag)", image)
+	}
+	return nil
+}
+
 // hardenedDockerArgs assembles the argv for an ephemeral, hardened one-shot box. It
-// mirrors the DockerIsolator posture (internal/host/isolation): network=none,
-// drop-all-caps, non-root, read-only rootfs, no-new-privs, and cpu/memory/pids caps.
-// The command runs via `sh -c` so snippets and pipelines work. Keep this list in
-// sync with the containment guarantees documented in the tool description.
-func hardenedDockerArgs(boxName, image, command string) []string {
-	return []string{
+// mirrors the DockerIsolator/OCI posture (internal/host/isolation): gVisor (runsc)
+// runtime, network=none, drop-all-caps, non-root, read-only rootfs, no-new-privs, a
+// restrictive seccomp profile, and cpu/memory/pids caps. The command runs via `sh -c`
+// so snippets and pipelines work. A "--" end-of-options separator precedes the image
+// so a hostile image reference cannot be parsed as a flag. Keep this list in sync
+// with the containment guarantees documented in the tool description.
+func hardenedDockerArgs(cfg sandboxExecConfig, boxName, image, command string) []string {
+	argv := []string{
 		"run", "--rm",
 		"--name", boxName,
+		"--runtime", cfg.runtime, // gVisor (runsc) by default: syscall interception, guest kernel
 		"--network", "none", // no NIC: egress is structurally impossible
 		"--cap-drop", "ALL", // drop every Linux capability
 		"--security-opt", "no-new-privileges", // suid binaries cannot escalate
-		"--read-only",             // rootfs is read-only
-		"--user", "65532:65532",   // non-root (nonroot uid, matches sandbox default)
-		"--pids-limit", "256",     // cap process/thread count
-		"--memory", "512m",        // cgroup memory cap
-		"--cpus", "1",             // one vCPU of bandwidth
+	}
+	if cfg.seccompPath != "" {
+		// Restrictive deny-by-default seccomp profile (matches the OCI path).
+		argv = append(argv, "--security-opt", "seccomp="+cfg.seccompPath)
+	}
+	argv = append(argv,
+		"--read-only",           // rootfs is read-only
+		"--user", "65532:65532", // non-root (nonroot uid, matches sandbox default)
+		"--pids-limit", "256", // cap process/thread count
+		"--memory", "512m", // cgroup memory cap
+		"--cpus", "1", // one vCPU of bandwidth
 		"--tmpfs", "/tmp:rw,nosuid,nodev,size=64m", // writable scratch only
 		"--workdir", "/tmp",
+		"--", // end of options: nothing after this is parsed as a flag
 		image,
 		"sh", "-c", command,
-	}
+	)
+	return argv
 }
 
 // formatExecResult renders the tool's text block: stdout, stderr, exit code, and an
-// explicit containment summary so the caller always sees the enforced controls.
-func formatExecResult(image string, exitCode int, stdout, stderr string) string {
+// explicit containment summary so the caller always sees the enforced controls and
+// the true isolation boundary (gVisor vs a labelled fallback).
+func formatExecResult(cfg sandboxExecConfig, image string, exitCode int, stdout, stderr string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "exit_code: %d\n", exitCode)
-	b.WriteString("containment: network=none, caps=drop-all, user=65532 (non-root), rootfs=read-only, no-new-privileges, pids<=256, mem<=512m, cpu<=1 (ephemeral ic-sbx-mcp-* box, torn down)\n")
+	b.WriteString("containment: " + containmentSummary(cfg) + "\n")
 	fmt.Fprintf(&b, "image: %s\n", image)
 	b.WriteString("--- stdout ---\n")
 	b.WriteString(strings.TrimRight(stdout, "\n"))
 	b.WriteString("\n--- stderr ---\n")
 	b.WriteString(strings.TrimRight(stderr, "\n"))
 	return b.String()
+}
+
+// containmentSummary describes the enforced controls, honestly labelling the
+// isolation boundary. Under gVisor (runsc) it advertises syscall interception; under
+// any other runtime it states plainly that the boundary is the shared host kernel and
+// is NOT gVisor-equivalent, so a client is never misled about the guarantee.
+func containmentSummary(cfg sandboxExecConfig) string {
+	boundary := fmt.Sprintf("runtime=%s (FALLBACK: shared host kernel, NOT gVisor)", cfg.runtime)
+	if cfg.usesGVisor() {
+		boundary = "runtime=runsc (gVisor: user-space guest kernel, syscall interception)"
+	}
+	seccomp := "seccomp=restrictive-default"
+	if cfg.seccompPath == "" {
+		seccomp = "seccomp=engine-default"
+	}
+	return boundary + ", network=none, caps=drop-all, user=65532 (non-root), rootfs=read-only, " +
+		"no-new-privileges, " + seccomp + ", pids<=256, mem<=512m, cpu<=1 (ephemeral ic-sbx-mcp-* box, torn down)"
+}
+
+// writeSeccompProfile serializes IronClaw's restrictive default seccomp profile to a
+// temp file the container runtime can read via --security-opt seccomp=<file>, and
+// returns the path plus a cleanup func to remove it on shutdown.
+func writeSeccompProfile() (path string, cleanup func(), err error) {
+	data, err := json.Marshal(isolation.DefaultSeccompProfile())
+	if err != nil {
+		return "", func() {}, err
+	}
+	f, err := os.CreateTemp("", "ic-mcp-seccomp-*.json")
+	if err != nil {
+		return "", func() {}, err
+	}
+	name := f.Name()
+	if _, werr := f.Write(data); werr != nil {
+		_ = f.Close()
+		_ = os.Remove(name)
+		return "", func() {}, werr
+	}
+	if cerr := f.Close(); cerr != nil {
+		_ = os.Remove(name)
+		return "", func() {}, cerr
+	}
+	return name, func() { _ = os.Remove(name) }, nil
+}
+
+// normalizeHTTPAddr resolves the --http bind address and reports whether it is a
+// loopback bind. A bare port (":9000") or empty host defaults to 127.0.0.1 so the
+// server is not world-exposed by accident; a caller must opt into a routable address
+// explicitly. Returns the normalized "host:port" and whether host is loopback.
+func normalizeHTTPAddr(addr string) (normalized string, loopback bool, err error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", false, fmt.Errorf("invalid --http address %q: %w", addr, err)
+	}
+	if host == "" {
+		host = "127.0.0.1" // default to loopback rather than all interfaces
+	}
+	return net.JoinHostPort(host, port), isLoopbackHost(host), nil
+}
+
+// isLoopbackHost reports whether host names the loopback interface. Literal IPs are
+// checked via net.IP.IsLoopback; the "localhost" name is treated as loopback.
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// bearerAuth wraps h so every request must carry "Authorization: Bearer <token>".
+// The comparison is constant-time to avoid leaking the token via timing.
+func bearerAuth(token string, h http.Handler) http.Handler {
+	want := []byte("Bearer " + token)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := []byte(r.Header.Get("Authorization"))
+		if subtle.ConstantTimeEq(int32(len(got)), int32(len(want))) != 1 ||
+			subtle.ConstantTimeCompare(got, want) != 1 {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
 }
 
 // sandboxBoxSuffix derives a per-call box name suffix. It avoids Math/rand and the

--- a/cmd/ironctl/mcp_serve.go
+++ b/cmd/ironctl/mcp_serve.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/IronSecCo/ironclaw/internal/host/mcp"
+	"github.com/IronSecCo/ironclaw/internal/version"
+)
+
+// cmdMCPServe runs IronClaw ITSELF as an MCP server so any MCP client (Claude
+// Desktop, Cursor, Windsurf, Cline, ...) can route code execution through an
+// ephemeral IronClaw sandbox with one config line. This is the INVERSE of the
+// broker (list/add/remove/probe/grant), which makes IronClaw a CLIENT of external
+// servers; here IronClaw is the server exposing a `sandbox_exec` tool.
+//
+//	ironctl mcp serve                 # stdio (what MCP clients spawn)
+//	ironctl mcp serve --http :9000    # streamable HTTP transport
+//	ironctl mcp serve --image IMG --timeout 30 --docker /path/to/docker
+//
+// The server holds no credentials and makes no model calls: `sandbox_exec` shells
+// a HARDENED `docker run` (network=none, drop-all-caps, non-root, read-only rootfs,
+// no-new-privs, pids/mem/cpu caps) into an ephemeral ic-sbx-mcp-* box, captures
+// stdout/stderr + exit code, and returns them with an explicit containment status.
+func cmdMCPServe(args []string) error {
+	fs := flag.NewFlagSet("mcp serve", flag.ContinueOnError)
+	httpAddr := fs.String("http", "", "serve over streamable HTTP on this address (e.g. :9000) instead of stdio")
+	image := fs.String("image", defaultSandboxImage, "container image for the ephemeral sandbox box")
+	dockerBin := fs.String("docker", "docker", "container runtime binary (docker/podman) used to launch the box")
+	timeout := fs.Int("timeout", 30, "default per-exec timeout in seconds (bounds a runaway command)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	cfg := sandboxExecConfig{
+		image:      *image,
+		dockerBin:  *dockerBin,
+		timeoutSec: *timeout,
+		run:        dockerExecRunner,
+	}
+	srv := newSandboxMCPServer(cfg)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if *httpAddr != "" {
+		mux := http.NewServeMux()
+		mux.Handle("/", srv.Handler())
+		httpServer := &http.Server{Addr: *httpAddr, Handler: mux}
+		go func() {
+			<-ctx.Done()
+			_ = httpServer.Close()
+		}()
+		fmt.Fprintf(os.Stderr, "ironctl mcp serve: MCP over HTTP at %s (image=%s)\n", *httpAddr, *image)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	}
+
+	// stdio is the default: MCP clients spawn `ironctl mcp serve` and speak
+	// newline-delimited JSON-RPC over the child's stdin/stdout. Diagnostics go to
+	// stderr so they never corrupt the protocol stream.
+	fmt.Fprintf(os.Stderr, "ironctl mcp serve: MCP over stdio (image=%s)\n", *image)
+	if err := srv.ServeStdio(ctx, os.Stdin, os.Stdout); err != nil && ctx.Err() == nil {
+		return err
+	}
+	return nil
+}
+
+// defaultSandboxImage is the image a sandbox box runs when the caller does not
+// override it. It is a minimal, credential-free base; the containment guarantees
+// come from the runtime flags, not the image.
+const defaultSandboxImage = "docker.io/library/alpine:3.20"
+
+// sandboxExecConfig is the injectable configuration for the sandbox_exec tool. The
+// run field is a seam: production uses dockerExecRunner; tests substitute a fake so
+// the hardened arg construction and result formatting are verified without Docker.
+type sandboxExecConfig struct {
+	image      string
+	dockerBin  string
+	timeoutSec int
+	run        execRunner
+}
+
+// execRunner launches a fully-formed argv and returns the combined stdout, stderr,
+// exit code, and any launch error (as opposed to a non-zero exit).
+type execRunner func(ctx context.Context, bin string, argv []string) (stdout, stderr string, exitCode int, err error)
+
+// newSandboxMCPServer builds the MCP server exposing the sandbox_exec tool.
+func newSandboxMCPServer(cfg sandboxExecConfig) *mcp.Server {
+	s := mcp.NewServer("ironclaw", version.String())
+	s.AddTool(mcp.Tool{
+		Name: "sandbox_exec",
+		Description: "Run a shell command (or code snippet via `sh -c`) inside an ephemeral, " +
+			"hardened IronClaw sandbox box and return its stdout, stderr, exit code, and " +
+			"containment status. The box has NO network (egress is impossible), drops all " +
+			"Linux capabilities, runs as a non-root user with a read-only root filesystem and " +
+			"no-new-privileges, and is bounded by cpu/memory/pids caps. It is torn down after " +
+			"the command completes. Use this to execute untrusted or model-generated code safely.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{` +
+			`"command":{"type":"string","description":"Command to run inside the sandbox, executed via sh -c."},` +
+			`"image":{"type":"string","description":"Optional container image override (default: the server's configured image)."},` +
+			`"timeout_seconds":{"type":"integer","minimum":1,"maximum":600,"description":"Optional per-exec timeout override in seconds."}` +
+			`},"required":["command"],"additionalProperties":false}`),
+	}, cfg.toolFunc())
+	return s
+}
+
+// toolFunc returns the sandbox_exec handler bound to this config.
+func (cfg sandboxExecConfig) toolFunc() mcp.ToolFunc {
+	return func(ctx context.Context, args json.RawMessage) (mcp.ToolResult, error) {
+		var in struct {
+			Command string `json:"command"`
+			Image   string `json:"image"`
+			Timeout int    `json:"timeout_seconds"`
+		}
+		if err := json.Unmarshal(args, &in); err != nil {
+			return mcp.ToolResult{}, fmt.Errorf("sandbox_exec: invalid arguments: %w", err)
+		}
+		if strings.TrimSpace(in.Command) == "" {
+			return mcp.ToolResult{}, fmt.Errorf("sandbox_exec: command is required")
+		}
+		image := cfg.image
+		if strings.TrimSpace(in.Image) != "" {
+			image = in.Image
+		}
+		timeoutSec := cfg.timeoutSec
+		if in.Timeout > 0 {
+			timeoutSec = in.Timeout
+		}
+
+		// Deterministic, unique box name per call from the RPC deadline-free clock.
+		// We derive it from the runner start so the ephemeral box is always ic-sbx-mcp-*.
+		boxName := "ic-sbx-mcp-" + sandboxBoxSuffix(ctx)
+		argv := hardenedDockerArgs(boxName, image, in.Command)
+
+		runCtx := ctx
+		if timeoutSec > 0 {
+			var cancel context.CancelFunc
+			runCtx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
+			defer cancel()
+		}
+
+		stdout, stderr, exitCode, err := cfg.run(runCtx, cfg.dockerBin, argv)
+		if err != nil {
+			// A launch failure (docker missing, image pull denied, timeout) is a tool
+			// error, not a protocol error: report it as text with IsError so the client
+			// surfaces it to the user/model rather than tearing down the session.
+			return mcp.ToolResult{
+				Content: []mcp.Content{{Type: "text", Text: fmt.Sprintf(
+					"sandbox_exec: launch failed: %v\n(runtime=%s image=%s)\ncontainment: box never gained network or host access.",
+					err, cfg.dockerBin, image)}},
+				IsError: true,
+			}, nil
+		}
+
+		result := formatExecResult(image, exitCode, stdout, stderr)
+		return mcp.TextResult(result), nil
+	}
+}
+
+// hardenedDockerArgs assembles the argv for an ephemeral, hardened one-shot box. It
+// mirrors the DockerIsolator posture (internal/host/isolation): network=none,
+// drop-all-caps, non-root, read-only rootfs, no-new-privs, and cpu/memory/pids caps.
+// The command runs via `sh -c` so snippets and pipelines work. Keep this list in
+// sync with the containment guarantees documented in the tool description.
+func hardenedDockerArgs(boxName, image, command string) []string {
+	return []string{
+		"run", "--rm",
+		"--name", boxName,
+		"--network", "none", // no NIC: egress is structurally impossible
+		"--cap-drop", "ALL", // drop every Linux capability
+		"--security-opt", "no-new-privileges", // suid binaries cannot escalate
+		"--read-only",             // rootfs is read-only
+		"--user", "65532:65532",   // non-root (nonroot uid, matches sandbox default)
+		"--pids-limit", "256",     // cap process/thread count
+		"--memory", "512m",        // cgroup memory cap
+		"--cpus", "1",             // one vCPU of bandwidth
+		"--tmpfs", "/tmp:rw,nosuid,nodev,size=64m", // writable scratch only
+		"--workdir", "/tmp",
+		image,
+		"sh", "-c", command,
+	}
+}
+
+// formatExecResult renders the tool's text block: stdout, stderr, exit code, and an
+// explicit containment summary so the caller always sees the enforced controls.
+func formatExecResult(image string, exitCode int, stdout, stderr string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "exit_code: %d\n", exitCode)
+	b.WriteString("containment: network=none, caps=drop-all, user=65532 (non-root), rootfs=read-only, no-new-privileges, pids<=256, mem<=512m, cpu<=1 (ephemeral ic-sbx-mcp-* box, torn down)\n")
+	fmt.Fprintf(&b, "image: %s\n", image)
+	b.WriteString("--- stdout ---\n")
+	b.WriteString(strings.TrimRight(stdout, "\n"))
+	b.WriteString("\n--- stderr ---\n")
+	b.WriteString(strings.TrimRight(stderr, "\n"))
+	return b.String()
+}
+
+// sandboxBoxSuffix derives a per-call box name suffix. It avoids Math/rand and the
+// wall clock (kept deterministic-friendly for tests) by using the process pid plus a
+// monotonic counter carried on the context when present.
+func sandboxBoxSuffix(ctx context.Context) string {
+	if v, ok := ctx.Value(boxSuffixKey{}).(string); ok && v != "" {
+		return v
+	}
+	return strconv.Itoa(os.Getpid()) + "-" + strconv.FormatInt(time.Now().UnixNano(), 36)
+}
+
+type boxSuffixKey struct{}
+
+// dockerExecRunner is the production execRunner: it launches the runtime binary,
+// captures stdout/stderr separately, and normalizes the exit code.
+func dockerExecRunner(ctx context.Context, bin string, argv []string) (string, string, int, error) {
+	cmd := exec.CommandContext(ctx, bin, argv...)
+	var outBuf, errBuf strings.Builder
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			exitCode = ee.ExitCode()
+			// A non-zero exit from the sandboxed command is a normal result, not a
+			// launch failure: clear err so the caller reports stdout/stderr/exit.
+			return outBuf.String(), errBuf.String(), exitCode, nil
+		}
+		return outBuf.String(), errBuf.String(), -1, err
+	}
+	return outBuf.String(), errBuf.String(), exitCode, nil
+}

--- a/cmd/ironctl/mcp_serve_test.go
+++ b/cmd/ironctl/mcp_serve_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -28,7 +30,8 @@ func TestSandboxExecHardenedArgs(t *testing.T) {
 	var gotBin string
 	var gotArgv []string
 	cfg := sandboxExecConfig{
-		image: "alpine:3.20", dockerBin: "docker", timeoutSec: 30,
+		image: "alpine:3.20", dockerBin: "docker", runtime: "runsc",
+		seccompPath: "/tmp/ic-mcp-seccomp.json", timeoutSec: 30,
 		run: func(_ context.Context, bin string, argv []string) (string, string, int, error) {
 			gotBin, gotArgv = bin, argv
 			return "hello\n", "", 0, nil
@@ -41,7 +44,8 @@ func TestSandboxExecHardenedArgs(t *testing.T) {
 	}
 	joined := strings.Join(gotArgv, " ")
 	for _, f := range []string{
-		"--network none", "--cap-drop ALL", "--security-opt no-new-privileges",
+		"--runtime runsc", "--network none", "--cap-drop ALL",
+		"--security-opt no-new-privileges", "--security-opt seccomp=/tmp/ic-mcp-seccomp.json",
 		"--read-only", "--user 65532:65532", "--pids-limit 256",
 		"--memory 512m", "--cpus 1", "--rm",
 	} {
@@ -51,6 +55,13 @@ func TestSandboxExecHardenedArgs(t *testing.T) {
 	}
 	if !strings.Contains(joined, "ic-sbx-mcp-") {
 		t.Errorf("box name not ic-sbx-mcp-*: %s", joined)
+	}
+	// An "--" end-of-options separator MUST precede the image so a hostile image
+	// reference cannot be parsed by docker as a flag (finding #4).
+	sep := indexOf(gotArgv, "--")
+	img := indexOf(gotArgv, "alpine:3.20")
+	if sep < 0 || img < 0 || sep+1 != img {
+		t.Errorf("expected '--' immediately before image; sep=%d img=%d argv=%v", sep, img, gotArgv)
 	}
 	n := len(gotArgv)
 	if gotArgv[n-3] != "sh" || gotArgv[n-2] != "-c" || gotArgv[n-1] != "echo hello" {
@@ -63,13 +74,121 @@ func TestSandboxExecHardenedArgs(t *testing.T) {
 	if !strings.Contains(txt, "exit_code: 0") || !strings.Contains(txt, "hello") || !strings.Contains(txt, "containment:") {
 		t.Errorf("result missing expected fields:\n%s", txt)
 	}
+	// gVisor must be advertised only when the runtime is actually runsc.
+	if !strings.Contains(txt, "runtime=runsc (gVisor") {
+		t.Errorf("containment should advertise gVisor for runsc:\n%s", txt)
+	}
+}
+
+func indexOf(argv []string, want string) int {
+	for i, a := range argv {
+		if a == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// Finding #1: a non-runsc runtime must be labelled a fallback, NOT gVisor.
+func TestSandboxExecFallbackRuntimeLabelled(t *testing.T) {
+	cfg := sandboxExecConfig{
+		image: "alpine:3.20", dockerBin: "docker", runtime: "runc",
+		run: func(_ context.Context, _ string, argv []string) (string, string, int, error) {
+			if indexOf(argv, "--runtime") < 0 || argv[indexOf(argv, "--runtime")+1] != "runc" {
+				t.Errorf("runc runtime not passed: %v", argv)
+			}
+			return "", "", 0, nil
+		},
+	}
+	txt := invoke(t, cfg, `{"command":"true"}`).Content[0].Text
+	if strings.Contains(txt, "gVisor:") {
+		t.Errorf("runc fallback must NOT be marketed as gVisor:\n%s", txt)
+	}
+	if !strings.Contains(txt, "NOT gVisor") {
+		t.Errorf("runc fallback must be explicitly labelled NOT gVisor:\n%s", txt)
+	}
+}
+
+// Finding #4: an image parsed as a docker flag is rejected before any runner call.
+func TestSandboxExecImageInjectionRejected(t *testing.T) {
+	for _, bad := range []string{"--volume=/:/host", "-v", "--user=0:0"} {
+		called := false
+		cfg := sandboxExecConfig{
+			image: "alpine:3.20", dockerBin: "docker", runtime: "runsc",
+			run: func(_ context.Context, _ string, _ []string) (string, string, int, error) {
+				called = true
+				return "", "", 0, nil
+			},
+		}
+		_, err := cfg.toolFunc()(context.Background(), json.RawMessage(`{"command":"true","image":"`+bad+`"}`))
+		if err == nil {
+			t.Errorf("image %q should be rejected", bad)
+		}
+		if called {
+			t.Errorf("runner must not run for hostile image %q", bad)
+		}
+	}
+}
+
+// Finding #3: bind-address defaulting and loopback classification.
+func TestNormalizeHTTPAddr(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantAddr string
+		wantLoop bool
+	}{
+		{":9000", "127.0.0.1:9000", true},          // bare port defaults to loopback
+		{"127.0.0.1:9000", "127.0.0.1:9000", true}, // explicit loopback
+		{"localhost:9000", "localhost:9000", true}, // localhost is loopback
+		{"0.0.0.0:9000", "0.0.0.0:9000", false},    // all-interfaces is NOT loopback
+		{"10.0.0.5:9000", "10.0.0.5:9000", false},  // routable IP is NOT loopback
+		{"[::1]:9000", "[::1]:9000", true},         // IPv6 loopback
+	}
+	for _, c := range cases {
+		gotAddr, gotLoop, err := normalizeHTTPAddr(c.in)
+		if err != nil {
+			t.Errorf("normalizeHTTPAddr(%q) error: %v", c.in, err)
+			continue
+		}
+		if gotAddr != c.wantAddr || gotLoop != c.wantLoop {
+			t.Errorf("normalizeHTTPAddr(%q) = (%q,%v), want (%q,%v)", c.in, gotAddr, gotLoop, c.wantAddr, c.wantLoop)
+		}
+	}
+	if _, _, err := normalizeHTTPAddr("garbage"); err == nil {
+		t.Errorf("malformed address should error")
+	}
+}
+
+// Finding #3: the bearer-auth wrapper rejects missing/wrong tokens and admits the right one.
+func TestBearerAuth(t *testing.T) {
+	ok := false
+	h := bearerAuth("s3cret", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		ok = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	check := func(hdr string, wantStatus int, wantOK bool) {
+		ok = false
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		if hdr != "" {
+			req.Header.Set("Authorization", hdr)
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != wantStatus || ok != wantOK {
+			t.Errorf("hdr=%q -> code=%d ok=%v, want code=%d ok=%v", hdr, rec.Code, ok, wantStatus, wantOK)
+		}
+	}
+	check("", http.StatusUnauthorized, false)
+	check("Bearer wrong", http.StatusUnauthorized, false)
+	check("s3cret", http.StatusUnauthorized, false)
+	check("Bearer s3cret", http.StatusOK, true)
 }
 
 // A per-call image override is honored.
 func TestSandboxExecImageOverride(t *testing.T) {
 	var gotArgv []string
 	cfg := sandboxExecConfig{
-		image: "alpine:3.20", dockerBin: "docker",
+		image: "alpine:3.20", dockerBin: "docker", runtime: "runsc",
 		run: func(_ context.Context, _ string, argv []string) (string, string, int, error) {
 			gotArgv = argv
 			return "", "", 0, nil

--- a/cmd/ironctl/mcp_serve_test.go
+++ b/cmd/ironctl/mcp_serve_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/host/mcp"
+)
+
+// The sandbox server must actually register the sandbox_exec tool.
+func TestSandboxServerRegistersTool(t *testing.T) {
+	srv := newSandboxMCPServer(sandboxExecConfig{image: "alpine:3.20", dockerBin: "docker", run: nopRunner})
+	var names []string
+	for _, tl := range srv.Tools() {
+		names = append(names, tl.Name)
+	}
+	if len(names) != 1 || names[0] != "sandbox_exec" {
+		t.Fatalf("tools = %v, want [sandbox_exec]", names)
+	}
+}
+
+// Test that sandbox_exec assembles the HARDENED docker argv. This is the containment
+// contract: if any flag regresses an escape becomes possible, so each is asserted
+// explicitly. Runs without Docker via a fake runner.
+func TestSandboxExecHardenedArgs(t *testing.T) {
+	var gotBin string
+	var gotArgv []string
+	cfg := sandboxExecConfig{
+		image: "alpine:3.20", dockerBin: "docker", timeoutSec: 30,
+		run: func(_ context.Context, bin string, argv []string) (string, string, int, error) {
+			gotBin, gotArgv = bin, argv
+			return "hello\n", "", 0, nil
+		},
+	}
+	res := invoke(t, cfg, `{"command":"echo hello"}`)
+
+	if gotBin != "docker" {
+		t.Fatalf("runtime binary = %q, want docker", gotBin)
+	}
+	joined := strings.Join(gotArgv, " ")
+	for _, f := range []string{
+		"--network none", "--cap-drop ALL", "--security-opt no-new-privileges",
+		"--read-only", "--user 65532:65532", "--pids-limit 256",
+		"--memory 512m", "--cpus 1", "--rm",
+	} {
+		if !strings.Contains(joined, f) {
+			t.Errorf("hardened argv missing %q\n  got: %s", f, joined)
+		}
+	}
+	if !strings.Contains(joined, "ic-sbx-mcp-") {
+		t.Errorf("box name not ic-sbx-mcp-*: %s", joined)
+	}
+	n := len(gotArgv)
+	if gotArgv[n-3] != "sh" || gotArgv[n-2] != "-c" || gotArgv[n-1] != "echo hello" {
+		t.Errorf("command tail wrong: %v", gotArgv[n-3:])
+	}
+	if res.IsError {
+		t.Errorf("expected success result, got IsError")
+	}
+	txt := res.Content[0].Text
+	if !strings.Contains(txt, "exit_code: 0") || !strings.Contains(txt, "hello") || !strings.Contains(txt, "containment:") {
+		t.Errorf("result missing expected fields:\n%s", txt)
+	}
+}
+
+// A per-call image override is honored.
+func TestSandboxExecImageOverride(t *testing.T) {
+	var gotArgv []string
+	cfg := sandboxExecConfig{
+		image: "alpine:3.20", dockerBin: "docker",
+		run: func(_ context.Context, _ string, argv []string) (string, string, int, error) {
+			gotArgv = argv
+			return "", "", 0, nil
+		},
+	}
+	invoke(t, cfg, `{"command":"true","image":"python:3.12-slim"}`)
+	// image is the 4th-from-last arg: <image> sh -c <command>
+	if gotArgv[len(gotArgv)-4] != "python:3.12-slim" {
+		t.Errorf("image override not applied: %v", gotArgv)
+	}
+}
+
+// A non-zero exit is a normal result; a launch failure is IsError with a containment note.
+func TestSandboxExecExitAndLaunchFailure(t *testing.T) {
+	res := invoke(t, sandboxExecConfig{
+		image: "alpine:3.20", dockerBin: "docker",
+		run: func(_ context.Context, _ string, _ []string) (string, string, int, error) {
+			return "", "boom\n", 7, nil
+		},
+	}, `{"command":"exit 7"}`)
+	if res.IsError {
+		t.Errorf("non-zero exit should not be a tool error")
+	}
+	if !strings.Contains(res.Content[0].Text, "exit_code: 7") {
+		t.Errorf("exit code not reported: %s", res.Content[0].Text)
+	}
+
+	res2 := invoke(t, sandboxExecConfig{
+		image: "alpine:3.20", dockerBin: "docker",
+		run: func(_ context.Context, _ string, _ []string) (string, string, int, error) {
+			return "", "", -1, context.DeadlineExceeded
+		},
+	}, `{"command":"sleep 999"}`)
+	if !res2.IsError {
+		t.Errorf("launch failure should be a tool error")
+	}
+	if !strings.Contains(res2.Content[0].Text, "containment:") {
+		t.Errorf("launch-failure result should still note containment: %s", res2.Content[0].Text)
+	}
+}
+
+// Empty command is rejected before any runner call.
+func TestSandboxExecEmptyCommand(t *testing.T) {
+	called := false
+	cfg := sandboxExecConfig{
+		image: "alpine:3.20", dockerBin: "docker",
+		run: func(_ context.Context, _ string, _ []string) (string, string, int, error) {
+			called = true
+			return "", "", 0, nil
+		},
+	}
+	if _, err := cfg.toolFunc()(context.Background(), json.RawMessage(`{"command":"   "}`)); err == nil {
+		t.Errorf("empty command should error")
+	}
+	if called {
+		t.Errorf("runner should not run for empty command")
+	}
+}
+
+func nopRunner(_ context.Context, _ string, _ []string) (string, string, int, error) {
+	return "", "", 0, nil
+}
+
+// invoke drives the sandbox_exec handler built from cfg with the given JSON args.
+func invoke(t *testing.T, cfg sandboxExecConfig, argsJSON string) mcp.ToolResult {
+	t.Helper()
+	res, err := cfg.toolFunc()(context.Background(), json.RawMessage(argsJSON))
+	if err != nil {
+		t.Fatalf("sandbox_exec returned rpc error: %v", err)
+	}
+	return res
+}

--- a/docs/integrations/.nav.yml
+++ b/docs/integrations/.nav.yml
@@ -10,4 +10,5 @@ nav:
   - OpenAI Agents SDK: openai-sdk.md
   - Claude Agent SDK: claude-sdk.md
   - CI (GitHub Action): ci.md
+  - MCP server (any client): mcp-server.md
   - "*.md"

--- a/docs/integrations/mcp-server.md
+++ b/docs/integrations/mcp-server.md
@@ -1,6 +1,6 @@
 ---
 title: "Run IronClaw as an MCP server (sandbox any tool call)"
-description: Add IronClaw to Claude Desktop, Cursor, Windsurf, Cline, or any MCP client with one config line. The sandbox_exec tool runs any command or code snippet inside an ephemeral, hardened IronClaw box with no network, dropped capabilities, a non-root user, and a read-only root filesystem. Model-generated code runs where it cannot reach your machine.
+description: Add IronClaw to Claude Desktop, Cursor, Windsurf, Cline, or any MCP client with one config line. The sandbox_exec tool runs any command or code snippet inside an ephemeral, hardened IronClaw box under gVisor (runsc) with no network, dropped capabilities, a non-root user, a restrictive seccomp profile, and a read-only root filesystem. Model-generated code runs where it cannot reach your machine.
 ---
 
 # Run IronClaw as an MCP server
@@ -14,9 +14,21 @@ filesystem and unrestricted network.
 IronClaw ships an MCP server that exposes a single, blunt tool, **`sandbox_exec`**,
 which runs the command inside an **ephemeral, hardened sandbox box** instead. Any
 MCP client can route untrusted, model-generated code through it with one config
-line. The box has no network card, drops every Linux capability, runs as a non-root
-user with a read-only root filesystem and `no-new-privileges`, is bounded by
-cpu/memory/pids caps, and is torn down after the command returns.
+line. By default the box runs under **gVisor (runsc)** - a user-space guest kernel
+that intercepts syscalls - so a kernel-level exploit cannot reach the host. It has
+no network card, drops every Linux capability, runs as a non-root user with a
+read-only root filesystem, `no-new-privileges`, and a restrictive seccomp profile,
+is bounded by cpu/memory/pids caps, and is torn down after the command returns.
+
+!!! warning "gVisor (runsc) is required for the full guarantee"
+    The primary boundary is gVisor's syscall interception. `ironctl mcp serve`
+    passes `--runtime runsc` by default; if runsc is not installed the launch fails
+    closed rather than silently downgrading. You can opt into a plain-runc fallback
+    with `--runtime runc`, but that shares the host kernel and is **not**
+    gVisor-equivalent - the tool's containment status labels it as a fallback so a
+    caller is never misled. Install gVisor from
+    [gvisor.dev](https://gvisor.dev/docs/user_guide/install/) and register the
+    `runsc` Docker runtime for the hardened default.
 
 !!! note "This is the inverse of registering an external MCP server"
     IronClaw can also act as a *client* of other MCP servers (see
@@ -48,18 +60,33 @@ That is it. The client spawns `ironctl mcp serve`, speaks MCP over stdio, and se
 one tool: `sandbox_exec`. IronClaw needs a container runtime (Docker or Podman)
 reachable on the host to launch the sandbox box.
 
-Prefer HTTP transport (for a shared or remote server)? Run it explicitly:
+Prefer HTTP transport? Run it explicitly. The server binds **loopback
+(`127.0.0.1`) by default** - a bare `:9000` becomes `127.0.0.1:9000`, reachable only
+from the same host:
 
 ```bash
 ironctl mcp serve --http :9000
 ```
+
+To expose the server on a routable address (a shared or remote server) you **must**
+provide an authentication token; IronClaw refuses to bind a non-loopback address
+without one, because `sandbox_exec` runs arbitrary code:
+
+```bash
+IRONCLAW_MCP_AUTH_TOKEN=$(openssl rand -hex 32) \
+  ironctl mcp serve --http 0.0.0.0:9000
+# clients must then send:  Authorization: Bearer <token>
+```
+
+Terminate TLS at a reverse proxy (or an SSH tunnel) in front of the server; the
+bearer token is transport-agnostic and does not encrypt traffic on its own.
 
 ## The `sandbox_exec` tool
 
 | Argument | Type | Default | Meaning |
 |---|---|---|---|
 | `command` | string (required) | | Command run inside the box via `sh -c`. |
-| `image` | string | `alpine:3.20` | Container image override (e.g. `python:3.12-slim`). |
+| `image` | string | `alpine:3.20` | Container image override (e.g. `python:3.12-slim`). Rejected if it starts with `-` (would be parsed as a docker flag). |
 | `timeout_seconds` | integer | `30` | Per-exec timeout that bounds a runaway command. |
 
 The tool returns the command's **stdout**, **stderr**, **exit code**, and an explicit
@@ -70,12 +97,17 @@ The tool returns the command's **stdout**, **stderr**, **exit code**, and an exp
 Every call runs `docker run --rm` against an ephemeral `ic-sbx-mcp-*` box with the
 same hardened posture as an IronClaw session sandbox:
 
+- `--runtime runsc` : **gVisor** user-space guest kernel intercepts syscalls (the primary boundary). A non-runsc runtime is an explicit, labelled fallback.
 - `--network none` : no NIC, so egress is structurally impossible.
 - `--cap-drop ALL` : every Linux capability dropped.
+- `--security-opt seccomp=<profile>` : IronClaw's restrictive deny-by-default seccomp profile (same as the OCI path).
 - `--security-opt no-new-privileges` : suid binaries cannot escalate.
 - `--read-only` rootfs, with a small writable `tmpfs` at `/tmp` only.
 - `--user 65532:65532` : non-root.
 - `--pids-limit 256`, `--memory 512m`, `--cpus 1` : bounded resources.
+
+The tool's `containment:` line names the actual runtime, so a caller always sees
+whether it ran under gVisor or a labelled fallback.
 
 ## Prove containment yourself
 

--- a/docs/integrations/mcp-server.md
+++ b/docs/integrations/mcp-server.md
@@ -1,0 +1,124 @@
+---
+title: "Run IronClaw as an MCP server (sandbox any tool call)"
+description: Add IronClaw to Claude Desktop, Cursor, Windsurf, Cline, or any MCP client with one config line. The sandbox_exec tool runs any command or code snippet inside an ephemeral, hardened IronClaw box with no network, dropped capabilities, a non-root user, and a read-only root filesystem. Model-generated code runs where it cannot reach your machine.
+---
+
+# Run IronClaw as an MCP server
+
+The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is how modern AI
+clients (Claude Desktop, Cursor, Windsurf, Cline, and others) discover and call
+tools. Most MCP servers that "run code" run it **on your machine**: a prompt
+injection or a hallucinated command becomes a shell on your host, with your
+filesystem and unrestricted network.
+
+IronClaw ships an MCP server that exposes a single, blunt tool, **`sandbox_exec`**,
+which runs the command inside an **ephemeral, hardened sandbox box** instead. Any
+MCP client can route untrusted, model-generated code through it with one config
+line. The box has no network card, drops every Linux capability, runs as a non-root
+user with a read-only root filesystem and `no-new-privileges`, is bounded by
+cpu/memory/pids caps, and is torn down after the command returns.
+
+!!! note "This is the inverse of registering an external MCP server"
+    IronClaw can also act as a *client* of other MCP servers (see
+    `ironctl mcp add`, which registers an external server behind the human-approval
+    gateway). This page is the opposite direction: IronClaw **is** the server, and
+    your MCP client is the caller.
+
+## One-line install
+
+`sandbox_exec` ships inside the `ironctl` binary you already installed
+([Quickstart](../quickstart.md)). Nothing new to download.
+
+Add IronClaw to your MCP client's config. For **Claude Desktop**
+(`claude_desktop_config.json`), **Cursor**, **Windsurf**, or **Cline**, the shape is
+the same:
+
+```json
+{
+  "mcpServers": {
+    "ironclaw": {
+      "command": "ironctl",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+That is it. The client spawns `ironctl mcp serve`, speaks MCP over stdio, and sees
+one tool: `sandbox_exec`. IronClaw needs a container runtime (Docker or Podman)
+reachable on the host to launch the sandbox box.
+
+Prefer HTTP transport (for a shared or remote server)? Run it explicitly:
+
+```bash
+ironctl mcp serve --http :9000
+```
+
+## The `sandbox_exec` tool
+
+| Argument | Type | Default | Meaning |
+|---|---|---|---|
+| `command` | string (required) | | Command run inside the box via `sh -c`. |
+| `image` | string | `alpine:3.20` | Container image override (e.g. `python:3.12-slim`). |
+| `timeout_seconds` | integer | `30` | Per-exec timeout that bounds a runaway command. |
+
+The tool returns the command's **stdout**, **stderr**, **exit code**, and an explicit
+**containment status** listing the controls that were enforced.
+
+### What the box enforces
+
+Every call runs `docker run --rm` against an ephemeral `ic-sbx-mcp-*` box with the
+same hardened posture as an IronClaw session sandbox:
+
+- `--network none` : no NIC, so egress is structurally impossible.
+- `--cap-drop ALL` : every Linux capability dropped.
+- `--security-opt no-new-privileges` : suid binaries cannot escalate.
+- `--read-only` rootfs, with a small writable `tmpfs` at `/tmp` only.
+- `--user 65532:65532` : non-root.
+- `--pids-limit 256`, `--memory 512m`, `--cpus 1` : bounded resources.
+
+## Prove containment yourself
+
+The value of the tool is what it **stops**. Ask your MCP client (or drive the server
+directly) to run an escape attempt and watch it fail closed.
+
+**Network escape is blocked** (no NIC):
+
+```
+sandbox_exec { "command": "wget -T3 -qO- http://example.com || echo BLOCKED" }
+-> stdout: BLOCKED
+   stderr: wget: bad address 'example.com'
+```
+
+**Host filesystem write is blocked** (read-only rootfs):
+
+```
+sandbox_exec { "command": "touch /etc/pwned || echo BLOCKED" }
+-> stdout: touch: /etc/pwned: Read-only file system
+           BLOCKED
+```
+
+**The process is non-root:**
+
+```
+sandbox_exec { "command": "id" }
+-> stdout: uid=65532 gid=65532 groups=65532
+```
+
+Meanwhile ordinary work runs normally, including writes to the scratch `/tmp`:
+
+```
+sandbox_exec { "command": "echo hello && python3 -c 'print(2+2)'", "image": "python:3.12-slim" }
+-> stdout: hello
+           4
+```
+
+## How it compares
+
+The framework guides ([LangChain](langchain.md), [CrewAI](crewai.md),
+[OpenAI Agents SDK](openai-sdk.md), [Claude Agent SDK](claude-sdk.md)) sandbox an
+agent you built. The MCP server sandboxes **any** MCP client's tool calls without
+touching your agent code at all: it is a drop-in perimeter for the code an assistant
+decides to run. See how the sandbox holds under attack in
+[Isolation, proven](../security-isolation.md) and the
+[threat model](../threat-model.md).

--- a/internal/host/mcp/server.go
+++ b/internal/host/mcp/server.go
@@ -47,6 +47,18 @@ func (s *Server) AddTool(t Tool, fn ToolFunc) {
 	s.handlers[t.Name] = fn
 }
 
+// Tools returns the registered tool metadata in registration order. It is a
+// read-only snapshot used by callers and tests to inspect the exposed tool set.
+func (s *Server) Tools() []Tool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Tool, 0, len(s.order))
+	for _, n := range s.order {
+		out = append(out, s.tools[n])
+	}
+	return out
+}
+
 // dispatch routes one request method to a JSON result. ok=false means "no response"
 // (a notification). An error is a JSON-RPC error to return to the caller.
 func (s *Server) dispatch(ctx context.Context, method string, params json.RawMessage) (result any, ok bool, err *rpcError) {


### PR DESCRIPTION
## IRO-366: Ship IronClaw as an MCP server (sandbox_exec)

Expose IronClaw **itself** as an MCP server so any MCP client (Claude Desktop, Cursor, Windsurf, Cline, ...) can route model-generated code through a hardened IronClaw sandbox with one config line. This is the **inverse** of IRO-145 / the broker (`ironctl mcp add/grant`), which makes IronClaw a *client* of external servers. Confirmed no overlap.

### What ships
- **`ironctl mcp serve [--http :addr]`** — stdio (default, what MCP clients spawn) or streamable-HTTP MCP server, built on the existing `internal/host/mcp` `Server`. Lives in `ironctl` because it is **already installed via install.sh** → zero new release-matrix work, honors the "normal install & run flow" directive. One config line:
  ```json
  { "mcpServers": { "ironclaw": { "command": "ironctl", "args": ["mcp", "serve"] } } }
  ```
- **`sandbox_exec` tool** — runs a command via `sh -c` inside an **ephemeral `ic-sbx-mcp-*` box** with the DockerIsolator posture: `network=none`, `--cap-drop ALL`, `no-new-privileges`, `--read-only` rootfs, non-root `65532`, pids/mem/cpu caps. Returns stdout/stderr/exit code + explicit containment status. Box torn down after each call (`--rm`).
- Exec runner is an **injectable seam**; unit tests assert the hardened argv + result formatting without Docker (`Server.Tools()` added for introspection).
- `docs/integrations/mcp-server.md` + nav; `mkdocs --strict` clean.

### Verification (live, against colima)
| Check | Result |
|---|---|
| MCP stdio handshake (initialize + tools/list) | ✅ returns `sandbox_exec` |
| Normal command | ✅ `uid=65532` (non-root) |
| **Network escape** (`wget http://example.com`) | ✅ **blocked** — `wget: bad address` (network=none) |
| **Host FS write** (`touch /etc/pwned`) | ✅ **blocked** — read-only rootfs |
| `/tmp` scratch | ✅ writable |
| Leftover boxes after runs | ✅ none (`--rm`) |
| `go build`/`go vet`/`go test` (CGO) | ✅ 114 tests pass |

### Supply-chain / trust lenses
- **New external code-exec entry point into the sandbox** = trust-model surface → **CEO review before merge**.
- **Least-privilege**: server holds no credentials, makes no model calls; only shells hardened `docker run`.
- **Checksum-first / release**: no change to signing/attestation/installers; `sandbox_exec` rides the already-signed `ironctl`.

### Follow-ups (not blocking this PR)
- PR to `awesome-mcp-servers` + MCP registry (non-gated inbound) — filing separately.

Closes IRO-366.
