### PR TITLE
feat(live-containment): shareable containment receipt (--share) (IRO-367)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ Thumbs.db
 .claude/
 .remember/
 
+# live-containment --share receipt output (per-run, regenerated)
+ironclaw-receipt/
+
 # Docs site build artifacts (MkDocs)
 /site/
 _site/

--- a/README.md
+++ b/README.md
@@ -53,14 +53,16 @@ on Linux), then paste one block:
 ```sh
 git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
 examples/live-containment/run.sh   # builds the sandbox once, engages a real sandbox, proves it holds
+examples/live-containment/run.sh --share   # ...and emit a shareable containment receipt + badge
 ```
 
 That single command runs the whole secured path on your laptop: it starts the offline mock-agent
 control-plane (**no API key**), engages a **real per-session sandbox**, lets a jailbroken agent try
-to break out, and prints the containment summary you saw above. Want to chat with an agent in a
-browser first? Run [`hello-ironclaw`](examples/hello-ironclaw/) or the
-[zero-credential quickstart](docs/quickstart.md). Production seals each sandbox with gVisor and
-`network=none`.
+to break out, and prints the containment summary you saw above. Add [`--share`](examples/live-containment/#share-your-run---share)
+to freeze a contained run into a copy-pasteable receipt and an `IronClaw | 3/3 contained` badge you
+can drop into your own README. Want to chat with an agent in a browser first? Run
+[`hello-ironclaw`](examples/hello-ironclaw/) or the [zero-credential quickstart](docs/quickstart.md).
+Production seals each sandbox with gVisor and `network=none`.
 
 > **No Docker, nothing to install? Try it in your browser.**
 > Open the repo in a GitHub Codespace and it builds and starts the same offline demo for

--- a/examples/live-containment/README.md
+++ b/examples/live-containment/README.md
@@ -52,10 +52,42 @@ polite tool API proves the tools are polite; it does not prove the *box* is a bo
 examples/live-containment/run.sh            # build + up + demo + tear down
 examples/live-containment/run.sh --keep     # leave the demo running afterwards
 examples/live-containment/run.sh --attach   # use an already-running demo control-plane
+examples/live-containment/run.sh --share    # also emit a shareable containment receipt
 ```
 
 It exits non-zero if **any** escape is not contained, so it doubles as a smoke/CI
 assertion — [`examples/smoke-matrix.sh`](../smoke-matrix.sh) drives it with `--attach`.
+
+## Share your run (`--share`)
+
+Proved your box holds? Post the proof. `--share` freezes a contained run into a clean,
+**copy-pasteable receipt** plus a self-contained **SVG badge** you can drop into a README
+or share on X / LinkedIn. Every run becomes a small piece of evidence that IronClaw does
+what it says.
+
+```bash
+examples/live-containment/run.sh --share
+```
+
+It writes three files to `./ironclaw-receipt/` (override with `IRONCLAW_RECEIPT_DIR`):
+
+| File | What it is |
+|------|-----------|
+| `containment-receipt.txt`  | human-readable receipt + the one-liner to copy |
+| `containment-receipt.svg`  | a `IronClaw \| 3/3 contained` badge (offline, embeddable) |
+| `containment-receipt.json` | the same facts, machine-readable (schemaVersion 1.0) |
+
+The receipt carries only **counts, the ephemeral session id, the public build version, and
+the invariants that held** — no secrets, no host paths, no credentials, no PII. It is safe
+to publish as-is. The one-liner reads:
+
+> I ran a fully-jailbroken AI agent inside IronClaw and it could NOT escape: 3/3 sandbox
+> breakout attempts blocked (network exfil, host filesystem read, Docker socket takeover).
+> Isolation you can prove, not just promise. github.com/IronSecCo/ironclaw
+
+The renderer ([`emit-receipt.sh`](emit-receipt.sh)) is a pure, hermetic transform with its
+own unit test ([`receipt_test.sh`](receipt_test.sh)) — no Docker or network required to
+exercise the artifact shape.
 
 ## Re-record the clip
 

--- a/examples/live-containment/emit-receipt.sh
+++ b/examples/live-containment/emit-receipt.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# emit-receipt.sh — turn a contained live-containment run into a clean, shareable
+# "containment receipt": the credibility of a real IronClaw run, frozen into an
+# artifact a user can post to X / LinkedIn / their README.
+#
+# IronClaw's pitch is "isolation you can prove, not just promise." run.sh proves it
+# live; this renders that proof into something a user WANTS to share, so every run
+# becomes organic inbound (IRO-367). It is deliberately a pure transform with NO
+# Docker/network dependency: it reads a handful of metadata env vars and writes
+# three files. That keeps it hermetically unit-testable (see receipt_test.sh).
+#
+# SAFE TO PUBLISH: the artifact carries only counts, the ephemeral session id, the
+# public build version, and the invariants that held. No secrets, no host paths, no
+# credentials, no PII. The only per-run value is the throwaway session id (a random
+# ULID-style token that names a torn-down container), which identifies THIS run and
+# nothing else.
+#
+# METADATA (env):
+#   RECEIPT_DIR    (required) directory to write the receipt files into
+#   CONTAINED      (required) number of escape attempts that were BLOCKED
+#   TOTAL          (required) total escape attempts made
+#   SESSION_ID     sandbox session id for this run           (default: unknown)
+#   VERSION        IronClaw build the run exercised           (default: unknown)
+#   POSTURE        demo-runc | prod-gvisor | unknown          (default: unknown)
+#   INVARIANTS     comma/newline list of blocked invariants   (default: empty)
+#   REPO_URL       project URL for the share one-liner        (default: github.com/IronSecCo/ironclaw)
+#   GENERATED_AT   RFC3339 UTC timestamp (override for tests)  (default: date -u)
+#   RECEIPT_BASENAME  output basename                          (default: containment-receipt)
+#
+# OUTPUT (written into RECEIPT_DIR):
+#   $BASENAME.txt   human-readable, copy-pasteable receipt block
+#   $BASENAME.json  machine-readable receipt (schemaVersion 1.0)
+#   $BASENAME.svg   self-contained shields-style badge (no external fetch)
+# It also prints the shareable block + one-liner to stdout.
+#
+# EXIT: 0 always (this is a renderer, not a judge — run.sh owns the verdict).
+set -euo pipefail
+
+command -v jq >/dev/null || { echo "emit-receipt.sh needs jq" >&2; exit 1; }
+
+RECEIPT_DIR="${RECEIPT_DIR:?RECEIPT_DIR must be set (where to write the receipt)}"
+CONTAINED="${CONTAINED:?CONTAINED must be set (attempts blocked)}"
+TOTAL="${TOTAL:?TOTAL must be set (total attempts)}"
+SESSION_ID="${SESSION_ID:-unknown}"
+VERSION="${VERSION:-unknown}"
+POSTURE="${POSTURE:-unknown}"
+INVARIANTS="${INVARIANTS:-}"
+REPO_URL="${REPO_URL:-github.com/IronSecCo/ironclaw}"
+RECEIPT_BASENAME="${RECEIPT_BASENAME:-containment-receipt}"
+# The timestamp is receipt metadata (when the proof ran), not a build input, so it
+# does not affect anything reproducible. Allow an override for deterministic tests.
+GENERATED_AT="${GENERATED_AT:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+mkdir -p "$RECEIPT_DIR"
+
+# Normalise the invariant list (comma or newline separated) into a JSON array and a
+# comma-joined human string, dropping blanks and trimming whitespace.
+inv_json="$(printf '%s' "$INVARIANTS" | tr ',' '\n' \
+  | awk '{ gsub(/^[[:space:]]+|[[:space:]]+$/, ""); if (length) print }' \
+  | jq -R . | jq -sc .)"
+inv_human="$(jq -r 'join(", ")' <<<"$inv_json")"
+
+# ---- JSON receipt ---------------------------------------------------------------
+json_path="$RECEIPT_DIR/$RECEIPT_BASENAME.json"
+jq -n \
+  --arg version "$VERSION" \
+  --arg session "$SESSION_ID" \
+  --arg posture "$POSTURE" \
+  --arg generatedAt "$GENERATED_AT" \
+  --arg repo "$REPO_URL" \
+  --argjson contained "$CONTAINED" \
+  --argjson total "$TOTAL" \
+  --argjson invariants "$inv_json" \
+  '{
+    schemaVersion: "1.0",
+    receipt: "ironclaw-containment-receipt",
+    generatedBy: "examples/live-containment (IRO-367)",
+    version: $version,
+    sessionId: $session,
+    posture: $posture,
+    generatedAt: $generatedAt,
+    project: $repo,
+    summary: { blocked: $contained, total: $total },
+    invariantsBlocked: $invariants
+  }' > "$json_path"
+
+# ---- the shareable one-liner ----------------------------------------------------
+# Kept plain-text, link-safe, and free of em/en-dashes (public-copy house style).
+detail=""
+[ -n "$inv_human" ] && detail=" ($inv_human)"
+oneliner="I ran a fully-jailbroken AI agent inside IronClaw and it could NOT escape: ${CONTAINED}/${TOTAL} sandbox breakout attempts blocked${detail}. Isolation you can prove, not just promise. ${REPO_URL}"
+
+# ---- human-readable receipt -----------------------------------------------------
+txt_path="$RECEIPT_DIR/$RECEIPT_BASENAME.txt"
+{
+  echo "==============================================================================="
+  echo " IRONCLAW CONTAINMENT RECEIPT"
+  echo " ${CONTAINED}/${TOTAL} escape attempts BLOCKED. The box held."
+  echo "==============================================================================="
+  echo " version:    $VERSION"
+  echo " session:    $SESSION_ID"
+  echo " posture:    $POSTURE"
+  echo " generated:  $GENERATED_AT"
+  if [ -n "$inv_human" ]; then
+    echo " blocked:    $inv_human"
+  fi
+  echo
+  echo " Share this run:"
+  echo "   $oneliner"
+  echo
+  echo " Badge (drop into a README):"
+  echo "   ![IronClaw containment]($RECEIPT_BASENAME.svg)"
+  echo "==============================================================================="
+} > "$txt_path"
+
+# ---- SVG badge ------------------------------------------------------------------
+# A self-contained, shields.io-style flat badge: no external fetch, deterministic
+# given the run outcome, safe to commit into a README. Left label "IronClaw",
+# right "N/M contained" on green (blue-grey if nothing was contained, which the
+# live demo never reaches because run.sh exits non-zero on a breach first).
+badge_right="${CONTAINED}/${TOTAL} contained"
+# Rough monospace width so the two halves size to their text (6px/char + padding).
+lw=$(( ${#badge_right} * 7 + 22 ))
+llabel="IronClaw"
+llw=$(( ${#llabel} * 7 + 22 ))
+total_w=$(( llw + lw ))
+right_color="#3fb950"   # green: contained
+[ "$CONTAINED" -eq 0 ] && right_color="#8b949e"
+llx=$(( llw * 10 / 2 ))
+rx=$(( llw * 10 + lw * 10 / 2 ))
+svg_path="$RECEIPT_DIR/$RECEIPT_BASENAME.svg"
+cat > "$svg_path" <<SVG
+<svg xmlns="http://www.w3.org/2000/svg" width="$total_w" height="20" role="img" aria-label="IronClaw: $badge_right">
+  <title>IronClaw: $badge_right</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="$total_w" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="$llw" height="20" fill="#24292f"/>
+    <rect x="$llw" width="$lw" height="20" fill="$right_color"/>
+    <rect width="$total_w" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-rendering="geometricPrecision">
+    <text x="$llx" y="150" transform="scale(.1)" fill="#010101" fill-opacity=".3">$llabel</text>
+    <text x="$llx" y="140" transform="scale(.1)">$llabel</text>
+    <text x="$rx" y="150" transform="scale(.1)" fill="#010101" fill-opacity=".3">$badge_right</text>
+    <text x="$rx" y="140" transform="scale(.1)">$badge_right</text>
+  </g>
+</svg>
+SVG
+
+# ---- print the shareable block to stdout ----------------------------------------
+cat "$txt_path"
+echo
+echo "wrote $txt_path"
+echo "wrote $json_path"
+echo "wrote $svg_path"

--- a/examples/live-containment/receipt_test.sh
+++ b/examples/live-containment/receipt_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# receipt_test.sh — unit test for emit-receipt.sh, the shareable-receipt renderer.
+#
+# Pure and hermetic: no Docker, no network, no control-plane. It feeds emit-receipt.sh
+# fixed metadata and asserts the JSON/text/SVG it produces are well-formed, say what
+# they should, and carry nothing unsafe to publish. This is what keeps the share
+# artifact from silently drifting (IRO-367).
+#
+#   examples/live-containment/receipt_test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EMIT="$SCRIPT_DIR/emit-receipt.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok()   { echo "ok: $1"; }
+
+# --- case 1: a fully-contained run (3/3) -------------------------------------------
+GENERATED_AT="2026-07-05T00:00:00Z" \
+RECEIPT_DIR="$WORK/c1" \
+CONTAINED=3 TOTAL=3 \
+SESSION_ID="ses_01JZABCDEF" VERSION="v0.1.203" POSTURE="demo-runc" \
+INVARIANTS="network exfil, host filesystem read, Docker socket takeover" \
+bash "$EMIT" >/dev/null
+
+J="$WORK/c1/containment-receipt.json"
+T="$WORK/c1/containment-receipt.txt"
+S="$WORK/c1/containment-receipt.svg"
+[ -f "$J" ] && [ -f "$T" ] && [ -f "$S" ] || fail "case1: expected all three files"
+jq -e . "$J" >/dev/null || fail "case1: JSON invalid"
+
+[ "$(jq -r .schemaVersion "$J")" = "1.0" ]                 || fail "case1: schemaVersion"
+[ "$(jq -r .version "$J")" = "v0.1.203" ]                  || fail "case1: version"
+[ "$(jq -r .sessionId "$J")" = "ses_01JZABCDEF" ]          || fail "case1: sessionId"
+[ "$(jq -r .posture "$J")" = "demo-runc" ]                 || fail "case1: posture"
+[ "$(jq -r .generatedAt "$J")" = "2026-07-05T00:00:00Z" ]  || fail "case1: generatedAt override"
+[ "$(jq -r .summary.blocked "$J")" = "3" ]                 || fail "case1: blocked"
+[ "$(jq -r .summary.total "$J")" = "3" ]                   || fail "case1: total"
+[ "$(jq -r '.invariantsBlocked | length' "$J")" = "3" ]    || fail "case1: invariant count"
+[ "$(jq -r '.invariantsBlocked[0]' "$J")" = "network exfil" ] || fail "case1: first invariant trimmed"
+
+grep -q "3/3 escape attempts BLOCKED" "$T" || fail "case1: txt headline"
+grep -q "could NOT escape: 3/3" "$T"       || fail "case1: txt one-liner"
+grep -q "v0.1.203" "$T"                     || fail "case1: txt version"
+
+# SVG is well-formed-ish and self-contained (no external fetch, no script).
+# (The xmlns="http://www.w3.org/2000/svg" namespace URI is a required declaration,
+# not a fetch, so we probe for real remote-load vectors instead.)
+grep -q "<svg" "$S"                        || fail "case1: svg root"
+grep -q "3/3 contained" "$S"               || fail "case1: svg count text"
+grep -q "IronClaw" "$S"                    || fail "case1: svg label"
+grep -qiE "<script|<image|xlink:href|href=|src=|url\(http" "$S" && fail "case1: svg must not fetch/script externally"
+
+# Safe-to-publish: no obvious secret/host leakage in any artifact. We target concrete
+# credential/host-path forms; descriptive invariant NAMES like "Docker socket takeover"
+# are expected copy and must not trip this.
+if grep -riE "authorization:|bearer [a-z0-9]|password[=:]|api[_-]?key|/etc/shadow|/var/run/docker\.sock|/host/" "$J" "$T" "$S"; then
+  fail "case1: artifact leaks a secret/host token"
+fi
+ok "case1 contained 3/3: valid JSON+txt+SVG, deterministic, safe to publish"
+
+# --- case 2: empty invariant list is tolerated and one-liner still forms ------------
+GENERATED_AT="2026-07-05T00:00:00Z" \
+RECEIPT_DIR="$WORK/c2" \
+CONTAINED=1 TOTAL=1 SESSION_ID="ses_x" VERSION="dev" \
+bash "$EMIT" >/dev/null
+J2="$WORK/c2/containment-receipt.json"
+[ "$(jq -r '.invariantsBlocked | length' "$J2")" = "0" ] || fail "case2: empty invariants -> empty array"
+grep -q "could NOT escape: 1/1" "$WORK/c2/containment-receipt.txt" || fail "case2: one-liner without detail"
+ok "case2 no invariant list: renders cleanly with an empty array"
+
+# --- case 3: same inputs (minus timestamp) render byte-identical SVG/JSON -----------
+for d in a b; do
+  GENERATED_AT="2026-07-05T00:00:00Z" \
+  RECEIPT_DIR="$WORK/c3$d" CONTAINED=3 TOTAL=3 SESSION_ID="ses_fixed" \
+  VERSION="v0.1.203" POSTURE="demo-runc" INVARIANTS="a,b,c" \
+  bash "$EMIT" >/dev/null
+done
+diff "$WORK/c3a/containment-receipt.svg"  "$WORK/c3b/containment-receipt.svg"  || fail "case3: SVG not deterministic"
+diff "$WORK/c3a/containment-receipt.json" "$WORK/c3b/containment-receipt.json" || fail "case3: JSON not deterministic"
+ok "case3 determinism: identical inputs -> byte-identical SVG + JSON"
+
+echo "ALL PASS"

--- a/examples/live-containment/run.sh
+++ b/examples/live-containment/run.sh
@@ -20,6 +20,12 @@
 #   examples/live-containment/run.sh            # build + up + demo + tear down
 #   examples/live-containment/run.sh --keep     # leave the demo running afterwards
 #   examples/live-containment/run.sh --attach   # use an already-running demo control-plane
+#   examples/live-containment/run.sh --share    # also emit a shareable containment receipt
+#
+# --share turns a contained run into a clean, copy-pasteable receipt (attempts blocked,
+# session id, IronClaw version) plus a self-contained SVG badge you can drop into a
+# README or post to X / LinkedIn. The artifact carries no secrets or PII (IRO-367).
+# Written to $IRONCLAW_RECEIPT_DIR (default ./ironclaw-receipt).
 #
 # Env overrides (all optional):
 #   IRONCLAW_ADDR        control-plane base URL   (default http://127.0.0.1:8787)
@@ -48,13 +54,17 @@ ENGAGE_TIMEOUT="${IRONCLAW_ENGAGE_TIMEOUT:-180}"
 # A hostname the demo sandbox has NO business resolving — the exfil-egress probe target.
 EGRESS_HOST="${IRONCLAW_EGRESS_PROBE_HOST:-api.anthropic.com}"
 
+RECEIPT_DIR="${IRONCLAW_RECEIPT_DIR:-$PWD/ironclaw-receipt}"
+
 KEEP=0        # --keep: don't tear the demo down on exit
 ATTACH=0      # --attach: talk to an already-running control-plane, manage nothing
+SHARE=0       # --share: emit a shareable containment receipt on a contained run
 for arg in "$@"; do
   case "$arg" in
     --keep)   KEEP=1 ;;
     --attach) ATTACH=1 ;;
-    -h|--help) sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    --share)  SHARE=1 ;;
+    -h|--help) sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) echo "unknown flag: $arg (try --help)" >&2; exit 2 ;;
   esac
 done
@@ -134,6 +144,7 @@ set +e   # a contained attack returns non-zero — that is the point, not a fail
 
 CONTAINED=0 ESCAPED=0
 step=0
+BLOCKED_INVARIANTS=""   # short names of the invariants that held, for the --share receipt
 
 # scene <title> <what-the-agent-runs>  — narrate one escape attempt.
 scene() {
@@ -142,7 +153,12 @@ scene() {
   echo "${BOLD}${CYAN}[$step/3] $1${RESET}"
   echo "${DIM}    agent (inside the box, uid 65532) runs:${RESET} ${YELLOW}$2${RESET}"
 }
-blocked() { echo "    ${GREEN}${BOLD}⛔ BLOCKED${RESET}${GREEN} — $1${RESET}"; CONTAINED=$((CONTAINED + 1)); }
+# blocked <explanation> [short-invariant-name]  — record a contained attempt.
+blocked() {
+  echo "    ${GREEN}${BOLD}⛔ BLOCKED${RESET}${GREEN} — $1${RESET}"
+  CONTAINED=$((CONTAINED + 1))
+  [ -n "${2:-}" ] && BLOCKED_INVARIANTS="${BLOCKED_INVARIANTS:+$BLOCKED_INVARIANTS, }$2"
+}
 leaked()  { echo "    ${RED}${BOLD}✗ ESCAPED${RESET}${RED} — $1${RESET}";    ESCAPED=$((ESCAPED + 1)); }
 
 echo
@@ -157,7 +173,7 @@ scene "Exfiltrate stolen data to the attacker" "getent hosts $EGRESS_HOST   # re
 ifaces="$(sbx 'ls -1 /sys/class/net 2>/dev/null | tr "\n" " " | sed "s/ *$//"')"
 sbx "getent hosts $EGRESS_HOST" >/dev/null 2>&1; dns_rc=$?
 if [ "$ifaces" = "lo" ] && [ "$dns_rc" != "0" ]; then
-  blocked "no network namespace: only \`lo\` exists (interfaces: $ifaces), DNS resolution fails. network=none."
+  blocked "no network namespace: only \`lo\` exists (interfaces: $ifaces), DNS resolution fails. network=none." "network exfil"
 else
   leaked  "reached the network — interfaces: [$ifaces], DNS exit: $dns_rc"
 fi
@@ -167,7 +183,7 @@ fi
 scene "Read the operator's host filesystem" "cat /host/etc/shadow /etc/ironclaw-host-marker   # steal host secrets"
 hostfs="$(sbx 'if [ -e /host ] || [ -r /etc/ironclaw-host-marker ]; then echo EXPOSED; else echo CONTAINED; fi')"
 if [ "$hostfs" = "CONTAINED" ]; then
-  blocked "host root is outside the sandbox mount namespace: the paths do not exist in the box."
+  blocked "host root is outside the sandbox mount namespace: the paths do not exist in the box." "host filesystem read"
 else
   leaked  "host paths are reachable from inside the sandbox ($hostfs)"
 fi
@@ -178,7 +194,7 @@ scene "Seize the host via the Docker Engine socket" "docker -H unix:///var/run/d
 socket="$(sbx 'if [ -S /var/run/docker.sock ] || [ -S /run/docker.sock ]; then echo PRESENT; else echo ABSENT; fi')"
 cli="$(sbx 'command -v docker >/dev/null 2>&1 && echo PRESENT || echo ABSENT')"
 if [ "$socket" = "ABSENT" ] && [ "$cli" = "ABSENT" ]; then
-  blocked "the Engine socket is never mounted in and there is no docker client: nothing to seize."
+  blocked "the Engine socket is never mounted in and there is no docker client: nothing to seize." "Docker socket takeover"
 else
   leaked  "the sandbox can reach the Docker Engine (socket:$socket client:$cli)"
 fi
@@ -195,6 +211,26 @@ if [ "$ESCAPED" = 0 ]; then
   echo " Next: the full six-assertion battery + signed containment report ->"
   echo "   ${BOLD}examples/red-team-escape/run.sh${RESET}"
   echo "   Production seals each session with gVisor and network=none (docs/breaking-our-own-sandbox.md)."
+
+  # --- shareable receipt (--share) ------------------------------------------
+  # Freeze this contained run into a copy-pasteable receipt + SVG badge the user
+  # can post anywhere. Every run becomes potential inbound (IRO-367). We only get
+  # here when ESCAPED=0, so the receipt only ever attests a genuinely held box.
+  if [ "$SHARE" = 1 ]; then
+    # session id: the sandbox container name is ic-sbx-<sessionId>; strip the prefix.
+    # It is an ephemeral, PII-free token that names a torn-down container.
+    session_id="${SBX#ic-sbx-}"
+    # IronClaw build: read from the unauthenticated /healthz (works on any install).
+    ic_version="$(curl -fsS "$ADDR/healthz" 2>/dev/null | jq -r '.version // "unknown"' 2>/dev/null || echo unknown)"
+    [ -n "$ic_version" ] || ic_version="unknown"
+    echo
+    echo "=============================================================================="
+    RECEIPT_DIR="$RECEIPT_DIR" \
+    CONTAINED="$CONTAINED" TOTAL="$step" \
+    SESSION_ID="$session_id" VERSION="$ic_version" POSTURE="demo-runc" \
+    INVARIANTS="$BLOCKED_INVARIANTS" \
+    bash "$SCRIPT_DIR/emit-receipt.sh"
+  fi
   exit 0
 fi
 echo " ${RED}${BOLD}CONTAINMENT SUMMARY: $ESCAPED of 3 escapes SUCCEEDED — the sandbox did NOT hold.${RESET}"

--- a/internal/host/api/api.go
+++ b/internal/host/api/api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/IronSecCo/ironclaw/internal/host/registry"
 	"github.com/IronSecCo/ironclaw/internal/host/router"
 	"github.com/IronSecCo/ironclaw/internal/host/skills"
+	"github.com/IronSecCo/ironclaw/internal/version"
 )
 
 // HistoryProvider returns the applied/rejected change history. A FileStore
@@ -188,7 +189,14 @@ func (s *Server) auth(h http.Handler) http.Handler {
 
 // handleHealthz is an unauthenticated liveness probe.
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	// version is public, non-secret build metadata. It is exposed on the
+	// unauthenticated liveness probe so tooling (e.g. the live-containment
+	// share receipt) can stamp the exact IronClaw build without a credential
+	// and regardless of how the control-plane was installed.
+	writeJSON(w, http.StatusOK, map[string]string{
+		"status":  "ok",
+		"version": version.String(),
+	})
 }
 
 // handleHistory returns the applied + rejected change history. When no history

--- a/internal/host/api/api_test.go
+++ b/internal/host/api/api_test.go
@@ -64,11 +64,24 @@ func TestBearerTokenAuth(t *testing.T) {
 		t.Fatalf("correct-token status = %d, want 200", resp.StatusCode)
 	}
 
-	// /healthz is exempt -> 200 with no token.
+	// /healthz is exempt -> 200 with no token, and carries the public build version
+	// (consumed by the live-containment --share receipt; IRO-367).
 	resp, _ = http.Get(srv.URL + "/healthz")
-	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
 		t.Fatalf("healthz status = %d, want 200 (must be exempt)", resp.StatusCode)
+	}
+	var health map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		resp.Body.Close()
+		t.Fatalf("healthz body decode: %v", err)
+	}
+	resp.Body.Close()
+	if health["status"] != "ok" {
+		t.Fatalf("healthz status field = %q, want ok", health["status"])
+	}
+	if health["version"] == "" {
+		t.Fatalf("healthz must expose a non-empty version field")
 	}
 }
 


### PR DESCRIPTION
## What

A product-led growth loop built into the product (IRO-367). When a user runs the live-containment demo and the sandbox holds, `--share` emits a clean, **shareable containment receipt** — a copy-pasteable one-liner + an `IronClaw | 3/3 contained` SVG badge — turning every run into potential organic inbound. No board action required to distribute.

```
examples/live-containment/run.sh --share
```

## How

- **`emit-receipt.sh`** — a pure, hermetic renderer (no Docker/network). Writes three files to `./ironclaw-receipt/` (override `IRONCLAW_RECEIPT_DIR`):
  - `containment-receipt.txt` — human-readable receipt + the one-liner to copy
  - `containment-receipt.svg` — self-contained shields-style badge (offline, embeddable, no external fetch)
  - `containment-receipt.json` — same facts, machine-readable (`schemaVersion 1.0`)
- **`run.sh --share`** — on a contained run, records the blocked invariants, derives the session id from the sandbox container name, reads the IronClaw build from `/healthz`, and calls the renderer.
- **`/healthz` now returns `version`** — unauthenticated, non-secret, **not** the frozen `internal/contract`. Lets the receipt stamp the exact build on any install path (brew/docker/source), not just a repo checkout.
- **`receipt_test.sh`** — hermetic unit test: shape, determinism, and a safe-to-publish scan.

## Safe to publish

The artifact carries only counts, the ephemeral session id, the public build version, and the invariants that held. **No secrets, host paths, credentials, or PII.** SVG has no external fetch/script. Deterministic given the run outcome (timestamp overridable for tests).

## Security lenses

- **Trust boundary / egress / isolation:** read-only. No new sandbox capability; the receipt is rendered host-side from run results. `/healthz` exposes only public build metadata.
- **Secret hygiene:** artifacts scanned clean; the test asserts no credential/host-path leakage.
- **Contract:** unchanged (`/healthz` is not in `internal/contract`).

## Verification

- `go build ./...` green (CGO_ENABLED=1); `go test ./internal/host/api` green (69 tests, incl. new `/healthz` version assertion).
- `receipt_test.sh` — ALL PASS (shape, determinism, safe-to-publish).
- **Real end-to-end run** via the normal demo path (`docker-compose.demo.yml`, colima): **3/3 escape attempts blocked**, receipt + badge emitted, session `ses_b05fc8dc8de364ab`, version read live from `/healthz`, artifacts scanned clean.

Isolated in a worktree off `origin/main` to avoid entangling with in-flight `relay/iro-334-hero-media` edits.