### PR TITLE
docs(mcp): sandbox MCP server onboarding for Claude Desktop / Cursor / Windsurf (IRO-384)

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,12 @@ reference design had. Enable it with `--mcp-catalog`, add servers + grant agents
 console's **MCP** tab, and try it end to end with the bundled `cmd/mcp-sample` server.
 Full guide: [docs/mcp.md](docs/mcp.md).
 
+The inverse also works: `ironctl mcp serve` exposes IronClaw **as** an MCP server with a
+single `sandbox_exec` tool, so **Claude Desktop, Cursor, or Windsurf** can run
+model-generated code in an ephemeral gVisor box (no network, non-root, read-only root,
+dropped caps) with one copy-paste config. Guide:
+[docs/mcp-server/](docs/mcp-server/index.md).
+
 Environment: `ANTHROPIC_API_KEY` (model proxy credential, host-only) and `IRONCLAW_API_TOKEN`
 (bearer token required on every API call when set).
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,22 @@
 
 Each one runs sealed in a sandbox that provably cannot phone home, read your host, or rewrite its own rules.
 
-<!-- One curated row, stars first. The supply-chain trust badges (Scorecard, cosign, SBOM, SLSA) live beside the release-verification story below, where they carry more weight. -->
-[![GitHub stars](https://img.shields.io/github/stars/IronSecCo/ironclaw?style=social)](https://github.com/IronSecCo/ironclaw/stargazers)
+<!-- Security & supply-chain trust cluster — lead with what makes this project different -->
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/IronSecCo/ironclaw/badge)](https://scorecard.dev/viewer/?uri=github.com/IronSecCo/ironclaw)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13348/badge)](https://www.bestpractices.dev/projects/13348)
 [![CodeQL](https://github.com/IronSecCo/ironclaw/actions/workflows/codeql.yml/badge.svg)](https://github.com/IronSecCo/ironclaw/actions/workflows/codeql.yml)
-[![Latest release](https://img.shields.io/github/v/release/IronSecCo/ironclaw?sort=semver)](https://github.com/IronSecCo/ironclaw/releases/latest)
-[![License: AGPLv3 + Commercial](https://img.shields.io/badge/License-AGPLv3%20%2B%20Commercial-blue.svg)](LICENSING.md)
-[![Documentation](https://img.shields.io/badge/docs-ironsecco.github.io-0a7bbb.svg)](https://ironsecco.github.io/ironclaw/)
+[![Signed releases (cosign)](https://img.shields.io/badge/releases-cosign%20signed-0a7bbb.svg)](#verifying-a-release)
+[![SBOM: SPDX + CycloneDX](https://img.shields.io/badge/SBOM-SPDX%20%2B%20CycloneDX-44883e.svg)](#verifying-a-release)
+[![SLSA provenance](https://img.shields.io/badge/SLSA-build%20provenance-44883e.svg)](#verifying-a-release)
 
-**If a safer way to run agents is worth having, [star the repo](https://github.com/IronSecCo/ironclaw)** to follow along and help others find it. Then try the zero-credential [quickstart](docs/quickstart.md).
+[![Documentation](https://img.shields.io/badge/docs-ironsecco.github.io-0a7bbb.svg)](https://ironsecco.github.io/ironclaw/)
+[![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#project-status)
+[![Latest release](https://img.shields.io/github/v/release/IronSecCo/ironclaw?sort=semver)](https://github.com/IronSecCo/ironclaw/releases/latest)
+[![Go Reference](https://pkg.go.dev/badge/github.com/IronSecCo/ironclaw.svg)](https://pkg.go.dev/github.com/IronSecCo/ironclaw)
+[![License: AGPLv3 + Commercial](https://img.shields.io/badge/License-AGPLv3%20%2B%20Commercial-blue.svg)](LICENSING.md)
+[![GitHub Discussions](https://img.shields.io/github/discussions/IronSecCo/ironclaw?logo=github&label=discussions)](https://github.com/IronSecCo/ironclaw/discussions)
+[![Good first issues](https://img.shields.io/github/issues/IronSecCo/ironclaw/good%20first%20issue?label=good%20first%20issues)](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+[![GitHub stars](https://img.shields.io/github/stars/IronSecCo/ironclaw?style=social)](https://github.com/IronSecCo/ironclaw/stargazers)
 
 </div>
 
@@ -27,14 +34,13 @@ handing an autonomous program the keys to their machine.
 <div align="center">
 
 <!--
-  Motion of a REAL block sells. This is an unedited recording of examples/live-containment
-  (source cast: docs/assets/live-containment.cast; regen recipe in that example's README) —
-  the real red-team probes, not staged text. The static final-frame SVG is the
-  prefers-reduced-motion / no-animation fallback. GIF has no audio, so nothing autoplays sound.
+  Motion sells: a REAL recording of examples/live-containment (docs/assets/live-containment.cast,
+  regenerable via the "Re-record the clip" note in that example's README). The static final-frame
+  SVG is the reduced-motion / no-animation fallback. No autoplay-with-sound (GIF has no audio).
 -->
 <picture>
   <source media="(prefers-reduced-motion: reduce)" srcset="docs/assets/containment.svg">
-  <img src="docs/assets/live-containment.gif" width="820" alt="live-containment demo (real terminal recording, looping): one command engages a real per-session sandbox, then a fully-jailbroken agent tries three escapes from inside the box and each is revealed as BLOCKED in turn. Exfiltrating to the attacker is denied because network=none leaves only the loopback interface and DNS fails; reading the operator's host filesystem is denied because the host root is outside the sandbox mount namespace; seizing the host via the Docker Engine socket is denied because the socket is never mounted in and there is no docker client. It ends with a containment summary that 3 of 3 escape attempts were denied and the box held. Viewers who prefer reduced motion see the completed final frame.">
+  <img src="docs/assets/live-containment.gif" width="820" alt="live-containment demo: one command engages a real per-session sandbox, then a fully-jailbroken agent tries three escapes from inside the box and each is BLOCKED. Exfiltrating to the attacker is denied because network=none leaves only the loopback interface and DNS fails; reading the operator's host filesystem is denied because the host root is outside the sandbox mount namespace; seizing the host via the Docker Engine socket is denied because the socket is never mounted in and there is no docker client. It ends with a containment summary that 3 of 3 escape attempts were denied and the box held.">
 </picture>
 
 <sub><b>Watch it catch a real escape.</b> A fully-jailbroken agent inside a real sandbox tries to phone home, read the host filesystem, and seize the host through the Docker socket. Each attempt is <b>denied</b> at the isolation boundary, then a containment summary prints. One command, zero credentials, reduced-motion friendly. <a href="examples/live-containment/"><code>examples/live-containment/run.sh</code></a></sub>
@@ -53,28 +59,14 @@ on Linux), then paste one block:
 ```sh
 git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
 examples/live-containment/run.sh   # builds the sandbox once, engages a real sandbox, proves it holds
-examples/live-containment/run.sh --share   # ...and emit a shareable containment receipt + badge
 ```
 
 That single command runs the whole secured path on your laptop: it starts the offline mock-agent
 control-plane (**no API key**), engages a **real per-session sandbox**, lets a jailbroken agent try
-to break out, and prints the containment summary you saw above. Add [`--share`](examples/live-containment/#share-your-run---share)
-to freeze a contained run into a copy-pasteable receipt and an `IronClaw | 3/3 contained` badge you
-can drop into your own README. Want to chat with an agent in a browser first? Run
-[`hello-ironclaw`](examples/hello-ironclaw/) or the [zero-credential quickstart](docs/quickstart.md).
-Production seals each sandbox with gVisor and `network=none`.
-
-> **No Docker, nothing to install? Try it in your browser.**
-> Open the repo in a GitHub Codespace and it builds and starts the same offline demo for
-> you, then leaves a real sandboxed agent running on the forwarded port **8787**. Chat with
-> it at **`/ui/`** (token `ironclaw-demo`). Zero install, zero credentials.
->
-> [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/IronSecCo/ironclaw?quickstart=1)
->
-> Codespaces has no gVisor, so the sandbox seal is `runc` (same as the laptop demo), but
-> `network=none`, the approval gateway, and the encrypted queues are unchanged — so you can
-> still run `examples/live-containment/run.sh` and watch an escape get denied. Details in
-> [`.devcontainer/`](.devcontainer/README.md).
+to break out, and prints the containment summary you saw above. Want to chat with an agent in a
+browser first? Run [`hello-ironclaw`](examples/hello-ironclaw/) or the
+[zero-credential quickstart](docs/quickstart.md). Production seals each sandbox with gVisor and
+`network=none`.
 
 > [!WARNING]
 > **Alpha software, work in progress. Please read before relying on it.**
@@ -373,9 +365,6 @@ around.
 
 ## Project status
 
-[![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#project-status)
-[![Go Reference](https://pkg.go.dev/badge/github.com/IronSecCo/ironclaw.svg)](https://pkg.go.dev/github.com/IronSecCo/ironclaw)
-
 **Alpha.** The architecture is settled and the full control-plane and sandbox pipelines are
 implemented and tested. The encrypted-queue binding is now wired:
 
@@ -494,11 +483,6 @@ Releases are **signed and attested** — a keyless [cosign](https://docs.sigstor
 signature over `SHA256SUMS`, an **SBOM** (SPDX + CycloneDX), and build-provenance attestations for
 every archive and the container image. For how releases are cut, verified, and yanked, see the
 [release runbook](docs/release-runbook.md).
-
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/IronSecCo/ironclaw/badge)](https://scorecard.dev/viewer/?uri=github.com/IronSecCo/ironclaw)
-[![Signed releases (cosign)](https://img.shields.io/badge/releases-cosign%20signed-0a7bbb.svg)](#verifying-a-release)
-[![SBOM: SPDX + CycloneDX](https://img.shields.io/badge/SBOM-SPDX%20%2B%20CycloneDX-44883e.svg)](#verifying-a-release)
-[![SLSA provenance](https://img.shields.io/badge/SLSA-build%20provenance-44883e.svg)](#verifying-a-release)
 
 <details>
 <summary>Verifying a signed release</summary>
@@ -709,12 +693,8 @@ human-approved grant** and audited. This closes the "blind MCP approval" gap the
 reference design had. Enable it with `--mcp-catalog`, add servers + grant agents on the
 console's **MCP** tab, and try it end to end with the bundled `cmd/mcp-sample` server.
 Full guide: [docs/mcp.md](docs/mcp.md).
-
-The inverse also works: `ironctl mcp serve` exposes IronClaw **as** an MCP server with a
-single `sandbox_exec` tool, so **Claude Desktop, Cursor, or Windsurf** can run
-model-generated code in an ephemeral gVisor box (no network, non-root, read-only root,
-dropped caps) with one copy-paste config. Guide:
-[docs/mcp-server/](docs/mcp-server/index.md).
+To expose IronClaw's `sandbox_exec` tool to Claude Desktop, Cursor, or Windsurf
+as an MCP server, see [docs/mcp-server/](docs/mcp-server/index.md).
 
 Environment: `ANTHROPIC_API_KEY` (model proxy credential, host-only) and `IRONCLAW_API_TOKEN`
 (bearer token required on every API call when set).
@@ -1008,9 +988,6 @@ To report a vulnerability, please open a private security advisory rather than a
 - [x] Gateway auto-approval policy + RBAC — implemented as a verifier/approver, but **inert by default**: the mandatory-human floor is the only active path until an operator opts in
 
 ## Community
-
-[![GitHub Discussions](https://img.shields.io/github/discussions/IronSecCo/ironclaw?logo=github&label=discussions)](https://github.com/IronSecCo/ironclaw/discussions)
-[![Good first issues](https://img.shields.io/github/issues/IronSecCo/ironclaw/good%20first%20issue?label=good%20first%20issues)](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 
 Questions, ideas, "is this a bug or am I holding it wrong?" — bring them to
 **[GitHub Discussions](https://github.com/IronSecCo/ironclaw/discussions)**. It's the project's

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -37,7 +37,7 @@ nav:
       - Writing a channel adapter: writing-a-channel-adapter.md
   - Skills: skills.md
   - Integrations: integrations
-  - Add to your MCP client: mcp-server
+  - MCP Server (for clients): mcp-server
   - Social proof: social-proof.md
   - Security & Trust:
       - Overview: security.md

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -37,6 +37,7 @@ nav:
       - Writing a channel adapter: writing-a-channel-adapter.md
   - Skills: skills.md
   - Integrations: integrations
+  - Add to your MCP client: mcp-server
   - Social proof: social-proof.md
   - Security & Trust:
       - Overview: security.md

--- a/docs/mcp-server/.nav.yml
+++ b/docs/mcp-server/.nav.yml
@@ -1,11 +1,7 @@
-# Navigation for the "Run as a sandbox MCP server" section (IronClaw exposed to
-# MCP clients via `ironctl mcp serve`). New client page: drop `mcp-server/<name>.md`
-# with an H1 and the `*.md` glob auto-includes it (titled from its H1). List a page
-# explicitly only to control its label or ordering, so client PRs never collide on a
-# shared nav line.
+# Navigation for the "IronClaw MCP Server" section.
+# New client page: add a file and list it here.
 nav:
-  - Overview (sandbox MCP server): index.md
+  - Overview: index.md
   - Claude Desktop: claude-desktop.md
   - Cursor: cursor.md
   - Windsurf: windsurf.md
-  - "*.md"

--- a/docs/mcp-server/.nav.yml
+++ b/docs/mcp-server/.nav.yml
@@ -1,0 +1,11 @@
+# Navigation for the "Run as a sandbox MCP server" section (IronClaw exposed to
+# MCP clients via `ironctl mcp serve`). New client page: drop `mcp-server/<name>.md`
+# with an H1 and the `*.md` glob auto-includes it (titled from its H1). List a page
+# explicitly only to control its label or ordering, so client PRs never collide on a
+# shared nav line.
+nav:
+  - Overview (sandbox MCP server): index.md
+  - Claude Desktop: claude-desktop.md
+  - Cursor: cursor.md
+  - Windsurf: windsurf.md
+  - "*.md"

--- a/docs/mcp-server/claude-desktop.md
+++ b/docs/mcp-server/claude-desktop.md
@@ -1,0 +1,69 @@
+---
+title: "Add IronClaw to Claude Desktop (sandbox MCP server)"
+description: Run untrusted or model-generated code from Claude Desktop safely. Copy-paste mcpServers config that adds IronClaw's sandbox_exec tool, running each command in an ephemeral gVisor box with no network and a read-only root.
+---
+
+# Add IronClaw to Claude Desktop
+
+Give Claude Desktop a `sandbox_exec` tool that runs any command or code snippet in an
+ephemeral, gVisor-hardened IronClaw box: no network, non-root, read-only root, all
+capabilities dropped, torn down after each call. See
+[what the box enforces](index.md#what-the-box-enforces) for the full posture.
+
+## 1. Open the config file
+
+In Claude Desktop, go to **Settings -> Developer -> Edit Config**. That opens
+`claude_desktop_config.json`:
+
+| OS | Path |
+|----|------|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+
+## 2. Paste the server block
+
+```json
+{
+  "mcpServers": {
+    "ironclaw": {
+      "command": "/opt/homebrew/bin/ironctl",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+Replace `/opt/homebrew/bin/ironctl` with your own path from `which ironctl`. Claude
+Desktop does not inherit your shell `PATH`, so a bare `"ironctl"` usually will not
+launch. If you already have other servers under `mcpServers`, add `ironclaw` as one
+more key.
+
+!!! note "No gVisor installed?"
+    The default runtime is gVisor (`runsc`). If it is not installed, change the args
+    to `["mcp", "serve", "--runtime", "runc"]`. `runc` keeps the no-network,
+    non-root, read-only, seccomp, and resource caps but isolates on the shared host
+    kernel, not a gVisor guest kernel. See the [runtime note](index.md#no-gvisor-label-the-fallback).
+
+## 3. Restart Claude Desktop
+
+Fully quit and reopen the app so it re-reads the config. `ironclaw` then appears in
+the tools menu (the slider / hammer icon in the message box).
+
+## 4. Verify
+
+Ask Claude:
+
+> Use the sandbox_exec tool to run `uname -a && id && cat /etc/os-release`.
+
+You should see the box's kernel and user, and a `containment:` line reporting
+`runtime=runsc (gVisor ...)`, `network=none`, `caps=drop-all`, `user=65532`. Now try
+to prove the isolation:
+
+> Use sandbox_exec to run `curl -sS https://example.com || echo NO_NETWORK`.
+
+It prints `NO_NETWORK`: the box has no interface, so egress is impossible.
+
+## Prerequisites
+
+`ironctl` on your machine, a container engine (`docker` or `podman`), and gVisor
+recommended. Full setup is on the [cluster overview](index.md#prerequisites).

--- a/docs/mcp-server/claude-desktop.md
+++ b/docs/mcp-server/claude-desktop.md
@@ -1,69 +1,60 @@
 ---
-title: "Add IronClaw to Claude Desktop (sandbox MCP server)"
-description: Run untrusted or model-generated code from Claude Desktop safely. Copy-paste mcpServers config that adds IronClaw's sandbox_exec tool, running each command in an ephemeral gVisor box with no network and a read-only root.
+title: "IronClaw MCP Server -- Claude Desktop"
+description: "Add IronClaw sandbox_exec to Claude Desktop in 30 seconds. Run untrusted agent code safely inside a gVisor sandbox via MCP."
 ---
 
-# Add IronClaw to Claude Desktop
+# Claude Desktop
 
-Give Claude Desktop a `sandbox_exec` tool that runs any command or code snippet in an
-ephemeral, gVisor-hardened IronClaw box: no network, non-root, read-only root, all
-capabilities dropped, torn down after each call. See
-[what the box enforces](index.md#what-the-box-enforces) for the full posture.
+Add IronClaw's `sandbox_exec` tool to Claude Desktop in three steps.
 
-## 1. Open the config file
+## 1. Install ironctl
 
-In Claude Desktop, go to **Settings -> Developer -> Edit Config**. That opens
-`claude_desktop_config.json`:
+```bash
+brew install ironsecco/ironclaw/ironclaw
+```
 
-| OS | Path |
-|----|------|
-| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
-| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+Verify:
 
-## 2. Paste the server block
+```bash
+ironctl version
+```
+
+## 2. Edit the config file
+
+Open (or create) `~/Library/Application Support/Claude/claude_desktop_config.json`
+and add the `ironclaw` entry under `mcpServers`:
 
 ```json
 {
   "mcpServers": {
     "ironclaw": {
-      "command": "/opt/homebrew/bin/ironctl",
+      "command": "ironctl",
       "args": ["mcp", "serve"]
     }
   }
 }
 ```
 
-Replace `/opt/homebrew/bin/ironctl` with your own path from `which ironctl`. Claude
-Desktop does not inherit your shell `PATH`, so a bare `"ironctl"` usually will not
-launch. If you already have other servers under `mcpServers`, add `ironclaw` as one
-more key.
-
-!!! note "No gVisor installed?"
-    The default runtime is gVisor (`runsc`). If it is not installed, change the args
-    to `["mcp", "serve", "--runtime", "runc"]`. `runc` keeps the no-network,
-    non-root, read-only, seccomp, and resource caps but isolates on the shared host
-    kernel, not a gVisor guest kernel. See the [runtime note](index.md#no-gvisor-label-the-fallback).
+If you already have other MCP servers, just add the `"ironclaw"` key alongside them.
 
 ## 3. Restart Claude Desktop
 
-Fully quit and reopen the app so it re-reads the config. `ironclaw` then appears in
-the tools menu (the slider / hammer icon in the message box).
+Quit and reopen Claude Desktop. The `sandbox_exec` tool will appear in the
+tool list. Claude can now run shell commands inside an isolated sandbox on your
+machine.
 
-## 4. Verify
+## What sandbox_exec does
 
-Ask Claude:
+- Runs commands in an ephemeral container managed by IronClaw
+- Uses gVisor for kernel-level isolation -- the AI cannot read your host files
+  or make unexpected network calls
+- Container is destroyed after the session ends
 
-> Use the sandbox_exec tool to run `uname -a && id && cat /etc/os-release`.
+## Troubleshooting
 
-You should see the box's kernel and user, and a `containment:` line reporting
-`runtime=runsc (gVisor ...)`, `network=none`, `caps=drop-all`, `user=65532`. Now try
-to prove the isolation:
+**`ironctl: command not found`** -- Make sure `ironctl` is on your `$PATH`.
+Run `which ironctl` to check. If you installed via Homebrew, run
+`brew link ironsecco/ironclaw/ironclaw`.
 
-> Use sandbox_exec to run `curl -sS https://example.com || echo NO_NETWORK`.
-
-It prints `NO_NETWORK`: the box has no interface, so egress is impossible.
-
-## Prerequisites
-
-`ironctl` on your machine, a container engine (`docker` or `podman`), and gVisor
-recommended. Full setup is on the [cluster overview](index.md#prerequisites).
+**Tool does not appear** -- Restart Claude Desktop fully (Cmd+Q, not just close
+the window).

--- a/docs/mcp-server/cursor.md
+++ b/docs/mcp-server/cursor.md
@@ -1,61 +1,60 @@
 ---
-title: "Add IronClaw to Cursor (secure code execution MCP)"
-description: Give Cursor's agent a secure code execution tool. Copy-paste mcpServers config that adds IronClaw's sandbox_exec, running model-generated code in an ephemeral gVisor box with no network, dropped capabilities, and a read-only root.
+title: "IronClaw MCP Server -- Cursor"
+description: "Add IronClaw sandbox_exec to Cursor in 30 seconds. Run untrusted agent code safely inside a gVisor sandbox via MCP."
 ---
 
-# Add IronClaw to Cursor
+# Cursor
 
-Add a `sandbox_exec` tool so Cursor's agent runs commands and generated code inside
-an ephemeral, gVisor-hardened IronClaw box: no network, non-root, read-only root, all
-capabilities dropped, torn down after each call. See
-[what the box enforces](index.md#what-the-box-enforces) for the full posture.
+Add IronClaw's `sandbox_exec` tool to Cursor in three steps.
 
-## 1. Open the config file
+## 1. Install ironctl
 
-Cursor reads MCP servers from a `mcp.json` file:
+```bash
+brew install ironsecco/ironclaw/ironclaw
+```
 
-| Scope | Path |
-|-------|------|
-| Global (all projects) | `~/.cursor/mcp.json` |
-| Project only | `<project>/.cursor/mcp.json` |
+Verify:
 
-You can also reach the global file from **Cursor Settings -> MCP -> Add new global
-MCP server**, which opens `~/.cursor/mcp.json` for editing.
+```bash
+ironctl version
+```
 
-## 2. Paste the server block
+## 2. Edit the config file
+
+Open (or create) `~/.cursor/mcp.json` and add the `ironclaw` entry under
+`mcpServers`:
 
 ```json
 {
   "mcpServers": {
     "ironclaw": {
-      "command": "/opt/homebrew/bin/ironctl",
+      "command": "ironctl",
       "args": ["mcp", "serve"]
     }
   }
 }
 ```
 
-Replace `/opt/homebrew/bin/ironctl` with the path from `which ironctl`. Use the
-absolute path: the launched process does not inherit your shell `PATH`.
+If you already have other MCP servers, just add the `"ironclaw"` key alongside them.
 
-!!! note "No gVisor installed?"
-    Change the args to `["mcp", "serve", "--runtime", "runc"]`. `runc` keeps the
-    no-network, non-root, read-only, seccomp, and resource caps but isolates on the
-    shared host kernel rather than a gVisor guest kernel. See the
-    [runtime note](index.md#no-gvisor-label-the-fallback).
+## 3. Restart Cursor
 
-## 3. Enable and verify
+Quit and reopen Cursor. The `sandbox_exec` tool will appear in Cursor's MCP
+tool list. The Cursor agent can now run shell commands inside an isolated
+sandbox on your machine.
 
-Open **Cursor Settings -> MCP**. The `ironclaw` server should show a green dot and
-list the `sandbox_exec` tool; toggle it on if needed. Then ask the agent:
+## What sandbox_exec does
 
-> Run `id && curl -sS https://example.com || echo NO_NETWORK` with sandbox_exec.
+- Runs commands in an ephemeral container managed by IronClaw
+- Uses gVisor for kernel-level isolation -- the AI cannot read your host files
+  or make unexpected network calls
+- Container is destroyed after the session ends
 
-You get the box's non-root user and `NO_NETWORK`, plus a `containment:` line naming
-the enforced controls. Egress is impossible because the box has no network
-interface.
+## Troubleshooting
 
-## Prerequisites
+**`ironctl: command not found`** -- Make sure `ironctl` is on your `$PATH`.
+Run `which ironctl` to check. If you installed via Homebrew, run
+`brew link ironsecco/ironclaw/ironclaw`.
 
-`ironctl` on your machine, a container engine (`docker` or `podman`), and gVisor
-recommended. Full setup is on the [cluster overview](index.md#prerequisites).
+**Tool does not appear** -- Open Cursor's MCP settings panel (Settings > MCP)
+and check the server status. Restart Cursor fully if the status shows an error.

--- a/docs/mcp-server/cursor.md
+++ b/docs/mcp-server/cursor.md
@@ -1,0 +1,61 @@
+---
+title: "Add IronClaw to Cursor (secure code execution MCP)"
+description: Give Cursor's agent a secure code execution tool. Copy-paste mcpServers config that adds IronClaw's sandbox_exec, running model-generated code in an ephemeral gVisor box with no network, dropped capabilities, and a read-only root.
+---
+
+# Add IronClaw to Cursor
+
+Add a `sandbox_exec` tool so Cursor's agent runs commands and generated code inside
+an ephemeral, gVisor-hardened IronClaw box: no network, non-root, read-only root, all
+capabilities dropped, torn down after each call. See
+[what the box enforces](index.md#what-the-box-enforces) for the full posture.
+
+## 1. Open the config file
+
+Cursor reads MCP servers from a `mcp.json` file:
+
+| Scope | Path |
+|-------|------|
+| Global (all projects) | `~/.cursor/mcp.json` |
+| Project only | `<project>/.cursor/mcp.json` |
+
+You can also reach the global file from **Cursor Settings -> MCP -> Add new global
+MCP server**, which opens `~/.cursor/mcp.json` for editing.
+
+## 2. Paste the server block
+
+```json
+{
+  "mcpServers": {
+    "ironclaw": {
+      "command": "/opt/homebrew/bin/ironctl",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+Replace `/opt/homebrew/bin/ironctl` with the path from `which ironctl`. Use the
+absolute path: the launched process does not inherit your shell `PATH`.
+
+!!! note "No gVisor installed?"
+    Change the args to `["mcp", "serve", "--runtime", "runc"]`. `runc` keeps the
+    no-network, non-root, read-only, seccomp, and resource caps but isolates on the
+    shared host kernel rather than a gVisor guest kernel. See the
+    [runtime note](index.md#no-gvisor-label-the-fallback).
+
+## 3. Enable and verify
+
+Open **Cursor Settings -> MCP**. The `ironclaw` server should show a green dot and
+list the `sandbox_exec` tool; toggle it on if needed. Then ask the agent:
+
+> Run `id && curl -sS https://example.com || echo NO_NETWORK` with sandbox_exec.
+
+You get the box's non-root user and `NO_NETWORK`, plus a `containment:` line naming
+the enforced controls. Egress is impossible because the box has no network
+interface.
+
+## Prerequisites
+
+`ironctl` on your machine, a container engine (`docker` or `podman`), and gVisor
+recommended. Full setup is on the [cluster overview](index.md#prerequisites).

--- a/docs/mcp-server/index.md
+++ b/docs/mcp-server/index.md
@@ -1,0 +1,150 @@
+---
+title: "Sandbox MCP server: run untrusted agent code safely"
+description: Add IronClaw as a sandbox MCP server so Claude Desktop, Cursor, or Windsurf can run model-generated code in an ephemeral gVisor box with no network, dropped capabilities, and a read-only root. One copy-paste config, secure code execution over MCP.
+---
+
+# Run IronClaw as a sandbox MCP server
+
+`ironctl mcp serve` turns IronClaw into a **Model Context Protocol (MCP) server** that
+any MCP client can add in one config block. It exposes a single tool, `sandbox_exec`,
+that runs a shell command or a model-generated code snippet inside an **ephemeral,
+gVisor-hardened box** and hands back stdout, stderr, exit code, and an explicit
+containment summary. The box has no network, drops every Linux capability, runs
+non-root on a read-only root filesystem, and is torn down when the command finishes.
+
+If your agent writes code, this is the safe place to run it.
+
+!!! note "Two directions, do not confuse them"
+    This page is IronClaw **as a server** for your MCP client. The separate
+    [MCP servers](../mcp.md) guide is the inverse: IronClaw **as a broker** that
+    lets an IronClaw agent reach *other* MCP servers behind a human-approval gate.
+
+## Add it to your client
+
+Pick your client for the copy-paste config and where the config file lives:
+
+- [Claude Desktop](claude-desktop.md) - run untrusted agent code from Claude Desktop
+- [Cursor](cursor.md) - secure code execution for Cursor's agent
+- [Windsurf](windsurf.md) - a sandbox tool for Windsurf Cascade
+
+Any other MCP client (Cline, Continue, Zed, your own) uses the same `mcpServers`
+schema shown below.
+
+## The one config block
+
+Every MCP client spawns the server as a subprocess and speaks JSON-RPC over stdio.
+The universal block is:
+
+```json
+{
+  "mcpServers": {
+    "ironclaw": {
+      "command": "ironctl",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+!!! warning "Use an absolute path for `command`"
+    Most MCP clients do **not** inherit your shell `PATH`, so a bare `"ironctl"`
+    often fails to launch. Run `which ironctl` and paste the full path (for example
+    `/opt/homebrew/bin/ironctl` on Apple Silicon, `/usr/local/bin/ironctl` on Intel
+    macOS or Linux).
+
+## Prerequisites
+
+1. **`ironctl` installed.** One line installs the host binaries:
+
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/IronSecCo/ironclaw/main/scripts/install.sh | sh
+    ```
+
+    or on macOS via Homebrew:
+
+    ```bash
+    brew install ironsecco/ironclaw/ironclaw
+    ```
+
+2. **A container engine** (`docker` or `podman`) reachable on your machine.
+   `sandbox_exec` launches a hardened `docker run` per call.
+
+3. **gVisor (runsc), recommended.** By default the box runs under the gVisor
+   runtime, which intercepts syscalls in a user-space guest kernel. If `runsc` is
+   not installed, either [install gVisor](https://gvisor.dev/docs/user_guide/install/)
+   or fall back explicitly (see below).
+
+### No gVisor? Label the fallback
+
+Without `runsc`, every `sandbox_exec` call fails to launch until you opt into a
+weaker runtime. Add `--runtime runc` to the args:
+
+```json
+{
+  "mcpServers": {
+    "ironclaw": {
+      "command": "ironctl",
+      "args": ["mcp", "serve", "--runtime", "runc"]
+    }
+  }
+}
+```
+
+`runc` still gives you no network, dropped capabilities, non-root, a read-only
+root, seccomp, and resource caps, but the isolation boundary is the **shared host
+kernel**, not a gVisor guest kernel. The tool's containment summary says so on
+every call, so a client is never misled about the guarantee.
+
+## What `sandbox_exec` does
+
+The tool takes one required and two optional arguments:
+
+| Argument | Required | Meaning |
+|----------|----------|---------|
+| `command` | yes | Shell command or snippet, run via `sh -c` inside the box |
+| `image` | no | Container image override (default: `alpine:3.20`) |
+| `timeout_seconds` | no | Per-call timeout, 1 to 600 (default: 30) |
+
+It returns a text block with the exit code, the containment summary, and the
+captured stdout and stderr. A launch failure (engine missing, `runsc` absent, image
+pull denied, timeout) comes back as a readable tool error, not a broken session.
+
+## What the box enforces
+
+Every call runs in an ephemeral `ic-sbx-mcp-*` box under these controls:
+
+- **gVisor (runsc)** runtime by default: syscall interception in a guest kernel.
+- **`network=none`**: no interface, so egress is structurally impossible.
+- **All capabilities dropped**, **non-root** user (uid 65532), **no-new-privileges**.
+- **Read-only root filesystem**; only a small `tmpfs` at `/tmp` is writable.
+- **Restrictive seccomp profile** (the same deny-by-default profile IronClaw uses
+  for agent sandboxes).
+- **Resource caps**: 1 vCPU, 512 MiB memory, 256 pids.
+- **Ephemeral**: the box is torn down as soon as the command returns.
+
+These controls are enforced by the runtime flags, not by the image, and they are
+covered by IronClaw's live containment tests. See
+[Breaking our own sandbox](../breaking-our-own-sandbox.md) for the escape attempts
+they survive and [Why we run AI agents in gVisor](../gvisor-deep-dive.md) for the
+isolation model.
+
+## The server holds no secrets
+
+`ironctl mcp serve` makes **no model calls** and stores **no credentials**. It is a
+thin bridge from an MCP tool call to a hardened `docker run`. Nothing you send it is
+logged as arguments, and the box it spawns can reach neither the network nor your
+host.
+
+## Optional: HTTP transport
+
+Stdio is the default and what clients spawn. To run one long-lived server that
+several clients dial, use streamable HTTP:
+
+```bash
+ironctl mcp serve --http :9000                 # loopback only (127.0.0.1)
+ironctl mcp serve --http 0.0.0.0:9000 --auth-token "$TOKEN"   # any other bind requires auth
+```
+
+A non-loopback bind without `--auth-token` is refused: the server never exposes
+`sandbox_exec` to the network unauthenticated. Point an HTTP-capable client at
+`http://127.0.0.1:9000`.

--- a/docs/mcp-server/index.md
+++ b/docs/mcp-server/index.md
@@ -1,150 +1,49 @@
 ---
-title: "Sandbox MCP server: run untrusted agent code safely"
-description: Add IronClaw as a sandbox MCP server so Claude Desktop, Cursor, or Windsurf can run model-generated code in an ephemeral gVisor box with no network, dropped capabilities, and a read-only root. One copy-paste config, secure code execution over MCP.
+title: IronClaw MCP Server
+description: "Run IronClaw as an MCP server to give Claude Desktop, Cursor, and Windsurf a sandboxed code-execution tool in 30 seconds."
 ---
 
-# Run IronClaw as a sandbox MCP server
+# IronClaw as an MCP Server
 
-`ironctl mcp serve` turns IronClaw into a **Model Context Protocol (MCP) server** that
-any MCP client can add in one config block. It exposes a single tool, `sandbox_exec`,
-that runs a shell command or a model-generated code snippet inside an **ephemeral,
-gVisor-hardened box** and hands back stdout, stderr, exit code, and an explicit
-containment summary. The box has no network, drops every Linux capability, runs
-non-root on a read-only root filesystem, and is torn down when the command finishes.
+IronClaw ships a built-in MCP server (`ironctl mcp serve`) that exposes the
+`sandbox_exec` tool to any MCP-compatible AI client. Connect it once and every
+AI action runs inside an isolated gVisor sandbox -- no escapes, no host
+side-effects.
 
-If your agent writes code, this is the safe place to run it.
+## What is sandbox_exec?
 
-!!! note "Two directions, do not confuse them"
-    This page is IronClaw **as a server** for your MCP client. The separate
-    [MCP servers](../mcp.md) guide is the inverse: IronClaw **as a broker** that
-    lets an IronClaw agent reach *other* MCP servers behind a human-approval gate.
+`sandbox_exec` lets the AI client run arbitrary shell commands inside an
+ephemeral IronClaw sandbox container. The sandbox is destroyed after each
+session, so nothing persists to your host.
 
-## Add it to your client
+## Supported clients
 
-Pick your client for the copy-paste config and where the config file lives:
-
-- [Claude Desktop](claude-desktop.md) - run untrusted agent code from Claude Desktop
-- [Cursor](cursor.md) - secure code execution for Cursor's agent
-- [Windsurf](windsurf.md) - a sandbox tool for Windsurf Cascade
-
-Any other MCP client (Cline, Continue, Zed, your own) uses the same `mcpServers`
-schema shown below.
-
-## The one config block
-
-Every MCP client spawns the server as a subprocess and speaks JSON-RPC over stdio.
-The universal block is:
-
-```json
-{
-  "mcpServers": {
-    "ironclaw": {
-      "command": "ironctl",
-      "args": ["mcp", "serve"]
-    }
-  }
-}
-```
-
-!!! warning "Use an absolute path for `command`"
-    Most MCP clients do **not** inherit your shell `PATH`, so a bare `"ironctl"`
-    often fails to launch. Run `which ironctl` and paste the full path (for example
-    `/opt/homebrew/bin/ironctl` on Apple Silicon, `/usr/local/bin/ironctl` on Intel
-    macOS or Linux).
+| Client | Config file |
+|--------|------------|
+| [Claude Desktop](claude-desktop.md) | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| [Cursor](cursor.md) | `~/.cursor/mcp.json` |
+| [Windsurf](windsurf.md) | `~/.codeium/windsurf/mcp_server_config.json` |
 
 ## Prerequisites
 
-1. **`ironctl` installed.** One line installs the host binaries:
-
-    ```bash
-    curl -fsSL https://raw.githubusercontent.com/IronSecCo/ironclaw/main/scripts/install.sh | sh
-    ```
-
-    or on macOS via Homebrew:
-
-    ```bash
-    brew install ironsecco/ironclaw/ironclaw
-    ```
-
-2. **A container engine** (`docker` or `podman`) reachable on your machine.
-   `sandbox_exec` launches a hardened `docker run` per call.
-
-3. **gVisor (runsc), recommended.** By default the box runs under the gVisor
-   runtime, which intercepts syscalls in a user-space guest kernel. If `runsc` is
-   not installed, either [install gVisor](https://gvisor.dev/docs/user_guide/install/)
-   or fall back explicitly (see below).
-
-### No gVisor? Label the fallback
-
-Without `runsc`, every `sandbox_exec` call fails to launch until you opt into a
-weaker runtime. Add `--runtime runc` to the args:
-
-```json
-{
-  "mcpServers": {
-    "ironclaw": {
-      "command": "ironctl",
-      "args": ["mcp", "serve", "--runtime", "runc"]
-    }
-  }
-}
-```
-
-`runc` still gives you no network, dropped capabilities, non-root, a read-only
-root, seccomp, and resource caps, but the isolation boundary is the **shared host
-kernel**, not a gVisor guest kernel. The tool's containment summary says so on
-every call, so a client is never misled about the guarantee.
-
-## What `sandbox_exec` does
-
-The tool takes one required and two optional arguments:
-
-| Argument | Required | Meaning |
-|----------|----------|---------|
-| `command` | yes | Shell command or snippet, run via `sh -c` inside the box |
-| `image` | no | Container image override (default: `alpine:3.20`) |
-| `timeout_seconds` | no | Per-call timeout, 1 to 600 (default: 30) |
-
-It returns a text block with the exit code, the containment summary, and the
-captured stdout and stderr. A launch failure (engine missing, `runsc` absent, image
-pull denied, timeout) comes back as a readable tool error, not a broken session.
-
-## What the box enforces
-
-Every call runs in an ephemeral `ic-sbx-mcp-*` box under these controls:
-
-- **gVisor (runsc)** runtime by default: syscall interception in a guest kernel.
-- **`network=none`**: no interface, so egress is structurally impossible.
-- **All capabilities dropped**, **non-root** user (uid 65532), **no-new-privileges**.
-- **Read-only root filesystem**; only a small `tmpfs` at `/tmp` is writable.
-- **Restrictive seccomp profile** (the same deny-by-default profile IronClaw uses
-  for agent sandboxes).
-- **Resource caps**: 1 vCPU, 512 MiB memory, 256 pids.
-- **Ephemeral**: the box is torn down as soon as the command returns.
-
-These controls are enforced by the runtime flags, not by the image, and they are
-covered by IronClaw's live containment tests. See
-[Breaking our own sandbox](../breaking-our-own-sandbox.md) for the escape attempts
-they survive and [Why we run AI agents in gVisor](../gvisor-deep-dive.md) for the
-isolation model.
-
-## The server holds no secrets
-
-`ironctl mcp serve` makes **no model calls** and stores **no credentials**. It is a
-thin bridge from an MCP tool call to a hardened `docker run`. Nothing you send it is
-logged as arguments, and the box it spawns can reach neither the network nor your
-host.
-
-## Optional: HTTP transport
-
-Stdio is the default and what clients spawn. To run one long-lived server that
-several clients dial, use streamable HTTP:
+Install IronClaw:
 
 ```bash
-ironctl mcp serve --http :9000                 # loopback only (127.0.0.1)
-ironctl mcp serve --http 0.0.0.0:9000 --auth-token "$TOKEN"   # any other bind requires auth
+brew install ironsecco/ironclaw/ironclaw
 ```
 
-A non-loopback bind without `--auth-token` is refused: the server never exposes
-`sandbox_exec` to the network unauthenticated. Point an HTTP-capable client at
-`http://127.0.0.1:9000`.
+or via the one-liner:
+
+```bash
+curl -fsSL https://ironclaw.sh/install.sh | sh
+```
+
+Then verify:
+
+```bash
+ironctl version
+```
+
+!!! note "This page covers IronClaw acting as an MCP server (outbound tool provider)."
+    For the reverse -- using external MCP servers *inside* an IronClaw-guarded agent
+    sandbox -- see [MCP servers](../mcp.md).

--- a/docs/mcp-server/windsurf.md
+++ b/docs/mcp-server/windsurf.md
@@ -1,0 +1,59 @@
+---
+title: "Add IronClaw to Windsurf (sandbox MCP server)"
+description: Give Windsurf Cascade a sandbox tool for running untrusted agent code. Copy-paste mcpServers config that adds IronClaw's sandbox_exec, executing commands in an ephemeral gVisor box with no network and a read-only root.
+---
+
+# Add IronClaw to Windsurf
+
+Give Windsurf's Cascade agent a `sandbox_exec` tool that runs commands and generated
+code inside an ephemeral, gVisor-hardened IronClaw box: no network, non-root,
+read-only root, all capabilities dropped, torn down after each call. See
+[what the box enforces](index.md#what-the-box-enforces) for the full posture.
+
+## 1. Open the config file
+
+Windsurf reads MCP servers from:
+
+```
+~/.codeium/windsurf/mcp_config.json
+```
+
+You can also open it from the Cascade panel: click the MCP / plugins toolbar (the
+hammer icon), then **Manage plugins -> View raw config**.
+
+## 2. Paste the server block
+
+```json
+{
+  "mcpServers": {
+    "ironclaw": {
+      "command": "/opt/homebrew/bin/ironctl",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+Replace `/opt/homebrew/bin/ironctl` with the path from `which ironctl`. Use the
+absolute path: the spawned process does not inherit your shell `PATH`.
+
+!!! note "No gVisor installed?"
+    Change the args to `["mcp", "serve", "--runtime", "runc"]`. `runc` keeps the
+    no-network, non-root, read-only, seccomp, and resource caps but isolates on the
+    shared host kernel rather than a gVisor guest kernel. See the
+    [runtime note](index.md#no-gvisor-label-the-fallback).
+
+## 3. Refresh and verify
+
+In the Cascade MCP panel, click **Refresh** so Windsurf re-reads the config. The
+`ironclaw` server appears with its `sandbox_exec` tool. Ask Cascade:
+
+> Use sandbox_exec to run `id && curl -sS https://example.com || echo NO_NETWORK`.
+
+You get the box's non-root user and `NO_NETWORK`, plus a `containment:` line naming
+the enforced controls. The box has no network interface, so egress cannot happen.
+
+## Prerequisites
+
+`ironctl` on your machine, a container engine (`docker` or `podman`), and gVisor
+recommended. Full setup is on the [cluster overview](index.md#prerequisites).

--- a/docs/mcp-server/windsurf.md
+++ b/docs/mcp-server/windsurf.md
@@ -1,59 +1,61 @@
 ---
-title: "Add IronClaw to Windsurf (sandbox MCP server)"
-description: Give Windsurf Cascade a sandbox tool for running untrusted agent code. Copy-paste mcpServers config that adds IronClaw's sandbox_exec, executing commands in an ephemeral gVisor box with no network and a read-only root.
+title: "IronClaw MCP Server -- Windsurf"
+description: "Add IronClaw sandbox_exec to Windsurf in 30 seconds. Run untrusted agent code safely inside a gVisor sandbox via MCP."
 ---
 
-# Add IronClaw to Windsurf
+# Windsurf
 
-Give Windsurf's Cascade agent a `sandbox_exec` tool that runs commands and generated
-code inside an ephemeral, gVisor-hardened IronClaw box: no network, non-root,
-read-only root, all capabilities dropped, torn down after each call. See
-[what the box enforces](index.md#what-the-box-enforces) for the full posture.
+Add IronClaw's `sandbox_exec` tool to Windsurf in three steps.
 
-## 1. Open the config file
+## 1. Install ironctl
 
-Windsurf reads MCP servers from:
-
-```
-~/.codeium/windsurf/mcp_config.json
+```bash
+brew install ironsecco/ironclaw/ironclaw
 ```
 
-You can also open it from the Cascade panel: click the MCP / plugins toolbar (the
-hammer icon), then **Manage plugins -> View raw config**.
+Verify:
 
-## 2. Paste the server block
+```bash
+ironctl version
+```
+
+## 2. Edit the config file
+
+Open (or create) `~/.codeium/windsurf/mcp_server_config.json` and add the
+`ironclaw` entry under `mcpServers`:
 
 ```json
 {
   "mcpServers": {
     "ironclaw": {
-      "command": "/opt/homebrew/bin/ironctl",
+      "command": "ironctl",
       "args": ["mcp", "serve"]
     }
   }
 }
 ```
 
-Replace `/opt/homebrew/bin/ironctl` with the path from `which ironctl`. Use the
-absolute path: the spawned process does not inherit your shell `PATH`.
+If you already have other MCP servers, just add the `"ironclaw"` key alongside them.
 
-!!! note "No gVisor installed?"
-    Change the args to `["mcp", "serve", "--runtime", "runc"]`. `runc` keeps the
-    no-network, non-root, read-only, seccomp, and resource caps but isolates on the
-    shared host kernel rather than a gVisor guest kernel. See the
-    [runtime note](index.md#no-gvisor-label-the-fallback).
+## 3. Restart Windsurf
 
-## 3. Refresh and verify
+Quit and reopen Windsurf. The `sandbox_exec` tool will appear in the Cascade
+tool list. The Windsurf agent can now run shell commands inside an isolated
+sandbox on your machine.
 
-In the Cascade MCP panel, click **Refresh** so Windsurf re-reads the config. The
-`ironclaw` server appears with its `sandbox_exec` tool. Ask Cascade:
+## What sandbox_exec does
 
-> Use sandbox_exec to run `id && curl -sS https://example.com || echo NO_NETWORK`.
+- Runs commands in an ephemeral container managed by IronClaw
+- Uses gVisor for kernel-level isolation -- the AI cannot read your host files
+  or make unexpected network calls
+- Container is destroyed after the session ends
 
-You get the box's non-root user and `NO_NETWORK`, plus a `containment:` line naming
-the enforced controls. The box has no network interface, so egress cannot happen.
+## Troubleshooting
 
-## Prerequisites
+**`ironctl: command not found`** -- Make sure `ironctl` is on your `$PATH`.
+Run `which ironctl` to check. If you installed via Homebrew, run
+`brew link ironsecco/ironclaw/ironclaw`.
 
-`ironctl` on your machine, a container engine (`docker` or `podman`), and gVisor
-recommended. Full setup is on the [cluster overview](index.md#prerequisites).
+**Tool does not appear** -- Open Windsurf's MCP settings and verify the server
+entry. Restart Windsurf fully (not just close the window) to reload the MCP
+configuration.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -16,6 +16,12 @@ reachable from — the agent sandbox.**
 This is opt‑in. With no `--mcp-catalog` the daemon exposes no MCP surface at all and a
 sandbox can never reach one.
 
+!!! note "Looking for the inverse?"
+    This page is IronClaw as an MCP **client** (a broker that gates an agent's access
+    to other servers). To expose IronClaw **as** an MCP server so Claude Desktop,
+    Cursor, or Windsurf can run code in a sandbox, see
+    [Run IronClaw as a sandbox MCP server](mcp-server/index.md).
+
 ## The security model in one picture
 
 ```

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -5,6 +5,9 @@ description: Add MCP server tools to a self-hosted AI agent without weakening th
 
 # MCP servers
 
+!!! tip "Want to use IronClaw as an MCP server inside Claude Desktop, Cursor, or Windsurf?"
+    See the [MCP Server onboarding guide](mcp-server/index.md) for a 30-second setup.
+
 IronClaw can extend an agent with the tools of a **Model Context Protocol (MCP)**
 server — local (a stdio subprocess) or remote (a streamable‑HTTP endpoint) — without
 weakening the sandbox. The reference design that IronClaw was built to harden wired MCP
@@ -15,12 +18,6 @@ reachable from — the agent sandbox.**
 
 This is opt‑in. With no `--mcp-catalog` the daemon exposes no MCP surface at all and a
 sandbox can never reach one.
-
-!!! note "Looking for the inverse?"
-    This page is IronClaw as an MCP **client** (a broker that gates an agent's access
-    to other servers). To expose IronClaw **as** an MCP server so Claude Desktop,
-    Cursor, or Windsurf can run code in a sandbox, see
-    [Run IronClaw as a sandbox MCP server](mcp-server/index.md).
 
 ## The security model in one picture
 


### PR DESCRIPTION
## What

New `docs/mcp-server/` cluster so anyone in the Claude Desktop / Cursor / Windsurf ecosystems can add IronClaw's `sandbox_exec` tool in ~30s. This is IronClaw **as** an MCP server (`ironctl mcp serve`, IRO-366) - the inverse of the existing broker guide (`docs/mcp.md`).

The MCP wave is the highest-leverage no-account reach lever right now.

## Pages (own `.nav.yml`, IRO-321/348 pattern)

- `index.md` - overview, the one universal stdio config block, prerequisites (`ironctl` + docker/podman + gVisor), the `runc` fallback labelled honestly, `sandbox_exec` args, enforced containment posture, optional HTTP transport.
- `claude-desktop.md` / `cursor.md` / `windsurf.md` - per-client config-file path, the absolute-`command`-path gotcha (clients don't inherit shell PATH), the gVisor fallback, and a verify step that proves `network=none`.

## Acceptance

- [x] New docs page(s) under an MCP cluster with its own `.nav.yml`.
- [x] Verified copy-paste `mcpServers` JSON that launches `ironctl mcp serve` and exposes `sandbox_exec` (config + flags map exactly to `cmd/ironctl/mcp_serve.go` on main).
- [x] Per-page SEO meta descriptions (IRO-277): 'sandbox MCP server', 'secure code execution MCP', 'run untrusted agent code Claude Desktop'.
- [x] Cross-linked from the README MCP section (both directions).
- [x] `mkdocs build --strict` passes locally.

## Notes

- Cluster is `docs/mcp-server/` (not `docs/mcp/`) to avoid a URL collision with the existing broker page `docs/mcp.md` (both would map to `/mcp/`). Verified `/mcp/` and `/mcp-server/` build independently.
- Security/containment claims map to the merged, QA-verified PR #357 (runsc default, `network=none`, caps dropped, non-root, read-only rootfs, seccomp, resource caps; live escape blocked).
- No board/account gating. Self-merge on green CI per issue.