### PR TITLE
feat(integrations): package llama-index-tools-ironclaw for LlamaIndex (IRO-372)

### DIFF
--- a/examples/integrations/llamaindex/README.md
+++ b/examples/integrations/llamaindex/README.md
@@ -16,6 +16,19 @@ with IronClawSandbox() as sandbox:            # engage a per-session sandbox
     # agent = FunctionAgent(tools=[tool], llm=llm)  # ... drop into any LlamaIndex agent
 ```
 
+## Install it as a package
+
+This example is also packaged as a standalone, PyPI-installable LlamaIndex tool
+integration, [`llama-index-tools-ironclaw`](llama-index-tools-ironclaw/), which
+exposes the same `sandboxed_shell` via an `IronClawToolSpec` (`BaseToolSpec`):
+
+```python
+from llama_index.tools.ironclaw import IronClawToolSpec
+
+tool_spec = IronClawToolSpec()                       # points at the demo control-plane
+agent = FunctionAgent(tools=tool_spec.to_tool_list(), llm=llm)
+```
+
 ## Try it in one command
 
 Zero credentials — the LLM side uses the offline **mock provider**, the sandbox

--- a/examples/integrations/llamaindex/llama-index-tools-ironclaw/.gitignore
+++ b/examples/integrations/llamaindex/llama-index-tools-ironclaw/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+build/
+dist/
+.pytest_cache/
+.ruff_cache/
+.venv/
+venv/

--- a/examples/integrations/llamaindex/llama-index-tools-ironclaw/LICENSE
+++ b/examples/integrations/llamaindex/llama-index-tools-ironclaw/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 IronSec Co
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/integrations/llamaindex/llama-index-tools-ironclaw/README.md
+++ b/examples/integrations/llamaindex/llama-index-tools-ironclaw/README.md
@@ -1,0 +1,88 @@
+# LlamaIndex Tool: IronClaw sandbox
+
+`llama-index-tools-ironclaw` lets a LlamaIndex agent run untrusted,
+model-generated code inside an **IronClaw sandbox** instead of on your host. The
+agent calls it exactly like a normal shell/code tool, but every command runs
+with **no network, no host filesystem, and no Docker socket** -- the isolation
+boundary IronClaw [proves holds](https://github.com/IronSecCo/ironclaw/tree/main/examples/red-team-escape),
+not just promises.
+
+## Install
+
+```sh
+pip install llama-index-tools-ironclaw
+```
+
+## Usage
+
+```python
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.llms.openai import OpenAI
+from llama_index.tools.ironclaw import IronClawToolSpec
+
+tool_spec = IronClawToolSpec()  # points at the local IronClaw demo control-plane
+
+agent = FunctionAgent(
+    tools=tool_spec.to_tool_list(),
+    llm=OpenAI(model="gpt-4o-mini"),
+    system_prompt="Answer the user by running commands with the sandboxed_shell tool.",
+)
+```
+
+Or call the tool directly:
+
+```python
+from llama_index.tools.ironclaw import IronClawToolSpec
+
+tool_spec = IronClawToolSpec()
+print(tool_spec.sandboxed_shell("id"))   # runs INSIDE the sandbox, not on your host
+# [exit 0]
+# uid=65532 gid=65532 groups=65532
+```
+
+`IronClawToolSpec` exposes a single tool, `sandboxed_shell(command: str)`, which
+returns the command's combined stdout/stderr prefixed with its exit code. A
+non-zero exit (for example, a blocked network call) is returned as data, never
+raised -- a contained attack is observable output.
+
+### Pointing at your control-plane
+
+```python
+IronClawToolSpec(
+    addr="http://your-control-plane:8787",
+    token="your-token",
+    agent="your-agent-group",
+)
+```
+
+By default it targets the offline demo control-plane (mock provider, no model
+key, no channel tokens), so the whole thing runs **zero-credential**.
+
+## Requirements
+
+The tool `docker exec`s into a live IronClaw per-session sandbox, so it needs:
+
+- A running IronClaw control-plane (the runnable, one-command demo is in
+  [`examples/integrations/llamaindex`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/llamaindex)).
+- The Docker CLI on `PATH`.
+
+The client itself is pure standard library; the only runtime dependency this
+package adds is `llama-index-core`.
+
+## How it works
+
+A chat message to the demo agent makes the IronClaw router launch that
+conversation's per-session sandbox as a sibling container (`ic-sbx-*`). The tool
+then `docker exec`s into that container as its own non-root uid (65532) -- the
+exact privilege a fully-jailbroken agent with arbitrary code execution would
+have. This is the same boundary IronClaw's red-team-escape harness attacks:
+`network=none`, no Docker socket, host filesystem not mounted, non-root,
+read-only rootfs.
+
+See the [IronClaw repo](https://github.com/IronSecCo/ironclaw) and the
+[LlamaIndex integration example](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/llamaindex)
+for the full isolation model and a live PASS/FAIL containment demo.
+
+## License
+
+MIT

--- a/examples/integrations/llamaindex/llama-index-tools-ironclaw/llama_index/tools/ironclaw/__init__.py
+++ b/examples/integrations/llamaindex/llama-index-tools-ironclaw/llama_index/tools/ironclaw/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.tools.ironclaw.base import IronClawToolSpec
+
+__all__ = ["IronClawToolSpec"]

--- a/examples/integrations/llamaindex/llama-index-tools-ironclaw/llama_index/tools/ironclaw/_sandbox.py
+++ b/examples/integrations/llamaindex/llama-index-tools-ironclaw/llama_index/tools/ironclaw/_sandbox.py
@@ -1,0 +1,178 @@
+"""IronClaw sandbox client (vendored, pure standard library).
+
+Run untrusted, agent-generated commands inside a live IronClaw per-session
+sandbox instead of on the host. The :class:`IronClawToolSpec` wraps this: the
+LlamaIndex agent hands us a command string, we execute it inside the isolated
+sandbox and hand back stdout + exit code.
+
+This is a self-contained copy of ``examples/integrations/_shared/ironclaw_sandbox.py``
+from the IronClaw repo (https://github.com/IronSecCo/ironclaw), vendored so the
+published ``llama-index-tools-ironclaw`` package has zero third-party runtime
+dependencies beyond ``llama-index-core``.
+
+Zero credentials. It talks to the offline demo control-plane (mock provider, no
+model key, no channel tokens) by default.
+
+Execution primitive. A chat message to the demo agent makes the router launch
+that conversation's per-session sandbox as a sibling container (``ic-sbx-*``). We
+then ``docker exec`` into that container as its own non-root uid (65532) -- the
+exact privilege a fully-jailbroken agent with arbitrary code execution would
+have. This is the boundary IronClaw's red-team-escape harness proves holds:
+network=none, no Docker socket, host filesystem not mounted, non-root, read-only
+rootfs.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+
+@dataclass
+class ExecResult:
+    """Result of running one command inside the sandbox."""
+
+    stdout: str
+    exit_code: int
+
+    def __str__(self) -> str:  # what a tool typically returns to the agent
+        return f"[exit {self.exit_code}]\n{self.stdout}".rstrip()
+
+
+class SandboxError(RuntimeError):
+    """The sandbox could not be engaged or reached."""
+
+
+class IronClawSandbox:
+    """A handle to one live IronClaw per-session sandbox.
+
+    Typical use::
+
+        with IronClawSandbox() as sbx:
+            print(sbx.run("id"))              # runs INSIDE the sandbox
+
+    The control-plane lifecycle (build image, ``docker compose up``) is owned by
+    the example's run.sh; this client assumes the demo control-plane is already
+    healthy and simply engages a session against it.
+    """
+
+    def __init__(
+        self,
+        addr: str = "http://127.0.0.1:8787",
+        token: str = "ironclaw-demo",
+        agent: str = "mock-agent",
+        exec_uid: str = "65532:65532",
+    ) -> None:
+        self.addr = addr.rstrip("/")
+        self.token = token
+        self.agent = agent
+        self.exec_uid = exec_uid
+        self.container: str | None = None
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def __enter__(self) -> "IronClawSandbox":
+        self.engage()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        # The per-session container is reaped by the control-plane when the demo
+        # is torn down (run.sh owns ``docker compose down``); nothing to close.
+        return None
+
+    def _http(self, method: str, path: str, body: dict | None = None) -> bytes:
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(f"{self.addr}{path}", data=data, method=method)
+        req.add_header("Authorization", f"Bearer {self.token}")
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                return resp.read()
+        except urllib.error.URLError as exc:  # connection refused, timeout, 5xx
+            raise SandboxError(f"{method} {path} failed: {exc}") from exc
+
+    def engage(self, timeout: int = 180) -> str:
+        """Launch this session's sandbox and return its container name.
+
+        Sends a chat to the demo agent (which makes the router spin up the
+        per-session sandbox), then polls ``docker ps`` until the ``ic-sbx-*``
+        container is running. Idempotent-ish: re-engaging just finds the
+        already-running container.
+        """
+        marker = f"llama-index-tools-ironclaw engage {int(time.time())}"
+        self._http(
+            "POST",
+            "/v1/ui/chat/send",
+            {"agentGroupID": self.agent, "text": marker},
+        )
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            # Drain the reply so the agent loop keeps advancing, then look for
+            # the running sandbox container for this session.
+            try:
+                self._http("GET", f"/v1/ui/chat/{self.agent}/messages")
+            except SandboxError:
+                pass
+            name = self._find_container()
+            if name:
+                self.container = name
+                return name
+            time.sleep(1)
+        raise SandboxError(
+            f"no running sandbox container (ic-sbx-*) appeared within {timeout}s -- "
+            "is the demo control-plane up? (docker compose -f docker-compose.demo.yml up)"
+        )
+
+    @staticmethod
+    def _find_container() -> str | None:
+        out = subprocess.run(
+            [
+                "docker", "ps",
+                "--filter", "label=ironclaw.session",
+                "--filter", "name=ic-sbx-",
+                "--filter", "status=running",
+                "--format", "{{.Names}}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        names = [n for n in out.stdout.splitlines() if n.strip()]
+        return names[0] if names else None
+
+    # -- execution ----------------------------------------------------------
+
+    def run(self, command: str, timeout: int = 30) -> ExecResult:
+        """Execute a shell command INSIDE the sandbox and capture the result.
+
+        Runs as the sandbox's own non-root uid, exactly what a jailbroken agent
+        would have. Never raises on a non-zero command exit -- a contained
+        attack is data, returned in ExecResult.exit_code / .stdout. Raises
+        SandboxError only if the sandbox itself is unreachable.
+        """
+        if not self.container:
+            self.engage()
+        assert self.container is not None
+        try:
+            out = subprocess.run(
+                [
+                    "docker", "exec",
+                    "-u", self.exec_uid,
+                    self.container,
+                    "sh", "-c", command,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return ExecResult(stdout="(command timed out)", exit_code=124)
+        except FileNotFoundError as exc:  # docker not installed
+            raise SandboxError("docker CLI not found on PATH") from exc
+        combined = (out.stdout + out.stderr).rstrip()
+        return ExecResult(stdout=combined, exit_code=out.returncode)

--- a/examples/integrations/llamaindex/llama-index-tools-ironclaw/llama_index/tools/ironclaw/base.py
+++ b/examples/integrations/llamaindex/llama-index-tools-ironclaw/llama_index/tools/ironclaw/base.py
@@ -1,0 +1,77 @@
+"""IronClaw sandbox tool spec for LlamaIndex.
+
+``IronClawToolSpec`` exposes a single ``sandboxed_shell`` tool that runs a shell
+command inside an isolated IronClaw per-session sandbox instead of on the host.
+It is a drop-in replacement for LlamaIndex's host-executing code/shell tools: a
+LlamaIndex agent calls it exactly the same way, but every command runs with
+**no network, no host filesystem, and no Docker socket** -- the isolation
+boundary IronClaw proves holds, not just promises.
+
+    from llama_index.tools.ironclaw import IronClawToolSpec
+
+    tool_spec = IronClawToolSpec()                 # points at the demo control-plane
+    agent = FunctionAgent(tools=tool_spec.to_tool_list(), llm=llm)
+
+See https://github.com/IronSecCo/ironclaw (examples/integrations/llamaindex) for
+the runnable, zero-credential demo this package is extracted from.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+from llama_index.tools.ironclaw._sandbox import IronClawSandbox
+
+_DESCRIPTION = (
+    "Execute a shell command inside an isolated IronClaw sandbox and return its "
+    "stdout/stderr and exit code. Use this for any code the user asks you to run. "
+    "The sandbox has no network, no access to the host filesystem, and no Docker "
+    "socket, so it is safe to run untrusted commands."
+)
+
+
+class IronClawToolSpec(BaseToolSpec):
+    """Tool spec that backs a LlamaIndex agent's code execution with an IronClaw sandbox."""
+
+    spec_functions = ["sandboxed_shell"]
+
+    def __init__(
+        self,
+        addr: str = "http://127.0.0.1:8787",
+        token: str = "ironclaw-demo",
+        agent: str = "mock-agent",
+        sandbox: Optional[IronClawSandbox] = None,
+    ) -> None:
+        """Initialize the tool spec.
+
+        Args:
+            addr: Base URL of the IronClaw control-plane. Defaults to the local
+                offline demo control-plane.
+            token: Bearer token for the control-plane. Defaults to the demo token.
+            agent: Agent group ID whose per-session sandbox to engage.
+            sandbox: An already-constructed :class:`IronClawSandbox` to reuse. If
+                given, ``addr``/``token``/``agent`` are ignored.
+        """
+        self.sandbox: IronClawSandbox = sandbox or IronClawSandbox(
+            addr=addr, token=token, agent=agent
+        )
+
+    def sandboxed_shell(self, command: str) -> str:
+        """
+        Run a shell command inside the isolated IronClaw sandbox.
+
+        The sandbox is engaged lazily on first call and reused across calls. The
+        command runs as the sandbox's own non-root uid with no network, no host
+        filesystem, and no Docker socket. A non-zero exit is returned as data
+        (never raised), so a contained attack is observable output.
+
+        Args:
+            command: The shell command to execute inside the sandbox.
+
+        Returns:
+            The combined stdout/stderr prefixed with the exit code, e.g.
+            ``"[exit 0]\\nhello"``.
+        """
+        return str(self.sandbox.run(command))

--- a/examples/integrations/llamaindex/llama-index-tools-ironclaw/pyproject.toml
+++ b/examples/integrations/llamaindex/llama-index-tools-ironclaw/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "llama-index-tools-ironclaw"
+version = "0.1.0"
+description = "IronClaw sandbox tool spec for LlamaIndex -- run agent code in an isolated, network-less sandbox"
+authors = [{name = "IronSec Co", email = "oss@ironsec.co"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+keywords = ["llama-index", "ironclaw", "sandbox", "code-execution", "security", "isolation"]
+maintainers = [{name = "IronSecCo"}]
+dependencies = [
+    "llama-index-core>=0.12,<0.15",
+]
+
+[project.urls]
+Homepage = "https://github.com/IronSecCo/ironclaw"
+Repository = "https://github.com/IronSecCo/ironclaw"
+Example = "https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/llamaindex"
+
+[dependency-groups]
+dev = [
+    "pytest>=7.2.1",
+    "pytest-mock>=3.11.1",
+    "ruff>=0.11.11",
+]
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.tools.ironclaw"
+
+[tool.llamahub.class_authors]
+IronClawToolSpec = "IronSecCo"

--- a/examples/integrations/llamaindex/llama-index-tools-ironclaw/tests/test_tools_ironclaw.py
+++ b/examples/integrations/llamaindex/llama-index-tools-ironclaw/tests/test_tools_ironclaw.py
@@ -1,0 +1,68 @@
+from unittest.mock import Mock
+
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+from llama_index.tools.ironclaw import IronClawToolSpec
+from llama_index.tools.ironclaw._sandbox import ExecResult, IronClawSandbox
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in IronClawToolSpec.__mro__]
+    assert BaseToolSpec.__name__ in names_of_base_classes
+
+
+def test_spec_functions():
+    assert IronClawToolSpec.spec_functions == ["sandboxed_shell"]
+
+
+def test_default_sandbox_is_demo_control_plane():
+    spec = IronClawToolSpec()
+    assert isinstance(spec.sandbox, IronClawSandbox)
+    assert spec.sandbox.addr == "http://127.0.0.1:8787"
+    assert spec.sandbox.token == "ironclaw-demo"
+    assert spec.sandbox.agent == "mock-agent"
+
+
+def test_init_passes_params_to_sandbox():
+    spec = IronClawToolSpec(
+        addr="http://cp.example:9999/",
+        token="tok",
+        agent="my-agent",
+    )
+    assert spec.sandbox.addr == "http://cp.example:9999"  # trailing slash stripped
+    assert spec.sandbox.token == "tok"
+    assert spec.sandbox.agent == "my-agent"
+
+
+def test_injected_sandbox_is_reused():
+    injected = IronClawSandbox(addr="http://x:1")
+    spec = IronClawToolSpec(sandbox=injected)
+    assert spec.sandbox is injected
+
+
+def test_sandboxed_shell_delegates_to_sandbox_run():
+    fake = Mock(spec=IronClawSandbox)
+    fake.run.return_value = ExecResult(stdout="hello from inside", exit_code=0)
+    spec = IronClawToolSpec(sandbox=fake)
+
+    result = spec.sandboxed_shell("echo hello")
+
+    fake.run.assert_called_once_with("echo hello")
+    assert result == "[exit 0]\nhello from inside"
+
+
+def test_sandboxed_shell_returns_nonzero_exit_as_data():
+    fake = Mock(spec=IronClawSandbox)
+    fake.run.return_value = ExecResult(stdout="curl: could not resolve host", exit_code=6)
+    spec = IronClawToolSpec(sandbox=fake)
+
+    result = spec.sandboxed_shell("curl https://api.anthropic.com")
+
+    assert result == "[exit 6]\ncurl: could not resolve host"
+
+
+def test_to_tool_list_exposes_sandboxed_shell():
+    spec = IronClawToolSpec(sandbox=Mock(spec=IronClawSandbox))
+    tools = spec.to_tool_list()
+    names = [t.metadata.name for t in tools]
+    assert names == ["sandboxed_shell"]


### PR DESCRIPTION
## What

Packages the IronClaw sandbox as a standalone, PyPI-installable **LlamaIndex tool integration**: `llama-index-tools-ironclaw`, an `IronClawToolSpec` (`BaseToolSpec`) exposing a single `sandboxed_shell` tool. Extracted from the existing `examples/integrations/llamaindex` demo (IRO-365).

Lands under `examples/integrations/llamaindex/llama-index-tools-ironclaw/`:
- `llama_index/tools/ironclaw/{__init__,base,_sandbox}.py` — ToolSpec + **vendored** pure-stdlib sandbox client (self-contained: zero third-party runtime deps beyond `llama-index-core`).
- `pyproject.toml` (hatchling + `[tool.llamahub]` import-path/class-authors metadata), `README.md`, MIT `LICENSE`, `.gitignore`.
- `tests/` — 8 unit tests (ToolSpec subclass, spec_functions, param wiring, delegation, non-zero-exit-as-data, `to_tool_list`).
- Bidirectional link with the LlamaIndex example README.

## Verify

- `pytest tests` → **8 passed**
- `python -m build` → wheel + sdist build clean; correct package contents.
- `twine check dist/*` → **PASSED** (both artifacts). PyPI-ready.

## Distribution note (acceptance criteria changed upstream)

The issue's acceptance asks for a PR to `run-llama/llama_index` (llama-index-integrations/tools). That path is **no longer valid**: their `CONTRIBUTING.md` now states they are *"no longer accepting new integration packages... PRs that add a new pyproject.toml will be automatically closed"* — new integrations must live in **their own repo and publish to PyPI**. This PR adapts to that: the package lands in-repo, PyPI-ready.

**Escalated to CEO** (governance/credential): the actual PyPI publish needs a PyPI account/token, and the MIT-vs-AGPLv3 license choice for a distributed subcomponent is a board decision. See IRO-372 comment.