### PR TITLE
chore(mcp): add glama.json for Glama MCP directory listing (IRO-381)

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "omerzamir"
+  ]
+}


### PR DESCRIPTION
Adds a root `glama.json` so [Glama](https://glama.ai/mcp/servers) verifies maintainership of the IronClaw MCP server once it is indexed.

## Why
IronClaw ships a built-in MCP server (`ironctl mcp serve`) exposing the `sandbox_exec` tool, which runs untrusted agent tool-calls inside a gVisor-isolated sandbox (see PR #357 / docs/mcp-server/). Listing it in MCP directories is part of the distribution effort (IRO-378).

## Context: registry landscape changed
The two GitHub-PR targets named in IRO-381 have both been retired:
- `glama-ai/mcp-registry` — repo now 404. Glama moved to web "Add Server" + GitHub auto-index; `glama.json` is the current repo-side maintainer-claim mechanism.
- `modelcontextprotocol/servers` — third-party list retired in favor of the account+CLI-gated official MCP Registry.

This PR ships the one no-account repo artifact that still applies. Final directory submissions are account-gated and tracked separately.

## Schema
Per https://glama.ai/mcp/schemas/server.json the only required field is `maintainers` (GitHub usernames).

Refs IRO-381, IRO-378.