### PR TITLE
feat(release): publish IronClaw to the official MCP Registry via GHCR OIDC (IRO-391)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -409,3 +409,117 @@ jobs:
               exit 1
             fi
           done
+
+  # Publish (or refresh) the IronClaw listing on the official MCP Registry
+  # (registry.modelcontextprotocol.io) under the account-free `io.github.IronSecCo`
+  # namespace. This runs ONLY after the image is built, merged, attested, AND proven
+  # anonymously pullable by verify-consumer — the registry's OCI validator fetches the
+  # image and requires the `io.modelcontextprotocol.server.name` label to match the
+  # server.json name, so a private or unlabelled image would fail-close here rather than
+  # half-list. Skipped on untagged commits (VERSION=dev): we list immutable releases only.
+  #
+  # Trust anchors: namespace ownership is proven by THIS repo's GitHub Actions OIDC token
+  # (id-token: write, no long-lived secret); the mcp-publisher binary is pinned by version
+  # AND sha256 AND cosign-verified against the registry repo's release provenance before it
+  # runs. A publish failure fails the workflow (fail-loud) but never rolls back the already
+  # -published, already-attested image — the listing points at an artifact that stands on
+  # its own.
+  publish-mcp-registry:
+    needs: [prepare, merge, verify-consumer]
+    if: ${{ needs.prepare.outputs.present == 'true' && needs.prepare.outputs.version != 'dev' && needs.prepare.outputs.version != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout the trust-gated commit to read server.json
+      id-token: write # OIDC token that proves io.github.IronSecCo namespace ownership
+    env:
+      # Pinned mcp-publisher release. Bump all three in lock-step (see runbooks/mcp-registry.md).
+      MCP_PUBLISHER_VERSION: v1.7.9
+      MCP_PUBLISHER_SHA256: ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac
+      # Sigstore identity that signed the pinned mcp-publisher release archive.
+      MCP_PUBLISHER_CERT_IDENTITY: https://github.com/modelcontextprotocol/registry/.github/workflows/release.yml@refs/tags/v1.7.9
+      MCP_PUBLISHER_CERT_ISSUER: https://token.actions.githubusercontent.com
+      IMAGE: ${{ needs.prepare.outputs.image }}
+      VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+      # Check out the commit prepare already trust-gated to the protected branch — never
+      # the raw event head_sha (Dangerous-Workflow: no untrusted checkout while holding
+      # id-token: write).
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Download + verify mcp-publisher (pinned version, sha256, cosign provenance)
+        run: |
+          set -euo pipefail
+          base="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}"
+          asset="mcp-publisher_linux_amd64.tar.gz"
+          curl -fsSL "${base}/${asset}" -o "${asset}"
+          curl -fsSL "${base}/${asset}.sigstore.json" -o "${asset}.sigstore.json"
+
+          # 1) Exact-digest pin: the archive must be the byte-for-byte one we reviewed.
+          echo "${MCP_PUBLISHER_SHA256}  ${asset}" | sha256sum -c -
+
+          # 2) Provenance pin: the archive must be signed by the registry repo's own
+          #    release workflow (keyless Sigstore). Fail closed on any identity mismatch.
+          cosign verify-blob \
+            --bundle "${asset}.sigstore.json" \
+            --certificate-identity "${MCP_PUBLISHER_CERT_IDENTITY}" \
+            --certificate-oidc-issuer "${MCP_PUBLISHER_CERT_ISSUER}" \
+            "${asset}"
+
+          tar xzf "${asset}" mcp-publisher
+          chmod +x mcp-publisher
+          ./mcp-publisher --version || true
+
+      - name: Stamp the release version into server.json
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The MCP registry version is semver — strip the leading v from our vX.Y.Z tag.
+          semver="${VERSION#v}"
+          # Pin the OCI package to THIS release's immutable image tag (never :latest), so
+          # the listing is re-derivable from the tagged commit (reproducibility/provenance).
+          oci_ref="${IMAGE}:${VERSION}"
+          tmp="$(mktemp)"
+          jq --arg v "${semver}" --arg ref "${oci_ref}" \
+            '.version = $v | .packages[0].identifier = $ref' \
+            server.json > "${tmp}"
+          mv "${tmp}" server.json
+          echo "Stamped server.json -> version=${semver}, package=${oci_ref}"
+          cat server.json
+
+      - name: Validate server.json against the registry schema
+        run: ./mcp-publisher validate server.json
+
+      - name: Authenticate to the MCP Registry via GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish the IronClaw listing
+        run: ./mcp-publisher publish
+
+      - name: Verify the listing resolves on the registry
+        run: |
+          set -euo pipefail
+          semver="${VERSION#v}"
+          # Fail-closed post-check: the registry must now serve our namespace at this
+          # version. Brief retry to absorb indexing lag, then fail loud.
+          url="https://registry.modelcontextprotocol.io/v0/servers?search=io.github.IronSecCo/ironclaw"
+          ok=""
+          for attempt in 1 2 3 4 5; do
+            body="$(curl -fsSL "${url}" || true)"
+            if printf '%s' "${body}" | jq -e \
+              --arg v "${semver}" \
+              '.servers[]? | select(.name == "io.github.IronSecCo/ironclaw" and .version == $v)' >/dev/null 2>&1; then
+              ok="yes"; break
+            fi
+            echo "  attempt ${attempt}: listing not yet resolvable, retrying in 10s..."
+            sleep 10
+          done
+          if [ -z "${ok}" ]; then
+            echo "::error::io.github.IronSecCo/ironclaw ${semver} did not resolve on registry.modelcontextprotocol.io after publish. Failing the release." >&2
+            exit 1
+          fi
+          echo "Listing live: io.github.IronSecCo/ironclaw ${semver}"

--- a/container/controlplane.Dockerfile
+++ b/container/controlplane.Dockerfile
@@ -75,6 +75,13 @@ RUN mkdir -p /var/lib/ironclaw/state /run/ironclaw \
  && chmod 0700 /var/lib/ironclaw/state \
  && chmod +x /usr/local/bin/controlplane-entrypoint.sh
 
+# OCI ownership proof for the official MCP Registry (registry.modelcontextprotocol.io).
+# The registry's OCI validator fetches this image and requires this exact label to match
+# the server.json `name`, proving the publisher controls the image before it will bind the
+# `io.github.IronSecCo/ironclaw` listing to it. Without it, `mcp-publisher publish` fails
+# closed. Keep this string in lock-step with server.json's `name` (see runbooks/mcp-registry.md).
+LABEL io.modelcontextprotocol.server.name="io.github.IronSecCo/ironclaw"
+
 USER 65532:65532
 WORKDIR /var/lib/ironclaw
 EXPOSE 8787

--- a/runbooks/mcp-registry.md
+++ b/runbooks/mcp-registry.md
@@ -1,0 +1,131 @@
+# Publishing IronClaw to the official MCP Registry
+
+IronClaw is listed on the official MCP Registry
+(`registry.modelcontextprotocol.io`) under the account-free namespace
+**`io.github.IronSecCo/ironclaw`**. This runbook covers how the listing is
+authored, how it is published reproducibly from a tagged release, and how a user
+verifies it.
+
+## Trust model (why this is account-free)
+
+The `io.github.*` namespace on the official registry is authenticated by the
+**owning GitHub org's Actions OIDC token** — no interactive account, no
+long-lived secret. Because the `publish-mcp-registry` job runs in
+`IronSecCo/ironclaw`, GitHub issues it an OIDC token whose subject proves the
+job belongs to the `IronSecCo` org, and the registry binds the
+`io.github.IronSecCo/*` namespace to it. The only permission the job holds is
+`id-token: write` (plus `contents: read` to check out `server.json`).
+
+## Moving parts
+
+| Artifact | Role |
+| --- | --- |
+| [`server.json`](https://github.com/IronSecCo/ironclaw/blob/main/server.json) | The listing: name, description, repository, and the OCI package that points at our GHCR control-plane image. |
+| `LABEL io.modelcontextprotocol.server.name` in `container/controlplane.Dockerfile` | Ownership proof. The registry fetches the image and refuses to bind the listing unless this label equals the `server.json` name. |
+| `publish-mcp-registry` job in `.github/workflows/image.yml` | Chains off the image build/merge/attest/verify chain and publishes the listing via the pinned `mcp-publisher` CLI. |
+
+The publish job runs **only after** `verify-consumer` proves the image is
+anonymously pullable and attested, and **only for tagged releases**
+(`VERSION != dev`). A failure fails the workflow loudly but never rolls back the
+already-published, already-attested image.
+
+## How the version is bound
+
+`image.yml`'s `prepare` job resolves the release tag this commit carries
+(`vX.Y.Z`). The publish job then stamps `server.json` at publish time:
+
+- `.version` = the semver form (`X.Y.Z`, leading `v` stripped).
+- `.packages[0].identifier` = `ghcr.io/ironsecco/ironclaw-controlplane:vX.Y.Z`
+  — the **immutable release tag**, never `:latest`, so the listing is
+  re-derivable from the tagged commit.
+
+The checked-in `server.json` carries `0.0.0` placeholders; they are overwritten
+in-job and never committed back.
+
+## Supply-chain pinning of `mcp-publisher`
+
+The `mcp-publisher` binary is pinned three ways before it is allowed to run
+(see the `env:` block in the job):
+
+1. **Version** — `MCP_PUBLISHER_VERSION` (exact release tag, never `latest`).
+2. **Digest** — `MCP_PUBLISHER_SHA256` verified with `sha256sum -c`.
+3. **Provenance** — `cosign verify-blob` against the release's Sigstore bundle,
+   pinned to the registry repo's own release workflow identity
+   (`MCP_PUBLISHER_CERT_IDENTITY` / `MCP_PUBLISHER_CERT_ISSUER`).
+
+### Bumping `mcp-publisher`
+
+Update all four `MCP_PUBLISHER_*` env values in lock-step:
+
+```bash
+V=v1.7.10   # the new tag
+gh release download "$V" --repo modelcontextprotocol/registry \
+  -p 'mcp-publisher_linux_amd64.tar.gz' -O mp.tgz
+sha256sum mp.tgz                                  # -> MCP_PUBLISHER_SHA256
+# Identity is the SAN URI on the archive's .sigstore.json signing cert:
+#   https://github.com/modelcontextprotocol/registry/.github/workflows/release.yml@refs/tags/<V>
+# -> MCP_PUBLISHER_CERT_IDENTITY (issuer stays token.actions.githubusercontent.com)
+```
+
+## Cutting a listing (normal path)
+
+Nothing manual. Push to `main` cuts a release
+(`v0.1.<commit-count>`); the `Image` workflow builds + attests the GHCR image,
+`verify-consumer` proves it is pullable, then `publish-mcp-registry` publishes
+the listing and post-checks that
+`registry.modelcontextprotocol.io/v0/servers?search=io.github.IronSecCo/ironclaw`
+resolves at the new version.
+
+## Yanking / superseding a listing
+
+The registry has no destructive delete for publishers; you supersede or
+deprecate:
+
+- **Supersede** — publish a newer `version`. The registry marks the newest as
+  `isLatest: true`; older versions remain queryable but drop out of the default
+  view.
+- **Deprecate** — set the server's lifecycle status to `deprecated` (registry
+  API, authenticated with the same GitHub OIDC/PAT). Clients surface deprecated
+  servers with a warning instead of hiding them.
+
+If a bad image was published, cut a fixed release: the new listing repoints at
+the new immutable image tag; the bad tag can be separately yanked from GHCR.
+
+## How a user verifies the listing
+
+```bash
+# 1. The listing resolves and points at our image + repo:
+curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.IronSecCo/ironclaw" | jq .
+
+# 2. The image the listing names carries build provenance tying it to this repo:
+gh attestation verify oci://ghcr.io/ironsecco/ironclaw-controlplane:vX.Y.Z \
+  --repo IronSecCo/ironclaw
+```
+
+## Open design decision (CEO review — IRO-391)
+
+The registry accepts packages only from supported package registries
+(npm, PyPI, OCI, MCPB, NuGet, Cargo). IronClaw ships via Homebrew, `curl | sh`,
+and the GHCR image — of these, **only the GHCR image is a registry-supported
+package type**, so the listing uses the OCI form.
+
+But `ironctl mcp serve` spawns each `sandbox_exec` run as a sibling gVisor
+container, so a `docker run` launch of the image needs the **host Docker
+socket** (`-v /var/run/docker.sock:/var/run/docker.sock` in
+`server.json`'s `runtimeArguments`). Mounting the host Docker socket into a
+container is effectively host-root and sits in tension with IronClaw's
+hardening promise. Options:
+
+- **A. OCI + docker socket (implemented here).** Works via plain `docker run`;
+  documents the socket requirement explicitly. Trade-off: the socket exposure.
+- **B. Dedicated slim MCP image** whose entrypoint is `ironctl mcp serve` and
+  whose sandbox backend is scoped tighter than a raw socket mount. More work;
+  cleaner trust story.
+- **C. Native-only** (`command: ironctl, args: [mcp, serve]`, per
+  `docs/mcp-server/`). This is the flow we already document and recommend, but
+  it is **not a registry-supported package type**, so it cannot be the registry
+  listing today.
+
+This runbook ships the **A** implementation as the reviewable default; the
+go/no-go on A-vs-B (and on listing at all under the socket trade-off) is the
+CEO decision this issue is gated on.

--- a/server.json
+++ b/server.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.IronSecCo/ironclaw",
+  "description": "Sandboxed shell exec for MCP clients: run untrusted agent commands in a gVisor container.",
+  "version": "0.0.0",
+  "repository": {
+    "url": "https://github.com/IronSecCo/ironclaw",
+    "source": "github"
+  },
+  "websiteUrl": "https://ironclaw.sh",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/ironsecco/ironclaw-controlplane:0.0.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeHint": "docker",
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "--rm",
+          "description": "Remove the container when the MCP session ends (ephemeral by design)."
+        },
+        {
+          "type": "named",
+          "name": "-i",
+          "description": "Keep stdin open for the MCP stdio transport."
+        },
+        {
+          "type": "named",
+          "name": "-v",
+          "value": "/var/run/docker.sock:/var/run/docker.sock",
+          "description": "IronClaw launches each sandbox_exec run as a sibling gVisor container; it needs the host Docker socket to do so. This grants the MCP server control of the host Docker daemon -- review before enabling.",
+          "isRequired": true
+        },
+        {
+          "type": "named",
+          "name": "--entrypoint",
+          "value": "ironctl",
+          "description": "Override the control-plane daemon entrypoint to run the bundled ironctl MCP server instead."
+        }
+      ],
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Spun out of IRO-390 / IRO-381. Lists IronClaw on **registry.modelcontextprotocol.io** under the account-free **`io.github.IronSecCo/ironclaw`** namespace, published reproducibly from a tagged release with **no interactive account and no new long-lived secret**.

## What's in the diff
- **`server.json`** — the listing (name, description, repo, OCI package → GHCR control-plane image). Validated green with `mcp-publisher validate` against the live registry schema.
- **`container/controlplane.Dockerfile`** — adds `LABEL io.modelcontextprotocol.server.name="io.github.IronSecCo/ironclaw"`, the ownership proof the registry's OCI validator requires (publish fails closed without it).
- **`.github/workflows/image.yml`** — new `publish-mcp-registry` job, chained off `merge` + `verify-consumer`, tagged-release only (`VERSION != dev`). Least-privilege `id-token: write` (+ `contents: read`). `mcp-publisher` pinned by **version + sha256 + cosign provenance** (verified against the registry repo's own release identity). Stamps the immutable release tag into `server.json`, then post-checks the listing resolves on the registry.
- **`runbooks/mcp-registry.md`** — version binding, mcp-publisher pin/bump, cut/yank, user verification, and the open design decision below.

## Supply-chain lenses
- **Provenance** — listing pinned to the release's immutable `ghcr.io/…:vX.Y.Z` image tag, never `:latest`.
- **Least-privilege CI** — `id-token: write` only.
- **Pinned + verified actions** — mcp-publisher triple-pinned; cosign-installer/checkout reuse existing repo SHAs.
- **Fail-closed** — missing label, failed publish, or unresolved post-check fails the workflow; never half-lists. Publish runs only after the image is built, attested, and proven anonymously pullable.

## ⚠️ Open design decision — CEO go/no-go (this PR is gated)
The registry accepts only npm/PyPI/OCI/MCPB/NuGet/Cargo packages. IronClaw ships via Homebrew, `curl|sh`, and the GHCR image — **only the OCI image is a supported package type**, so the listing is OCI.

But `ironctl mcp serve` spawns each `sandbox_exec` run as a sibling gVisor container, so a `docker run` launch needs the **host Docker socket** (`-v /var/run/docker.sock:…` in `server.json` runtimeArguments). That is effectively host-root and sits in tension with IronClaw's hardening promise.

- **A. OCI + docker socket (implemented here)** — works via plain `docker run`, socket requirement documented. Trade-off: socket exposure.
- **B. Dedicated slim MCP image** with a tighter sandbox backend. More work, cleaner trust story.
- **C. Native-only** (`command: ironctl … mcp serve`, per `docs/mcp-server/`) — what we already recommend, but **not a registry-supported package type**, so it can't be the listing today.

**Do not merge** until CEO signs off on A-vs-B (and on listing at all under the socket trade-off). Trust-model-touching per my review contract.

Refs IRO-391.