### PR TITLE
docs: update outbound reader factory comment

### DIFF
--- a/internal/host/delivery/delivery.go
+++ b/internal/host/delivery/delivery.go
@@ -25,7 +25,7 @@ import (
 
 // OutboundReaderFactory returns the host's read-only outbound view for a session.
 // Tests inject a fake (host/queue.MemOutbound); production wires it to
-// host/queue.OpenOutbound once the encrypted-SQLite binding lands.
+// host/queue.OpenOutbound for the encrypted outbound queue.
 type OutboundReaderFactory func(contract.SessionID) (contract.OutboundReader, error)
 
 // SkillInstallResolver resolves a NAMED, curated, signed skill into its gateway


### PR DESCRIPTION
## Summary

- Update the `OutboundReaderFactory` comment to reflect the current production wiring.
- Replace the stale “once the encrypted-SQLite binding lands” wording with the current `host/queue.OpenOutbound` encrypted outbound queue behavior.

## Testing

- `go build ./...`

Closes #284