### PR TITLE
refactor: name ironctl table layout constants

### DIFF
--- a/cmd/ironctl/main.go
+++ b/cmd/ironctl/main.go
@@ -515,8 +515,16 @@ type table struct {
 	w *tabwriter.Writer
 }
 
+const (
+	tableMinWidth = 0
+	tableTabWidth = 2
+	tablePadding  = 2
+	tablePadChar  = ' '
+	tableFlags    = 0
+)
+
 func newTable(headers ...string) *table {
-	tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+	tw := tabwriter.NewWriter(os.Stdout, tableMinWidth, tableTabWidth, tablePadding, tablePadChar, tableFlags)
 	fmt.Fprintln(tw, dim(strings.Join(headers, "\t")))
 	return &table{w: tw}
 }

--- a/cmd/ironctl/main_test.go
+++ b/cmd/ironctl/main_test.go
@@ -2,6 +2,24 @@ package main
 
 import "testing"
 
+func TestTableLayoutConstantsDocumentTabwriterDefaults(t *testing.T) {
+	if tableMinWidth != 0 {
+		t.Fatalf("tableMinWidth = %d, want 0", tableMinWidth)
+	}
+	if tableTabWidth != 2 {
+		t.Fatalf("tableTabWidth = %d, want 2", tableTabWidth)
+	}
+	if tablePadding != 2 {
+		t.Fatalf("tablePadding = %d, want 2", tablePadding)
+	}
+	if tablePadChar != ' ' {
+		t.Fatalf("tablePadChar = %q, want space", tablePadChar)
+	}
+	if tableFlags != 0 {
+		t.Fatalf("tableFlags = %d, want 0", tableFlags)
+	}
+}
+
 // TestRunFirstRunHelp covers the F10 first-run UX fix (IRO-39): bare `ironctl`
 // and explicit `help` greet the user and succeed (exit 0), while genuine misuse
 // still fails (exit non-zero). None of these paths touch the network.


### PR DESCRIPTION
## Summary

- Add named constants for the `tabwriter.NewWriter` table layout parameters in `cmd/ironctl`.
- Use the constants in `newTable()` so the CLI table formatting defaults are self-documenting.
- Add a small test that locks the table layout defaults to the existing values.

## Testing

- `go test ./cmd/ironctl/...`
- `go vet ./cmd/ironctl/...`

Closes #285