### PR TITLE
test: cover default seccomp profile

### DIFF
--- a/internal/host/isolation/seccomp_test.go
+++ b/internal/host/isolation/seccomp_test.go
@@ -1,0 +1,46 @@
+package isolation
+
+import "testing"
+
+func TestDefaultSeccompProfile(t *testing.T) {
+	profile := DefaultSeccompProfile()
+	if profile.DefaultAction != seccompActErrno {
+		t.Fatalf("DefaultAction = %q, want %q", profile.DefaultAction, seccompActErrno)
+	}
+	if len(profile.Architectures) == 0 {
+		t.Fatal("Architectures is empty")
+	}
+	for _, arch := range seccompArchitectures {
+		if !contains(profile.Architectures, arch) {
+			t.Fatalf("Architectures missing %q", arch)
+		}
+	}
+	if len(profile.Syscalls) == 0 {
+		t.Fatal("Syscalls is empty")
+	}
+	allowed := map[string]struct{}{}
+	for _, rule := range profile.Syscalls {
+		if rule.Action != seccompActAllow {
+			t.Fatalf("syscall rule action = %q, want %q", rule.Action, seccompActAllow)
+		}
+		if len(rule.Names) == 0 {
+			t.Fatal("syscall rule has no names")
+		}
+		for _, name := range rule.Names {
+			allowed[name] = struct{}{}
+		}
+	}
+	// Mounting filesystems would widen the sandbox boundary; deny-by-default should keep it blocked.
+	if _, ok := allowed["mount"]; ok {
+		t.Fatal("mount syscall is unexpectedly allowed")
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Add unit coverage for `DefaultSeccompProfile()`.
- Assert the profile is deny-by-default with `SCMP_ACT_ERRNO`.
- Assert the configured architecture list is populated and includes all declared `seccompArchitectures`.
- Assert allow rules are non-empty and use `SCMP_ACT_ALLOW`.
- Document and verify that `mount` is not in the allow set.

## Testing

- `go test ./internal/host/isolation/...`

Closes #281