### PR TITLE
feat(integrations): smolagents + Google ADK sandboxed examples (IRO-395)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -108,7 +108,7 @@ docker compose -f docker-compose.demo.yml down            # tear down
 
 ### Framework integrations
 
-Already using LangChain, CrewAI, AutoGen, or Semantic Kernel?
+Already using LangChain, CrewAI, AutoGen, Semantic Kernel, smolagents, or Google ADK?
 [**`integrations/`**](integrations/) backs
 your agent's untrusted code execution with a real IronClaw sandbox instead of a
 host shell — the same tool interface, none of the host risk. Each ships a
@@ -120,6 +120,8 @@ one-command, zero-credential containment demo:
 | [`integrations/crewai/`](integrations/crewai/) | The same pattern as a CrewAI `BaseTool` for a crew agent. | ✅ `run.sh` (self-contained) |
 | [`integrations/autogen/`](integrations/autogen/) | The same pattern as an **AutoGen** `FunctionTool` for an `AssistantAgent`. | ✅ `run.sh` (self-contained) |
 | [`integrations/semantic-kernel/`](integrations/semantic-kernel/) | The same pattern as a **Semantic Kernel** native `@kernel_function` plugin. | ✅ `run.sh` (self-contained) |
+| [`integrations/smolagents/`](integrations/smolagents/) | The same pattern as a **smolagents** (HuggingFace) `Tool` for a `ToolCallingAgent`. | ✅ `run.sh` (self-contained) |
+| [`integrations/google-adk/`](integrations/google-adk/) | The same pattern as a **Google ADK** `FunctionTool` for an `Agent`. | ✅ `run.sh` (self-contained) |
 
 ## Prerequisites
 

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -21,6 +21,8 @@ foot-gun for a boundary IronClaw [proves holds](../red-team-escape/).
 | [`pydantic-ai/`](pydantic-ai/) | [Pydantic AI](https://ai.pydantic.dev) | `examples/integrations/pydantic-ai/run.sh` |
 | [`autogen/`](autogen/) | [AutoGen (Microsoft)](https://github.com/microsoft/autogen) | `examples/integrations/autogen/run.sh` |
 | [`semantic-kernel/`](semantic-kernel/) | [Semantic Kernel (Microsoft)](https://github.com/microsoft/semantic-kernel) | `examples/integrations/semantic-kernel/run.sh` |
+| [`smolagents/`](smolagents/) | [smolagents (HuggingFace)](https://github.com/huggingface/smolagents) | `examples/integrations/smolagents/run.sh` |
+| [`google-adk/`](google-adk/) | [Google ADK](https://github.com/google/adk-python) | `examples/integrations/google-adk/run.sh` |
 | [`openai-agents/`](openai-agents/) | [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | `examples/integrations/openai-agents/run.sh` |
 | [`claude-agent-sdk/`](claude-agent-sdk/) | [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python) | `examples/integrations/claude-agent-sdk/run.sh` |
 | [`vercel-ai-sdk/`](vercel-ai-sdk/) | [Vercel AI SDK](https://ai-sdk.dev/) *(TS)* | `examples/integrations/vercel-ai-sdk/run.sh` |
@@ -51,7 +53,7 @@ The IronClaw-specific piece is one small, standard-library client that engages a
 per-session sandbox and runs commands inside it. The examples come in two shapes:
 
 - **Framework tools** (LangChain, LangGraph, CrewAI, Agno, LlamaIndex, Pydantic AI,
-  AutoGen, Semantic Kernel) wrap the shared
+  AutoGen, Semantic Kernel, smolagents, Google ADK) wrap the shared
   [`_shared/ironclaw_sandbox.py`](_shared/ironclaw_sandbox.py) client as a native tool
   via a thin `ironclaw_tool.py` adapter (~15-20 lines):
 

--- a/examples/integrations/google-adk/README.md
+++ b/examples/integrations/google-adk/README.md
@@ -1,0 +1,67 @@
+# Google ADK agents, sandboxed by IronClaw
+
+Your **Google ADK** (Agent Development Kit) agent runs untrusted, model-generated
+code. Point that execution at an **IronClaw sandbox** instead of your host and the
+same agent gets real code execution with **no network, no host filesystem, and no
+Docker socket** — the isolation boundary IronClaw
+[proves holds](../../red-team-escape/), not just promises.
+
+```python
+from ironclaw_sandbox import IronClawSandbox
+from ironclaw_tool import make_sandbox_tool
+
+with IronClawSandbox() as sandbox:            # engage a per-session sandbox
+    tool = make_sandbox_tool(sandbox)         # a real ADK FunctionTool
+    # agent = Agent(name="coder", model=..., tools=[tool])
+```
+
+The `sandboxed_shell` FunctionTool is a drop-in for the host-executing shell /
+code tool you would otherwise hand an ADK `Agent`. The agent plans the tool calls
+exactly as before; only the execution moves into the box.
+
+## Try it in one command
+
+Zero credentials — the LLM side uses the offline **mock provider**, the sandbox
+is real:
+
+```sh
+examples/integrations/google-adk/run.sh
+```
+
+It engages a live IronClaw per-session sandbox, drives the `sandboxed_shell`
+FunctionTool exactly as an ADK `Agent`'s tool loop would
+(`tool.run_async(args={"command": ...})`), runs one benign task plus a battery of
+escape attempts, and prints a PASS/FAIL containment table:
+
+```
+  [OK ] benign task: run agent code                    ->  [exit 0] hello from inside the IronClaw sandbox uid=65532...
+  [OK ] network egress: only loopback exists           ->  [exit 0] lo
+  [OK ] network egress: DNS lookup of api.anthropic...  ->  [exit 0] NO_EGRESS
+  [OK ] host escape: Docker Engine socket is absent    ->  [exit 0] ABSENT
+  [OK ] host escape: host filesystem is not mounted    ->  [exit 0] CONTAINED
+
+RESULT: PASS -- benign code ran; every escape attempt was contained.
+```
+
+`run.sh --keep` leaves the demo running; `run.sh --attach` reuses an already-up
+demo control-plane.
+
+## Use a real LLM
+
+Set `GOOGLE_API_KEY` and `run.sh` drives a real Gemini-backed `Agent` (via ADK's
+`InMemoryRunner`) instead of the scripted probes. The tool — and therefore the
+isolation — is identical; the key never enters the sandbox.
+
+## How it works
+
+- [`ironclaw_sandbox.py`](../_shared/ironclaw_sandbox.py) — engages a per-session
+  IronClaw sandbox (`ic-sbx-*`) against the demo control-plane and runs commands
+  inside it as its own non-root uid (65532). Pure standard library.
+- [`ironclaw_tool.py`](ironclaw_tool.py) — wraps that sandbox as an ADK
+  `FunctionTool` named `sandboxed_shell`. **This is the ~15 lines you copy** to
+  swap a host shell tool for a sandboxed one.
+- [`run.py`](run.py) — engages the sandbox and drives the tool.
+
+The execution primitive is the same one IronClaw's red-team harness attacks: a
+`docker exec` into the live per-session sandbox as its non-root uid. See the
+repo root [`README`](../../../README.md) for the full isolation model.

--- a/examples/integrations/google-adk/ironclaw_tool.py
+++ b/examples/integrations/google-adk/ironclaw_tool.py
@@ -1,0 +1,50 @@
+"""Google ADK tool backed by an IronClaw sandbox.
+
+Drop-in replacement for the host-executing code/shell tool you would normally
+hand a **Google ADK** (Agent Development Kit) agent (a `FunctionTool` wrapping a
+shell callable, the built-in code executor, ...): the agent calls it exactly the
+same way, but every command runs inside an isolated IronClaw per-session sandbox
+instead of on your machine.
+
+    from ironclaw_tool import make_sandbox_tool
+    from ironclaw_sandbox import IronClawSandbox
+
+    sandbox = IronClawSandbox().__enter__()
+    tool = make_sandbox_tool(sandbox)          # a real ADK FunctionTool
+    agent = Agent(name="coder", model=..., tools=[tool])
+"""
+
+from __future__ import annotations
+
+from google.adk.tools import FunctionTool
+
+from ironclaw_sandbox import IronClawSandbox
+
+_DESCRIPTION = (
+    "Execute a shell command inside an isolated IronClaw sandbox and return its "
+    "stdout/stderr and exit code. Use this for any code the user asks you to run. "
+    "The sandbox has no network, no access to the host filesystem, and no Docker "
+    "socket, so it is safe to run untrusted commands."
+)
+
+
+def make_sandbox_tool(sandbox: IronClawSandbox) -> FunctionTool:
+    """Wrap a live IronClaw sandbox as a Google ADK FunctionTool.
+
+    The sandbox handle is captured in a closure so the wrapped callable is a
+    plain function ADK can introspect for its automatic function-declaration
+    schema, robust across google-adk versions.
+    """
+
+    def sandboxed_shell(command: str) -> str:
+        """Run a shell command inside the IronClaw sandbox and return its output.
+
+        Args:
+            command: The shell command to run inside the sandbox.
+
+        Returns:
+            The command's combined stdout/stderr prefixed with its exit code.
+        """
+        return str(sandbox.run(command))
+
+    return FunctionTool(func=sandboxed_shell)

--- a/examples/integrations/google-adk/requirements.txt
+++ b/examples/integrations/google-adk/requirements.txt
@@ -1,0 +1,8 @@
+# The IronClaw sandbox client is pure standard library; the only dependency the
+# default credential-free path adds is Google ADK itself. Floor-pinned to the 1.x
+# line where `google.adk.tools.FunctionTool` and its `run_async(args=...)` loop
+# are stable. ADK moves fast -- bump the ceiling deliberately.
+google-adk>=1.0,<2.0
+
+# The real-LLM path (set GOOGLE_API_KEY) uses ADK's bundled Gemini connector and
+# InMemoryRunner -- no extra install.

--- a/examples/integrations/google-adk/run.py
+++ b/examples/integrations/google-adk/run.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Run a Google ADK agent whose code execution is backed by an IronClaw sandbox.
+
+Zero credentials by default: it engages a real IronClaw per-session sandbox
+against the offline demo control-plane (mock provider) and drives the ADK
+`sandboxed_shell` FunctionTool exactly as an `Agent`'s tool loop would when a
+model picks it -- one benign task plus a battery of escape attempts -- then prints
+a PASS/FAIL containment table.
+
+Set GOOGLE_API_KEY to instead let a real Gemini-driven `Agent` decide what to run;
+the tool (and therefore the isolation) is identical either way.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+# Make the shared client + demo importable (examples/integrations/_shared).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "_shared"))
+
+from containment_demo import PROBES, run_containment_demo  # noqa: E402
+from ironclaw_sandbox import IronClawSandbox  # noqa: E402
+from ironclaw_tool import make_sandbox_tool  # noqa: E402
+
+
+def _invoke_tool(tool, command: str) -> str:
+    """Call the FunctionTool exactly as ADK's tool loop does: run_async(args=...)."""
+
+    async def _call() -> str:
+        result = await tool.run_async(args={"command": command}, tool_context=None)
+        return str(result)
+
+    return asyncio.run(_call())
+
+
+def drive_with_real_agent(tool) -> int:
+    """Optional: let a real Gemini-driven ADK Agent decide what to run (needs a key)."""
+    from google.adk.agents import Agent
+    from google.adk.runners import InMemoryRunner
+    from google.genai import types
+
+    async def _run() -> None:
+        agent = Agent(
+            name="sandboxed_coder",
+            model="gemini-2.0-flash",
+            instruction="Run commands with the sandboxed_shell tool to answer.",
+            tools=[tool],
+        )
+        runner = InMemoryRunner(agent=agent, app_name="ironclaw")
+        session = await runner.session_service.create_session(
+            app_name="ironclaw", user_id="demo"
+        )
+        message = types.Content(
+            role="user",
+            parts=[types.Part(text="Run `id` and tell me which user the sandbox runs as.")],
+        )
+        async for event in runner.run_async(
+            user_id="demo", session_id=session.id, new_message=message
+        ):
+            if event.is_final_response() and event.content:
+                print("".join(p.text or "" for p in event.content.parts))
+
+    asyncio.run(_run())
+    return 0
+
+
+def main() -> int:
+    print("==> engaging an IronClaw per-session sandbox (mock provider, zero-cred)")
+    with IronClawSandbox() as sandbox:
+        print(f"    sandbox container: {sandbox.container}")
+        tool = make_sandbox_tool(sandbox)
+
+        if os.environ.get("GOOGLE_API_KEY"):
+            print("==> GOOGLE_API_KEY set: driving a real Gemini Agent")
+            return drive_with_real_agent(tool)
+
+        # Deterministic, zero-cred path: call the FunctionTool exactly as ADK's
+        # tool loop does -- run_async(args={"command": ...}) -- per probe.
+        print(f"==> driving the '{tool.name}' tool over {len(PROBES)} agent commands")
+        return run_containment_demo(
+            lambda command: _invoke_tool(tool, command),
+            framework="Google ADK",
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/integrations/google-adk/run.sh
+++ b/examples/integrations/google-adk/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Google ADK (Agent Development Kit) + IronClaw sandbox -- one-command demo.
+#
+# Brings up the offline demo control-plane (mock provider -- no model key, no
+# channel tokens), then runs a Google ADK agent whose `sandboxed_shell`
+# FunctionTool executes inside a real IronClaw per-session sandbox. It runs one
+# benign task and a battery of escape attempts and prints a PASS/FAIL containment
+# table.
+#
+#   examples/integrations/google-adk/run.sh           # build + up + demo + tear down
+#   examples/integrations/google-adk/run.sh --keep     # leave the demo running
+#   examples/integrations/google-adk/run.sh --attach   # use an already-running demo
+#
+# Env overrides (all optional):
+#   IRONCLAW_ADDR        control-plane base URL  (default http://127.0.0.1:8787)
+#   IRONCLAW_API_TOKEN   API bearer token        (default ironclaw-demo)
+#   IRONCLAW_DEMO_AGENT  agent group id          (default mock-agent)
+#   SKIP_BUILD=1         skip the sandbox image build (assume it exists)
+#   GOOGLE_API_KEY       if set, drive a real Gemini agent instead of the scripted one
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../_shared/demo-lifecycle.sh"
+
+# Google ADK supports Python 3.9+. Pick a compatible interpreter unless the caller
+# pinned one via PYTHON.
+if [ -z "${PYTHON:-}" ]; then
+  for cand in python3.12 python3.11 python3.10 python3; do
+    if command -v "$cand" >/dev/null 2>&1; then PYTHON="$cand"; break; fi
+  done
+  export PYTHON
+fi
+
+ensure_demo_up "$@"
+setup_venv "$SCRIPT_DIR"
+
+echo "==> running the Google ADK sandbox demo"
+python "$SCRIPT_DIR/run.py"

--- a/examples/integrations/smolagents/README.md
+++ b/examples/integrations/smolagents/README.md
@@ -1,0 +1,68 @@
+# smolagents agents, sandboxed by IronClaw
+
+Your **smolagents** (HuggingFace) agent runs untrusted, model-generated code.
+Point that execution at an **IronClaw sandbox** instead of your host and the same
+agent gets real code execution with **no network, no host filesystem, and no
+Docker socket** — the isolation boundary IronClaw
+[proves holds](../../red-team-escape/), not just promises.
+
+```python
+from ironclaw_sandbox import IronClawSandbox
+from ironclaw_tool import make_sandbox_tool
+
+with IronClawSandbox() as sandbox:            # engage a per-session sandbox
+    tool = make_sandbox_tool(sandbox)         # a real smolagents Tool
+    # agent = ToolCallingAgent(tools=[tool], model=...)
+```
+
+The `sandboxed_shell` Tool is a drop-in for the host-executing shell / code tool
+you would otherwise hand a `ToolCallingAgent`. The agent plans the tool calls
+exactly as before; only the execution moves into the box.
+
+## Try it in one command
+
+Zero credentials — the LLM side uses the offline **mock provider**, the sandbox
+is real:
+
+```sh
+examples/integrations/smolagents/run.sh
+```
+
+It engages a live IronClaw per-session sandbox, drives the `sandboxed_shell` Tool
+exactly as a `ToolCallingAgent`'s tool loop would (`tool(command=...)`), runs one
+benign task plus a battery of escape attempts, and prints a PASS/FAIL containment
+table:
+
+```
+  [OK ] benign task: run agent code                    ->  [exit 0] hello from inside the IronClaw sandbox uid=65532...
+  [OK ] network egress: only loopback exists           ->  [exit 0] lo
+  [OK ] network egress: DNS lookup of api.anthropic...  ->  [exit 0] NO_EGRESS
+  [OK ] host escape: Docker Engine socket is absent    ->  [exit 0] ABSENT
+  [OK ] host escape: host filesystem is not mounted    ->  [exit 0] CONTAINED
+
+RESULT: PASS -- benign code ran; every escape attempt was contained.
+```
+
+`run.sh --keep` leaves the demo running; `run.sh --attach` reuses an already-up
+demo control-plane.
+
+## Use a real LLM
+
+Set `OPENAI_API_KEY` (and install the LiteLLM extra — uncomment
+`smolagents[litellm]` in [`requirements.txt`](requirements.txt)) and `run.sh`
+drives a real `ToolCallingAgent` instead of the scripted probes. The tool — and
+therefore the isolation — is identical.
+
+## How it works
+
+- [`ironclaw_sandbox.py`](../_shared/ironclaw_sandbox.py) — engages a per-session
+  IronClaw sandbox (`ic-sbx-*`) against the demo control-plane and runs commands
+  inside it as its own non-root uid (65532). Pure standard library.
+- [`ironclaw_tool.py`](ironclaw_tool.py) — wraps that sandbox as a smolagents
+  `Tool` named `sandboxed_shell`. **This is the ~20 lines you copy** to swap a
+  host shell tool for a sandboxed one.
+- [`run.py`](run.py) — engages the sandbox and drives the tool.
+
+The execution primitive is the same one IronClaw's red-team harness attacks: a
+`docker exec` into the live per-session sandbox as its non-root uid. See the
+repo root [`README`](../../../README.md) for the full isolation model.

--- a/examples/integrations/smolagents/ironclaw_tool.py
+++ b/examples/integrations/smolagents/ironclaw_tool.py
@@ -1,0 +1,54 @@
+"""smolagents tool backed by an IronClaw sandbox.
+
+Drop-in replacement for the host-executing code/shell tool you would normally
+hand a **smolagents** (HuggingFace) agent (a `Tool` subclass that shells out, the
+built-in Python executor, ...): the agent calls it exactly the same way, but every
+command runs inside an isolated IronClaw per-session sandbox instead of on your
+machine.
+
+    from ironclaw_tool import make_sandbox_tool
+    from ironclaw_sandbox import IronClawSandbox
+
+    sandbox = IronClawSandbox().__enter__()
+    tool = make_sandbox_tool(sandbox)          # a real smolagents Tool
+    agent = ToolCallingAgent(tools=[tool], model=...)
+"""
+
+from __future__ import annotations
+
+from smolagents import Tool
+
+from ironclaw_sandbox import IronClawSandbox
+
+_DESCRIPTION = (
+    "Execute a shell command inside an isolated IronClaw sandbox and return its "
+    "stdout/stderr and exit code. Use this for any code the user asks you to run. "
+    "The sandbox has no network, no access to the host filesystem, and no Docker "
+    "socket, so it is safe to run untrusted commands."
+)
+
+
+def make_sandbox_tool(sandbox: IronClawSandbox) -> Tool:
+    """Wrap a live IronClaw sandbox as a smolagents Tool.
+
+    The sandbox handle is captured in a closure so it does not have to be a
+    constructor field on the Tool, which keeps this robust across smolagents
+    versions (the `Tool` base validates declared attributes on subclasses).
+    """
+
+    class IronClawSandboxTool(Tool):
+        name = "sandboxed_shell"
+        description = _DESCRIPTION
+        inputs = {
+            "command": {
+                "type": "string",
+                "description": "The shell command to run inside the sandbox.",
+            }
+        }
+        output_type = "string"
+
+        def forward(self, command: str) -> str:
+            """Run a shell command inside the IronClaw sandbox and return its output."""
+            return str(sandbox.run(command))
+
+    return IronClawSandboxTool()

--- a/examples/integrations/smolagents/requirements.txt
+++ b/examples/integrations/smolagents/requirements.txt
@@ -1,0 +1,9 @@
+# The IronClaw sandbox client is pure standard library; the only dependency the
+# default credential-free path adds is smolagents itself. Floor-pinned to the 1.x
+# line where the `Tool` subclass API (name/description/inputs/output_type/forward)
+# is stable. smolagents moves fast -- bump the ceiling deliberately.
+smolagents>=1.0,<2.0
+
+# Optional -- only needed for the real-LLM path (set OPENAI_API_KEY). smolagents
+# routes model calls through LiteLLM:
+# smolagents[litellm]>=1.0,<2.0

--- a/examples/integrations/smolagents/run.py
+++ b/examples/integrations/smolagents/run.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Run a smolagents agent whose code execution is backed by an IronClaw sandbox.
+
+Zero credentials by default: it engages a real IronClaw per-session sandbox
+against the offline demo control-plane (mock provider) and drives the smolagents
+`sandboxed_shell` Tool exactly as a `ToolCallingAgent` would when a model picks it
+-- one benign task plus a battery of escape attempts -- then prints a PASS/FAIL
+containment table.
+
+Set OPENAI_API_KEY to instead let a real LLM-driven agent decide what to run; the
+tool (and therefore the isolation) is identical either way.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Make the shared client + demo importable (examples/integrations/_shared).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "_shared"))
+
+from containment_demo import PROBES, run_containment_demo  # noqa: E402
+from ironclaw_sandbox import IronClawSandbox  # noqa: E402
+from ironclaw_tool import make_sandbox_tool  # noqa: E402
+
+
+def drive_with_real_agent(tool) -> int:
+    """Optional: let a real LLM-driven agent decide what to run (needs a key)."""
+    from smolagents import LiteLLMModel, ToolCallingAgent
+
+    model = LiteLLMModel(model_id="gpt-4o-mini")
+    agent = ToolCallingAgent(tools=[tool], model=model)
+    answer = agent.run(
+        "Run `id` with the sandboxed_shell tool and tell me which user the "
+        "sandbox runs as."
+    )
+    print(answer)
+    return 0
+
+
+def main() -> int:
+    print("==> engaging an IronClaw per-session sandbox (mock provider, zero-cred)")
+    with IronClawSandbox() as sandbox:
+        print(f"    sandbox container: {sandbox.container}")
+        tool = make_sandbox_tool(sandbox)
+
+        if os.environ.get("OPENAI_API_KEY"):
+            print("==> OPENAI_API_KEY set: driving a real smolagents ToolCallingAgent")
+            return drive_with_real_agent(tool)
+
+        # Deterministic, zero-cred path: call the Tool exactly as smolagents'
+        # tool-calling loop does -- tool(command=...) -- per probe.
+        print(f"==> driving the '{tool.name}' tool over {len(PROBES)} agent commands")
+        return run_containment_demo(
+            lambda command: tool(command=command),
+            framework="smolagents",
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/integrations/smolagents/run.sh
+++ b/examples/integrations/smolagents/run.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# smolagents (HuggingFace) + IronClaw sandbox -- one-command demo.
+#
+# Brings up the offline demo control-plane (mock provider -- no model key, no
+# channel tokens), then runs a smolagents agent whose `sandboxed_shell` Tool
+# executes inside a real IronClaw per-session sandbox. It runs one benign task and
+# a battery of escape attempts and prints a PASS/FAIL containment table.
+#
+#   examples/integrations/smolagents/run.sh           # build + up + demo + tear down
+#   examples/integrations/smolagents/run.sh --keep     # leave the demo running
+#   examples/integrations/smolagents/run.sh --attach   # use an already-running demo
+#
+# Env overrides (all optional):
+#   IRONCLAW_ADDR        control-plane base URL  (default http://127.0.0.1:8787)
+#   IRONCLAW_API_TOKEN   API bearer token        (default ironclaw-demo)
+#   IRONCLAW_DEMO_AGENT  agent group id          (default mock-agent)
+#   SKIP_BUILD=1         skip the sandbox image build (assume it exists)
+#   OPENAI_API_KEY       if set, drive a real LLM agent instead of the scripted one
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../_shared/demo-lifecycle.sh"
+
+# smolagents supports Python 3.10+. Pick a compatible interpreter unless the
+# caller pinned one via PYTHON.
+if [ -z "${PYTHON:-}" ]; then
+  for cand in python3.12 python3.11 python3.10 python3; do
+    if command -v "$cand" >/dev/null 2>&1; then PYTHON="$cand"; break; fi
+  done
+  export PYTHON
+fi
+
+ensure_demo_up "$@"
+setup_venv "$SCRIPT_DIR"
+
+echo "==> running the smolagents sandbox demo"
+python "$SCRIPT_DIR/run.py"


### PR DESCRIPTION
## What

Two new framework-integration examples under \`examples/integrations/\`, mirroring the proven IRO-385 playbook (FunctionTool-style wrapper that execs into a live \`ic-sbx-*\` per-session sandbox as uid 65532):

- **\`smolagents/\`** (HuggingFace) — a real smolagents \`Tool\` subclass (\`sandboxed_shell\`). \`run.py\` drives it via \`tool(command=...)\`, exactly the path a \`ToolCallingAgent\`'s tool loop takes.
- **\`google-adk/\`** (Google Agent Development Kit) — a native ADK \`FunctionTool\` (\`sandboxed_shell\`). \`run.py\` drives it via \`tool.run_async(args={...})\`, exactly the path ADK's tool loop takes.

Both reuse the shared \`_shared/ironclaw_sandbox.py\` client + \`containment_demo\`, so \`smoke-matrix.sh\` auto-discovers each (\`run.sh --attach\`) with **zero wiring changes**. Each ships \`run.sh\` + \`README\` (copy-paste quickstart + repo CTA) + version-pinned \`requirements.txt\` + a zero-credential Docker e2e.

## Why

CEO growth thesis (IRO-393): more Python framework wedges in untapped high-reach ecosystems. HuggingFace and Google/enterprise audiences, zero board accounts required (examples + PRs only).

## Verification (real Docker sandbox, colima)

Both ran e2e against the live demo control-plane and printed the PASS/FAIL containment table, exit 0:

- benign code runs as **uid 65532(nonroot)** ✅
- network egress (only \`lo\`) **BLOCKED** ✅
- DNS lookup of api.anthropic.com **BLOCKED** ✅
- Docker socket **ABSENT** ✅
- host filesystem **not mounted** ✅

\`RESULT: PASS -- benign code ran; every escape attempt was contained.\`

Adapter APIs validated against **smolagents 1.26.0** and **google-adk 1.36.0** (both floor-pinned \`>=1.0,<2.0\`).

## Notes

- Distribution (awesome-lists / SEO docs pages) is a separate Growth issue — not blocked here.
- No contract changes; examples only. No security-boundary changes (reuses the same sandbox exec primitive the red-team harness attacks).