### PR TITLE
docs(compare): IronClaw vs Modal + vs Daytona comparison pages (IRO-404)

### DIFF
--- a/docs/compare/.nav.yml
+++ b/docs/compare/.nav.yml
@@ -12,5 +12,7 @@ nav:
   - vs raw Docker: ironclaw-vs-docker-agent-sandbox.md
   - vs gVisor alone: ironclaw-vs-gvisor-alone.md
   - vs hosted sandboxes (E2B): ironclaw-vs-e2b-hosted-sandboxes.md
+  - vs Modal Sandboxes: ironclaw-vs-modal-sandboxes.md
+  - vs Daytona: ironclaw-vs-daytona.md
   - Containment benchmark (vs runc / E2B / Daytona): sandbox-containment-benchmark.md
   - "*.md"

--- a/docs/compare/index.md
+++ b/docs/compare/index.md
@@ -28,6 +28,10 @@ change and you should verify them against that project's own docs.
   strong wall, but a wall is not a runtime. What the rest of the agent lifecycle needs.
 - [IronClaw vs hosted agent sandboxes (E2B and similar)](ironclaw-vs-e2b-hosted-sandboxes.md) -
   the self-hosted vs managed trade: who holds your keys and data, and when each side wins.
+- [IronClaw vs Modal Sandboxes](ironclaw-vs-modal-sandboxes.md) - the managed serverless
+  cloud vs a complete self-hosted agent runtime, and where each one fits.
+- [IronClaw vs Daytona](ironclaw-vs-daytona.md) - fast ephemeral sandboxes optimized for
+  spin-up speed vs a boundary built to be verified against a hostile agent.
 - [Sandbox containment benchmark](sandbox-containment-benchmark.md) - a reproducible
   head-to-head: one fixed escape-attempt suite run against raw Docker, hardened runc, and
   gVisor, with honest labels for where E2B and Daytona sit.

--- a/docs/compare/ironclaw-vs-daytona.md
+++ b/docs/compare/ironclaw-vs-daytona.md
@@ -1,0 +1,66 @@
+---
+title: "IronClaw vs Daytona for AI agent sandboxes"
+description: "Daytona spins up fast, ephemeral sandboxes for running AI-generated code. IronClaw is the security-first, self-hosted runtime built around a boundary you can verify. Where each one fits."
+---
+
+# IronClaw vs Daytona
+
+Daytona provides fast, ephemeral sandboxes for running AI-generated and agent code, with a
+focus on quick spin-up and a clean API for executing untrusted code. It targets a real
+need: developers and agent builders who want a sandbox in milliseconds without wiring one
+up themselves. IronClaw targets an adjacent but distinct job. It is a **security-first,
+self-hosted agent runtime** whose whole design point is a containment boundary you can
+inspect and prove, not just a place to run code quickly.
+
+We describe the common fast-sandbox pattern here and do not assert the specifics of any
+named platform. Daytona documents its own isolation and hosting model, so verify those
+against Daytona's docs. This page is about matching the tool to what you are optimizing
+for: spin-up speed and developer ergonomics, or a verifiable boundary around a hostile
+agent.
+
+## The trade, honestly
+
+| Axis | Daytona (fast sandboxes) | IronClaw (security-first runtime) |
+| --- | --- | --- |
+| Primary optimization | Sandbox spin-up speed and DX | Verifiable containment of a compromised agent |
+| Hosting model | Cloud, verify self-host options in their docs | Self-hosted, on infrastructure you own |
+| Where provider keys live | Commonly passed into the execution environment | Host-side on your box, never inside the sandbox |
+| Isolation you can inspect | Platform detail you verify from their docs | gVisor + `network=none` + read-only rootfs, open source |
+| Agent lifecycle (approval, per-conversation) | You build the agent runtime on top | Built in: one sandbox per conversation, human-approval gateway |
+| Egress control | Depends on the platform | `network=none` enforced at the syscall layer by default on Linux |
+| Threat model | Focused on isolation for code execution | Published, versioned, and red-team tested every push |
+| Cost model | Usage-based | Your infrastructure, AGPLv3 + commercial |
+
+## When Daytona wins
+
+Pick a fast-sandbox platform when time-to-first-sandbox and developer ergonomics dominate:
+you want to hand an agent a place to run code with minimal setup, spin-up latency matters
+more than proving the boundary, and a managed API beats owning the runtime. For coding
+agents, quick experiments, and workflows where the sandbox is a convenience rather than a
+security control, that is often the faster call. IronClaw does not compete for it.
+
+## When to reach for IronClaw
+
+Reach for IronClaw when the sandbox **is** the security control and you have to prove it.
+Regulated data, strict residency, secrets that cannot leave your network, or a security
+team that needs to inspect the isolation rather than trust a description. IronClaw keeps
+the entire path on infrastructure you control: the provider key never enters the box, every
+conversation gets its own gVisor-backed sandbox with `network=none` and a read-only rootfs,
+a human-approval gateway guards capability changes with no bypass, and the boundary is open
+source and re-tested by a red-team containment gate on every push. See the reproducible
+[sandbox containment benchmark](sandbox-containment-benchmark.md) for where different
+isolation models actually land against a fixed escape suite.
+
+## Run the self-hosted path in minutes
+
+```bash
+docker compose -f docker-compose.demo.yml up --build -d
+./bin/ironctl doctor   # reports the sandbox runtime and isolation posture
+```
+
+## Where to go next
+
+- The reproducible head-to-head: [sandbox containment benchmark](sandbox-containment-benchmark.md).
+- The full alternative rundown: [Why IronClaw](../comparison.md).
+- What self-hosting buys you at the boundary: [How to sandbox an AI agent](../learn/how-to-sandbox-an-ai-agent.md).
+- From clone to held approval: [quickstart](../quickstart.md).

--- a/docs/compare/ironclaw-vs-modal-sandboxes.md
+++ b/docs/compare/ironclaw-vs-modal-sandboxes.md
@@ -1,0 +1,66 @@
+---
+title: "IronClaw vs Modal Sandboxes for AI agents"
+description: "Modal runs agent sandboxes as a serverless cloud you rent. IronClaw is the self-hosted alternative that keeps the sandbox, your keys, and your data on infrastructure you own. When each side wins."
+---
+
+# IronClaw vs Modal Sandboxes
+
+Modal is a serverless cloud for AI and data workloads, and its Sandboxes let you run
+untrusted or agent-generated code in an isolated container the platform spins up for you.
+It solves a real problem well: you call an API, code runs in a strong isolated environment,
+and you never operate a cluster. The trade is architectural, not a knock on the product.
+Modal runs that sandbox on **its** infrastructure, and in most agent setups the keys and
+data flowing through the agent pass through that managed environment. IronClaw is the
+self-hosted answer to the same job.
+
+We describe the common managed-cloud pattern here and do not assert the specifics of any
+named platform. Modal, for example, documents its own isolation approach, so verify those
+details against Modal's docs. This page is about the managed-cloud-vs-self-hosted trade so
+you can pick the side that fits your constraints.
+
+## The trade, honestly
+
+| Axis | Modal Sandboxes (managed cloud) | IronClaw (self-hosted) |
+| --- | --- | --- |
+| Ops burden | None, Modal runs it | You run it, self-hosted |
+| Where sandboxes execute | On Modal's cloud | On your infrastructure |
+| Where your data lives | On the platform's infrastructure | On yours |
+| Where provider keys live | Commonly with the platform or passed through it | Host-side on your box, never inside the sandbox |
+| Isolation you can inspect | Platform internal detail you verify from their docs | gVisor + `network=none` + read-only rootfs, open source |
+| Agent lifecycle (approval, per-conversation) | You build the agent runtime on top | Built in: one sandbox per conversation, human-approval gateway |
+| Data residency and compliance | Depends on the platform's regions and terms | Fully under your control |
+| Cost model | Usage-based, per second of compute | Your infrastructure, AGPLv3 + commercial |
+| Lock-in | Platform API and runtime | Own the stack, portable |
+
+## When Modal wins
+
+Pick a managed serverless sandbox when zero ops and elastic scale matter most: spiky or
+bursty workloads, GPU jobs you do not want to run yourself, prototyping, or a team with no
+platform engineers. If your data and keys are comfortable living with a third party and
+usage-based pricing beats owning infrastructure, a hosted platform is often the faster and
+cheaper call. That is a legitimate choice and IronClaw does not compete for it.
+
+## When to reach for IronClaw
+
+Reach for IronClaw when the answer to "who holds our keys and data" has to be "we do."
+Modal gives you a strong sandbox primitive; IronClaw gives you a **complete self-hosted
+agent runtime** built around a boundary you can inspect: the provider key never enters the
+box (a host-side proxy injects it and makes the outbound call), every conversation gets its
+own gVisor-backed sandbox with `network=none` and a read-only rootfs, and a human-approval
+gateway sits in front of capability changes with no bypass path. The isolation is open
+source and re-tested by a red-team containment gate on every push, so a security team can
+prove it rather than trust a description.
+
+## Run the self-hosted path in minutes
+
+```bash
+docker compose -f docker-compose.demo.yml up --build -d
+./bin/ironctl doctor   # reports the sandbox runtime and isolation posture
+```
+
+## Where to go next
+
+- The full alternative rundown, including hosted platforms: [Why IronClaw](../comparison.md).
+- The other managed option, side by side: [IronClaw vs hosted sandboxes (E2B)](ironclaw-vs-e2b-hosted-sandboxes.md).
+- What self-hosting buys you at the boundary: [How to sandbox an AI agent](../learn/how-to-sandbox-an-ai-agent.md).
+- From clone to held approval: [quickstart](../quickstart.md).


### PR DESCRIPTION
## What

Two net-new, high-intent comparison SEO pages for the compare cluster, targeting sandbox competitors not yet covered (E2B is already in docs/compare/):

- `docs/compare/ironclaw-vs-modal-sandboxes.md` - managed serverless cloud (Modal) vs a complete self-hosted agent runtime.
- `docs/compare/ironclaw-vs-daytona.md` - fast ephemeral sandboxes (Daytona) vs a boundary built to be verified against a hostile agent.

Both wired into `compare/.nav.yml` and `compare/index.md`.

## Why

Comparison-intent keywords convert best (IRO-330 cluster rationale). These capture buyers actively evaluating sandbox options for AI agents. Part of IRO-404 (own the category).

## Bar

- Follows the existing cluster pattern: per-page meta description, honest trade table, when-each-wins boxes, containment angle, try-it snippet.
- **Credibility over hype:** no third-party capability claims asserted; readers are pointed to each vendor's own docs. Modal itself uses gVisor, so the page positions on self-hosted / key-and-data residency / full runtime, NOT on isolation tech we don't have an edge in.
- No em/en-dashes (standing public-copy rule).
- `mkdocs build --strict` exits 0; both pages render.

Companion play (awesome-agent-sandboxing category list repo) tracked separately under IRO-404.