### PR TITLE
fix(isolation): allow fork/vfork in default seccomp profile (IRO-406)

### DIFF
--- a/internal/host/isolation/oci_limits_test.go
+++ b/internal/host/isolation/oci_limits_test.go
@@ -74,7 +74,9 @@ func TestDefaultSeccompProfileAllowsRuntimeDeniesDangerous(t *testing.T) {
 		allow[n] = true
 	}
 	// Core runtime + the model-proxy socket connect path must be permitted.
-	for _, must := range []string{"read", "write", "futex", "mmap", "connect", "epoll_wait", "clone"} {
+	// fork/vfork are required so musl/glibc shells can spawn subprocesses for a
+	// multi-command `sh -c` under the runc (non-gVisor) runtime (IRO-406).
+	for _, must := range []string{"read", "write", "futex", "mmap", "connect", "epoll_wait", "clone", "fork", "vfork"} {
 		if !allow[must] {
 			t.Errorf("allowlist missing required syscall %q", must)
 		}

--- a/internal/host/isolation/seccomp.go
+++ b/internal/host/isolation/seccomp.go
@@ -71,8 +71,13 @@ var allowedSyscalls = []string{
 	"rt_sigaction", "rt_sigprocmask", "rt_sigreturn", "rt_sigpending",
 	"rt_sigtimedwait", "rt_sigqueueinfo", "rt_sigsuspend", "sigaltstack",
 	"tgkill", "tkill", "kill", "restart_syscall",
-	// Process / thread lifecycle.
-	"clone", "clone3", "execve", "execveat", "exit", "exit_group", "wait4",
+	// Process / thread lifecycle. fork/vfork are needed by musl (busybox) and
+	// glibc (dash) shells to spawn subprocesses for a multi-command `sh -c`;
+	// omitting them made runc's non-gVisor fallback unable to run a normal shell
+	// script ("sh: can't fork"). Allowing them does not widen the boundary —
+	// network=none, all caps dropped, non-root, read-only rootfs, and no host
+	// socket all remain. Docker's own default profile allows both.
+	"clone", "clone3", "fork", "vfork", "execve", "execveat", "exit", "exit_group", "wait4",
 	"waitid", "set_tid_address", "set_robust_list", "get_robust_list", "gettid",
 	"getpid", "getppid", "prctl", "arch_prctl", "setpgid", "getpgid", "setsid",
 	// Identity (read-only; caps are already dropped).


### PR DESCRIPTION
## Problem

\`ironctl mcp serve --runtime runc\` produced a sandbox that could not fork/vfork. Any multi-command \`sh -c\` (a pipeline, or an \`a; b; c\` list where a non-last command is external) failed with:

\`\`\`
sh: can't fork: Operation not permitted
\`\`\`

Only a single/last command (which the shell execve's without forking) ran. Surfaced while building the n8n node (IRO-403, PR #380); reproduced on colima/runc with both alpine:3.20 and debian:stable-slim.

## Root cause

\`internal/host/isolation/seccomp.go\` \`DefaultSeccompProfile()\` is deny-by-default (\`SCMP_ACT_ERRNO\`). Its allowlist included \`clone\`/\`clone3\`/\`execve\` but **omitted \`fork\` and \`vfork\`**. musl (busybox) and glibc (dash) shells spawn subprocesses via \`fork\`/\`vfork\` → default ERRNO → EPERM. gVisor masked this: its guest kernel handles fork/vfork internally, so they never reach the host filter (why gVisor worked and runc did not).

## Fix

Add \`fork\`,\`vfork\` to the process-lifecycle allowlist group.

**Not a boundary weakening.** network=none, all caps dropped, non-root, read-only rootfs, and no host socket all remain. Docker's own default seccomp profile allows both syscalls.

## Verification

- \`go test ./internal/host/isolation/\` → 81 pass
- \`go build ./...\`, \`go vet\` clean
- Added a regression assertion in \`TestDefaultSeccompProfileAllowsRuntimeDeniesDangerous\` requiring fork/vfork on the allowlist.

Closes IRO-406.