### PR TITLE
feat(mcp): socket-free thin-client backend + slim ironclaw-mcp image (IRO-414)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/IronSecCo/ironclaw/internal/host/queue"
 	"github.com/IronSecCo/ironclaw/internal/host/registry"
 	"github.com/IronSecCo/ironclaw/internal/host/router"
+	"github.com/IronSecCo/ironclaw/internal/host/sandboxexec"
 	"github.com/IronSecCo/ironclaw/internal/host/session"
 	"github.com/IronSecCo/ironclaw/internal/host/skills"
 	"github.com/IronSecCo/ironclaw/internal/host/sweep"
@@ -107,6 +108,16 @@ func main() {
 		"OCI runtime for container MCP isolation, passed as docker --runtime (e.g. \"runsc\" for gVisor); empty uses the container CLI default")
 	mcpImage := flag.String("mcp-image", "",
 		"default container image for isolated local MCP servers when a server config sets no image")
+	sandboxExec := flag.Bool("sandbox-exec", envBool("IRONCLAW_ENABLE_SANDBOX_EXEC"),
+		"enable POST /v1/sandbox/exec: run one-shot HARDENED ephemeral boxes on behalf of a privilege-free thin MCP client (the slim ironclaw-mcp image running `ironctl mcp serve --controlplane`). Requires a container runtime CLI on this host")
+	sandboxExecRuntime := flag.String("sandbox-exec-runtime", envOr("IRONCLAW_SANDBOX_EXEC_RUNTIME", isolation.DefaultRuntimeBinary),
+		"OCI runtime for sandbox_exec boxes, passed as docker --runtime; default is gVisor (runsc). Any other value is a LABELLED fallback that does NOT provide gVisor's syscall interception")
+	sandboxExecImage := flag.String("sandbox-exec-image", envOr("IRONCLAW_SANDBOX_EXEC_IMAGE", sandboxexec.DefaultImage),
+		"default container image for sandbox_exec boxes")
+	sandboxExecDocker := flag.String("sandbox-exec-docker", envOr("IRONCLAW_SANDBOX_EXEC_DOCKER", "docker"),
+		"container runtime binary (docker/podman) used to launch sandbox_exec boxes")
+	sandboxExecTimeout := flag.Int("sandbox-exec-timeout", 30,
+		"default per-exec timeout in seconds for sandbox_exec boxes")
 	localModelURL := flag.String("local-model-url", os.Getenv("IRONCLAW_LOCAL_MODEL_URL"),
 		"OPT-IN: base URL of a LOCAL OpenAI-compatible model server — Ollama (http://localhost:11434/v1), LM Studio, vLLM, or llama.cpp. Allowlists its host, forwards to a loopback host over plain HTTP, and makes it the deployment-default model — no cloud credential. Empty disables local-model mode")
 	localModel := flag.String("local-model", os.Getenv("IRONCLAW_LOCAL_MODEL"),
@@ -703,6 +714,33 @@ func main() {
 	apiToken := os.Getenv("IRONCLAW_API_TOKEN")
 	if apiToken != "" {
 		server = server.WithToken(apiToken)
+	}
+
+	// Optional ephemeral sandbox_exec endpoint (POST /v1/sandbox/exec). It lets a
+	// privilege-free thin MCP client (the slim ironclaw-mcp image running
+	// `ironctl mcp serve --controlplane`) delegate one-shot code execution to THIS
+	// control-plane, which owns the hardened gVisor spawning — so the MCP container
+	// needs no docker.sock or runsc. The box posture is the containment single-source-
+	// of-truth in internal/host/sandboxexec (same as `ironctl mcp serve` standalone).
+	if *sandboxExec {
+		seccompPath, seccompCleanup, err := sandboxexec.WriteSeccompProfile()
+		if err != nil {
+			logger.Error("could not stage sandbox_exec seccomp profile", "err", err)
+			os.Exit(1)
+		}
+		defer seccompCleanup()
+		server = server.WithSandboxExec(&sandboxexec.Config{
+			Image:       *sandboxExecImage,
+			DockerBin:   *sandboxExecDocker,
+			Runtime:     *sandboxExecRuntime,
+			SeccompPath: seccompPath,
+			TimeoutSec:  *sandboxExecTimeout,
+			Run:         sandboxexec.DockerRunner,
+		})
+		gvisor := *sandboxExecRuntime == isolation.DefaultRuntimeBinary
+		logger.Info("sandbox_exec endpoint enabled",
+			"runtime", *sandboxExecRuntime, "gvisor", gvisor,
+			"image", *sandboxExecImage, "engine", *sandboxExecDocker)
 	}
 
 	// Isolation: per session, build a hardened OCI bundle and exec the runtime

--- a/cmd/ironctl/mcp_serve.go
+++ b/cmd/ironctl/mcp_serve.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"os/signal"
 	"strconv"
 	"strings"
@@ -19,6 +17,7 @@ import (
 
 	"github.com/IronSecCo/ironclaw/internal/host/isolation"
 	"github.com/IronSecCo/ironclaw/internal/host/mcp"
+	"github.com/IronSecCo/ironclaw/internal/host/sandboxexec"
 	"github.com/IronSecCo/ironclaw/internal/version"
 )
 
@@ -28,48 +27,70 @@ import (
 // broker (list/add/remove/probe/grant), which makes IronClaw a CLIENT of external
 // servers; here IronClaw is the server exposing a `sandbox_exec` tool.
 //
-//	ironctl mcp serve                      # stdio (what MCP clients spawn)
+//	ironctl mcp serve                      # stdio, standalone: shells `docker run` on THIS host
 //	ironctl mcp serve --http :9000         # HTTP transport, loopback-only by default
 //	ironctl mcp serve --http 0.0.0.0:9000 --auth-token $TOK   # world-bound requires auth
-//	ironctl mcp serve --image IMG --timeout 30 --docker /path/to/docker
-//	ironctl mcp serve --runtime runc       # explicit, LABELLED runc fallback (NOT gVisor)
+//	ironctl mcp serve --controlplane http://cp:8787 --token-env IRONCLAW_API_TOKEN
+//	                                       # THIN-CLIENT mode: delegate the box to a running
+//	                                       # control-plane over its API; this process holds NO
+//	                                       # host privilege (no docker.sock, no runsc in-image).
 //
-// The server holds no credentials and makes no model calls: `sandbox_exec` shells
-// a HARDENED `docker run` under gVisor (runsc) with network=none, drop-all-caps,
-// non-root, read-only rootfs, no-new-privileges, a restrictive seccomp profile, and
-// pids/mem/cpu caps into an ephemeral ic-sbx-mcp-* box, captures stdout/stderr +
-// exit code, and returns them with an explicit containment status.
+// Two backends:
+//   - default (standalone): `sandbox_exec` shells a HARDENED `docker run` under gVisor
+//     (runsc) with network=none, drop-all-caps, non-root, read-only rootfs,
+//     no-new-privileges, a restrictive seccomp profile, and pids/mem/cpu caps. For
+//     native/host use where this process may hold the runtime.
+//   - --controlplane (thin client): `sandbox_exec` POSTs the command to a running
+//     IronClaw control-plane, which owns the hardened gVisor spawning. Used by the
+//     slim, socket-free ghcr.io/ironsecco/ironclaw-mcp image so the MCP container
+//     holds no host privilege. Fail-closed: if the control-plane is unreachable the
+//     tool errors; it NEVER falls back to host docker.
 func cmdMCPServe(args []string) error {
 	fs := flag.NewFlagSet("mcp serve", flag.ContinueOnError)
 	httpAddr := fs.String("http", "", "serve over streamable HTTP on this address (e.g. :9000); host defaults to loopback (127.0.0.1)")
-	image := fs.String("image", defaultSandboxImage, "container image for the ephemeral sandbox box")
-	dockerBin := fs.String("docker", "docker", "container runtime binary (docker/podman) used to launch the box")
-	runtime := fs.String("runtime", isolation.DefaultRuntimeBinary, "OCI runtime for the box; default is gVisor (runsc). Any other value is an explicit, LABELLED fallback that does NOT provide gVisor's syscall interception")
+	image := fs.String("image", sandboxexec.DefaultImage, "container image for the ephemeral sandbox box")
+	dockerBin := fs.String("docker", "docker", "container runtime binary (docker/podman) used to launch the box (standalone backend only)")
+	runtime := fs.String("runtime", isolation.DefaultRuntimeBinary, "OCI runtime for the box; default is gVisor (runsc). Any other value is an explicit, LABELLED fallback that does NOT provide gVisor's syscall interception (standalone backend only)")
 	authToken := fs.String("auth-token", os.Getenv("IRONCLAW_MCP_AUTH_TOKEN"), "bearer token required for HTTP clients; REQUIRED for any non-loopback --http bind (env: IRONCLAW_MCP_AUTH_TOKEN)")
 	timeout := fs.Int("timeout", 30, "default per-exec timeout in seconds (bounds a runaway command)")
+	controlplane := fs.String("controlplane", os.Getenv("IRONCLAW_CONTROLPLANE_URL"), "delegate sandbox_exec to a running IronClaw control-plane at this URL (thin-client mode; no host privilege in this process). Env: IRONCLAW_CONTROLPLANE_URL")
+	tokenEnv := fs.String("token-env", "IRONCLAW_API_TOKEN", "name of the env var holding the control-plane API bearer token (--controlplane mode)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	// Materialize IronClaw's restrictive default seccomp profile to a temp file so
-	// the container runtime can enforce it (--security-opt seccomp=<file>). Matches
-	// the DockerIsolator/OCI path (internal/host/isolation/seccomp.go); without it a
-	// box would get only the runtime's default profile.
-	seccompPath, cleanup, err := writeSeccompProfile()
-	if err != nil {
-		return fmt.Errorf("mcp serve: could not stage seccomp profile: %w", err)
+	// Select the sandbox_exec backend. --controlplane wins and never touches host
+	// docker/runsc; otherwise the standalone docker backend runs the box locally.
+	var backend sandboxBackend
+	if strings.TrimSpace(*controlplane) != "" {
+		backend = &controlplaneBackend{
+			baseURL:    strings.TrimRight(*controlplane, "/"),
+			token:      os.Getenv(*tokenEnv),
+			image:      *image,
+			timeoutSec: *timeout,
+			client:     &http.Client{},
+		}
+		fmt.Fprintf(os.Stderr, "ironctl mcp serve: thin-client backend -> control-plane %s (this process holds no host privilege)\n", *controlplane)
+	} else {
+		// Materialize IronClaw's restrictive default seccomp profile to a temp file so
+		// the container runtime can enforce it (--security-opt seccomp=<file>). Matches
+		// the DockerIsolator/OCI path; without it a box would get only the runtime's
+		// default profile.
+		seccompPath, cleanup, err := sandboxexec.WriteSeccompProfile()
+		if err != nil {
+			return fmt.Errorf("mcp serve: could not stage seccomp profile: %w", err)
+		}
+		defer cleanup()
+		backend = sandboxExecConfig{
+			image:       *image,
+			dockerBin:   *dockerBin,
+			runtime:     *runtime,
+			seccompPath: seccompPath,
+			timeoutSec:  *timeout,
+			run:         sandboxexec.DockerRunner,
+		}
 	}
-	defer cleanup()
-
-	cfg := sandboxExecConfig{
-		image:       *image,
-		dockerBin:   *dockerBin,
-		runtime:     *runtime,
-		seccompPath: seccompPath,
-		timeoutSec:  *timeout,
-		run:         dockerExecRunner,
-	}
-	srv := newSandboxMCPServer(cfg)
+	srv := newSandboxMCPServer(backend)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -100,7 +121,7 @@ func cmdMCPServe(args []string) error {
 		if *authToken != "" {
 			authNote = "bearer-auth required"
 		}
-		fmt.Fprintf(os.Stderr, "ironctl mcp serve: MCP over HTTP at %s (%s, runtime=%s image=%s)\n", addr, authNote, *runtime, *image)
+		fmt.Fprintf(os.Stderr, "ironctl mcp serve: MCP over HTTP at %s (%s, %s)\n", addr, authNote, srv.backendNote)
 		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			return err
 		}
@@ -110,21 +131,34 @@ func cmdMCPServe(args []string) error {
 	// stdio is the default: MCP clients spawn `ironctl mcp serve` and speak
 	// newline-delimited JSON-RPC over the child's stdin/stdout. Diagnostics go to
 	// stderr so they never corrupt the protocol stream.
-	fmt.Fprintf(os.Stderr, "ironctl mcp serve: MCP over stdio (runtime=%s image=%s)\n", *runtime, *image)
+	fmt.Fprintf(os.Stderr, "ironctl mcp serve: MCP over stdio (%s)\n", srv.backendNote)
 	if err := srv.ServeStdio(ctx, os.Stdin, os.Stdout); err != nil && ctx.Err() == nil {
 		return err
 	}
 	return nil
 }
 
-// defaultSandboxImage is the image a sandbox box runs when the caller does not
-// override it. It is a minimal, credential-free base; the containment guarantees
-// come from the runtime flags, not the image.
-const defaultSandboxImage = "docker.io/library/alpine:3.20"
+// sandboxBackend is the seam between the MCP surface and the sandbox_exec
+// implementation: the standalone docker backend (sandboxExecConfig) and the
+// thin-client control-plane backend (controlplaneBackend) both satisfy it.
+type sandboxBackend interface {
+	toolFunc() mcp.ToolFunc
+	// note is a short human-readable description of the backend for the startup log.
+	note() string
+}
 
-// sandboxExecConfig is the injectable configuration for the sandbox_exec tool. The
-// run field is a seam: production uses dockerExecRunner; tests substitute a fake so
-// the hardened arg construction and result formatting are verified without Docker.
+// sandboxServer wraps mcp.Server with the backend note for the startup log.
+type sandboxServer struct {
+	*mcp.Server
+	backendNote string
+}
+
+// sandboxExecConfig is the standalone docker backend for the sandbox_exec tool. The
+// run field is a seam: production uses sandboxexec.DockerRunner; tests substitute a
+// fake so the hardened arg construction and result formatting are verified without
+// Docker. It delegates all containment-critical logic to internal/host/sandboxexec
+// (the single source of truth), so the standalone and control-plane backends cannot
+// drift apart.
 type sandboxExecConfig struct {
 	image       string
 	dockerBin   string
@@ -134,19 +168,29 @@ type sandboxExecConfig struct {
 	run         execRunner
 }
 
-// usesGVisor reports whether the configured runtime is gVisor (runsc), which is the
-// only runtime that gives syscall-interception containment. Anything else runs under
-// the shared host kernel and must be labelled as a fallback, not as gVisor.
-func (cfg sandboxExecConfig) usesGVisor() bool {
-	return cfg.runtime == isolation.DefaultRuntimeBinary
+// execRunner is the exec seam type, aliased to the shared Runner so tests and callers
+// can pass a plain func literal.
+type execRunner = sandboxexec.Runner
+
+// shared projects the backend config onto the shared containment config.
+func (cfg sandboxExecConfig) shared() sandboxexec.Config {
+	return sandboxexec.Config{
+		Image:       cfg.image,
+		DockerBin:   cfg.dockerBin,
+		Runtime:     cfg.runtime,
+		SeccompPath: cfg.seccompPath,
+		TimeoutSec:  cfg.timeoutSec,
+		Run:         cfg.run,
+	}
 }
 
-// execRunner launches a fully-formed argv and returns the combined stdout, stderr,
-// exit code, and any launch error (as opposed to a non-zero exit).
-type execRunner func(ctx context.Context, bin string, argv []string) (stdout, stderr string, exitCode int, err error)
+func (cfg sandboxExecConfig) note() string {
+	return fmt.Sprintf("standalone docker backend, runtime=%s image=%s", cfg.runtime, cfg.image)
+}
 
-// newSandboxMCPServer builds the MCP server exposing the sandbox_exec tool.
-func newSandboxMCPServer(cfg sandboxExecConfig) *mcp.Server {
+// newSandboxMCPServer builds the MCP server exposing the sandbox_exec tool, bound to
+// the given backend.
+func newSandboxMCPServer(backend sandboxBackend) *sandboxServer {
 	s := mcp.NewServer("ironclaw", version.String())
 	s.AddTool(mcp.Tool{
 		Name: "sandbox_exec",
@@ -163,12 +207,13 @@ func newSandboxMCPServer(cfg sandboxExecConfig) *mcp.Server {
 			`"image":{"type":"string","description":"Optional container image override (default: the server's configured image)."},` +
 			`"timeout_seconds":{"type":"integer","minimum":1,"maximum":600,"description":"Optional per-exec timeout override in seconds."}` +
 			`},"required":["command"],"additionalProperties":false}`),
-	}, cfg.toolFunc())
-	return s
+	}, backend.toolFunc())
+	return &sandboxServer{Server: s, backendNote: backend.note()}
 }
 
-// toolFunc returns the sandbox_exec handler bound to this config.
+// toolFunc returns the standalone docker sandbox_exec handler bound to this config.
 func (cfg sandboxExecConfig) toolFunc() mcp.ToolFunc {
+	sc := cfg.shared()
 	return func(ctx context.Context, args json.RawMessage) (mcp.ToolResult, error) {
 		var in struct {
 			Command string `json:"command"`
@@ -178,167 +223,30 @@ func (cfg sandboxExecConfig) toolFunc() mcp.ToolFunc {
 		if err := json.Unmarshal(args, &in); err != nil {
 			return mcp.ToolResult{}, fmt.Errorf("sandbox_exec: invalid arguments: %w", err)
 		}
-		if strings.TrimSpace(in.Command) == "" {
-			return mcp.ToolResult{}, fmt.Errorf("sandbox_exec: command is required")
-		}
-		image := cfg.image
-		if strings.TrimSpace(in.Image) != "" {
-			image = in.Image
-		}
-		// Argument-injection guard: the image is placed in the docker argv. A value
-		// like "--volume=/:/host" or "--user=0:0" would otherwise be parsed by docker
-		// as a flag and could relax the sandbox. Reject a leading '-'; the "--"
-		// end-of-options separator in the argv (see hardenedDockerArgs) is the second
-		// layer of defense.
-		if err := validateImageRef(image); err != nil {
+		res, err := sc.Exec(ctx, in.Command, in.Image, in.Timeout, sandboxBoxSuffix(ctx))
+		if err != nil {
+			// Invalid input (empty command, hostile image ref): a protocol-level error.
 			return mcp.ToolResult{}, fmt.Errorf("sandbox_exec: %w", err)
 		}
-		timeoutSec := cfg.timeoutSec
-		if in.Timeout > 0 {
-			timeoutSec = in.Timeout
-		}
-
-		// Deterministic, unique box name per call from the RPC deadline-free clock.
-		// We derive it from the runner start so the ephemeral box is always ic-sbx-mcp-*.
-		boxName := "ic-sbx-mcp-" + sandboxBoxSuffix(ctx)
-		argv := hardenedDockerArgs(cfg, boxName, image, in.Command)
-
-		runCtx := ctx
-		if timeoutSec > 0 {
-			var cancel context.CancelFunc
-			runCtx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
-			defer cancel()
-		}
-
-		stdout, stderr, exitCode, err := cfg.run(runCtx, cfg.dockerBin, argv)
-		if err != nil {
+		if res.LaunchErr != "" {
 			// A launch failure (docker missing, image pull denied, runsc absent,
 			// timeout) is a tool error, not a protocol error: report it as text with
 			// IsError so the client surfaces it to the user/model rather than tearing
 			// down the session.
 			hint := ""
-			if cfg.usesGVisor() {
-				hint = "\n(if the runtime %q is not registered with your engine, install gVisor/runsc " +
-					"or re-run with an explicit --runtime fallback; the fallback is NOT gVisor-equivalent)"
-				hint = fmt.Sprintf(hint, cfg.runtime)
+			if res.GVisor {
+				hint = fmt.Sprintf("\n(if the runtime %q is not registered with your engine, install gVisor/runsc "+
+					"or re-run with an explicit --runtime fallback; the fallback is NOT gVisor-equivalent)", cfg.runtime)
 			}
 			return mcp.ToolResult{
 				Content: []mcp.Content{{Type: "text", Text: fmt.Sprintf(
-					"sandbox_exec: launch failed: %v\n(runtime=%s engine=%s image=%s)%s\ncontainment: box never gained network or host access.",
-					err, cfg.runtime, cfg.dockerBin, image, hint)}},
+					"sandbox_exec: launch failed: %s\n(runtime=%s engine=%s image=%s)%s\ncontainment: box never gained network or host access.",
+					res.LaunchErr, cfg.runtime, cfg.dockerBin, res.Image, hint)}},
 				IsError: true,
 			}, nil
 		}
-
-		result := formatExecResult(cfg, image, exitCode, stdout, stderr)
-		return mcp.TextResult(result), nil
+		return mcp.TextResult(sandboxexec.FormatText(res)), nil
 	}
-}
-
-// validateImageRef rejects an image reference that docker would parse as a flag. A
-// leading '-' (e.g. "--volume=/:/host") is the injection vector; everything else is
-// left to docker's own reference parsing (the "--" separator handles the rest).
-func validateImageRef(image string) error {
-	image = strings.TrimSpace(image)
-	if image == "" {
-		return fmt.Errorf("image is required")
-	}
-	if strings.HasPrefix(image, "-") {
-		return fmt.Errorf("invalid image %q: must not start with '-' (would be parsed as a docker flag)", image)
-	}
-	return nil
-}
-
-// hardenedDockerArgs assembles the argv for an ephemeral, hardened one-shot box. It
-// mirrors the DockerIsolator/OCI posture (internal/host/isolation): gVisor (runsc)
-// runtime, network=none, drop-all-caps, non-root, read-only rootfs, no-new-privs, a
-// restrictive seccomp profile, and cpu/memory/pids caps. The command runs via `sh -c`
-// so snippets and pipelines work. A "--" end-of-options separator precedes the image
-// so a hostile image reference cannot be parsed as a flag. Keep this list in sync
-// with the containment guarantees documented in the tool description.
-func hardenedDockerArgs(cfg sandboxExecConfig, boxName, image, command string) []string {
-	argv := []string{
-		"run", "--rm",
-		"--name", boxName,
-		"--runtime", cfg.runtime, // gVisor (runsc) by default: syscall interception, guest kernel
-		"--network", "none", // no NIC: egress is structurally impossible
-		"--cap-drop", "ALL", // drop every Linux capability
-		"--security-opt", "no-new-privileges", // suid binaries cannot escalate
-	}
-	if cfg.seccompPath != "" {
-		// Restrictive deny-by-default seccomp profile (matches the OCI path).
-		argv = append(argv, "--security-opt", "seccomp="+cfg.seccompPath)
-	}
-	argv = append(argv,
-		"--read-only",           // rootfs is read-only
-		"--user", "65532:65532", // non-root (nonroot uid, matches sandbox default)
-		"--pids-limit", "256", // cap process/thread count
-		"--memory", "512m", // cgroup memory cap
-		"--cpus", "1", // one vCPU of bandwidth
-		"--tmpfs", "/tmp:rw,nosuid,nodev,size=64m", // writable scratch only
-		"--workdir", "/tmp",
-		"--", // end of options: nothing after this is parsed as a flag
-		image,
-		"sh", "-c", command,
-	)
-	return argv
-}
-
-// formatExecResult renders the tool's text block: stdout, stderr, exit code, and an
-// explicit containment summary so the caller always sees the enforced controls and
-// the true isolation boundary (gVisor vs a labelled fallback).
-func formatExecResult(cfg sandboxExecConfig, image string, exitCode int, stdout, stderr string) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "exit_code: %d\n", exitCode)
-	b.WriteString("containment: " + containmentSummary(cfg) + "\n")
-	fmt.Fprintf(&b, "image: %s\n", image)
-	b.WriteString("--- stdout ---\n")
-	b.WriteString(strings.TrimRight(stdout, "\n"))
-	b.WriteString("\n--- stderr ---\n")
-	b.WriteString(strings.TrimRight(stderr, "\n"))
-	return b.String()
-}
-
-// containmentSummary describes the enforced controls, honestly labelling the
-// isolation boundary. Under gVisor (runsc) it advertises syscall interception; under
-// any other runtime it states plainly that the boundary is the shared host kernel and
-// is NOT gVisor-equivalent, so a client is never misled about the guarantee.
-func containmentSummary(cfg sandboxExecConfig) string {
-	boundary := fmt.Sprintf("runtime=%s (FALLBACK: shared host kernel, NOT gVisor)", cfg.runtime)
-	if cfg.usesGVisor() {
-		boundary = "runtime=runsc (gVisor: user-space guest kernel, syscall interception)"
-	}
-	seccomp := "seccomp=restrictive-default"
-	if cfg.seccompPath == "" {
-		seccomp = "seccomp=engine-default"
-	}
-	return boundary + ", network=none, caps=drop-all, user=65532 (non-root), rootfs=read-only, " +
-		"no-new-privileges, " + seccomp + ", pids<=256, mem<=512m, cpu<=1 (ephemeral ic-sbx-mcp-* box, torn down)"
-}
-
-// writeSeccompProfile serializes IronClaw's restrictive default seccomp profile to a
-// temp file the container runtime can read via --security-opt seccomp=<file>, and
-// returns the path plus a cleanup func to remove it on shutdown.
-func writeSeccompProfile() (path string, cleanup func(), err error) {
-	data, err := json.Marshal(isolation.DefaultSeccompProfile())
-	if err != nil {
-		return "", func() {}, err
-	}
-	f, err := os.CreateTemp("", "ic-mcp-seccomp-*.json")
-	if err != nil {
-		return "", func() {}, err
-	}
-	name := f.Name()
-	if _, werr := f.Write(data); werr != nil {
-		_ = f.Close()
-		_ = os.Remove(name)
-		return "", func() {}, werr
-	}
-	if cerr := f.Close(); cerr != nil {
-		_ = os.Remove(name)
-		return "", func() {}, cerr
-	}
-	return name, func() { _ = os.Remove(name) }, nil
 }
 
 // normalizeHTTPAddr resolves the --http bind address and reports whether it is a
@@ -384,9 +292,8 @@ func bearerAuth(token string, h http.Handler) http.Handler {
 	})
 }
 
-// sandboxBoxSuffix derives a per-call box name suffix. It avoids Math/rand and the
-// wall clock (kept deterministic-friendly for tests) by using the process pid plus a
-// monotonic counter carried on the context when present.
+// sandboxBoxSuffix derives a per-call box name suffix. It avoids Math/rand and uses
+// the process pid plus a monotonic counter carried on the context when present.
 func sandboxBoxSuffix(ctx context.Context) string {
 	if v, ok := ctx.Value(boxSuffixKey{}).(string); ok && v != "" {
 		return v
@@ -395,25 +302,3 @@ func sandboxBoxSuffix(ctx context.Context) string {
 }
 
 type boxSuffixKey struct{}
-
-// dockerExecRunner is the production execRunner: it launches the runtime binary,
-// captures stdout/stderr separately, and normalizes the exit code.
-func dockerExecRunner(ctx context.Context, bin string, argv []string) (string, string, int, error) {
-	cmd := exec.CommandContext(ctx, bin, argv...)
-	var outBuf, errBuf strings.Builder
-	cmd.Stdout = &outBuf
-	cmd.Stderr = &errBuf
-	err := cmd.Run()
-	exitCode := 0
-	if err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
-			exitCode = ee.ExitCode()
-			// A non-zero exit from the sandboxed command is a normal result, not a
-			// launch failure: clear err so the caller reports stdout/stderr/exit.
-			return outBuf.String(), errBuf.String(), exitCode, nil
-		}
-		return outBuf.String(), errBuf.String(), -1, err
-	}
-	return outBuf.String(), errBuf.String(), exitCode, nil
-}

--- a/cmd/ironctl/mcp_serve_controlplane.go
+++ b/cmd/ironctl/mcp_serve_controlplane.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/IronSecCo/ironclaw/internal/host/mcp"
+	"github.com/IronSecCo/ironclaw/internal/host/sandboxexec"
+)
+
+// controlplaneBackend is the THIN-CLIENT sandbox_exec backend: it delegates the box
+// to a running IronClaw control-plane over its authenticated API instead of shelling
+// `docker run` locally. This process holds NO host privilege (no docker.sock, no
+// runsc in-image) — the control-plane, which already owns hardened gVisor spawning,
+// does the work.
+//
+// Fail-closed: if the control-plane is unreachable or returns a launch failure, the
+// tool reports an error. It NEVER falls back to an unhardened host path.
+type controlplaneBackend struct {
+	baseURL    string // e.g. http://cp:8787 (no trailing slash)
+	token      string // control-plane API bearer token (may be empty for a mesh-only CP)
+	image      string // default image when the call does not override it
+	timeoutSec int    // default per-exec timeout in seconds
+	client     *http.Client
+}
+
+func (b *controlplaneBackend) note() string {
+	return "thin-client backend -> control-plane " + b.baseURL + " (no host privilege)"
+}
+
+// sandboxExecRequest is the POST body sent to the control-plane's exec endpoint.
+type sandboxExecRequest struct {
+	Command string `json:"command"`
+	Image   string `json:"image,omitempty"`
+	Timeout int    `json:"timeout_seconds,omitempty"`
+}
+
+// toolFunc returns the sandbox_exec handler that POSTs to the control-plane.
+func (b *controlplaneBackend) toolFunc() mcp.ToolFunc {
+	return func(ctx context.Context, args json.RawMessage) (mcp.ToolResult, error) {
+		var in struct {
+			Command string `json:"command"`
+			Image   string `json:"image"`
+			Timeout int    `json:"timeout_seconds"`
+		}
+		if err := json.Unmarshal(args, &in); err != nil {
+			return mcp.ToolResult{}, fmt.Errorf("sandbox_exec: invalid arguments: %w", err)
+		}
+		if strings.TrimSpace(in.Command) == "" {
+			return mcp.ToolResult{}, fmt.Errorf("sandbox_exec: command is required")
+		}
+		image := in.Image
+		if strings.TrimSpace(image) == "" {
+			image = b.image
+		}
+		timeout := in.Timeout
+		if timeout <= 0 {
+			timeout = b.timeoutSec
+		}
+
+		body, _ := json.Marshal(sandboxExecRequest{Command: in.Command, Image: image, Timeout: timeout})
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, b.baseURL+"/v1/sandbox/exec", bytes.NewReader(body))
+		if err != nil {
+			return mcp.ToolResult{}, fmt.Errorf("sandbox_exec: build request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if b.token != "" {
+			req.Header.Set("Authorization", "Bearer "+b.token)
+		}
+
+		resp, err := b.client.Do(req)
+		if err != nil {
+			// Fail-closed: the control-plane is unreachable. The box never ran; there
+			// is NO local fallback. Surface as a tool error.
+			return mcp.ToolResult{
+				Content: []mcp.Content{{Type: "text", Text: fmt.Sprintf(
+					"sandbox_exec: control-plane unreachable at %s: %v\n"+
+						"containment: no box was launched; this thin client never has host docker/runsc access (fail-closed).",
+					b.baseURL, err)}},
+				IsError: true,
+			}, nil
+		}
+		defer resp.Body.Close()
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+
+		// The control-plane returns a structured sandboxexec-style body. A non-2xx
+		// status or a body carrying launch_error is a tool error (fail-closed).
+		var out struct {
+			Stdout      string `json:"stdout"`
+			Stderr      string `json:"stderr"`
+			ExitCode    int    `json:"exit_code"`
+			Image       string `json:"image"`
+			Containment string `json:"containment"`
+			LaunchError string `json:"launch_error"`
+			Error       string `json:"error"`
+		}
+		_ = json.Unmarshal(raw, &out)
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			msg := strings.TrimSpace(out.Error)
+			if msg == "" {
+				msg = strings.TrimSpace(string(raw))
+			}
+			if msg == "" {
+				msg = resp.Status
+			}
+			return mcp.ToolResult{
+				Content: []mcp.Content{{Type: "text", Text: fmt.Sprintf(
+					"sandbox_exec: control-plane rejected the request (%d): %s\ncontainment: no box gained network or host access (fail-closed).",
+					resp.StatusCode, msg)}},
+				IsError: true,
+			}, nil
+		}
+		if strings.TrimSpace(out.LaunchError) != "" {
+			return mcp.ToolResult{
+				Content: []mcp.Content{{Type: "text", Text: fmt.Sprintf(
+					"sandbox_exec: launch failed on control-plane: %s\n(image=%s)\ncontainment: %s",
+					out.LaunchError, out.Image, out.Containment)}},
+				IsError: true,
+			}, nil
+		}
+		// Success (or a normal non-zero exit): render the same text block the docker
+		// backend produces so a client cannot tell the backends apart.
+		return mcp.TextResult(sandboxexec.FormatText(sandboxexec.Result{
+			Stdout:      out.Stdout,
+			Stderr:      out.Stderr,
+			ExitCode:    out.ExitCode,
+			Image:       out.Image,
+			Containment: out.Containment,
+		})), nil
+	}
+}

--- a/cmd/ironctl/mcp_serve_controlplane_test.go
+++ b/cmd/ironctl/mcp_serve_controlplane_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func cpInvoke(t *testing.T, b *controlplaneBackend, argsJSON string) (result string, isError bool) {
+	t.Helper()
+	res, err := b.toolFunc()(context.Background(), json.RawMessage(argsJSON))
+	if err != nil {
+		t.Fatalf("rpc error: %v", err)
+	}
+	return res.Content[0].Text, res.IsError
+}
+
+// The thin client POSTs command/image/timeout to /v1/sandbox/exec with the bearer
+// token and renders the control-plane's structured result as the standard text block.
+func TestControlplaneBackendSuccess(t *testing.T) {
+	var gotAuth, gotPath string
+	var gotBody sandboxExecRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"stdout": "hi\n", "stderr": "", "exit_code": 0,
+			"image": "alpine:3.20", "containment": "runtime=runsc (gVisor: ...)",
+		})
+	}))
+	defer srv.Close()
+
+	b := &controlplaneBackend{baseURL: srv.URL, token: "s3cret", image: "alpine:3.20", timeoutSec: 30, client: srv.Client()}
+	txt, isErr := cpInvoke(t, b, `{"command":"echo hi"}`)
+	if isErr {
+		t.Fatalf("unexpected tool error: %s", txt)
+	}
+	if gotPath != "/v1/sandbox/exec" {
+		t.Errorf("path = %q, want /v1/sandbox/exec", gotPath)
+	}
+	if gotAuth != "Bearer s3cret" {
+		t.Errorf("auth = %q, want Bearer s3cret", gotAuth)
+	}
+	if gotBody.Command != "echo hi" || gotBody.Image != "alpine:3.20" || gotBody.Timeout != 30 {
+		t.Errorf("body = %+v", gotBody)
+	}
+	if !strings.Contains(txt, "exit_code: 0") || !strings.Contains(txt, "hi") || !strings.Contains(txt, "containment:") {
+		t.Errorf("result missing fields:\n%s", txt)
+	}
+}
+
+// A launch failure reported by the control-plane becomes a fail-closed tool error.
+func TestControlplaneBackendLaunchFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"launch_error": "runsc not found", "image": "alpine:3.20", "containment": "box never ran",
+		})
+	}))
+	defer srv.Close()
+	b := &controlplaneBackend{baseURL: srv.URL, image: "alpine:3.20", client: srv.Client()}
+	txt, isErr := cpInvoke(t, b, `{"command":"true"}`)
+	if !isErr {
+		t.Fatalf("launch failure should be a tool error")
+	}
+	if !strings.Contains(txt, "runsc not found") {
+		t.Errorf("result should surface the launch error:\n%s", txt)
+	}
+}
+
+// An unreachable control-plane is a fail-closed tool error, NOT a host fallback.
+func TestControlplaneBackendUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close() // now refuses connections
+	b := &controlplaneBackend{baseURL: url, image: "alpine:3.20", client: &http.Client{}}
+	txt, isErr := cpInvoke(t, b, `{"command":"true"}`)
+	if !isErr {
+		t.Fatalf("unreachable control-plane should be a tool error")
+	}
+	if !strings.Contains(txt, "unreachable") || !strings.Contains(txt, "fail-closed") {
+		t.Errorf("result should state fail-closed unreachability:\n%s", txt)
+	}
+}
+
+// Empty command is rejected before any HTTP call.
+func TestControlplaneBackendEmptyCommand(t *testing.T) {
+	b := &controlplaneBackend{baseURL: "http://127.0.0.1:0", client: &http.Client{}}
+	if _, err := b.toolFunc()(context.Background(), json.RawMessage(`{"command":"  "}`)); err == nil {
+		t.Errorf("empty command should error")
+	}
+}

--- a/container/mcp.Dockerfile
+++ b/container/mcp.Dockerfile
@@ -1,0 +1,58 @@
+# IronClaw slim MCP-server image  ->  ghcr.io/ironsecco/ironclaw-mcp
+#
+# A privilege-free MCP server for the official MCP Registry. It ships ONLY the
+# static `ironctl` binary and runs `ironctl mcp serve` in THIN-CLIENT mode: the
+# sandbox_exec tool delegates every box to a running IronClaw control-plane over its
+# authenticated API (POST /v1/sandbox/exec). The control-plane owns the hardened
+# gVisor (runsc) spawning; THIS container holds NO host privilege:
+#
+#   * NO /var/run/docker.sock mount (no host Docker control)
+#   * NO runsc / OCI runtime in the image
+#   * static binary, non-root, read-only-friendly rootfs, no shell
+#
+# That is the trade-off CEO chose (IRO-414, option B) over listing the full
+# control-plane image with a host Docker-socket mount. Fail-closed: with no
+# control-plane reachable the tool errors; it never falls back to host docker.
+#
+# Runtime configuration (env, set by the MCP client / registry server.json):
+#   IRONCLAW_CONTROLPLANE_URL   required — base URL of the control-plane (e.g. http://cp:8787)
+#   IRONCLAW_API_TOKEN          control-plane API bearer token (name overridable via --token-env)
+#
+# Build from the repository root:
+#   docker build -f container/mcp.Dockerfile -t ghcr.io/ironsecco/ironclaw-mcp:latest .
+
+# --- build stage ------------------------------------------------------------
+FROM golang:1.23-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db AS build
+
+WORKDIR /src
+# Prime the module cache first for better layer caching.
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+
+# ironctl is a pure HTTP/stdio client: it does NOT link the encrypted-queue
+# (go-sqlcipher) binding, so it builds fully static with CGO disabled. A static
+# binary lets us ship on distroless/static with no libc, no shell, no package
+# manager — the minimal attack surface the registry image needs.
+ENV CGO_ENABLED=0
+RUN go build -trimpath -ldflags "-s -w" -o /out/ironctl ./cmd/ironctl
+
+# --- runtime stage ----------------------------------------------------------
+# distroless static: no shell, no package manager, ships ca-certificates and a
+# nonroot (65532) user. Nothing else is needed — the box lifecycle lives on the
+# control-plane, not here.
+FROM gcr.io/distroless/static-debian12:nonroot AS runtime
+
+# NOTE (handoff to IRO-391 / Relay): add the MCP Registry ownership label here, e.g.
+#   LABEL io.modelcontextprotocol.server.name="<name from server.json>"
+# It is intentionally omitted so the exact name stays owned by server.json, which
+# Relay maintains alongside the publish-mcp-registry job.
+
+COPY --from=build /out/ironctl /ironctl
+
+USER 65532:65532
+# stdio MCP: the client spawns this container with -i and speaks newline-delimited
+# JSON-RPC over stdin/stdout. --controlplane defaults to $IRONCLAW_CONTROLPLANE_URL,
+# so thin-client mode engages automatically when that env is set; there is no docker
+# in this image, so it can never run a box locally.
+ENTRYPOINT ["/ironctl", "mcp", "serve"]

--- a/docs/integrations/mcp-server.md
+++ b/docs/integrations/mcp-server.md
@@ -109,6 +109,69 @@ same hardened posture as an IronClaw session sandbox:
 The tool's `containment:` line names the actual runtime, so a caller always sees
 whether it ran under gVisor or a labelled fallback.
 
+## Two backends: standalone vs. thin client
+
+`ironctl mcp serve` has two interchangeable sandbox_exec backends. Both build the
+**same** hardened box (the posture above lives in one place,
+`internal/host/sandboxexec`, so the two backends cannot drift apart).
+
+**Standalone (default).** The command shells `docker run` on **this** host. Use it
+for native/host installs where the process can hold the container runtime. This is
+what the one-line install above uses.
+
+**Thin client (`--controlplane`).** The command is delegated to a running IronClaw
+**control-plane** over its authenticated API; the control-plane (which already owns
+hardened gVisor spawning) launches the box. The `ironctl mcp serve` process then
+holds **no host privilege** - no `docker.sock`, no `runsc` - so it is safe to
+containerize for the [MCP Registry](https://github.com/modelcontextprotocol/registry)
+without mounting the host Docker socket.
+
+```bash
+# Thin-client mode: this process never touches host docker/runsc.
+ironctl mcp serve \
+  --controlplane http://control-plane:8787 \
+  --token-env IRONCLAW_API_TOKEN
+```
+
+Enable the endpoint on the control-plane with `--sandbox-exec` (runtime defaults to
+gVisor `runsc`; override with `--sandbox-exec-runtime`):
+
+```bash
+ironclaw-controlplane --sandbox-exec        # exposes POST /v1/sandbox/exec
+```
+
+**Fail-closed.** If the control-plane is unreachable, the tool returns an error; it
+**never** falls back to a host run. The containerized image ships no runtime, so a
+local box is not even possible.
+
+### Slim registry image
+
+`container/mcp.Dockerfile` builds `ghcr.io/ironsecco/ironclaw-mcp`: a ~15&nbsp;MB
+distroless image with only the static `ironctl` binary (no shell, no package
+manager, non-root 65532) whose entrypoint is `ironctl mcp serve` in thin-client
+mode. Point it at a control-plane with env:
+
+```json
+{
+  "mcpServers": {
+    "ironclaw": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm",
+        "-e", "IRONCLAW_CONTROLPLANE_URL",
+        "-e", "IRONCLAW_API_TOKEN",
+        "ghcr.io/ironsecco/ironclaw-mcp:latest"],
+      "env": {
+        "IRONCLAW_CONTROLPLANE_URL": "http://control-plane:8787",
+        "IRONCLAW_API_TOKEN": "..."
+      }
+    }
+  }
+}
+```
+
+The MCP container gets normal egress **only to reach the control-plane**; the actual
+`sandbox_exec` box still runs on the control-plane under gVisor with `network=none`.
+
 ## Prove containment yourself
 
 The value of the tool is what it **stops**. Ask your MCP client (or drive the server

--- a/internal/host/api/api.go
+++ b/internal/host/api/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/IronSecCo/ironclaw/internal/host/mcp"
 	"github.com/IronSecCo/ironclaw/internal/host/registry"
 	"github.com/IronSecCo/ironclaw/internal/host/router"
+	"github.com/IronSecCo/ironclaw/internal/host/sandboxexec"
 	"github.com/IronSecCo/ironclaw/internal/host/skills"
 	"github.com/IronSecCo/ironclaw/internal/version"
 )
@@ -47,6 +48,7 @@ type Server struct {
 	mcpCatalog *mcp.Catalog             // operator-configured MCP server catalog; nil = MCP disabled
 	mcpBroker  *mcp.Broker              // host MCP broker, for probe/discovery; nil = MCP disabled
 	vault      VaultPolicyReader        // per-group vault policy, for the read surface; nil = vault read disabled
+	sandbox    *sandboxexec.Config      // ephemeral hardened sandbox_exec backend; nil = POST /v1/sandbox/exec disabled
 	mux        *http.ServeMux
 
 	// Hardening (all opt-in; see hardening.go). Zero values disable the feature.
@@ -161,6 +163,7 @@ func (s *Server) routes() {
 	s.skillsRoutes()      // skills install/list/remove at /v1/skills (see skills.go)
 	s.mcpRoutes()         // MCP server CRUD/probe + read-model at /v1/registry/mcp-servers|/v1/ui/mcp-servers (see mcp.go)
 	s.vaultRoutes()       // per-group vault policy read surface at /v1/vault/policy (see vault.go)
+	s.sandboxRoutes()     // ephemeral hardened sandbox_exec at POST /v1/sandbox/exec (see sandbox.go)
 }
 
 // auth wraps h with optional bearer-token authentication. With no token set, the

--- a/internal/host/api/sandbox.go
+++ b/internal/host/api/sandbox.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/IronSecCo/ironclaw/internal/host/sandboxexec"
+)
+
+// WithSandboxExec enables the ephemeral hardened sandbox_exec endpoint
+// (POST /v1/sandbox/exec). It lets a privilege-free MCP client (the slim
+// ghcr.io/ironsecco/ironclaw-mcp image running `ironctl mcp serve --controlplane`)
+// delegate one-shot code execution to THIS control-plane, which owns the hardened
+// gVisor spawning. The container privilege stays here; the client holds none.
+//
+// A nil config (the default) leaves the endpoint disabled: it returns 501. Returns
+// the Server for chaining.
+func (s *Server) WithSandboxExec(cfg *sandboxexec.Config) *Server {
+	s.sandbox = cfg
+	return s
+}
+
+func (s *Server) sandboxRoutes() {
+	s.mux.HandleFunc("POST /v1/sandbox/exec", s.handleSandboxExec)
+}
+
+// sandboxExecCounter disambiguates two box names created within the same nanosecond.
+var sandboxExecCounter uint64
+
+// sandboxExecReq is the request body for POST /v1/sandbox/exec.
+type sandboxExecReq struct {
+	Command string `json:"command"`
+	Image   string `json:"image"`
+	Timeout int    `json:"timeout_seconds"`
+}
+
+// sandboxExecResp is the structured response. LaunchError is set (and the status is
+// 502) only when the box FAILED TO START — the client must treat that as fail-closed
+// and never fall back. A normal non-zero ExitCode with an empty LaunchError is a
+// completed command, returned 200.
+type sandboxExecResp struct {
+	Stdout      string `json:"stdout"`
+	Stderr      string `json:"stderr"`
+	ExitCode    int    `json:"exit_code"`
+	Image       string `json:"image"`
+	Containment string `json:"containment"`
+	LaunchError string `json:"launch_error,omitempty"`
+}
+
+// handleSandboxExec runs a single hardened, ephemeral box on behalf of a thin MCP
+// client. It reuses internal/host/sandboxexec (the containment single-source-of-truth)
+// so the box is spawned with the same posture as `ironctl mcp serve` standalone:
+// gVisor (runsc), network=none, drop-all-caps, non-root, read-only rootfs,
+// no-new-privileges, restrictive seccomp, and pids/mem/cpu caps. The box is torn down
+// after the command completes. This endpoint sits behind the API's bearer-token auth
+// (defense-in-depth behind the mesh boundary); an arbitrary code-exec entry must not
+// be reachable without the API token when one is configured.
+func (s *Server) handleSandboxExec(w http.ResponseWriter, r *http.Request) {
+	if s.sandbox == nil {
+		http.Error(w, "sandbox exec is not enabled on this control-plane", http.StatusNotImplemented)
+		return
+	}
+	var req sandboxExecReq
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		http.Error(w, "invalid sandbox exec request JSON", http.StatusBadRequest)
+		return
+	}
+
+	suffix := "cp-" + strconv.Itoa(os.Getpid()) + "-" +
+		strconv.FormatInt(time.Now().UnixNano(), 36) + "-" +
+		strconv.FormatUint(atomic.AddUint64(&sandboxExecCounter, 1), 36)
+
+	res, err := s.sandbox.Exec(r.Context(), req.Command, req.Image, req.Timeout, suffix)
+	if err != nil {
+		// Invalid input (empty command, hostile image reference): 400.
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	resp := sandboxExecResp{
+		Stdout:      res.Stdout,
+		Stderr:      res.Stderr,
+		ExitCode:    res.ExitCode,
+		Image:       res.Image,
+		Containment: res.Containment,
+		LaunchError: res.LaunchErr,
+	}
+	status := http.StatusOK
+	if res.LaunchErr != "" {
+		// The box never started; report a bad-gateway so the client fails closed.
+		status = http.StatusBadGateway
+	}
+	writeJSON(w, status, resp)
+}

--- a/internal/host/api/sandbox_test.go
+++ b/internal/host/api/sandbox_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/host/gateway"
+	"github.com/IronSecCo/ironclaw/internal/host/sandboxexec"
+)
+
+func newSandboxTestServer(cfg *sandboxexec.Config) *Server {
+	gw := gateway.New(gateway.VerifierChain{}, gateway.NewManualApprover(), gateway.NewLogApplier(), gateway.NewMemoryStore())
+	s := New(gw)
+	if cfg != nil {
+		s = s.WithSandboxExec(cfg)
+	}
+	return s
+}
+
+func postExec(s *Server, body string) *httptest.ResponseRecorder {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/sandbox/exec", strings.NewReader(body))
+	s.Handler().ServeHTTP(rr, req)
+	return rr
+}
+
+// When no backend is configured the endpoint is disabled (501), never a bare host run.
+func TestSandboxExecDisabled(t *testing.T) {
+	rr := postExec(newSandboxTestServer(nil), `{"command":"echo hi"}`)
+	if rr.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// A successful run returns 200 with the hardened argv actually built and a
+// gVisor-labelled containment string.
+func TestSandboxExecSuccess(t *testing.T) {
+	var gotArgv []string
+	cfg := &sandboxexec.Config{
+		Image: "alpine:3.20", DockerBin: "docker", Runtime: "runsc", SeccompPath: "/tmp/s.json", TimeoutSec: 30,
+		Run: func(_ context.Context, _ string, argv []string) (string, string, int, error) {
+			gotArgv = argv
+			return "hello\n", "", 0, nil
+		},
+	}
+	rr := postExec(newSandboxTestServer(cfg), `{"command":"echo hello"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var out sandboxExecResp
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Stdout != "hello\n" || out.ExitCode != 0 || out.LaunchError != "" {
+		t.Errorf("bad response: %+v", out)
+	}
+	if !strings.Contains(out.Containment, "runtime=runsc (gVisor") {
+		t.Errorf("containment should advertise gVisor: %s", out.Containment)
+	}
+	joined := strings.Join(gotArgv, " ")
+	for _, f := range []string{"--network none", "--cap-drop ALL", "--runtime runsc", "--read-only", "--user 65532:65532"} {
+		if !strings.Contains(joined, f) {
+			t.Errorf("hardened argv missing %q: %s", f, joined)
+		}
+	}
+	if !strings.Contains(joined, "ic-sbx-mcp-cp-") {
+		t.Errorf("box name should be control-plane-scoped: %s", joined)
+	}
+}
+
+// A launch failure returns 502 with launch_error set — the client must fail closed.
+func TestSandboxExecLaunchFailure(t *testing.T) {
+	cfg := &sandboxexec.Config{
+		Image: "alpine:3.20", DockerBin: "docker", Runtime: "runsc",
+		Run: func(_ context.Context, _ string, _ []string) (string, string, int, error) {
+			return "", "", -1, context.DeadlineExceeded
+		},
+	}
+	rr := postExec(newSandboxTestServer(cfg), `{"command":"sleep 999"}`)
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body=%s", rr.Code, rr.Body.String())
+	}
+	var out sandboxExecResp
+	_ = json.Unmarshal(rr.Body.Bytes(), &out)
+	if out.LaunchError == "" {
+		t.Errorf("launch_error should be set: %+v", out)
+	}
+}
+
+// Invalid input (empty command, hostile image ref) is rejected 400 before any run.
+func TestSandboxExecInvalidInput(t *testing.T) {
+	called := false
+	cfg := &sandboxexec.Config{
+		Image: "alpine:3.20", DockerBin: "docker", Runtime: "runsc",
+		Run: func(_ context.Context, _ string, _ []string) (string, string, int, error) {
+			called = true
+			return "", "", 0, nil
+		},
+	}
+	for _, body := range []string{`{"command":"  "}`, `{"command":"true","image":"--volume=/:/host"}`} {
+		rr := postExec(newSandboxTestServer(cfg), body)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("body %s: status = %d, want 400", body, rr.Code)
+		}
+	}
+	if called {
+		t.Errorf("runner must not run for invalid input")
+	}
+}
+
+// The endpoint sits behind bearer-token auth when a token is configured.
+func TestSandboxExecRequiresAuth(t *testing.T) {
+	cfg := &sandboxexec.Config{
+		Image: "alpine:3.20", DockerBin: "docker", Runtime: "runsc",
+		Run: func(_ context.Context, _ string, _ []string) (string, string, int, error) { return "", "", 0, nil },
+	}
+	s := newSandboxTestServer(cfg).WithToken("s3cret")
+	rr := postExec(s, `{"command":"echo hi"}`)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated exec should be 401, got %d", rr.Code)
+	}
+	// With the token it goes through.
+	rr = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/sandbox/exec", strings.NewReader(`{"command":"echo hi"}`))
+	req.Header.Set("Authorization", "Bearer s3cret")
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("authenticated exec should be 200, got %d; body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/host/sandboxexec/exec.go
+++ b/internal/host/sandboxexec/exec.go
@@ -1,0 +1,235 @@
+// Package sandboxexec is the single source of truth for IronClaw's ephemeral,
+// hardened one-shot code-exec box. Both `ironctl mcp serve` (standalone/native
+// docker backend) and the control-plane's POST /v1/sandbox/exec endpoint build the
+// SAME `docker run` argv here, so the containment posture (gVisor/runsc,
+// network=none, drop-all-caps, non-root, read-only rootfs, no-new-privileges,
+// restrictive seccomp, pids/mem/cpu caps) cannot drift between the two entrypoints.
+//
+// The box is torn down after every call (--rm). Nothing in this package holds
+// credentials or makes model calls: it is pure containment plumbing.
+package sandboxexec
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/IronSecCo/ironclaw/internal/host/isolation"
+)
+
+// DefaultImage is the image a box runs when the caller does not override it. It is a
+// minimal, credential-free base; the containment guarantees come from the runtime
+// flags, not the image.
+const DefaultImage = "docker.io/library/alpine:3.20"
+
+// BoxNamePrefix is the deterministic prefix for every ephemeral exec box, so the
+// sweep/leak checks (and operators) can always identify and reap them.
+const BoxNamePrefix = "ic-sbx-mcp-"
+
+// Runner launches a fully-formed argv and returns the combined stdout, stderr, exit
+// code, and any launch error (as opposed to a non-zero exit from the command). It is
+// an injectable seam: production uses DockerRunner; tests substitute a fake so the
+// hardened arg construction and result handling are verified without Docker.
+type Runner func(ctx context.Context, bin string, argv []string) (stdout, stderr string, exitCode int, err error)
+
+// Config is the injectable configuration for a hardened one-shot exec.
+type Config struct {
+	Image       string // default image when the call does not override it
+	DockerBin   string // container runtime binary (docker/podman)
+	Runtime     string // OCI runtime: "runsc" (gVisor) by default; anything else is a labelled fallback
+	SeccompPath string // path to the seccomp profile JSON; empty omits the flag (tests)
+	TimeoutSec  int    // default per-exec timeout in seconds; <=0 means no bound
+	Run         Runner // exec seam
+}
+
+// Result is the structured outcome of a hardened exec. LaunchErr is non-empty only
+// when the box FAILED TO START (docker missing, image pull denied, runsc absent,
+// timeout): callers must treat that as a fail-closed tool error and never fall back
+// to an unhardened path. A non-zero ExitCode with an empty LaunchErr is a normal
+// command result, not a containment failure.
+type Result struct {
+	Stdout      string
+	Stderr      string
+	ExitCode    int
+	Image       string
+	Containment string
+	GVisor      bool
+	LaunchErr   string
+}
+
+// UsesGVisor reports whether the configured runtime is gVisor (runsc), the only
+// runtime that gives syscall-interception containment. Anything else runs under the
+// shared host kernel and must be labelled a fallback, not gVisor.
+func (c Config) UsesGVisor() bool {
+	return c.Runtime == isolation.DefaultRuntimeBinary
+}
+
+// ValidateImageRef rejects an image reference that docker would parse as a flag. A
+// leading '-' (e.g. "--volume=/:/host") is the injection vector; everything else is
+// left to docker's own reference parsing (the "--" separator handles the rest).
+func ValidateImageRef(image string) error {
+	image = strings.TrimSpace(image)
+	if image == "" {
+		return errors.New("image is required")
+	}
+	if strings.HasPrefix(image, "-") {
+		return fmt.Errorf("invalid image %q: must not start with '-' (would be parsed as a docker flag)", image)
+	}
+	return nil
+}
+
+// HardenedArgs assembles the argv for an ephemeral, hardened one-shot box. It mirrors
+// the DockerIsolator/OCI posture (internal/host/isolation): gVisor (runsc) runtime,
+// network=none, drop-all-caps, non-root, read-only rootfs, no-new-privs, a
+// restrictive seccomp profile, and cpu/memory/pids caps. The command runs via `sh -c`
+// so snippets and pipelines work. A "--" end-of-options separator precedes the image
+// so a hostile image reference cannot be parsed as a flag. Keep this list in sync
+// with the containment guarantees documented in the tool description.
+func HardenedArgs(c Config, boxName, image, command string) []string {
+	argv := []string{
+		"run", "--rm",
+		"--name", boxName,
+		"--runtime", c.Runtime, // gVisor (runsc) by default: syscall interception, guest kernel
+		"--network", "none", // no NIC: egress is structurally impossible
+		"--cap-drop", "ALL", // drop every Linux capability
+		"--security-opt", "no-new-privileges", // suid binaries cannot escalate
+	}
+	if c.SeccompPath != "" {
+		// Restrictive deny-by-default seccomp profile (matches the OCI path).
+		argv = append(argv, "--security-opt", "seccomp="+c.SeccompPath)
+	}
+	argv = append(argv,
+		"--read-only",           // rootfs is read-only
+		"--user", "65532:65532", // non-root (nonroot uid, matches sandbox default)
+		"--pids-limit", "256", // cap process/thread count
+		"--memory", "512m", // cgroup memory cap
+		"--cpus", "1", // one vCPU of bandwidth
+		"--tmpfs", "/tmp:rw,nosuid,nodev,size=64m", // writable scratch only
+		"--workdir", "/tmp",
+		"--", // end of options: nothing after this is parsed as a flag
+		image,
+		"sh", "-c", command,
+	)
+	return argv
+}
+
+// ContainmentSummary describes the enforced controls, honestly labelling the
+// isolation boundary. Under gVisor (runsc) it advertises syscall interception; under
+// any other runtime it states plainly that the boundary is the shared host kernel and
+// is NOT gVisor-equivalent, so a caller is never misled about the guarantee.
+func ContainmentSummary(c Config) string {
+	boundary := fmt.Sprintf("runtime=%s (FALLBACK: shared host kernel, NOT gVisor)", c.Runtime)
+	if c.UsesGVisor() {
+		boundary = "runtime=runsc (gVisor: user-space guest kernel, syscall interception)"
+	}
+	seccomp := "seccomp=restrictive-default"
+	if c.SeccompPath == "" {
+		seccomp = "seccomp=engine-default"
+	}
+	return boundary + ", network=none, caps=drop-all, user=65532 (non-root), rootfs=read-only, " +
+		"no-new-privileges, " + seccomp + ", pids<=256, mem<=512m, cpu<=1 (ephemeral " + BoxNamePrefix + "* box, torn down)"
+}
+
+// Exec runs command in an ephemeral hardened box and returns a structured Result. A
+// returned error is reserved for INVALID INPUT (empty command, hostile image ref);
+// a box that fails to start is reported via Result.LaunchErr (fail-closed), never as
+// a silent fallback. image overrides c.Image when non-empty; timeoutSec overrides
+// c.TimeoutSec when > 0. boxSuffix makes the box name unique per call.
+func (c Config) Exec(ctx context.Context, command, image string, timeoutSec int, boxSuffix string) (Result, error) {
+	if strings.TrimSpace(command) == "" {
+		return Result{}, errors.New("command is required")
+	}
+	if strings.TrimSpace(image) == "" {
+		image = c.Image
+	}
+	if err := ValidateImageRef(image); err != nil {
+		return Result{}, err
+	}
+	if timeoutSec <= 0 {
+		timeoutSec = c.TimeoutSec
+	}
+
+	boxName := BoxNamePrefix + boxSuffix
+	argv := HardenedArgs(c, boxName, image, command)
+
+	runCtx := ctx
+	if timeoutSec > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
+		defer cancel()
+	}
+
+	res := Result{Image: image, Containment: ContainmentSummary(c), GVisor: c.UsesGVisor()}
+	stdout, stderr, exitCode, err := c.Run(runCtx, c.DockerBin, argv)
+	res.Stdout, res.Stderr, res.ExitCode = stdout, stderr, exitCode
+	if err != nil {
+		res.ExitCode = -1
+		res.LaunchErr = err.Error()
+	}
+	return res, nil
+}
+
+// DockerRunner is the production Runner: it launches the runtime binary, captures
+// stdout/stderr separately, and normalizes the exit code. A non-zero exit from the
+// sandboxed command is a normal result (err cleared); only a launch failure returns
+// a non-nil error.
+func DockerRunner(ctx context.Context, bin string, argv []string) (string, string, int, error) {
+	cmd := exec.CommandContext(ctx, bin, argv...)
+	var outBuf, errBuf strings.Builder
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return outBuf.String(), errBuf.String(), ee.ExitCode(), nil
+		}
+		return outBuf.String(), errBuf.String(), -1, err
+	}
+	return outBuf.String(), errBuf.String(), 0, nil
+}
+
+// WriteSeccompProfile serializes IronClaw's restrictive default seccomp profile to a
+// temp file the container runtime can read via --security-opt seccomp=<file>, and
+// returns the path plus a cleanup func to remove it on shutdown.
+func WriteSeccompProfile() (path string, cleanup func(), err error) {
+	data, err := json.Marshal(isolation.DefaultSeccompProfile())
+	if err != nil {
+		return "", func() {}, err
+	}
+	f, err := os.CreateTemp("", "ic-mcp-seccomp-*.json")
+	if err != nil {
+		return "", func() {}, err
+	}
+	name := f.Name()
+	if _, werr := f.Write(data); werr != nil {
+		_ = f.Close()
+		_ = os.Remove(name)
+		return "", func() {}, werr
+	}
+	if cerr := f.Close(); cerr != nil {
+		_ = os.Remove(name)
+		return "", func() {}, cerr
+	}
+	return name, func() { _ = os.Remove(name) }, nil
+}
+
+// FormatText renders a Result as the human/model-facing text block used by the MCP
+// sandbox_exec tool: exit code, containment summary, image, then stdout/stderr. It is
+// shared by the docker and control-plane backends so their output is identical.
+func FormatText(res Result) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "exit_code: %d\n", res.ExitCode)
+	b.WriteString("containment: " + res.Containment + "\n")
+	fmt.Fprintf(&b, "image: %s\n", res.Image)
+	b.WriteString("--- stdout ---\n")
+	b.WriteString(strings.TrimRight(res.Stdout, "\n"))
+	b.WriteString("\n--- stderr ---\n")
+	b.WriteString(strings.TrimRight(res.Stderr, "\n"))
+	return b.String()
+}

--- a/internal/host/sandboxexec/exec_test.go
+++ b/internal/host/sandboxexec/exec_test.go
@@ -1,0 +1,125 @@
+package sandboxexec
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func indexOf(argv []string, want string) int {
+	for i, a := range argv {
+		if a == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// HardenedArgs is the containment contract: if any flag regresses an escape becomes
+// possible, so each is asserted explicitly.
+func TestHardenedArgs(t *testing.T) {
+	c := Config{Image: "alpine:3.20", DockerBin: "docker", Runtime: "runsc", SeccompPath: "/tmp/s.json"}
+	argv := HardenedArgs(c, "ic-sbx-mcp-x", "alpine:3.20", "echo hi")
+	joined := strings.Join(argv, " ")
+	for _, f := range []string{
+		"--runtime runsc", "--network none", "--cap-drop ALL",
+		"--security-opt no-new-privileges", "--security-opt seccomp=/tmp/s.json",
+		"--read-only", "--user 65532:65532", "--pids-limit 256",
+		"--memory 512m", "--cpus 1", "--rm", "ic-sbx-mcp-x",
+	} {
+		if !strings.Contains(joined, f) {
+			t.Errorf("hardened argv missing %q\n  got: %s", f, joined)
+		}
+	}
+	sep, img := indexOf(argv, "--"), indexOf(argv, "alpine:3.20")
+	if sep < 0 || img < 0 || sep+1 != img {
+		t.Errorf("expected '--' immediately before image; sep=%d img=%d", sep, img)
+	}
+	n := len(argv)
+	if argv[n-3] != "sh" || argv[n-2] != "-c" || argv[n-1] != "echo hi" {
+		t.Errorf("command tail wrong: %v", argv[n-3:])
+	}
+}
+
+func TestContainmentSummaryLabelsRuntime(t *testing.T) {
+	gv := ContainmentSummary(Config{Runtime: "runsc", SeccompPath: "/tmp/s"})
+	if !strings.Contains(gv, "runtime=runsc (gVisor") {
+		t.Errorf("runsc must advertise gVisor: %s", gv)
+	}
+	fb := ContainmentSummary(Config{Runtime: "runc"})
+	if strings.Contains(fb, "gVisor:") || !strings.Contains(fb, "NOT gVisor") {
+		t.Errorf("runc fallback must be labelled NOT gVisor: %s", fb)
+	}
+	if !strings.Contains(fb, "seccomp=engine-default") {
+		t.Errorf("empty seccomp path must report engine-default: %s", fb)
+	}
+}
+
+func TestValidateImageRefRejectsFlags(t *testing.T) {
+	for _, bad := range []string{"--volume=/:/host", "-v", "--user=0:0"} {
+		if err := ValidateImageRef(bad); err == nil {
+			t.Errorf("image %q should be rejected", bad)
+		}
+	}
+	if err := ValidateImageRef("alpine:3.20"); err != nil {
+		t.Errorf("valid image rejected: %v", err)
+	}
+}
+
+func TestExecStructuredResult(t *testing.T) {
+	var gotArgv []string
+	c := Config{
+		Image: "alpine:3.20", DockerBin: "docker", Runtime: "runsc", TimeoutSec: 30,
+		Run: func(_ context.Context, _ string, argv []string) (string, string, int, error) {
+			gotArgv = argv
+			return "hello\n", "", 0, nil
+		},
+	}
+	res, err := c.Exec(context.Background(), "echo hello", "", 0, "suf1")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res.ExitCode != 0 || res.Stdout != "hello\n" || res.LaunchErr != "" || !res.GVisor {
+		t.Errorf("bad result: %+v", res)
+	}
+	if indexOf(gotArgv, "ic-sbx-mcp-suf1") < 0 {
+		t.Errorf("box name suffix not applied: %v", gotArgv)
+	}
+}
+
+func TestExecImageOverrideAndValidation(t *testing.T) {
+	c := Config{Image: "alpine:3.20", DockerBin: "docker", Runtime: "runsc",
+		Run: func(_ context.Context, _ string, _ []string) (string, string, int, error) { return "", "", 0, nil }}
+	// override honored
+	res, _ := c.Exec(context.Background(), "true", "python:3.12", 0, "s")
+	if res.Image != "python:3.12" {
+		t.Errorf("image override not applied: %s", res.Image)
+	}
+	// hostile override rejected before run
+	if _, err := c.Exec(context.Background(), "true", "--volume=/:/x", 0, "s"); err == nil {
+		t.Errorf("hostile image should be rejected")
+	}
+	// empty command rejected
+	if _, err := c.Exec(context.Background(), "   ", "", 0, "s"); err == nil {
+		t.Errorf("empty command should be rejected")
+	}
+}
+
+// A launch failure is surfaced via LaunchErr (fail-closed), not a returned error.
+func TestExecLaunchFailureIsFailClosed(t *testing.T) {
+	c := Config{Image: "alpine:3.20", DockerBin: "docker", Runtime: "runsc",
+		Run: func(_ context.Context, _ string, _ []string) (string, string, int, error) {
+			return "", "", -1, errors.New("runsc not found")
+		}}
+	res, err := c.Exec(context.Background(), "true", "", 0, "s")
+	if err != nil {
+		t.Fatalf("launch failure must not be a returned error: %v", err)
+	}
+	if res.LaunchErr == "" || res.ExitCode != -1 {
+		t.Errorf("launch failure not reported: %+v", res)
+	}
+	if !strings.Contains(FormatText(res), "containment:") {
+		t.Errorf("formatted result should note containment")
+	}
+}


### PR DESCRIPTION
Unblocks **IRO-391** (official MCP Registry listing) per CEO **option B**: list a dedicated slim MCP-server image whose sandbox backend needs no raw host Docker socket, instead of the control-plane image with a `docker.sock` mount.

## What
- **`internal/host/sandboxexec`** — new package, the containment single-source-of-truth for the ephemeral hardened one-shot box (gVisor/runsc, `network=none`, cap-drop ALL, non-root 65532, read-only rootfs, no-new-privileges, restrictive seccomp, pids/mem/cpu caps). `ironctl mcp serve` delegates its argv/containment/seccomp construction here so the two backends can't drift apart.
- **`ironctl mcp serve --controlplane <url> --token-env IRONCLAW_API_TOKEN`** — thin-client `sandbox_exec` backend that POSTs to the control-plane instead of shelling `docker run`. Fail-closed: unreachable control-plane errors, never falls back to host docker. Standalone docker backend stays the default for native/host use.
- **Control-plane `POST /v1/sandbox/exec`** (opt-in `--sandbox-exec`) — spawns one hardened ephemeral box reusing the same posture; returns stdout/stderr/exit + containment; tears down. Behind API bearer auth; 501 disabled, 502 fail-closed on launch failure.
- **`container/mcp.Dockerfile` → `ghcr.io/ironsecco/ironclaw-mcp`** — ~15 MB distroless static image, `ironctl` only, no docker.sock, no runsc in-image, non-root.
- Docs: two-backends + slim-image section in `docs/integrations/mcp-server.md`.

## Verified live (colima, runsc registered)
Full chain **MCP client → slim container (thin-client, no host privilege) → control-plane → gVisor box**:
- `uid=65532 gid=65532` (non-root), kernel `4.19.0-gvisor` (syscall interception)
- egress `Network unreachable` → `EGRESS_BLOCKED` (`network=none`)
- rootfs `Permission denied` → read-only
- **Fail-closed**: unreachable control-plane → `isError`, command never ran (and the image ships no runtime, so a local box is impossible).

215 tests pass, build green (`CGO_ENABLED=1`).

## Trust lenses
least-privilege (MCP container privilege-free) · fail-closed (no host-docker fallback) · containment unchanged (control-plane spawns the same hardened box). New external code-exec entry into the control-plane → **requesting CEO review**.

## Handoff → IRO-391 (Relay)
Repoint `server.json`'s OCI package at `ghcr.io/ironsecco/ironclaw-mcp:<tag>`, drop the docker-socket `runtimeArguments`, add the `io.modelcontextprotocol.server.name` LABEL to `container/mcp.Dockerfile` (placeholder comment left in place), and let the `publish-mcp-registry` job (PR #370) publish it.