### PR TITLE
docs(mcp-server): MCP onboarding for VS Code coding agents — Cline / Roo Code / Continue (IRO-416)

### DIFF
--- a/docs/mcp-server/.nav.yml
+++ b/docs/mcp-server/.nav.yml
@@ -5,3 +5,6 @@ nav:
   - Claude Desktop: claude-desktop.md
   - Cursor: cursor.md
   - Windsurf: windsurf.md
+  - Cline: cline.md
+  - Roo Code: roo-code.md
+  - Continue.dev: continue.md

--- a/docs/mcp-server/cline.md
+++ b/docs/mcp-server/cline.md
@@ -1,0 +1,79 @@
+---
+title: "IronClaw MCP Server -- Cline"
+description: "Add IronClaw sandbox_exec to Cline (VS Code) in 30 seconds. Cline's agent runs untrusted AI-generated shell inside a gVisor sandbox instead of on your host."
+---
+
+# Cline
+
+[Cline](https://cline.bot) is a VS Code coding agent that plans and runs shell
+commands and edits files on your behalf. By default those commands run directly
+on your development machine. Point Cline at IronClaw's `sandbox_exec` tool and
+the agent runs untrusted, AI-generated commands inside an isolated gVisor
+sandbox instead.
+
+## Why sandbox Cline?
+
+A coding agent executes code the model wrote, not code you reviewed. A single
+bad command can read your SSH keys, exfiltrate a token, or wipe a directory.
+IronClaw contains each command in an ephemeral gVisor container: no host
+filesystem, no unexpected egress, destroyed after the session.
+
+- See it stop real escape attempts: [nivardsec.com/containment](https://nivardsec.com/containment)
+- Read the isolation benchmark: [Containment benchmark](../blog/containment-benchmark-docker-gvisor-e2b-daytona.md)
+
+## 1. Install ironctl
+
+```bash
+brew install ironsecco/ironclaw/ironclaw
+```
+
+Verify:
+
+```bash
+ironctl version
+```
+
+## 2. Add the MCP server
+
+In VS Code, open the Cline panel and click the **MCP Servers** icon, then
+**Configure MCP Servers**. This opens `cline_mcp_settings.json`. Add the
+`ironclaw` entry under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "ironclaw": {
+      "command": "ironctl",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+If you already have other MCP servers, add the `"ironclaw"` key alongside them.
+
+!!! note "Cline CLI"
+    Using the Cline CLI instead of the VS Code extension? Put the same
+    `mcpServers` block in `~/.cline/mcp.json`.
+
+## 3. Reload
+
+Cline picks up the new server automatically. If the tool does not appear, click
+the refresh icon in the MCP Servers panel, or run **Developer: Reload Window**
+from the VS Code command palette.
+
+## What sandbox_exec does
+
+- Runs commands in an ephemeral container managed by IronClaw
+- Uses gVisor for kernel-level isolation -- the AI cannot read your host files
+  or make unexpected network calls
+- Container is destroyed after the session ends
+
+## Troubleshooting
+
+**`ironctl: command not found`** -- Make sure `ironctl` is on your `$PATH`.
+Run `which ironctl` to check. If you installed via Homebrew, run
+`brew link ironsecco/ironclaw/ironclaw`.
+
+**Tool does not appear** -- Open the Cline MCP Servers panel and check the
+server status. Use the refresh icon, or reload the VS Code window.

--- a/docs/mcp-server/continue.md
+++ b/docs/mcp-server/continue.md
@@ -1,0 +1,77 @@
+---
+title: "IronClaw MCP Server -- Continue.dev"
+description: "Add IronClaw sandbox_exec to Continue.dev (VS Code) in 30 seconds. Continue's agent runs untrusted AI-generated shell inside a gVisor sandbox instead of on your host."
+---
+
+# Continue.dev
+
+[Continue](https://continue.dev) is an open-source VS Code coding agent. In
+agent mode it runs shell commands and edits files on your behalf. By default
+those commands run on your host. Point Continue at IronClaw's `sandbox_exec`
+tool and the agent runs untrusted, AI-generated commands inside an isolated
+gVisor sandbox instead.
+
+## Why sandbox Continue?
+
+A coding agent executes code the model wrote, not code you reviewed. One bad
+command can read your credentials, exfiltrate a token, or delete files. IronClaw
+contains each command in an ephemeral gVisor container: no host filesystem, no
+unexpected egress, destroyed after the session.
+
+- See it stop real escape attempts: [nivardsec.com/containment](https://nivardsec.com/containment)
+- Read the isolation benchmark: [Containment benchmark](../blog/containment-benchmark-docker-gvisor-e2b-daytona.md)
+
+## 1. Install ironctl
+
+```bash
+brew install ironsecco/ironclaw/ironclaw
+```
+
+Verify:
+
+```bash
+ironctl version
+```
+
+## 2. Edit the config file
+
+Continue uses YAML config. Open (or create) `~/.continue/config.yaml` and add
+the `ironclaw` entry under `mcpServers`:
+
+```yaml
+mcpServers:
+  - name: ironclaw
+    type: stdio
+    command: ironctl
+    args:
+      - mcp
+      - serve
+```
+
+If you already have other MCP servers, add the `ironclaw` entry alongside them
+in the same `mcpServers` list.
+
+!!! note "MCP runs in agent mode"
+    Continue only exposes MCP tools in **agent** mode. Switch the Continue chat
+    to Agent before expecting `sandbox_exec` to appear.
+
+## 3. Reload
+
+Save the file. Continue reloads its config automatically. If the tool does not
+appear, run **Developer: Reload Window** from the VS Code command palette.
+
+## What sandbox_exec does
+
+- Runs commands in an ephemeral container managed by IronClaw
+- Uses gVisor for kernel-level isolation -- the AI cannot read your host files
+  or make unexpected network calls
+- Container is destroyed after the session ends
+
+## Troubleshooting
+
+**`ironctl: command not found`** -- Make sure `ironctl` is on your `$PATH`.
+Run `which ironctl` to check. If you installed via Homebrew, run
+`brew link ironsecco/ironclaw/ironclaw`.
+
+**Tool does not appear** -- Confirm Continue is in Agent mode, check the
+config for YAML indentation errors, and reload the VS Code window.

--- a/docs/mcp-server/index.md
+++ b/docs/mcp-server/index.md
@@ -1,6 +1,6 @@
 ---
 title: IronClaw MCP Server
-description: "Run IronClaw as an MCP server to give Claude Desktop, Cursor, and Windsurf a sandboxed code-execution tool in 30 seconds."
+description: "Run IronClaw as an MCP server to give Claude Desktop, Cursor, Windsurf, Cline, Roo Code, and Continue.dev a sandboxed code-execution tool in 30 seconds."
 ---
 
 # IronClaw as an MCP Server
@@ -23,6 +23,9 @@ session, so nothing persists to your host.
 | [Claude Desktop](claude-desktop.md) | `~/Library/Application Support/Claude/claude_desktop_config.json` |
 | [Cursor](cursor.md) | `~/.cursor/mcp.json` |
 | [Windsurf](windsurf.md) | `~/.codeium/windsurf/mcp_server_config.json` |
+| [Cline](cline.md) | `cline_mcp_settings.json` (VS Code panel) / `~/.cline/mcp.json` |
+| [Roo Code](roo-code.md) | `mcp_settings.json` (VS Code panel) / `.roo/mcp.json` |
+| [Continue.dev](continue.md) | `~/.continue/config.yaml` |
 
 ## Prerequisites
 

--- a/docs/mcp-server/roo-code.md
+++ b/docs/mcp-server/roo-code.md
@@ -1,0 +1,79 @@
+---
+title: "IronClaw MCP Server -- Roo Code"
+description: "Add IronClaw sandbox_exec to Roo Code (VS Code) in 30 seconds. Roo Code's agent runs untrusted AI-generated shell inside a gVisor sandbox instead of on your host."
+---
+
+# Roo Code
+
+[Roo Code](https://roocode.com) is a VS Code coding agent that executes shell
+commands and edits files autonomously. By default those commands run on your
+host. Wire Roo Code to IronClaw's `sandbox_exec` tool and the agent runs
+untrusted, AI-generated commands inside an isolated gVisor sandbox instead.
+
+## Why sandbox Roo Code?
+
+A coding agent runs code the model wrote, not code you reviewed. One bad command
+can read your credentials, exfiltrate a token, or delete files. IronClaw
+contains each command in an ephemeral gVisor container: no host filesystem, no
+unexpected egress, destroyed after the session.
+
+- See it stop real escape attempts: [nivardsec.com/containment](https://nivardsec.com/containment)
+- Read the isolation benchmark: [Containment benchmark](../blog/containment-benchmark-docker-gvisor-e2b-daytona.md)
+
+## 1. Install ironctl
+
+```bash
+brew install ironsecco/ironclaw/ironclaw
+```
+
+Verify:
+
+```bash
+ironctl version
+```
+
+## 2. Add the MCP server
+
+In VS Code, open the Roo Code panel, open the **MCP** view, and click
+**Edit Global MCP** (this opens `mcp_settings.json`). Add the `ironclaw` entry
+under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "ironclaw": {
+      "command": "ironctl",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+If you already have other MCP servers, add the `"ironclaw"` key alongside them.
+
+!!! note "Project-scoped config"
+    To share the sandbox with your team, put the same `mcpServers` block in
+    `.roo/mcp.json` at your project root. Project settings override the global
+    config when server names match.
+
+## 3. Reload
+
+Roo Code picks up the new server automatically. If the tool does not appear,
+toggle the server off and on in the MCP view, or run **Developer: Reload
+Window** from the VS Code command palette.
+
+## What sandbox_exec does
+
+- Runs commands in an ephemeral container managed by IronClaw
+- Uses gVisor for kernel-level isolation -- the AI cannot read your host files
+  or make unexpected network calls
+- Container is destroyed after the session ends
+
+## Troubleshooting
+
+**`ironctl: command not found`** -- Make sure `ironctl` is on your `$PATH`.
+Run `which ironctl` to check. If you installed via Homebrew, run
+`brew link ironsecco/ironclaw/ironclaw`.
+
+**Tool does not appear** -- Open the Roo Code MCP view and check the server
+status. Toggle it off and on, or reload the VS Code window.


### PR DESCRIPTION
## What

Adds `docs/mcp-server/` onboarding pages for the three VS Code AI coding agents that execute untrusted AI-generated shell on the dev machine: **Cline**, **Roo Code**, **Continue.dev**. Each drops in `ironctl mcp serve` (`sandbox_exec`) as copy-paste MCP config so agent commands run inside a gVisor sandbox instead of on the host. Mirrors the IRO-384 claude-desktop/cursor/windsurf cluster.

## Pages
- `cline.md` — `cline_mcp_settings.json` (VS Code panel) / `~/.cline/mcp.json`, `mcpServers` JSON
- `roo-code.md` — `mcp_settings.json` (VS Code panel) / `.roo/mcp.json`, `mcpServers` JSON + project-scope note
- `continue.md` — `~/.continue/config.yaml`, YAML `mcpServers` list + agent-mode requirement
- why-sandbox framing on each, linking [/containment](https://nivardsec.com/containment) + the containment benchmark blog
- wired into per-dir `.nav.yml` + `index.md` supported-clients table

## Config verification (these move fast)
Verified each config against current upstream docs:
- Cline — `mcpServers` command/args, panel + `~/.cline/mcp.json`
- Roo Code — `mcpServers` JSON, global `mcp_settings.json` / project `.roo/mcp.json`
- Continue.dev — YAML `config.yaml`, `mcpServers` list with `type: stdio`, MCP agent-mode only

## Verification
- `mkdocs build --strict` → exit 0, all 3 pages render, nav renders, blog cross-link resolves
- Out of scope (per issue): upstream PRs (no IronClaw GitHub identity, board-gated)

Acceptance met: 3 pages build under `mkdocs --strict`, nav renders, configs verified.