### PR TITLE
docs(compare): IronClaw vs Firecracker + vs Kata Containers microVM pages (IRO-418)

### DIFF
--- a/docs/compare/.nav.yml
+++ b/docs/compare/.nav.yml
@@ -11,6 +11,8 @@ nav:
   - vs running agents unsandboxed: ironclaw-vs-unsandboxed-ai-agents.md
   - vs raw Docker: ironclaw-vs-docker-agent-sandbox.md
   - vs gVisor alone: ironclaw-vs-gvisor-alone.md
+  - vs Firecracker (microVM): ironclaw-vs-firecracker.md
+  - vs Kata Containers (microVM): ironclaw-vs-kata-containers.md
   - vs hosted sandboxes (E2B): ironclaw-vs-e2b-hosted-sandboxes.md
   - vs Modal Sandboxes: ironclaw-vs-modal-sandboxes.md
   - vs Daytona: ironclaw-vs-daytona.md

--- a/docs/compare/index.md
+++ b/docs/compare/index.md
@@ -26,6 +26,12 @@ change and you should verify them against that project's own docs.
   still have to build on top of it.
 - [IronClaw vs gVisor alone](ironclaw-vs-gvisor-alone.md) - a user-space kernel is a
   strong wall, but a wall is not a runtime. What the rest of the agent lifecycle needs.
+- [IronClaw vs Firecracker](ironclaw-vs-firecracker.md) - a KVM microVM is a genuinely
+  strong wall, but a VMM is not an agent runtime. What egress, keys, approval, and proof
+  still require around it.
+- [IronClaw vs Kata Containers](ironclaw-vs-kata-containers.md) - VM-grade isolation with
+  container ergonomics, and why the agent runtime and proof-of-containment posture still
+  have to be built on top.
 - [IronClaw vs hosted agent sandboxes (E2B and similar)](ironclaw-vs-e2b-hosted-sandboxes.md) -
   the self-hosted vs managed trade: who holds your keys and data, and when each side wins.
 - [IronClaw vs Modal Sandboxes](ironclaw-vs-modal-sandboxes.md) - the managed serverless

--- a/docs/compare/ironclaw-vs-firecracker.md
+++ b/docs/compare/ironclaw-vs-firecracker.md
@@ -1,0 +1,94 @@
+---
+title: "IronClaw vs Firecracker for AI agent isolation"
+description: "Firecracker is a minimal KVM microVM with a real separate guest kernel, a genuinely strong isolation wall. But a VMM is not an agent runtime. What egress, host-side keys, an approval gateway, and continuous proof still require."
+---
+
+# IronClaw vs Firecracker
+
+Firecracker is an excellent isolation primitive. It is a minimal virtual machine monitor
+that boots a lightweight microVM on KVM in around a hundred milliseconds, with a
+deliberately tiny device model and a real, separate guest kernel. AWS Lambda and Fargate
+run untrusted code on it for a reason: hardware-virtualized isolation is arguably a
+stronger kernel boundary than syscall interception, because the guest talks to its own
+kernel rather than a reimplementation of the host's ABI. If you are weighing Firecracker
+for agent workloads, you have picked a serious wall. The question this page answers is
+what sits around it.
+
+We describe the microVM pattern here and do not assert the specifics of any deployment.
+Firecracker documents its own security model and requirements, so verify those against
+its docs. This page is about matching the tool to the job: a bare VMM primitive, or a
+complete agent runtime built around a boundary you can prove.
+
+## A microVM is a wall, not a runtime
+
+Firecracker gives you one thing very well: a strong, hardware-virtualized boundary for a
+guest. An agent runtime has to answer several more questions that Firecracker on its own
+does not:
+
+- **Egress.** Firecracker isolates the guest; it does not decide the agent should have no
+  network. You wire TAP devices and rate limiters yourself, then enforce the policy.
+- **Credentials.** The provider API key has to reach the model somehow. If it lives inside
+  the microVM as an env var, a compromised agent can read it, hardware isolation or not.
+- **Approval.** Nothing in a VMM holds a new capability, tool, or egress rule for a human
+  to approve before it takes effect.
+- **Lifecycle.** One sandbox per conversation, sealed compiled-binary runtime, rootfs image
+  management, the chat and channel plumbing, provider routing. That is the runtime, not
+  the hypervisor.
+- **Proof.** A boundary you cannot re-test on every change is a boundary you are hoping
+  still holds.
+
+## Firecracker alone vs the full stack
+
+| Layer | Firecracker (bare microVM) | IronClaw |
+| --- | --- | --- |
+| Kernel isolation | Strong: separate guest kernel on KVM | Strong: gVisor user-space kernel, `network=none`, read-only rootfs |
+| Host requirement | Bare-metal or nested KVM (`/dev/kvm`) | Linux + gVisor; macOS/Windows fall back to runc in Docker Desktop's VM |
+| `network=none` enforced by default | You build TAP networking, then lock it down | Default on the sandbox |
+| Provider key kept out of the box | Not addressed | Host-side proxy injects the key over a Unix socket |
+| Human-approval gateway for capability changes | Not addressed | Built in, no bypass path |
+| Per-conversation sandbox and sealed runtime | You build it | Default |
+| Continuous proof the boundary holds | You script it | Red-team containment gate on every push |
+| Supply-chain attestation of the runtime | Your responsibility | cosign, SLSA provenance, SBOMs |
+
+## When Firecracker alone is the right call
+
+Pick a bare microVM when you want maximum kernel isolation, you run on bare metal or a
+KVM-capable host, and you are prepared to build the agent runtime around it: egress
+policy, secret handling, approval, lifecycle, and orchestration. If you are running a
+single well-understood workload at scale and already own that surrounding machinery, a
+VMM primitive by itself may be exactly right, and adding a runtime you do not need is its
+own cost. IronClaw does not compete for that.
+
+## When to reach for IronClaw
+
+Reach for IronClaw when you want a strong sandbox boundary *plus* the rest of the agent
+runtime designed to the same standard, without hand-rolling egress, credential handling,
+approvals, and containment tests around a bare hypervisor. IronClaw's distinctive posture
+is **proof of containment, not a promise of it**: the isolation boundary is open source
+and re-tested by a red-team escape suite on every push, so you inspect the wall rather
+than trust a description. The provider key never enters the box, every conversation gets
+its own sandbox with `network=none` and a read-only rootfs, and a human-approval gateway
+guards capability changes with no bypass path.
+
+IronClaw ships gVisor as its default boundary rather than a microVM, which trades a small
+amount of raw isolation strength for no KVM requirement and a lighter operational surface.
+The design point is not that gVisor beats a real VM; it is that the whole runtime around
+the wall is built and verified to the same standard. See the reproducible
+[sandbox containment benchmark](sandbox-containment-benchmark.md) for where different
+isolation models land against a fixed escape suite.
+
+## Confirm the posture locally
+
+```bash
+docker compose -f docker-compose.demo.yml up --build -d
+./bin/ironctl doctor   # reports the sandbox runtime and isolation posture
+```
+
+No `/dev/kvm` or nested virtualization required to try it.
+
+## Where to go next
+
+- The reproducible head-to-head: [sandbox containment benchmark](sandbox-containment-benchmark.md).
+- Why a user-space kernel wall: [Why we run AI agents in gVisor](../gvisor-deep-dive.md).
+- The measured overhead: [Performance and footprint](../benchmarks.md).
+- The full alternative rundown: [Why IronClaw](../comparison.md).

--- a/docs/compare/ironclaw-vs-kata-containers.md
+++ b/docs/compare/ironclaw-vs-kata-containers.md
@@ -1,0 +1,92 @@
+---
+title: "IronClaw vs Kata Containers for AI agent isolation"
+description: "Kata Containers wraps each container in a lightweight VM for VM-grade isolation with container ergonomics. But an OCI runtime is not an agent runtime. What egress, host-side keys, an approval gateway, and continuous proof still require."
+---
+
+# IronClaw vs Kata Containers
+
+Kata Containers is a strong isolation primitive with excellent ergonomics. It is an
+OCI-compatible runtime that runs each container inside its own lightweight virtual machine
+(backed by QEMU, Cloud Hypervisor, or Firecracker), so you get a real separate guest
+kernel while keeping the container workflow: it drops into containerd or CRI-O and
+Kubernetes as a runtime class. That gives you VM-grade isolation without rewriting how you
+ship containers. If you are weighing Kata for agent workloads, you have picked a serious
+wall. The question this page answers is what sits around it.
+
+We describe the VM-per-container pattern here and do not assert the specifics of any
+deployment. Kata documents its own security model and requirements, so verify those
+against its docs. This page is about matching the tool to the job: an isolation runtime
+you drop under your containers, or a complete agent runtime built around a boundary you
+can prove.
+
+## A VM-per-container is a wall, not a runtime
+
+Kata gives you one thing very well: a strong, VM-backed boundary for a container. An agent
+runtime has to answer several more questions that Kata on its own does not:
+
+- **Egress.** Kata isolates the container in a VM; it does not decide the agent should have
+  no network. You still define and enforce the network policy on top.
+- **Credentials.** The provider API key has to reach the model somehow. If it lives inside
+  the guest as an env var, a compromised agent can read it, VM boundary or not.
+- **Approval.** Nothing in an OCI runtime holds a new capability, tool, or egress rule for a
+  human to approve before it takes effect.
+- **Lifecycle.** One sandbox per conversation, sealed compiled-binary runtime, image and
+  channel plumbing, provider routing. That is the runtime, not the runtime class.
+- **Proof.** A boundary you cannot re-test on every change is a boundary you are hoping
+  still holds.
+
+## Kata alone vs the full stack
+
+| Layer | Kata Containers (bare runtime) | IronClaw |
+| --- | --- | --- |
+| Kernel isolation | Strong: separate guest kernel per container VM | Strong: gVisor user-space kernel, `network=none`, read-only rootfs |
+| Host requirement | Bare-metal or nested KVM for the VMM backend | Linux + gVisor; macOS/Windows fall back to runc in Docker Desktop's VM |
+| Fits existing container tooling | Yes, drops in as an OCI runtime class | Runs as its own runtime; uses OCI/gVisor under the hood |
+| `network=none` enforced by default | You configure it in the pod/container spec | Default on the sandbox |
+| Provider key kept out of the box | Not addressed | Host-side proxy injects the key over a Unix socket |
+| Human-approval gateway for capability changes | Not addressed | Built in, no bypass path |
+| Per-conversation sandbox and sealed runtime | You build it | Default |
+| Continuous proof the boundary holds | You script it | Red-team containment gate on every push |
+| Supply-chain attestation of the runtime | Your responsibility | cosign, SLSA provenance, SBOMs |
+
+## When Kata alone is the right call
+
+Pick Kata when you already run a container platform, want VM-grade isolation under your
+existing orchestration, and are prepared to build the agent runtime around it: egress
+policy, secret handling, approval, and lifecycle. If your workloads are general containers
+and the sandbox is a platform concern rather than an agent-specific security control, a
+drop-in OCI runtime is often the cleaner fit, and adding an agent runtime you do not need
+is its own cost. IronClaw does not compete for that.
+
+## When to reach for IronClaw
+
+Reach for IronClaw when you want a strong sandbox boundary *plus* the rest of the agent
+runtime designed to the same standard, without hand-rolling egress, credential handling,
+approvals, and containment tests around a bare OCI runtime. IronClaw's distinctive posture
+is **proof of containment, not a promise of it**: the isolation boundary is open source and
+re-tested by a red-team escape suite on every push, so you inspect the wall rather than
+trust a description. The provider key never enters the box, every conversation gets its own
+sandbox with `network=none` and a read-only rootfs, and a human-approval gateway guards
+capability changes with no bypass path.
+
+IronClaw ships gVisor as its default boundary rather than a per-container VM, which trades
+a small amount of raw isolation strength for no KVM requirement and a lighter operational
+surface, then builds the whole agent runtime around it to the same standard. See the
+reproducible [sandbox containment benchmark](sandbox-containment-benchmark.md) for where
+different isolation models land against a fixed escape suite.
+
+## Confirm the posture locally
+
+```bash
+docker compose -f docker-compose.demo.yml up --build -d
+./bin/ironctl doctor   # reports the sandbox runtime and isolation posture
+```
+
+No nested-virtualization host or runtime class to install to try it.
+
+## Where to go next
+
+- The reproducible head-to-head: [sandbox containment benchmark](sandbox-containment-benchmark.md).
+- Wall vs container: [gVisor vs containers for AI isolation](../learn/gvisor-vs-container-ai-isolation.md).
+- The measured overhead: [Performance and footprint](../benchmarks.md).
+- The full alternative rundown: [Why IronClaw](../comparison.md).

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -175,6 +175,7 @@ We'd rather you find this out here than after an install:
 - **Judge the security design:** [Security posture](security.md) → [Threat model](threat-model.md)
 - **Understand the architecture:** [IronClaw, explained](ironclaw-explained.md) → [Architecture](architecture.md)
 - **Verify a release yourself:** [Release runbook](release-runbook.md)
+- **Weigh a specific alternative:** head-to-head [comparison pages](compare/index.md), including [vs Firecracker](compare/ironclaw-vs-firecracker.md) and [vs Kata Containers](compare/ironclaw-vs-kata-containers.md) microVM isolation.
 
 ---
 


### PR DESCRIPTION
## What

Adds two comparison-intent SEO pages covering the **microVM isolation class** (Firecracker, Kata Containers), the highest-volume secure-agent-isolation search term not yet in the `compare/` cluster.

- `docs/compare/ironclaw-vs-firecracker.md` - KVM microVM (real separate guest kernel) as a strong wall vs a complete agent runtime.
- `docs/compare/ironclaw-vs-kata-containers.md` - VM-per-container with container ergonomics vs the runtime + verifiable boundary built on top.

Both follow the existing compare-page structure and tone: front-matter title/description, honest isolation-model/startup-footprint/operational-surface table, when-X-wins box, when-to-reach-for-IronClaw box, local confirm snippet, next steps, plus the architectural-pattern disclaimer used across the cluster.

## Honesty posture

Leads with the truth that hardware-virtualized isolation is arguably a **stronger kernel boundary than gVisor's syscall interception**, and positions IronClaw on **runtime completeness** (egress, host-side keys, approval gateway, lifecycle) and **proof-of-containment** (open-source boundary re-tested by a red-team escape gate every push), not on out-isolating a real VM. Credibility over hype for a security audience.

## Wiring

- Registered both in `docs/compare/.nav.yml` (grouped with gVisor as isolation-tech siblings).
- Cross-linked from `docs/compare/index.md` and `docs/comparison.md` Next steps.

## Verification

`mkdocs build --strict` exit 0 (no broken links / nav errors); both pages render under `compare/`. No em/en-dashes in new copy (IRO-254). No accounts or spend; pure docs to the site we control.

Closes IRO-418.