### PR TITLE
docs(readme): sharpen good-first-issue CTA + account-free contributor on-ramp (IRO-422)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,8 +1024,12 @@ home for Q&A, design discussion, and show-and-tell, and it's where maintainers a
 - **Found a bug or have a feature request?** Open an [issue](https://github.com/IronSecCo/ironclaw/issues/new/choose).
 - **Security report?** Do **not** open a public issue — follow [`SECURITY.md`](SECURITY.md).
 - **Want to contribute code?** Start with a
-  [**good first issue**](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-  — these are small, self-contained, and mentored. See [Contributing](#contributing) for the workflow.
+  [**good first issue**](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22),
+  or narrow to the ones
+  [ready to claim](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3A%22help+wanted%22)
+  (`good first issue` + `help wanted`). They are small, self-contained, and mentored, and every one
+  carries the standard labels that contributor boards such as [up-for-grabs.net](https://up-for-grabs.net)
+  and [goodfirstissue.dev](https://goodfirstissue.dev) index by. See [Contributing](#contributing) for the workflow.
 - **First time here?** Everyone interacting with the project is expected to follow our
   [**Code of Conduct**](CODE_OF_CONDUCT.md) — be excellent to each other.
 
@@ -1038,7 +1042,9 @@ to a category to follow along, and watch the repo for **Announcements**.
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the contract-freeze rule, the code layout
 (the control-plane and sandbox trees build against the frozen seam), how to report a vulnerability
 ([`SECURITY.md`](SECURITY.md)), our [Code of Conduct](CODE_OF_CONDUCT.md), and how to open a pull request.
-New here? Pick up a [**good first issue**](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+New here? Pick up a [**good first issue**](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+(or the [`help wanted`](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3A%22help+wanted%22) subset that is ready to claim).
+No account or sign-up needed beyond GitHub itself.
 
 ## License
 


### PR DESCRIPTION
Part of the account-free contributor on-ramp (IRO-422). Contributor acquisition is a non-gated growth lever: a clean, labeled GFI backlog auto-surfaces on third-party contributor boards with no submission needed.

## What changed
- README good-first-issue CTA now also links the **ready-to-claim** filter (`good first issue` + `help wanted`) and notes the labels are what [up-for-grabs.net](https://up-for-grabs.net) and [goodfirstissue.dev](https://goodfirstissue.dev) index by.
- Contributing section CTA gains the same combined-label filter link and a "no account beyond GitHub" note.

## Companion work (already live, no code here)
6 fresh, self-contained good first issues seeded across real gaps, each labeled `good first issue` + `help wanted`:
- #395 test: OpenRouter provider unit tests
- #396 provider shim: Groq (OpenAI-wire-compatible)
- #397 channel shim: Rocket.Chat outbound adapter
- #398 docs: environment-variable reference table
- #399 DX: `--json` output for `ironctl tools`
- #400 docs: Gemini provider quickstart page

## Verification
- All four public label-filter URLs return HTTP 200 (single label, combined label, both label pages).
- 14 open issues now carry both `good first issue` + `help wanted`.
- `CONTRIBUTING.md` already documents clone -> `make build vet test` -> branch -> PR ("your first PR in 5 minutes"), under the 10-minute bar.
- No em dashes or en dashes added to public copy.

Docs-only change; no build impact.