### PR TITLE
feat(ironctl): scan — containment self-audit scorecard for any container/runtime (IRO-425)

### DIFF
--- a/cmd/ironctl/main.go
+++ b/cmd/ironctl/main.go
@@ -125,6 +125,10 @@ parse:
 	if args[0] == "doctor" {
 		return cmdDoctor(addr, args[1:])
 	}
+	// Top-level "scan" command (local containment self-audit; no control-plane API).
+	if args[0] == "scan" {
+		return cmdScan(args[1:])
+	}
 	// `usage` / `commands` print the full command reference to stdout and exit 0:
 	// a help request is requested output, not an error. The model-call metrics
 	// report (which queries /metrics) now lives under `metrics`.
@@ -550,6 +554,7 @@ New here? Start with:
 
 Everyday commands:
   ironctl agent create | list             Create and inspect agents
+  ironctl scan <container>                Grade any container's containment 0-100
   ironctl change pending | approve <id>   Review gated capability changes
   ironctl audit                           Tail the append-only audit log
 
@@ -580,6 +585,7 @@ func printReference(w io.Writer) {
   ironctl [--addr URL] onboard [--yes] [--dry-run] [--force] [--config PATH]
   ironctl [--addr URL] [--token T] status [--json]
   ironctl [--addr URL] [--token T] doctor [--runtime BIN] [--model-proxy-socket PATH]
+  ironctl scan <container> | --compose FILE [--service N] | --k8s FILE   [--json] [--badge PATH] [--md] [--min-score N]
   ironctl [--addr URL] [--token T] metrics [--json]
   ironctl [--addr URL] [--token T] skill add <name>@<version> --group <id> [--by <user>]
   ironctl [--addr URL] [--token T] skill list

--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/IronSecCo/ironclaw/internal/host/scan"
+	"github.com/IronSecCo/ironclaw/internal/version"
+)
+
+// cmdScan implements `ironctl scan` — a containment self-audit that grades the
+// isolation posture of ANY running container, docker-compose service, or
+// Kubernetes pod/manifest 0-100. It is a LOCAL, read-only command: it inspects
+// configuration (docker inspect / a compose or k8s file) and never talks to the
+// control-plane API, so it works on a user's own setups, not just IronClaw's.
+//
+// Fail-closed: any dimension it cannot determine is graded as insecure.
+//
+// Usage:
+//
+//	ironctl scan <container>                 grade a running docker container
+//	ironctl scan --compose FILE [--service N]  grade a compose service
+//	ironctl scan --k8s FILE                    grade a pod/workload manifest
+//	  [--json] [--badge scan.svg] [--md] [--min-score N]
+func cmdScan(args []string) error {
+	fs := flag.NewFlagSet("scan", flag.ContinueOnError)
+	asJSON := fs.Bool("json", false, "emit the scorecard as JSON")
+	badge := fs.String("badge", "", "write a shareable SVG badge to this path")
+	md := fs.Bool("md", false, "print a shareable markdown block (README/blog section)")
+	compose := fs.String("compose", "", "grade a service in this docker-compose file")
+	service := fs.String("service", "", "compose service name (required if the file has >1 service)")
+	k8s := fs.String("k8s", "", "grade the first container in this Kubernetes pod/workload manifest")
+	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker inspect`")
+	minScore := fs.Int("min-score", 0, "exit non-zero if the score is below this threshold (CI gate)")
+	fs.Usage = func() { scanUsage(os.Stdout) }
+	// Go's flag package stops at the first positional, so `scan <target> --json`
+	// would silently drop the flags after the target. Re-parse around each
+	// positional so flags may appear anywhere (interspersed-flag handling).
+	var positional []string
+	rest := args
+	for len(rest) > 0 {
+		if err := fs.Parse(rest); err != nil {
+			return err
+		}
+		rest = fs.Args()
+		if len(rest) == 0 {
+			break
+		}
+		positional = append(positional, rest[0])
+		rest = rest[1:]
+	}
+
+	// Resolve the source and build a normalized Spec.
+	var (
+		spec scan.Spec
+		err  error
+	)
+	switch {
+	case *compose != "":
+		raw, rerr := os.ReadFile(*compose)
+		if rerr != nil {
+			return fmt.Errorf("read compose file: %w", rerr)
+		}
+		spec, err = scan.SpecFromCompose(raw, *service)
+	case *k8s != "":
+		raw, rerr := os.ReadFile(*k8s)
+		if rerr != nil {
+			return fmt.Errorf("read manifest: %w", rerr)
+		}
+		spec, err = scan.SpecFromK8s(raw)
+	default:
+		if len(positional) < 1 {
+			scanUsage(os.Stderr)
+			return fmt.Errorf("scan needs a target: a container name/id, or --compose/--k8s FILE")
+		}
+		if len(positional) > 1 {
+			return fmt.Errorf("scan grades one target at a time; got %d: %s", len(positional), strings.Join(positional, " "))
+		}
+		spec, err = dockerSpec(*dockerBin, positional[0])
+	}
+	if err != nil {
+		return err
+	}
+
+	report := scan.Score(spec)
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+
+	// Emit the requested representations. Table is the default; --json swaps it.
+	if *asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if *md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if *badge != "" {
+		if err := os.WriteFile(*badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !*asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", *badge)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold.
+	if *minScore > 0 && report.Score < *minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, *minScore)
+	}
+	return nil
+}
+
+// dockerSpec runs `docker inspect <target>` and parses the result into a Spec.
+func dockerSpec(dockerBin, target string) (scan.Spec, error) {
+	cmd := exec.Command(dockerBin, "inspect", target)
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			msg := strings.TrimSpace(string(ee.Stderr))
+			if msg == "" {
+				msg = err.Error()
+			}
+			return scan.Spec{}, fmt.Errorf("docker inspect %s: %s", target, msg)
+		}
+		return scan.Spec{}, fmt.Errorf("run %s inspect: %w (is Docker installed and the container running?)", dockerBin, err)
+	}
+	return scan.SpecFromDockerInspect(out)
+}
+
+func scanUsage(w *os.File) {
+	fmt.Fprint(w, `ironctl scan — grade a container's containment posture (0-100)
+
+USAGE:
+  ironctl scan <container>                    grade a running docker container
+  ironctl scan --compose FILE [--service N]   grade a docker-compose service
+  ironctl scan --k8s FILE                     grade a Kubernetes pod/workload manifest
+
+FLAGS:
+  --json              emit the scorecard as JSON
+  --badge PATH        write a shareable SVG badge to PATH
+  --md                print a shareable markdown block
+  --min-score N       exit non-zero if the score is below N (CI gate)
+  --service NAME      compose service to grade (if the file has >1)
+  --docker-bin BIN    docker binary for `+"`docker inspect`"+` (default: docker)
+
+Dimensions graded: non-root user, dropped capabilities, seccomp, network
+isolation, read-only rootfs, docker.sock exposure, shared host namespaces.
+Unknown postures are graded fail-closed (as insecure).
+`)
+}

--- a/cmd/ironctl/scan_test.go
+++ b/cmd/ironctl/scan_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTemp writes content to a temp file and returns its path.
+func writeTemp(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+const cliHardenedCompose = `
+services:
+  agent:
+    image: ironclaw
+    user: "65532:65532"
+    read_only: true
+    network_mode: none
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+`
+
+const cliWeakCompose = `
+services:
+  web:
+    image: nginx
+    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
+    pid: host
+`
+
+// The min-score gate must pass on a hardened target and fail on a weak one — the
+// CI-gate contract, and proof the flags after --compose are actually parsed.
+func TestCmdScan_MinScoreGate(t *testing.T) {
+	hard := writeTemp(t, "hard.yml", cliHardenedCompose)
+	if err := cmdScan([]string{"--compose", hard, "--min-score", "80"}); err != nil {
+		t.Errorf("hardened compose should pass min-score 80: %v", err)
+	}
+	weak := writeTemp(t, "weak.yml", cliWeakCompose)
+	err := cmdScan([]string{"--compose", weak, "--min-score", "80"})
+	if err == nil || !strings.Contains(err.Error(), "below") {
+		t.Errorf("weak compose should fail min-score 80, got: %v", err)
+	}
+}
+
+// --badge writes a self-contained SVG for the graded target.
+func TestCmdScan_BadgeWrite(t *testing.T) {
+	hard := writeTemp(t, "hard.yml", cliHardenedCompose)
+	badge := filepath.Join(t.TempDir(), "scan.svg")
+	if err := cmdScan([]string{"--compose", hard, "--badge", badge, "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(badge)
+	if err != nil {
+		t.Fatalf("badge not written: %v", err)
+	}
+	if !strings.HasPrefix(string(b), "<svg") {
+		t.Errorf("badge is not SVG: %.40s", b)
+	}
+}
+
+func TestCmdScan_NoTarget(t *testing.T) {
+	if err := cmdScan(nil); err == nil {
+		t.Error("expected an error when no target is given")
+	}
+}

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -21,6 +21,7 @@ nav:
       - Observability (metrics): observability.md
       - Troubleshooting: troubleshooting.md
       - FAQ: faq.md
+  - Scan any container: scan.md
   - Model providers: providers
   - Tutorials: tutorials
   - Examples & use cases: examples.md

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -1,0 +1,105 @@
+# Scan: audit any container's containment in 10 seconds
+
+`ironctl scan` grades the isolation posture of any running container, any
+docker-compose service, or any Kubernetes pod or manifest on a 0 to 100 scale.
+It works on your own setups, not just IronClaw's, so you can measure how much
+containment you actually have before you trust a sandbox with untrusted code.
+
+It grades the same dimensions IronClaw's own containment benchmark checks, and
+it is fail-closed: any posture it cannot determine is scored as insecure, never
+silently passed.
+
+```
+$ ironctl scan my-container
+IronClaw containment scan
+  target:  my-container (docker)
+  runtime: runc
+  score:   23/100  grade F  (wide open)
+
+DIMENSION                   VERDICT   SCORE  DETAIL
+Non-root user (uid != 0)    [x] FAIL  0/15   runs as root (user "0"); a container escape starts with host-uid 0
+Dropped capabilities        [x] FAIL  4/20   default capability set retained (includes CAP_NET_RAW, CAP_MKNOD)
+Seccomp profile             [+] PASS  15/15  seccomp profile active (syscall surface filtered)
+Network isolation / egress  [~] WARN  4/15   network=bridge: outbound egress is possible; prefer network=none
+Read-only root filesystem   [x] FAIL  0/10   root filesystem is writable: tamper/persistence surface
+No docker.sock exposure     [x] FAIL  0/15   docker.sock is mounted: trivial host-root escape
+No shared host namespaces   [x] FAIL  0/10   shares host namespace(s): PID
+```
+
+## Quick start
+
+```bash
+# grade a running docker container
+ironctl scan my-container
+
+# grade a docker-compose service (pass --service if the file has more than one)
+ironctl scan --compose docker-compose.yml --service web
+
+# grade a Kubernetes pod or workload manifest (Deployment, StatefulSet, ...)
+ironctl scan --k8s pod.yaml
+```
+
+## Output formats
+
+| Flag | What you get |
+|---|---|
+| (default) | a human-readable scorecard table |
+| `--json` | the full report as JSON (schemaVersion 1.0), for pipelines and dashboards |
+| `--badge scan.svg` | a self-contained SVG badge you can drop into a README |
+| `--md` | a shareable markdown block for a README or blog post |
+| `--min-score N` | exit non-zero when the score is below N (a CI gate) |
+
+## What it grades
+
+Each dimension is worth a fixed weight; the weights sum to 100. The heaviest
+weights sit on the boundaries whose breach is a full host compromise.
+
+| Dimension | Weight | PASS means |
+|---|---|---|
+| Non-root user | 15 | the workload runs as a uid that is not 0 |
+| Dropped capabilities | 20 | all Linux capabilities are dropped, none re-added |
+| Seccomp profile | 15 | a seccomp profile filters the syscall surface |
+| Network isolation | 15 | `network=none`: no NIC but loopback, no egress |
+| Read-only rootfs | 10 | the root filesystem is read-only |
+| No docker.sock exposure | 15 | no Docker or OCI control socket is mounted in |
+| No shared host namespaces | 10 | no host PID, IPC, or network namespace sharing |
+
+A `--privileged` container fails capabilities, seccomp, and host namespaces at
+once, because privilege is the master escape hatch.
+
+Grades map to bands: A is 90 or above, B is 75 to 89, C is 50 to 74, D is 25 to
+49, and F is below 25.
+
+## Why the numbers can differ from what you expect
+
+- Docker applies its default seccomp profile even to unhardened containers, so
+  seccomp often passes on a container that fails everything else. Passing
+  `--security-opt seccomp=unconfined` turns it red.
+- A Kubernetes pod manifest does not carry its NetworkPolicy, so egress is
+  graded conservatively (WARN) unless `hostNetwork` makes it strictly worse. A
+  hardened pod tops out at a strong B for that reason.
+- If a field is absent, scan assumes the insecure value. An auditor that cannot
+  see a boundary must never claim the boundary holds.
+
+## Use it as a CI gate
+
+```bash
+# fail the build if the sandbox posture regresses below an A
+ironctl scan my-sandbox --min-score 90
+```
+
+## What a hardened target looks like
+
+An IronClaw `ic-sbx-*` sandbox scores a clean 100:
+
+```
+$ ironctl scan ic-sbx-mg-abc123
+  score:   100/100  grade A  (hardened)
+```
+
+That is the posture IronClaw gives every session by default: non-root, all caps
+dropped, seccomp on, `network=none`, read-only rootfs, no control socket, no
+shared host namespaces, on a gVisor (runsc) runtime. See
+[Security and isolation](security-isolation.md) and the
+[containment benchmark](compare/sandbox-containment-benchmark.md) for how that
+posture is built and proven.

--- a/internal/host/scan/compose.go
+++ b/internal/host/scan/compose.go
@@ -1,0 +1,153 @@
+package scan
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// composeFile is the subset of a docker-compose file we grade.
+type composeFile struct {
+	Services map[string]composeService `yaml:"services"`
+}
+
+// composeService mirrors the security-relevant keys of a compose service. Scalars
+// that may be bool-or-string in the wild (pid/ipc) are read as strings.
+type composeService struct {
+	User        string   `yaml:"user"`
+	ReadOnly    *bool    `yaml:"read_only"`
+	Privileged  *bool    `yaml:"privileged"`
+	NetworkMode string   `yaml:"network_mode"`
+	CapAdd      []string `yaml:"cap_add"`
+	CapDrop     []string `yaml:"cap_drop"`
+	SecurityOpt []string `yaml:"security_opt"`
+	Pid         string   `yaml:"pid"`
+	Ipc         string   `yaml:"ipc"`
+	Runtime     string   `yaml:"runtime"`
+	Volumes     []string `yaml:"volumes"`
+}
+
+// SpecFromCompose parses a docker-compose file and grades the named service. If
+// service is empty and the file has exactly one service, that one is used. Pure
+// and unit-testable: it grades bytes, no Docker required.
+func SpecFromCompose(raw []byte, service string) (Spec, error) {
+	var cf composeFile
+	if err := yaml.Unmarshal(raw, &cf); err != nil {
+		return Spec{}, fmt.Errorf("parse compose file: %w", err)
+	}
+	if len(cf.Services) == 0 {
+		return Spec{}, fmt.Errorf("compose file declares no services")
+	}
+	if service == "" {
+		if len(cf.Services) != 1 {
+			names := make([]string, 0, len(cf.Services))
+			for n := range cf.Services {
+				names = append(names, n)
+			}
+			return Spec{}, fmt.Errorf("compose file has %d services; pass --service (one of: %s)",
+				len(cf.Services), strings.Join(names, ", "))
+		}
+		for n := range cf.Services {
+			service = n
+		}
+	}
+	svc, ok := cf.Services[service]
+	if !ok {
+		return Spec{}, fmt.Errorf("service %q not found in compose file", service)
+	}
+
+	s := Spec{Source: "compose", Target: service, Runtime: svc.Runtime}
+
+	// --- user ---------------------------------------------------------------
+	u := strings.TrimSpace(svc.User)
+	s.User = u
+	switch {
+	case u == "":
+		s.RunAsNonRoot = No // compose default is the image user, unknown; fail-closed to root
+		s.User = "0 (image default; not pinned)"
+		s.Notes = append(s.Notes, "no 'user:' pinned; the image default may be root")
+	case u == "0" || strings.HasPrefix(u, "0:") || u == "root" || strings.HasPrefix(u, "root:"):
+		s.RunAsNonRoot = No
+	default:
+		s.RunAsNonRoot = Yes
+	}
+
+	// --- capabilities -------------------------------------------------------
+	s.Privileged = triFromPtr(svc.Privileged)
+	s.CapDropAll = No
+	for _, c := range svc.CapDrop {
+		if strings.EqualFold(strings.TrimSpace(c), "ALL") {
+			s.CapDropAll = Yes
+		}
+	}
+	for _, c := range svc.CapAdd {
+		if c = strings.TrimSpace(c); c != "" {
+			s.CapAdd = append(s.CapAdd, strings.ToUpper(c))
+		}
+	}
+
+	// --- seccomp ------------------------------------------------------------
+	s.Seccomp = "confined" // compose->docker applies the default profile unless overridden
+	for _, opt := range svc.SecurityOpt {
+		low := strings.ToLower(strings.TrimSpace(opt))
+		switch {
+		case strings.HasPrefix(low, "no-new-privileges"):
+			s.NoNewPrivs = Yes
+		case strings.HasPrefix(low, "seccomp"):
+			if strings.Contains(low, "unconfined") {
+				s.Seccomp = "unconfined"
+			} else {
+				s.Seccomp = "confined"
+			}
+		}
+	}
+	if s.Privileged == Yes {
+		s.Seccomp = "unconfined"
+	}
+
+	// --- network ------------------------------------------------------------
+	s.NetworkMode = svc.NetworkMode
+	if svc.NetworkMode == "" {
+		// No network_mode means the default bridge network: egress-capable.
+		s.NetworkMode = "bridge"
+	}
+	s.HostNetwork = boolTri(strings.EqualFold(svc.NetworkMode, "host"))
+
+	// --- filesystem ---------------------------------------------------------
+	s.ReadonlyRoot = triFromPtr(svc.ReadOnly)
+
+	// --- docker.sock / host mounts ------------------------------------------
+	s.DockerSock = No
+	seen := map[string]bool{}
+	for _, v := range svc.Volumes {
+		parts := strings.SplitN(v, ":", 3)
+		src := strings.TrimSpace(parts[0])
+		dst := ""
+		if len(parts) > 1 {
+			dst = parts[1]
+		}
+		if isControlSocket(src) || isControlSocket(dst) {
+			s.DockerSock = Yes
+		}
+		if isSensitiveHostPath(src) && !seen[src] {
+			seen[src] = true
+			s.HostPathMounts = append(s.HostPathMounts, src)
+		}
+	}
+
+	// --- namespaces ---------------------------------------------------------
+	s.HostPID = boolTri(strings.EqualFold(strings.TrimSpace(svc.Pid), "host"))
+	s.HostIPC = boolTri(strings.EqualFold(strings.TrimSpace(svc.Ipc), "host"))
+
+	return s, nil
+}
+
+// triFromPtr maps a *bool (nil = key absent) to a Tristate. Absent stays Unknown
+// so scorers grade it fail-closed.
+func triFromPtr(p *bool) Tristate {
+	if p == nil {
+		return Unknown
+	}
+	return boolTri(*p)
+}

--- a/internal/host/scan/compose_test.go
+++ b/internal/host/scan/compose_test.go
@@ -1,0 +1,76 @@
+package scan
+
+import "testing"
+
+const composeWeak = `
+services:
+  web:
+    image: nginx
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    pid: host
+`
+
+const composeHardened = `
+services:
+  agent:
+    image: ironclaw
+    user: "65532:65532"
+    read_only: true
+    network_mode: none
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+    runtime: runsc
+`
+
+const composeTwo = `
+services:
+  a: { image: x }
+  b: { image: y }
+`
+
+func TestSpecFromCompose_Weak(t *testing.T) {
+	s, err := SpecFromCompose([]byte(composeWeak), "web")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.DockerSock != Yes || s.HostPID != Yes {
+		t.Errorf("docker.sock/hostPID not detected: %+v", s)
+	}
+	if s.RunAsNonRoot != No {
+		t.Error("no user: pinned -> fail-closed to root")
+	}
+	if Score(s).Score >= 50 {
+		t.Errorf("weak compose scored %d, want low", Score(s).Score)
+	}
+}
+
+func TestSpecFromCompose_Hardened(t *testing.T) {
+	s, err := SpecFromCompose([]byte(composeHardened), "agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.RunAsNonRoot != Yes || s.CapDropAll != Yes || s.ReadonlyRoot != Yes || s.NetworkMode != "none" {
+		t.Errorf("hardened postures not parsed: %+v", s)
+	}
+	r := Score(s)
+	if r.Grade != "A" {
+		t.Errorf("hardened compose graded %s (%d), want A", r.Grade, r.Score)
+	}
+}
+
+func TestSpecFromCompose_SingleServiceAutoSelect(t *testing.T) {
+	if _, err := SpecFromCompose([]byte(composeHardened), ""); err != nil {
+		t.Errorf("single service should auto-select: %v", err)
+	}
+}
+
+func TestSpecFromCompose_AmbiguousService(t *testing.T) {
+	if _, err := SpecFromCompose([]byte(composeTwo), ""); err == nil {
+		t.Error("expected error requiring --service for multi-service file")
+	}
+	if _, err := SpecFromCompose([]byte(composeTwo), "missing"); err == nil {
+		t.Error("expected error for unknown service")
+	}
+}

--- a/internal/host/scan/docker.go
+++ b/internal/host/scan/docker.go
@@ -1,0 +1,183 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// dockerInspect is the subset of `docker inspect <container>` we grade. Docker
+// serializes an ARRAY of these (one per queried container).
+type dockerInspect struct {
+	ID     string `json:"Id"`
+	Name   string `json:"Name"`
+	Config struct {
+		User string `json:"User"`
+	} `json:"Config"`
+	HostConfig struct {
+		NetworkMode    string   `json:"NetworkMode"`
+		Privileged     bool     `json:"Privileged"`
+		ReadonlyRootfs bool     `json:"ReadonlyRootfs"`
+		CapAdd         []string `json:"CapAdd"`
+		CapDrop        []string `json:"CapDrop"`
+		SecurityOpt    []string `json:"SecurityOpt"`
+		PidMode        string   `json:"PidMode"`
+		IpcMode        string   `json:"IpcMode"`
+		Runtime        string   `json:"Runtime"`
+		Binds          []string `json:"Binds"`
+	} `json:"HostConfig"`
+	Mounts []struct {
+		Source      string `json:"Source"`
+		Destination string `json:"Destination"`
+	} `json:"Mounts"`
+}
+
+// SpecFromDockerInspect parses the JSON emitted by `docker inspect <container>`
+// (an array) into a Spec for the first entry. It is pure: give it the bytes and
+// it grades them, so it is unit-testable without a Docker daemon.
+func SpecFromDockerInspect(raw []byte) (Spec, error) {
+	var arr []dockerInspect
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		// Tolerate a single (non-array) object too.
+		var one dockerInspect
+		if err2 := json.Unmarshal(raw, &one); err2 != nil {
+			return Spec{}, fmt.Errorf("parse docker inspect: %w", err)
+		}
+		arr = []dockerInspect{one}
+	}
+	if len(arr) == 0 {
+		return Spec{}, fmt.Errorf("docker inspect returned no containers")
+	}
+	d := arr[0]
+
+	s := Spec{
+		Source:  "docker",
+		Target:  strings.TrimPrefix(d.Name, "/"),
+		Runtime: d.HostConfig.Runtime,
+	}
+	if s.Target == "" {
+		s.Target = shortID(d.ID)
+	}
+
+	// --- user / uid ---------------------------------------------------------
+	// Docker's default (empty User) is uid 0. A non-empty user that is not
+	// "0"/"root" runs as a non-root uid.
+	u := strings.TrimSpace(d.Config.User)
+	s.User = u
+	switch {
+	case u == "" || u == "0" || strings.HasPrefix(u, "0:") || u == "root" || strings.HasPrefix(u, "root:"):
+		s.RunAsNonRoot = No
+		if u == "" {
+			s.User = "0 (docker default)"
+		}
+	default:
+		s.RunAsNonRoot = Yes
+	}
+
+	// --- capabilities -------------------------------------------------------
+	s.Privileged = boolTri(d.HostConfig.Privileged)
+	s.CapDropAll = No
+	for _, c := range d.HostConfig.CapDrop {
+		if strings.EqualFold(strings.TrimSpace(c), "ALL") {
+			s.CapDropAll = Yes
+		}
+	}
+	for _, c := range d.HostConfig.CapAdd {
+		if c = strings.TrimSpace(c); c != "" {
+			s.CapAdd = append(s.CapAdd, strings.ToUpper(c))
+		}
+	}
+
+	// --- seccomp ------------------------------------------------------------
+	// Docker applies its DEFAULT seccomp profile unless SecurityOpt overrides it
+	// (or the container is privileged). So absence of a seccomp opt means the
+	// default profile is active — a determinable, confined posture.
+	s.Seccomp = "confined"
+	for _, opt := range d.HostConfig.SecurityOpt {
+		low := strings.ToLower(strings.TrimSpace(opt))
+		switch {
+		case low == "no-new-privileges" || low == "no-new-privileges:true":
+			s.NoNewPrivs = Yes
+		case strings.HasPrefix(low, "seccomp="):
+			val := strings.TrimPrefix(opt, opt[:strings.Index(opt, "=")+1])
+			if strings.EqualFold(strings.TrimSpace(val), "unconfined") {
+				s.Seccomp = "unconfined"
+			} else {
+				s.Seccomp = "confined" // custom profile path
+			}
+		}
+	}
+	if s.Privileged == Yes {
+		s.Seccomp = "unconfined" // privileged disables seccomp
+	}
+
+	// --- network ------------------------------------------------------------
+	s.NetworkMode = d.HostConfig.NetworkMode
+	s.HostNetwork = boolTri(strings.EqualFold(d.HostConfig.NetworkMode, "host"))
+
+	// --- filesystem ---------------------------------------------------------
+	s.ReadonlyRoot = boolTri(d.HostConfig.ReadonlyRootfs)
+
+	// --- docker.sock / host mounts ------------------------------------------
+	s.DockerSock = No
+	seen := map[string]bool{}
+	consider := func(src, dst string) {
+		if src == "" {
+			return
+		}
+		if isControlSocket(src) || isControlSocket(dst) {
+			s.DockerSock = Yes
+		}
+		if isSensitiveHostPath(src) && !seen[src] {
+			seen[src] = true
+			s.HostPathMounts = append(s.HostPathMounts, src)
+		}
+	}
+	for _, m := range d.Mounts {
+		consider(m.Source, m.Destination)
+	}
+	for _, b := range d.HostConfig.Binds {
+		// Binds are "src:dst[:opts]".
+		parts := strings.SplitN(b, ":", 3)
+		src := parts[0]
+		dst := ""
+		if len(parts) > 1 {
+			dst = parts[1]
+		}
+		consider(src, dst)
+	}
+
+	// --- namespaces ---------------------------------------------------------
+	s.HostPID = boolTri(strings.EqualFold(d.HostConfig.PidMode, "host"))
+	s.HostIPC = boolTri(strings.EqualFold(d.HostConfig.IpcMode, "host"))
+
+	return s, nil
+}
+
+// isControlSocket reports whether a path is a container-runtime control socket,
+// whose exposure is a full host-root escape primitive.
+func isControlSocket(p string) bool {
+	p = strings.ToLower(strings.TrimSpace(p))
+	return strings.HasSuffix(p, "docker.sock") ||
+		strings.HasSuffix(p, "containerd.sock") ||
+		strings.HasSuffix(p, "crio.sock") ||
+		strings.Contains(p, "docker.sock")
+}
+
+// isSensitiveHostPath flags host bind sources that materially widen the blast
+// radius (host root, /proc, /sys, /etc, /var/run). Informational evidence.
+func isSensitiveHostPath(p string) bool {
+	p = strings.TrimSpace(p)
+	switch p {
+	case "/", "/proc", "/sys", "/etc", "/var/run", "/run":
+		return true
+	}
+	return false
+}
+
+func shortID(id string) string {
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
+}

--- a/internal/host/scan/docker_test.go
+++ b/internal/host/scan/docker_test.go
@@ -1,0 +1,135 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+// A weak, unhardened container: root, default caps, writable rootfs, bridge
+// network, docker.sock bind-mounted, host PID. The common misconfiguration.
+const weakInspect = `[{
+  "Id": "abc123def456789",
+  "Name": "/weak-app",
+  "Config": { "User": "" },
+  "HostConfig": {
+    "NetworkMode": "bridge",
+    "Privileged": false,
+    "ReadonlyRootfs": false,
+    "CapAdd": ["SYS_ADMIN"],
+    "CapDrop": null,
+    "SecurityOpt": ["seccomp=unconfined"],
+    "PidMode": "host",
+    "IpcMode": "",
+    "Runtime": "runc",
+    "Binds": ["/var/run/docker.sock:/var/run/docker.sock"]
+  },
+  "Mounts": [ { "Source": "/var/run/docker.sock", "Destination": "/var/run/docker.sock" } ]
+}]`
+
+// A hardened IronClaw ic-sbx container: non-root, all caps dropped, read-only,
+// network=none, no docker.sock, gVisor runtime, no host namespaces.
+const hardenedInspect = `[{
+  "Id": "sbx0011223344",
+  "Name": "/ic-sbx-mg-abc123",
+  "Config": { "User": "65532:65532" },
+  "HostConfig": {
+    "NetworkMode": "none",
+    "Privileged": false,
+    "ReadonlyRootfs": true,
+    "CapAdd": null,
+    "CapDrop": ["ALL"],
+    "SecurityOpt": ["no-new-privileges", "seccomp=/etc/ironclaw/seccomp.json"],
+    "PidMode": "",
+    "IpcMode": "private",
+    "Runtime": "runsc",
+    "Binds": []
+  },
+  "Mounts": []
+}]`
+
+func TestSpecFromDockerInspect_Weak(t *testing.T) {
+	s, err := SpecFromDockerInspect([]byte(weakInspect))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Target != "weak-app" {
+		t.Errorf("target=%q", s.Target)
+	}
+	if s.RunAsNonRoot != No {
+		t.Error("empty user should grade as root")
+	}
+	if s.DockerSock != Yes {
+		t.Error("docker.sock bind not detected")
+	}
+	if s.HostPID != Yes {
+		t.Error("host PID not detected")
+	}
+	if s.Seccomp != "unconfined" {
+		t.Errorf("seccomp=%q want unconfined", s.Seccomp)
+	}
+	r := Score(s)
+	if r.Score >= 50 {
+		t.Fatalf("weak container scored %d (grade %s); expected a low/failing score", r.Score, r.Grade)
+	}
+	if dimByKey(r, "docker.sock").Verdict != VerdictFail {
+		t.Error("docker.sock should FAIL")
+	}
+}
+
+func TestSpecFromDockerInspect_Hardened(t *testing.T) {
+	s, err := SpecFromDockerInspect([]byte(hardenedInspect))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(s.Target, "ic-sbx-") {
+		t.Errorf("target=%q", s.Target)
+	}
+	if s.RunAsNonRoot != Yes {
+		t.Error("65532 should grade as non-root")
+	}
+	if s.CapDropAll != Yes {
+		t.Error("cap drop ALL not detected")
+	}
+	if s.Runtime != "runsc" {
+		t.Errorf("runtime=%q want runsc", s.Runtime)
+	}
+	if s.Seccomp != "confined" {
+		t.Errorf("custom seccomp profile should grade confined, got %q", s.Seccomp)
+	}
+	r := Score(s)
+	if r.Score != 100 || r.Grade != "A" {
+		t.Fatalf("hardened ic-sbx scored %d/%s, want 100/A", r.Score, r.Grade)
+	}
+}
+
+// A --privileged container is the escape-hatch posture; it must score near the
+// floor even though nothing else is obviously wrong.
+func TestSpecFromDockerInspect_Privileged(t *testing.T) {
+	const priv = `[{"Name":"/p","Config":{"User":"0"},"HostConfig":{"Privileged":true,"NetworkMode":"bridge","Runtime":"runc"}}]`
+	s, err := SpecFromDockerInspect([]byte(priv))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Privileged != Yes {
+		t.Fatal("privileged not detected")
+	}
+	if s.Seccomp != "unconfined" {
+		t.Errorf("privileged disables seccomp, got %q", s.Seccomp)
+	}
+	if g := Score(s).Grade; g != "F" && g != "D" {
+		t.Fatalf("privileged graded %s; expected D or F", g)
+	}
+}
+
+func TestSpecFromDockerInspect_Errors(t *testing.T) {
+	if _, err := SpecFromDockerInspect([]byte("not json")); err == nil {
+		t.Error("expected parse error")
+	}
+	if _, err := SpecFromDockerInspect([]byte("[]")); err == nil {
+		t.Error("expected empty-array error")
+	}
+	// A single object (not wrapped in an array) is tolerated.
+	if _, err := SpecFromDockerInspect([]byte(`{"Name":"/x","HostConfig":{"NetworkMode":"none"}}`)); err != nil {
+		t.Errorf("single object should parse: %v", err)
+	}
+}

--- a/internal/host/scan/k8s.go
+++ b/internal/host/scan/k8s.go
@@ -1,0 +1,227 @@
+package scan
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// k8sObject is a minimal Kubernetes object: enough to locate the pod spec inside
+// a bare Pod or inside a workload template (Deployment/StatefulSet/DaemonSet/Job).
+type k8sObject struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		podSpec `yaml:",inline"` // bare Pod: spec IS the pod spec
+		// Workload kinds nest the pod under spec.template.spec.
+		Template struct {
+			Spec podSpec `yaml:"spec"`
+		} `yaml:"template"`
+	} `yaml:"spec"`
+}
+
+type podSpec struct {
+	HostPID         *bool          `yaml:"hostPID"`
+	HostIPC         *bool          `yaml:"hostIPC"`
+	HostNetwork     *bool          `yaml:"hostNetwork"`
+	SecurityContext *podSecCtx     `yaml:"securityContext"`
+	Containers      []k8sContainer `yaml:"containers"`
+	Volumes         []k8sVolume    `yaml:"volumes"`
+	RuntimeClass    string         `yaml:"runtimeClassName"`
+}
+
+type podSecCtx struct {
+	RunAsNonRoot   *bool  `yaml:"runAsNonRoot"`
+	RunAsUser      *int64 `yaml:"runAsUser"`
+	SeccompProfile *struct {
+		Type string `yaml:"type"`
+	} `yaml:"seccompProfile"`
+}
+
+type k8sContainer struct {
+	Name            string `yaml:"name"`
+	SecurityContext *struct {
+		RunAsNonRoot             *bool  `yaml:"runAsNonRoot"`
+		RunAsUser                *int64 `yaml:"runAsUser"`
+		Privileged               *bool  `yaml:"privileged"`
+		ReadOnlyRootFilesystem   *bool  `yaml:"readOnlyRootFilesystem"`
+		AllowPrivilegeEscalation *bool  `yaml:"allowPrivilegeEscalation"`
+		Capabilities             *struct {
+			Add  []string `yaml:"add"`
+			Drop []string `yaml:"drop"`
+		} `yaml:"capabilities"`
+		SeccompProfile *struct {
+			Type string `yaml:"type"`
+		} `yaml:"seccompProfile"`
+	} `yaml:"securityContext"`
+	VolumeMounts []struct {
+		Name      string `yaml:"name"`
+		MountPath string `yaml:"mountPath"`
+	} `yaml:"volumeMounts"`
+}
+
+type k8sVolume struct {
+	Name     string `yaml:"name"`
+	HostPath *struct {
+		Path string `yaml:"path"`
+	} `yaml:"hostPath"`
+}
+
+// SpecFromK8s parses a Kubernetes manifest (a bare Pod or a workload whose
+// template carries a pod spec) and grades its FIRST container. Pure and
+// unit-testable. Kubernetes network isolation is governed by NetworkPolicy,
+// which a pod manifest does not carry, so egress is graded conservatively
+// (fail-closed) unless hostNetwork makes it strictly worse.
+func SpecFromK8s(raw []byte) (Spec, error) {
+	var obj k8sObject
+	if err := yaml.Unmarshal(raw, &obj); err != nil {
+		return Spec{}, fmt.Errorf("parse kubernetes manifest: %w", err)
+	}
+
+	ps := obj.Spec.podSpec
+	// A workload kind (Deployment, …) carries the pod under spec.template.spec.
+	if len(ps.Containers) == 0 && len(obj.Spec.Template.Spec.Containers) > 0 {
+		ps = obj.Spec.Template.Spec
+	}
+	if len(ps.Containers) == 0 {
+		return Spec{}, fmt.Errorf("manifest has no containers to grade")
+	}
+	c := ps.Containers[0]
+
+	target := obj.Metadata.Name
+	if target == "" {
+		target = c.Name
+	}
+	s := Spec{Source: "k8s", Target: target, Runtime: ps.RuntimeClass}
+
+	// --- user (container securityContext overrides pod-level) ---------------
+	var nonRoot *bool
+	var runAsUser *int64
+	if ps.SecurityContext != nil {
+		nonRoot = ps.SecurityContext.RunAsNonRoot
+		runAsUser = ps.SecurityContext.RunAsUser
+	}
+	if c.SecurityContext != nil {
+		if c.SecurityContext.RunAsNonRoot != nil {
+			nonRoot = c.SecurityContext.RunAsNonRoot
+		}
+		if c.SecurityContext.RunAsUser != nil {
+			runAsUser = c.SecurityContext.RunAsUser
+		}
+	}
+	switch {
+	case nonRoot != nil && *nonRoot:
+		s.RunAsNonRoot = Yes
+		s.User = "runAsNonRoot: true"
+	case runAsUser != nil && *runAsUser != 0:
+		s.RunAsNonRoot = Yes
+		s.User = fmt.Sprintf("runAsUser: %d", *runAsUser)
+	case (nonRoot != nil && !*nonRoot) || (runAsUser != nil && *runAsUser == 0):
+		s.RunAsNonRoot = No
+		s.User = "runAsUser: 0"
+	default:
+		s.RunAsNonRoot = Unknown // no runAsNonRoot/runAsUser: image default may be root
+		s.Notes = append(s.Notes, "no runAsNonRoot/runAsUser set; the image default may be root")
+	}
+
+	// --- capabilities / privilege ------------------------------------------
+	if c.SecurityContext != nil {
+		s.Privileged = triFromPtr(c.SecurityContext.Privileged)
+		if c.SecurityContext.ReadOnlyRootFilesystem != nil {
+			s.ReadonlyRoot = boolTri(*c.SecurityContext.ReadOnlyRootFilesystem)
+		}
+		if c.SecurityContext.Capabilities != nil {
+			for _, d := range c.SecurityContext.Capabilities.Drop {
+				if strings.EqualFold(strings.TrimSpace(d), "ALL") {
+					s.CapDropAll = Yes
+				}
+			}
+			if s.CapDropAll == Unknown {
+				s.CapDropAll = No
+			}
+			for _, a := range c.SecurityContext.Capabilities.Add {
+				if a = strings.TrimSpace(a); a != "" {
+					s.CapAdd = append(s.CapAdd, strings.ToUpper(a))
+				}
+			}
+		}
+		// --- seccomp (container overrides pod) ------------------------------
+		if c.SecurityContext.SeccompProfile != nil {
+			s.Seccomp = normalizeK8sSeccomp(c.SecurityContext.SeccompProfile.Type)
+		}
+	}
+	if s.Seccomp == "" && ps.SecurityContext != nil && ps.SecurityContext.SeccompProfile != nil {
+		s.Seccomp = normalizeK8sSeccomp(ps.SecurityContext.SeccompProfile.Type)
+	}
+	// Kubernetes does NOT apply a seccomp profile by default (pre-SeccompDefault):
+	// an unset profile means unconfined. Leave Seccomp="" so it grades as unknown
+	// (fail-closed) and note it.
+	if s.Seccomp == "" {
+		s.Notes = append(s.Notes, "no seccompProfile set; Kubernetes leaves the syscall surface unconfined by default")
+	}
+
+	// --- network ------------------------------------------------------------
+	s.HostNetwork = triFromPtr(ps.HostNetwork)
+	if s.HostNetwork == Yes {
+		s.NetworkMode = "host"
+	} else {
+		// Pod networking is egress-capable unless a NetworkPolicy restricts it,
+		// which is not visible in the pod spec. Grade conservatively.
+		s.NetworkMode = "pod"
+		s.Notes = append(s.Notes, "egress depends on a NetworkPolicy not visible in this manifest; graded as egress-capable")
+	}
+
+	// --- namespaces ---------------------------------------------------------
+	s.HostPID = triFromPtr(ps.HostPID)
+	s.HostIPC = triFromPtr(ps.HostIPC)
+
+	// --- docker.sock / host mounts ------------------------------------------
+	s.DockerSock = No
+	sockVols := map[string]bool{}
+	seen := map[string]bool{}
+	for _, v := range ps.Volumes {
+		if v.HostPath == nil {
+			continue
+		}
+		p := v.HostPath.Path
+		if isControlSocket(p) {
+			s.DockerSock = Yes
+			sockVols[v.Name] = true
+		}
+		if isSensitiveHostPath(p) && !seen[p] {
+			seen[p] = true
+			s.HostPathMounts = append(s.HostPathMounts, p)
+		}
+	}
+	// Confirm the socket volume is actually mounted into the graded container.
+	if s.DockerSock == Yes {
+		mounted := false
+		for _, vm := range c.VolumeMounts {
+			if sockVols[vm.Name] || isControlSocket(vm.MountPath) {
+				mounted = true
+			}
+		}
+		if !mounted {
+			// Declared as a volume but not mounted into this container: not an
+			// exposure for the graded container.
+			s.DockerSock = No
+		}
+	}
+
+	return s, nil
+}
+
+// normalizeK8sSeccomp maps a k8s seccompProfile.type to the Spec vocabulary.
+func normalizeK8sSeccomp(t string) string {
+	switch strings.ToLower(strings.TrimSpace(t)) {
+	case "runtimedefault", "localhost":
+		return "confined"
+	case "unconfined":
+		return "unconfined"
+	default:
+		return ""
+	}
+}

--- a/internal/host/scan/k8s_test.go
+++ b/internal/host/scan/k8s_test.go
@@ -1,0 +1,119 @@
+package scan
+
+import "testing"
+
+const podWeak = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: weak-pod
+spec:
+  hostPID: true
+  hostNetwork: true
+  containers:
+    - name: app
+      image: nginx
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - name: sock
+          mountPath: /var/run/docker.sock
+  volumes:
+    - name: sock
+      hostPath:
+        path: /var/run/docker.sock
+`
+
+const podHardened = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hardened-pod
+spec:
+  containers:
+    - name: app
+      image: ironclaw
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
+        seccompProfile:
+          type: RuntimeDefault
+`
+
+const deploymentHardened = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          securityContext:
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+`
+
+func TestSpecFromK8s_Weak(t *testing.T) {
+	s, err := SpecFromK8s([]byte(podWeak))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Target != "weak-pod" {
+		t.Errorf("target=%q", s.Target)
+	}
+	if s.Privileged != Yes || s.HostPID != Yes || s.HostNetwork != Yes || s.DockerSock != Yes {
+		t.Errorf("weak postures not parsed: %+v", s)
+	}
+	if Score(s).Grade != "F" {
+		t.Errorf("weak pod graded %s, want F", Score(s).Grade)
+	}
+}
+
+func TestSpecFromK8s_Hardened(t *testing.T) {
+	s, err := SpecFromK8s([]byte(podHardened))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.RunAsNonRoot != Yes || s.CapDropAll != Yes || s.ReadonlyRoot != Yes || s.Seccomp != "confined" {
+		t.Errorf("hardened postures not parsed: %+v", s)
+	}
+	// Kubernetes network egress is not visible in a pod manifest, so a hardened
+	// pod cannot reach a perfect 100; it should still be a strong B or better.
+	r := Score(s)
+	if r.Grade != "A" && r.Grade != "B" {
+		t.Errorf("hardened pod graded %s (%d), want A or B", r.Grade, r.Score)
+	}
+	if dimByKey(r, "network.isolated").Verdict != VerdictWarn {
+		t.Error("pod network should grade WARN (NetworkPolicy not visible)")
+	}
+}
+
+func TestSpecFromK8s_Deployment(t *testing.T) {
+	s, err := SpecFromK8s([]byte(deploymentHardened))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A workload template's pod spec must be located under spec.template.spec.
+	if s.CapDropAll != Yes || s.ReadonlyRoot != Yes {
+		t.Errorf("deployment template not parsed: %+v", s)
+	}
+}
+
+func TestSpecFromK8s_Errors(t *testing.T) {
+	if _, err := SpecFromK8s([]byte("kind: Pod\nspec: {}\n")); err == nil {
+		t.Error("expected error for a pod with no containers")
+	}
+	if _, err := SpecFromK8s([]byte(":\n  not yaml")); err == nil {
+		t.Error("expected parse error")
+	}
+}

--- a/internal/host/scan/render.go
+++ b/internal/host/scan/render.go
@@ -1,0 +1,164 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+// RenderTable writes the human-readable scorecard to w: a header line with the
+// overall score + grade, then one row per dimension.
+func RenderTable(w io.Writer, r Report) {
+	fmt.Fprintf(w, "IronClaw containment scan\n")
+	fmt.Fprintf(w, "  target:  %s (%s)\n", nz(r.Target, "?"), nz(r.Source, "?"))
+	if r.Runtime != "" {
+		fmt.Fprintf(w, "  runtime: %s\n", r.Runtime)
+	}
+	fmt.Fprintf(w, "  score:   %d/%d  grade %s  %s\n\n", r.Score, r.Max, r.Grade, gradeBanner(r.Grade))
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "DIMENSION\tVERDICT\tSCORE\tDETAIL")
+	for _, d := range r.Dimensions {
+		fmt.Fprintf(tw, "%s\t%s %s\t%d/%d\t%s\n",
+			d.Title, verdictGlyph(d.Verdict), d.Verdict, d.Score, d.Max, d.Detail)
+	}
+	tw.Flush()
+
+	if len(r.Notes) > 0 {
+		fmt.Fprintln(w)
+		for _, n := range r.Notes {
+			fmt.Fprintf(w, "  note: %s\n", n)
+		}
+	}
+	fmt.Fprintf(w, "\n  Harden your sandbox: https://ironsecco.github.io/ironclaw/scan/\n")
+}
+
+func gradeBanner(g string) string {
+	switch g {
+	case "A":
+		return "(hardened)"
+	case "B":
+		return "(solid, minor gaps)"
+	case "C":
+		return "(weak, fix the FAILs)"
+	case "D":
+		return "(porous)"
+	default:
+		return "(wide open)"
+	}
+}
+
+func verdictGlyph(v Verdict) string {
+	switch v {
+	case VerdictPass:
+		return "[+]"
+	case VerdictWarn:
+		return "[~]"
+	default: // FAIL / UNKNOWN
+		return "[x]"
+	}
+}
+
+// RenderJSON writes the machine-readable report (schemaVersion 1.0).
+func RenderJSON(w io.Writer, r Report) error {
+	type envelope struct {
+		SchemaVersion string `json:"schemaVersion"`
+		Report        `json:",inline"`
+	}
+	// json does not honour ",inline"; marshal the report and splice the field in.
+	b, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return err
+	}
+	m["schemaVersion"] = "1.0"
+	m["report"] = "ironclaw-containment-scan"
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(append(out, '\n'))
+	return err
+}
+
+// RenderMarkdown returns a shareable markdown block (a README/blog section): the
+// headline score plus a dimension table. Public-copy house style: no em/en-dashes.
+func RenderMarkdown(r Report) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "### IronClaw containment scan: `%s` scored **%d/100 (grade %s)**\n\n",
+		nz(r.Target, "target"), r.Score, r.Grade)
+	fmt.Fprintf(&b, "| Dimension | Verdict | Score |\n|---|---|---|\n")
+	for _, d := range r.Dimensions {
+		fmt.Fprintf(&b, "| %s | %s %s | %d/%d |\n", d.Title, mdGlyph(d.Verdict), d.Verdict, d.Score, d.Max)
+	}
+	fmt.Fprintf(&b, "\nAudit your own sandbox: `ironctl scan <container>` (https://github.com/IronSecCo/ironclaw)\n")
+	return b.String()
+}
+
+func mdGlyph(v Verdict) string {
+	switch v {
+	case VerdictPass:
+		return "✅"
+	case VerdictWarn:
+		return "⚠️"
+	default:
+		return "❌"
+	}
+}
+
+// RenderBadgeSVG returns a self-contained, shields.io-style flat badge (no
+// external fetch), colored by grade. Safe to commit into a README. Deterministic
+// given the report score, matching the IRO-367 receipt badge conventions.
+func RenderBadgeSVG(r Report) string {
+	right := fmt.Sprintf("%d/100 %s", r.Score, r.Grade)
+	label := "containment"
+	// Rough monospace sizing (7px/char + padding), same math as emit-receipt.sh.
+	llw := len(label)*7 + 22
+	lw := len(right)*7 + 22
+	totalW := llw + lw
+	color := gradeColor(r.Grade)
+	llx := llw * 10 / 2
+	rx := llw*10 + lw*10/2
+	return fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="20" role="img" aria-label="%s: %s">
+  <title>%s: %s</title>
+  <linearGradient id="s" x2="0" y2="100%%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="%d" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="%d" height="20" fill="#24292f"/>
+    <rect x="%d" width="%d" height="20" fill="%s"/>
+    <rect width="%d" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-rendering="geometricPrecision">
+    <text x="%d" y="150" transform="scale(.1)" fill="#010101" fill-opacity=".3">%s</text>
+    <text x="%d" y="140" transform="scale(.1)">%s</text>
+    <text x="%d" y="150" transform="scale(.1)" fill="#010101" fill-opacity=".3">%s</text>
+    <text x="%d" y="140" transform="scale(.1)">%s</text>
+  </g>
+</svg>
+`, totalW, label, right, label, right, totalW, llw, llw, lw, color, totalW,
+		llx, label, llx, label, rx, right, rx, right)
+}
+
+// gradeColor maps a letter grade to the shields flat-badge palette.
+func gradeColor(g string) string {
+	switch g {
+	case "A":
+		return "#3fb950" // green
+	case "B":
+		return "#9acd32" // yellow-green
+	case "C":
+		return "#d4a72c" // amber
+	case "D":
+		return "#e8873a" // orange
+	default:
+		return "#d1242f" // red
+	}
+}

--- a/internal/host/scan/render_test.go
+++ b/internal/host/scan/render_test.go
@@ -1,0 +1,76 @@
+package scan
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func sampleReport() Report {
+	return Score(Spec{
+		Source: "docker", Target: "ic-sbx-demo", Runtime: "runsc",
+		RunAsNonRoot: Yes, User: "65532", CapDropAll: Yes, Seccomp: "confined",
+		NetworkMode: "none", ReadonlyRoot: Yes, DockerSock: No,
+		HostPID: No, HostIPC: No, HostNetwork: No,
+	})
+}
+
+func TestRenderTable(t *testing.T) {
+	var b bytes.Buffer
+	RenderTable(&b, sampleReport())
+	out := b.String()
+	for _, want := range []string{"ic-sbx-demo", "100/100", "grade A", "Non-root user", "Dropped capabilities"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderJSON(t *testing.T) {
+	var b bytes.Buffer
+	if err := RenderJSON(&b, sampleReport()); err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b.Bytes(), &m); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if m["schemaVersion"] != "1.0" {
+		t.Errorf("schemaVersion=%v", m["schemaVersion"])
+	}
+	if m["score"].(float64) != 100 {
+		t.Errorf("score=%v", m["score"])
+	}
+	if _, ok := m["dimensions"].([]any); !ok {
+		t.Error("dimensions array missing")
+	}
+}
+
+func TestRenderBadgeSVG(t *testing.T) {
+	svg := RenderBadgeSVG(sampleReport())
+	if !strings.HasPrefix(svg, "<svg") || !strings.Contains(svg, "100/100 A") {
+		t.Errorf("badge malformed: %s", svg)
+	}
+	if !strings.Contains(svg, gradeColor("A")) {
+		t.Error("badge missing grade color")
+	}
+	// A failing report must render red, not green.
+	fail := RenderBadgeSVG(Score(Spec{}))
+	if !strings.Contains(fail, gradeColor("F")) {
+		t.Error("failing badge should be red")
+	}
+}
+
+func TestRenderMarkdown(t *testing.T) {
+	md := RenderMarkdown(sampleReport())
+	for _, want := range []string{"ic-sbx-demo", "100/100", "| Dimension |", "ironctl scan"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("markdown missing %q\n%s", want, md)
+		}
+	}
+	// Public-copy house style: no em/en-dashes (IRO-254).
+	if strings.ContainsAny(md, "—–") {
+		t.Error("markdown contains an em/en-dash")
+	}
+}

--- a/internal/host/scan/score.go
+++ b/internal/host/scan/score.go
@@ -1,0 +1,253 @@
+package scan
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Verdict is a per-dimension outcome, ordered worst-to-best for sorting.
+type Verdict string
+
+const (
+	VerdictFail    Verdict = "FAIL"    // insecure posture observed
+	VerdictUnknown Verdict = "UNKNOWN" // could not determine — scored as FAIL (fail-closed)
+	VerdictWarn    Verdict = "WARN"    // partial / weakened posture
+	VerdictPass    Verdict = "PASS"    // hardened posture observed
+)
+
+// Dimension is one graded containment axis.
+type Dimension struct {
+	Key     string  `json:"key"`     // stable id, e.g. "user.nonroot"
+	Title   string  `json:"title"`   // human label
+	Verdict Verdict `json:"verdict"` // PASS|WARN|FAIL|UNKNOWN
+	Score   int     `json:"score"`   // points earned
+	Max     int     `json:"max"`     // points possible for this dimension
+	Detail  string  `json:"detail"`  // evidence / why
+}
+
+// Report is the full scorecard for one Spec.
+type Report struct {
+	Source     string      `json:"source"`
+	Target     string      `json:"target"`
+	Runtime    string      `json:"runtime,omitempty"`
+	Score      int         `json:"score"` // 0..100
+	Max        int         `json:"max"`   // always 100
+	Grade      string      `json:"grade"` // A..F
+	Dimensions []Dimension `json:"dimensions"`
+	Notes      []string    `json:"notes,omitempty"`
+	// GeneratedAt is set by the caller (injected for deterministic tests); the
+	// pure scorer never reads the clock.
+	GeneratedAt string `json:"generatedAt,omitempty"`
+	Version     string `json:"version,omitempty"`
+}
+
+// scorer grades one dimension of a Spec. Each returns points-earned and a
+// verdict+detail; Max is fixed per dimension below. Every scorer treats Unknown
+// fail-closed (0 points, UNKNOWN verdict).
+type scorer struct {
+	key   string
+	title string
+	max   int
+	grade func(Spec) (int, Verdict, string)
+}
+
+// scorers is the ordered dimension set. Weights sum to 100. The high weights sit
+// on the boundaries whose breach is a full host compromise: dropped capabilities
+// (20) and docker.sock exposure (15) each hand out host root when open.
+var scorers = []scorer{
+	{"user.nonroot", "Non-root user (uid != 0)", 15, gradeNonRoot},
+	{"caps.dropped", "Dropped capabilities", 20, gradeCaps},
+	{"seccomp", "Seccomp profile", 15, gradeSeccomp},
+	{"network.isolated", "Network isolation / egress", 15, gradeNetwork},
+	{"rootfs.readonly", "Read-only root filesystem", 10, gradeReadonly},
+	{"docker.sock", "No docker.sock exposure", 15, gradeDockerSock},
+	{"namespaces.host", "No shared host namespaces", 10, gradeHostNS},
+}
+
+// TotalWeight is the maximum achievable score (100 by construction).
+const TotalWeight = 100
+
+// Score grades a Spec across every dimension and returns the full Report. It is
+// pure: no I/O, no clock, deterministic for a given Spec.
+func Score(s Spec) Report {
+	r := Report{
+		Source:  s.Source,
+		Target:  s.Target,
+		Runtime: s.Runtime,
+		Max:     TotalWeight,
+		Notes:   append([]string(nil), s.Notes...),
+	}
+	sum := 0
+	for _, sc := range scorers {
+		pts, v, detail := sc.grade(s)
+		if pts < 0 {
+			pts = 0
+		}
+		if pts > sc.max {
+			pts = sc.max
+		}
+		sum += pts
+		r.Dimensions = append(r.Dimensions, Dimension{
+			Key: sc.key, Title: sc.title, Verdict: v, Score: pts, Max: sc.max, Detail: detail,
+		})
+	}
+	r.Score = sum
+	r.Grade = grade(sum)
+	return r
+}
+
+// grade maps a 0..100 score to a letter band.
+func grade(score int) string {
+	switch {
+	case score >= 90:
+		return "A"
+	case score >= 75:
+		return "B"
+	case score >= 50:
+		return "C"
+	case score >= 25:
+		return "D"
+	default:
+		return "F"
+	}
+}
+
+// --------------------------------------------------------------------------- //
+// Dimension scorers. Each is total for its dimension: full points for a
+// hardened posture, partial for a weakened one, zero for insecure OR unknown.
+// --------------------------------------------------------------------------- //
+
+func gradeNonRoot(s Spec) (int, Verdict, string) {
+	switch s.RunAsNonRoot {
+	case Yes:
+		u := s.User
+		if u == "" {
+			u = "non-root"
+		}
+		return 15, VerdictPass, fmt.Sprintf("runs as %s (uid != 0)", u)
+	case No:
+		return 0, VerdictFail, fmt.Sprintf("runs as root (user %q); a container escape starts with host-uid 0", nz(s.User, "0"))
+	default:
+		return 0, VerdictUnknown, "user not reported; assuming root (fail-closed)"
+	}
+}
+
+func gradeCaps(s Spec) (int, Verdict, string) {
+	// Privileged grants the full capability set regardless of cap_drop.
+	if s.Privileged == Yes {
+		return 0, VerdictFail, "privileged: the full capability set is granted"
+	}
+	switch s.CapDropAll {
+	case Yes:
+		if len(s.CapAdd) == 0 {
+			return 20, VerdictPass, "all capabilities dropped, none added back"
+		}
+		// Dropped ALL but added some back: partial credit, scaled by how many.
+		pts := 20 - 4*len(s.CapAdd)
+		if pts < 6 {
+			pts = 6
+		}
+		return pts, VerdictWarn, fmt.Sprintf("dropped ALL but re-added: %s", strings.Join(s.CapAdd, ", "))
+	case No:
+		if len(s.CapAdd) > 0 {
+			return 0, VerdictFail, fmt.Sprintf("default caps retained and extra caps added: %s", strings.Join(s.CapAdd, ", "))
+		}
+		return 4, VerdictFail, "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …)"
+	default:
+		return 0, VerdictUnknown, "capability set not reported; assuming default (fail-closed)"
+	}
+}
+
+func gradeSeccomp(s Spec) (int, Verdict, string) {
+	// Privileged disables seccomp entirely.
+	if s.Privileged == Yes {
+		return 0, VerdictFail, "privileged: seccomp is disabled"
+	}
+	switch strings.ToLower(strings.TrimSpace(s.Seccomp)) {
+	case "confined", "default", "runtime/default", "runtimedefault":
+		return 15, VerdictPass, "seccomp profile active (syscall surface filtered)"
+	case "unconfined", "":
+		if s.Seccomp == "" {
+			return 0, VerdictUnknown, "seccomp not reported; assuming unconfined (fail-closed)"
+		}
+		return 0, VerdictFail, "seccomp=unconfined: the full syscall surface is exposed"
+	default:
+		// A custom profile path — treat as confined (a profile is applied).
+		return 15, VerdictPass, fmt.Sprintf("custom seccomp profile: %s", s.Seccomp)
+	}
+}
+
+func gradeNetwork(s Spec) (int, Verdict, string) {
+	m := strings.ToLower(strings.TrimSpace(s.NetworkMode))
+	if s.HostNetwork == Yes || m == "host" {
+		return 0, VerdictFail, "host network namespace: full host network reachability"
+	}
+	switch {
+	case m == "none":
+		return 15, VerdictPass, "network=none: no NIC but loopback, no egress"
+	case m == "":
+		return 0, VerdictUnknown, "network mode not reported; assuming egress-capable (fail-closed)"
+	case strings.HasPrefix(m, "container:"):
+		return 6, VerdictWarn, fmt.Sprintf("shares another container's network stack (%s)", s.NetworkMode)
+	default:
+		// bridge / default / a named network: egress-capable.
+		return 4, VerdictWarn, fmt.Sprintf("network=%s: outbound egress is possible; prefer network=none", s.NetworkMode)
+	}
+}
+
+func gradeReadonly(s Spec) (int, Verdict, string) {
+	switch s.ReadonlyRoot {
+	case Yes:
+		return 10, VerdictPass, "root filesystem is read-only"
+	case No:
+		return 0, VerdictFail, "root filesystem is writable: tamper/persistence surface"
+	default:
+		return 0, VerdictUnknown, "root filesystem mode not reported; assuming writable (fail-closed)"
+	}
+}
+
+func gradeDockerSock(s Spec) (int, Verdict, string) {
+	// Polarity: DockerSock == Yes means the socket IS exposed (bad).
+	switch s.DockerSock {
+	case No:
+		return 15, VerdictPass, "no docker.sock / OCI control socket mounted"
+	case Yes:
+		return 0, VerdictFail, "docker.sock is mounted: trivial host-root escape (docker run --privileged -v /:/host)"
+	default:
+		return 0, VerdictUnknown, "mounts not reported; cannot rule out docker.sock (fail-closed)"
+	}
+}
+
+func gradeHostNS(s Spec) (int, Verdict, string) {
+	if s.Privileged == Yes {
+		return 0, VerdictFail, "privileged: host devices and namespaces are reachable"
+	}
+	var shared []string
+	if s.HostPID == Yes {
+		shared = append(shared, "PID")
+	}
+	if s.HostIPC == Yes {
+		shared = append(shared, "IPC")
+	}
+	if s.HostNetwork == Yes {
+		shared = append(shared, "network")
+	}
+	if len(shared) > 0 {
+		sort.Strings(shared)
+		return 0, VerdictFail, fmt.Sprintf("shares host namespace(s): %s", strings.Join(shared, ", "))
+	}
+	// None shared. If we had no signal at all for any of them, that is unknown.
+	if s.HostPID == Unknown && s.HostIPC == Unknown && s.HostNetwork == Unknown {
+		return 0, VerdictUnknown, "namespace sharing not reported; assuming shared (fail-closed)"
+	}
+	return 10, VerdictPass, "no host PID/IPC/network namespace sharing"
+}
+
+// nz returns v if non-empty, else fallback.
+func nz(v, fallback string) string {
+	if strings.TrimSpace(v) == "" {
+		return fallback
+	}
+	return v
+}

--- a/internal/host/scan/score_test.go
+++ b/internal/host/scan/score_test.go
@@ -1,0 +1,242 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+// dimByKey returns the graded dimension with the given key.
+func dimByKey(r Report, key string) Dimension {
+	for _, d := range r.Dimensions {
+		if d.Key == key {
+			return d
+		}
+	}
+	return Dimension{}
+}
+
+// Each dimension scorer is exercised across PASS / FAIL / UNKNOWN, asserting the
+// fail-closed rule: an Unknown posture is never scored above zero.
+
+func TestGradeNonRoot(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    Spec
+		want    Verdict
+		wantPts int
+	}{
+		{"nonroot", Spec{RunAsNonRoot: Yes, User: "65532"}, VerdictPass, 15},
+		{"root", Spec{RunAsNonRoot: No, User: "0"}, VerdictFail, 0},
+		{"unknown", Spec{RunAsNonRoot: Unknown}, VerdictUnknown, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := Score(c.spec)
+			d := dimByKey(r, "user.nonroot")
+			if d.Verdict != c.want || d.Score != c.wantPts {
+				t.Fatalf("got %s/%d want %s/%d", d.Verdict, d.Score, c.want, c.wantPts)
+			}
+		})
+	}
+}
+
+func TestGradeCaps(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    Spec
+		want    Verdict
+		wantPts int
+	}{
+		{"drop-all", Spec{CapDropAll: Yes}, VerdictPass, 20},
+		{"drop-all-readd-one", Spec{CapDropAll: Yes, CapAdd: []string{"NET_BIND_SERVICE"}}, VerdictWarn, 16},
+		{"privileged", Spec{Privileged: Yes, CapDropAll: Yes}, VerdictFail, 0},
+		{"default-caps", Spec{CapDropAll: No}, VerdictFail, 4},
+		{"unknown", Spec{CapDropAll: Unknown}, VerdictUnknown, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := dimByKey(Score(c.spec), "caps.dropped")
+			if d.Verdict != c.want || d.Score != c.wantPts {
+				t.Fatalf("got %s/%d want %s/%d", d.Verdict, d.Score, c.want, c.wantPts)
+			}
+		})
+	}
+}
+
+func TestGradeSeccomp(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    Spec
+		want    Verdict
+		wantPts int
+	}{
+		{"default", Spec{Seccomp: "confined"}, VerdictPass, 15},
+		{"runtime-default", Spec{Seccomp: "RuntimeDefault"}, VerdictPass, 15},
+		{"custom-path", Spec{Seccomp: "/etc/profile.json"}, VerdictPass, 15},
+		{"unconfined", Spec{Seccomp: "unconfined"}, VerdictFail, 0},
+		{"privileged", Spec{Privileged: Yes, Seccomp: "confined"}, VerdictFail, 0},
+		{"unknown", Spec{Seccomp: ""}, VerdictUnknown, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := dimByKey(Score(c.spec), "seccomp")
+			if d.Verdict != c.want || d.Score != c.wantPts {
+				t.Fatalf("got %s/%d want %s/%d", d.Verdict, d.Score, c.want, c.wantPts)
+			}
+		})
+	}
+}
+
+func TestGradeNetwork(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    Spec
+		want    Verdict
+		wantPts int
+	}{
+		{"none", Spec{NetworkMode: "none"}, VerdictPass, 15},
+		{"host", Spec{NetworkMode: "host"}, VerdictFail, 0},
+		{"host-flag", Spec{HostNetwork: Yes, NetworkMode: "bridge"}, VerdictFail, 0},
+		{"bridge", Spec{NetworkMode: "bridge"}, VerdictWarn, 4},
+		{"container", Spec{NetworkMode: "container:abc"}, VerdictWarn, 6},
+		{"unknown", Spec{NetworkMode: ""}, VerdictUnknown, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := dimByKey(Score(c.spec), "network.isolated")
+			if d.Verdict != c.want || d.Score != c.wantPts {
+				t.Fatalf("got %s/%d want %s/%d", d.Verdict, d.Score, c.want, c.wantPts)
+			}
+		})
+	}
+}
+
+func TestGradeReadonly(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    Spec
+		want    Verdict
+		wantPts int
+	}{
+		{"readonly", Spec{ReadonlyRoot: Yes}, VerdictPass, 10},
+		{"writable", Spec{ReadonlyRoot: No}, VerdictFail, 0},
+		{"unknown", Spec{ReadonlyRoot: Unknown}, VerdictUnknown, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := dimByKey(Score(c.spec), "rootfs.readonly")
+			if d.Verdict != c.want || d.Score != c.wantPts {
+				t.Fatalf("got %s/%d want %s/%d", d.Verdict, d.Score, c.want, c.wantPts)
+			}
+		})
+	}
+}
+
+func TestGradeDockerSock(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    Spec
+		want    Verdict
+		wantPts int
+	}{
+		{"absent", Spec{DockerSock: No}, VerdictPass, 15},
+		{"exposed", Spec{DockerSock: Yes}, VerdictFail, 0},
+		{"unknown", Spec{DockerSock: Unknown}, VerdictUnknown, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := dimByKey(Score(c.spec), "docker.sock")
+			if d.Verdict != c.want || d.Score != c.wantPts {
+				t.Fatalf("got %s/%d want %s/%d", d.Verdict, d.Score, c.want, c.wantPts)
+			}
+		})
+	}
+}
+
+func TestGradeHostNS(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    Spec
+		want    Verdict
+		wantPts int
+	}{
+		{"none-shared", Spec{HostPID: No, HostIPC: No, HostNetwork: No}, VerdictPass, 10},
+		{"host-pid", Spec{HostPID: Yes, HostIPC: No, HostNetwork: No}, VerdictFail, 0},
+		{"privileged", Spec{Privileged: Yes, HostPID: No, HostIPC: No, HostNetwork: No}, VerdictFail, 0},
+		{"unknown", Spec{}, VerdictUnknown, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := dimByKey(Score(c.spec), "namespaces.host")
+			if d.Verdict != c.want || d.Score != c.wantPts {
+				t.Fatalf("got %s/%d want %s/%d", d.Verdict, d.Score, c.want, c.wantPts)
+			}
+		})
+	}
+}
+
+// TestScoreWeightsSumTo100 guards the invariant that a fully-hardened spec earns
+// exactly 100 and the weights never drift.
+func TestScoreWeightsSumTo100(t *testing.T) {
+	hardened := Spec{
+		RunAsNonRoot: Yes, User: "65532",
+		CapDropAll:   Yes,
+		Seccomp:      "confined",
+		NetworkMode:  "none",
+		ReadonlyRoot: Yes,
+		DockerSock:   No,
+		HostPID:      No, HostIPC: No, HostNetwork: No,
+	}
+	r := Score(hardened)
+	if r.Score != 100 || r.Max != 100 {
+		t.Fatalf("hardened spec scored %d/%d, want 100/100", r.Score, r.Max)
+	}
+	if r.Grade != "A" {
+		t.Fatalf("hardened grade %s, want A", r.Grade)
+	}
+	sum := 0
+	for _, s := range scorers {
+		sum += s.max
+	}
+	if sum != TotalWeight {
+		t.Fatalf("dimension weights sum to %d, want %d", sum, TotalWeight)
+	}
+}
+
+// TestScoreFailClosedEmpty asserts an empty Spec (all Unknown) scores 0/F: an
+// auditor that can see nothing must report the worst grade, never a passing one.
+func TestScoreFailClosedEmpty(t *testing.T) {
+	r := Score(Spec{})
+	if r.Score != 0 || r.Grade != "F" {
+		t.Fatalf("empty spec scored %d grade %s, want 0/F (fail-closed)", r.Score, r.Grade)
+	}
+	for _, d := range r.Dimensions {
+		if d.Verdict == VerdictPass {
+			t.Fatalf("dimension %s passed on an empty spec (not fail-closed)", d.Key)
+		}
+	}
+}
+
+func TestGrades(t *testing.T) {
+	cases := map[int]string{100: "A", 90: "A", 89: "B", 75: "B", 74: "C", 50: "C", 49: "D", 25: "D", 24: "F", 0: "F"}
+	for score, want := range cases {
+		if g := grade(score); g != want {
+			t.Errorf("grade(%d)=%s want %s", score, g, want)
+		}
+	}
+}
+
+func TestPrivilegedTanksScore(t *testing.T) {
+	// A privileged root container should land in the failing band regardless of
+	// any other posture: privilege is the master escape.
+	r := Score(Spec{
+		Privileged: Yes, RunAsNonRoot: No,
+		NetworkMode: "none", ReadonlyRoot: Yes, DockerSock: No,
+	})
+	if r.Grade == "A" || r.Grade == "B" {
+		t.Fatalf("privileged container graded %s (%d); expected a failing band", r.Grade, r.Score)
+	}
+	if d := dimByKey(r, "caps.dropped"); !strings.Contains(d.Detail, "privileged") {
+		t.Fatalf("caps detail did not flag privileged: %q", d.Detail)
+	}
+}

--- a/internal/host/scan/spec.go
+++ b/internal/host/scan/spec.go
@@ -1,0 +1,110 @@
+// Package scan implements `ironctl scan`: a containment self-audit that grades
+// the isolation posture of ANY container, docker-compose service, or Kubernetes
+// pod/manifest on a 0-100 scale across the same dimensions IronClaw's own
+// containment benchmark checks (IRO-369): non-root user, dropped capabilities,
+// seccomp, network isolation, read-only rootfs, docker.sock exposure, and shared
+// host namespaces.
+//
+// The package is deliberately split into a PURE core (this file, score.go,
+// render.go) that operates on a normalized Spec, and thin SOURCE ADAPTERS
+// (docker.go, compose.go, k8s.go) that extract a Spec from a `docker inspect`
+// JSON blob, a compose service, or a pod manifest. That keeps the scorers
+// hermetically unit-testable with no Docker or Kubernetes dependency, and lets a
+// single grading model serve every runtime.
+//
+// FAIL-CLOSED is the governing principle: a dimension whose posture cannot be
+// determined is scored as if it were INSECURE (Unknown -> the worst verdict),
+// never silently passed. A scan that cannot see a boundary must never claim the
+// boundary holds.
+package scan
+
+// Tristate is a three-valued boolean used for every security posture that a
+// source may or may not report. Unlike a plain bool (or *bool), it makes the
+// "we could not determine this" case a first-class, non-optional value so the
+// scorers can treat unknowns fail-closed instead of defaulting to a safe-looking
+// zero value.
+type Tristate int
+
+const (
+	// Unknown means the source did not report enough to decide. Scored as the
+	// worst outcome (fail-closed).
+	Unknown Tristate = iota
+	// Yes means the posture is present/true.
+	Yes
+	// No means the posture is absent/false.
+	No
+)
+
+func (t Tristate) String() string {
+	switch t {
+	case Yes:
+		return "yes"
+	case No:
+		return "no"
+	default:
+		return "unknown"
+	}
+}
+
+// boolTri maps a definitely-known bool to Yes/No. Use it only when the source
+// unambiguously reported the field; leave Unknown otherwise.
+func boolTri(b bool) Tristate {
+	if b {
+		return Yes
+	}
+	return No
+}
+
+// Spec is the normalized, source-agnostic containment posture of a single
+// workload. Every source adapter produces one of these; every scorer reads one.
+// Fields left at their zero value (Unknown / "" / nil) are treated as unknown
+// and graded fail-closed.
+type Spec struct {
+	// Source identity (informational; shown in the report header).
+	Source string // "docker" | "compose" | "k8s"
+	Target string // container name/id, compose service, or pod name
+
+	// --- user namespace / uid ------------------------------------------------
+	// RunAsNonRoot is Yes when the workload is known to run as a uid != 0.
+	RunAsNonRoot Tristate
+	// User is the raw user spec observed ("65532", "nobody", "0:0", ""), shown
+	// as evidence in the detail column.
+	User string
+
+	// --- capabilities --------------------------------------------------------
+	// CapDropAll is Yes when ALL capabilities are dropped (cap_drop: [ALL] or an
+	// empty effective set). Additions in CapAdd weaken this.
+	CapDropAll Tristate
+	CapAdd     []string // capabilities added back (each one weakens the posture)
+
+	// --- seccomp -------------------------------------------------------------
+	// Seccomp is the profile posture: "confined" (default/runtime profile or a
+	// custom path), "unconfined" (explicitly disabled), or "" (unknown).
+	Seccomp string
+
+	// --- network -------------------------------------------------------------
+	// NetworkMode is the raw mode ("none", "host", "bridge", "default",
+	// "container:...", or a compose/k8s equivalent). "none" is the only fully
+	// egress-isolated mode; "host" is the worst.
+	NetworkMode string
+
+	// --- filesystem ----------------------------------------------------------
+	ReadonlyRoot Tristate // read-only root filesystem
+	// DockerSock is Yes when the Docker/OCI control socket is mounted into the
+	// workload — a full host-root escape primitive. Note the polarity: Yes is BAD.
+	DockerSock Tristate
+	// HostPathMounts lists sensitive host paths bind-mounted in (informational
+	// evidence for the docker.sock / host-mount findings).
+	HostPathMounts []string
+
+	// --- namespaces / privilege ---------------------------------------------
+	Privileged  Tristate // --privileged (disables seccomp, grants all caps)
+	HostPID     Tristate // shares the host PID namespace
+	HostNetwork Tristate // shares the host network namespace
+	HostIPC     Tristate // shares the host IPC namespace
+
+	// --- informational -------------------------------------------------------
+	Runtime    string   // OCI runtime ("runc", "runsc", "kata-runtime", …)
+	NoNewPrivs Tristate // no-new-privileges set
+	Notes      []string // adapter-level notes (e.g. "field absent, assuming insecure")
+}


### PR DESCRIPTION
## What

`ironctl scan` grades the containment posture of **any** running container, docker-compose service, or Kubernetes pod/manifest on a 0-100 scale across the dimensions IronClaw's own containment benchmark checks (IRO-369):

non-root user, dropped capabilities (CapEff), seccomp, network isolation/egress, read-only rootfs, docker.sock exposure, and shared host PID/IPC/network namespaces.

A tool users run on **their own** setups, not just ours: "audit your sandbox in 10s". Every scan of a weak config is a soft ad for IronClaw's containment.

## How

- **`internal/host/scan`** — pure, source-agnostic core: a normalized `Spec`, per-dimension scorers, and table/JSON/SVG-badge/markdown renderers. Hermetically unit-testable with no Docker or Kubernetes dependency. **Fail-closed**: any posture that cannot be determined is scored as insecure, never silently passed.
- **Source adapters** parse `docker inspect` JSON, a compose service, and a k8s pod/workload manifest (Deployment/StatefulSet/...) into the `Spec`.
- **`cmd/ironctl/scan.go`** — a local, read-only command (no control-plane API). Flags: `--json`, `--badge PATH`, `--md`, `--min-score N` (CI gate), `--compose/--service`, `--k8s`. Reuses the IRO-367 receipt badge conventions.
- **`docs/scan.md`** + nav entry.

## Verification (live, colima)

| Target | Score |
|---|---|
| weak container (root, docker.sock, host PID, writable, bridge) | **23 / F** |
| hardened ic-sbx-style (non-root, caps dropped, network=none, read-only) | **100 / A** |

`--json`, `--badge` (writes SVG), `--md`, and `--min-score` gate (exit 1 when below threshold) all verified end-to-end.

- Unit tests: **160 pass** (`./cmd/ironctl/...` + `./internal/host/scan/...`), one per dimension scorer plus each adapter and renderer.
- `CGO_ENABLED=1 go build ./...` green; `go vet` clean; gofmt clean.

## Security lenses

- **Isolation / egress**: the tool is a *reporter*, read-only. It grades `network=none`, dropped caps, seccomp, and host-namespace sharing; it never widens any boundary.
- **Fail-closed** is load-bearing: an auditor that cannot see a boundary reports the worst grade, so a missing field can never inflate a score.
- No secrets read or logged; output carries only posture facts.

## Follow-ups (per issue)

- QA smoke of `ironctl scan` under gVisor (runsc).
- Growth blog + README section ("audit your sandbox in 10s").

Requesting CEO merge confirmation (trust-model-adjacent surface).