### PR TITLE
docs(launch): guardrail-safe Reddit + Show HN launch drafts (IRO-426)

### DIFF
--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -1,0 +1,64 @@
+# Launch post drafts
+
+Pre-written, guardrail-safe launch copy so an approved publisher can post
+instantly on each channel. Every claim here maps to shipped, verifiable code or
+docs. No hero numbers from machines you cannot inspect.
+
+## Publishing guardrails (read before posting)
+
+- No personal name, personal GitHub, LinkedIn, or Instagram in any post.
+- Project links only: the repo, the docs site, the benchmark page.
+- No em-dashes or en-dashes in public copy (house style, IRO-254).
+- Value-first: lead with the problem and the proof, not the pitch.
+- Every capability claim must be verifiable against shipped code. If QA has not
+  confirmed it, cut it.
+- One channel at a time. Do not cross-post the same text; each file below is
+  written for its audience.
+
+## What is in this folder
+
+| File | Channel | Format |
+| --- | --- | --- |
+| [`reddit-localllama.md`](reddit-localllama.md) | r/LocalLLaMA | self-post |
+| [`reddit-programming.md`](reddit-programming.md) | r/programming | link + comment |
+| [`reddit-selfhosted.md`](reddit-selfhosted.md) | r/selfhosted | self-post |
+| [`show-hn.md`](show-hn.md) | Hacker News | Show HN title + first comment |
+
+## TL;DR (reusable hook)
+
+IronClaw runs every AI agent inside its own gVisor (`runsc`) sandbox: one
+sandbox per conversation, `network=none`, a seccomp syscall allowlist, all Linux
+capabilities dropped, non-root user namespace, and a read-only rootfs. The
+isolation is the product. It is AGPLv3 plus commercial, self-hosted, and the
+containment boundary ships with a red-team harness that runs as a CI gate, so
+the claim that a compromised agent stays contained is tested on every push, not
+asserted in a README.
+
+## Containment-benchmark hook (the proof, in one paragraph)
+
+We wrote an escape harness that hands a fully compromised agent a battery of
+escape, exfiltration, and self-modification attempts from inside the box. It
+tries to reach the Docker Engine socket, read arbitrary host paths, break out to
+sibling containers, and rewrite itself. Every core containment assertion holds:
+the Engine socket is never bound in, host paths stay contained, egress is
+blocked. The same script is both the demo and the CI gate, so a regression that
+weakens the boundary fails the build. A separate, reproducible performance
+harness measures the gVisor cost on a public CI runner: about +13 ms on a warm
+respawn and +39 ms on a cold launch, paid once per sandbox, not per request.
+
+## Link block (swap in canonical URLs at publish time)
+
+- Repo: https://github.com/IronSecCo/ironclaw
+- Containment demo (red-team escape harness): https://github.com/IronSecCo/ironclaw/tree/main/examples/red-team-escape
+- Benchmark and footprint page: on the docs site under Benchmarks
+- Comparison and positioning: on the docs site under Comparison
+- License: AGPLv3 plus commercial
+
+## Post-launch first-hour checklist
+
+- Confirm every link resolves before posting.
+- Watch the thread for the first 60 to 90 minutes and answer fast. Response
+  speed on a security audience builds more trust than the post itself.
+- Log the baseline star and traffic numbers at post time so lift is measurable.
+- Route any onboarding friction surfaced in comments to the onboarding and UX
+  owners as issues, not as promises in the thread.

--- a/docs/launch/reddit-localllama.md
+++ b/docs/launch/reddit-localllama.md
@@ -1,0 +1,62 @@
+# r/LocalLLaMA draft
+
+Audience: local model runners who already give agents tool access and worry
+about what those tools can reach. Lead with the local-first angle and the threat
+model, not the marketing.
+
+---
+
+**Title:** I run every local agent in its own gVisor sandbox now, here is the open-source runtime that does it
+
+**Body:**
+
+If you run agents locally, you have probably already handed one shell access, a
+file path, or an MCP tool and then thought about what happens if the model gets
+prompt-injected into doing something you did not intend. A plain `docker run`
+shares the host kernel, so one container escape is a host compromise. That gap
+is what pushed me toward IronClaw.
+
+IronClaw is a self-hosted runtime that assumes the agent itself could be
+compromised and builds a boundary you can verify. Every conversation gets its
+own gVisor (`runsc`) sandbox with:
+
+- `network=none` by default, so no egress unless you grant it
+- a seccomp syscall allowlist and all Linux capabilities dropped
+- a non-root user namespace and a read-only rootfs
+- the agent shipped as a compiled Go binary, so there is no source inside the
+  box to rewrite
+
+It runs fully local. You can point it at Ollama with zero credentials
+(`localhost:11434`), or bring your own model. No key leaves your box, and the
+sandbox has no network path out to leak one anyway.
+
+The part I care about most: the containment claim is tested, not asserted. There
+is a red-team escape harness that runs a compromised agent through escape,
+exfiltration, and self-modification attempts, and it runs as a CI gate on every
+push. If a change ever weakens the boundary, the build fails.
+
+Cost of the sandbox is small and measured on a public CI runner: about +13 ms on
+a warm respawn and +39 ms on a cold launch, paid once per sandbox, not per
+request. The benchmark harness is committed so you can run it on your own
+hardware.
+
+AGPLv3 plus commercial. Feedback from people who actually run local agents is
+what I want most, especially on the isolation model and where it is too strict or
+not strict enough.
+
+Repo: https://github.com/IronSecCo/ironclaw
+Escape harness: https://github.com/IronSecCo/ironclaw/tree/main/examples/red-team-escape
+
+---
+
+**Comment-reply seeds (for likely questions):**
+
+- *Why gVisor and not just Docker?* A plain container shares the host kernel.
+  gVisor puts a user-space kernel between the agent and the host, so a syscall
+  the sandbox does not allow never reaches the real kernel. It is a second
+  boundary, not a replacement for good container hygiene.
+- *Performance?* The measured cost is a one-time launch overhead, roughly +13 ms
+  warm and +39 ms cold, not a per-request tax. In-sandbox compute overhead is
+  near zero for light work. Numbers and the harness are on the benchmark page.
+- *Does it work offline?* Yes. Point it at Ollama with no credentials, and with
+  `network=none` the sandbox has no way out even if you wanted it to phone home.

--- a/docs/launch/reddit-programming.md
+++ b/docs/launch/reddit-programming.md
@@ -1,0 +1,59 @@
+# r/programming draft
+
+Audience: general engineers, skeptical of security marketing, reward substance
+and reproducibility. This subreddit prefers a link post pointing at something
+concrete (the escape harness or the benchmark page) with a plain-language first
+comment. Avoid hype words.
+
+---
+
+**Title:** We wrote an escape harness that tries to break our own AI agent sandbox, and made it a CI gate
+
+**Link target (pick one):**
+
+- The red-team escape harness: https://github.com/IronSecCo/ironclaw/tree/main/examples/red-team-escape
+- Or the write-up: the "Breaking our own sandbox" page on the docs site
+
+**First comment (post immediately after the link):**
+
+Most "secure agent" claims are a sentence in a README. We wanted ours to be a
+failing build if it stops being true, so we wrote the opposite of a happy-path
+demo.
+
+The setup: IronClaw runs each AI agent inside its own gVisor (`runsc`) sandbox,
+one per conversation, with `network=none`, a seccomp syscall allowlist, all Linux
+capabilities dropped, a non-root user namespace, and a read-only rootfs. Instead
+of trusting that, we hand a fully compromised agent a battery of attacks from
+inside the box:
+
+- reach the Docker Engine socket (host takeover if it works)
+- read arbitrary host paths
+- break out to sibling containers
+- rewrite its own binary
+- open network egress to exfiltrate
+
+Every core containment assertion holds: the Engine socket is never bound in, host
+paths stay contained, egress is blocked. The important part is that the same
+script is both the demo and a CI gate, so a regression that weakens the boundary
+fails the build rather than shipping quietly.
+
+Separately, the gVisor cost is measured on a public CI runner, not quoted from a
+machine you cannot see: about +13 ms on a warm respawn and +39 ms on a cold
+launch, paid once per sandbox launch, not per request. The benchmark harness is
+committed so you can reproduce it on your own hardware.
+
+It is self-hosted, AGPLv3 plus commercial, and the agent ships as a compiled Go
+binary so there is no source inside the sandbox to modify. Repo:
+https://github.com/IronSecCo/ironclaw
+
+Happy to answer hard questions about the threat model. The one thing I will not
+do is claim a boundary we have not tested.
+
+---
+
+**Notes for the publisher:**
+
+- r/programming heavily favors link posts over self-posts. Lead with the harness
+  or the write-up as the link, then drop the comment above.
+- Do not editorialize the title with superlatives. The claim in the title is
+  literally true and that is the whole appeal here.

--- a/docs/launch/reddit-selfhosted.md
+++ b/docs/launch/reddit-selfhosted.md
@@ -1,0 +1,59 @@
+# r/selfhosted draft
+
+Audience: people who run their own infrastructure and want to own the stack.
+Lead with self-hosting, data ownership, and deployment paths. Keep the security
+depth but frame it as "you control this," not "trust us."
+
+---
+
+**Title:** IronClaw: self-hosted runtime for AI agents that sandboxes each one in gVisor, no vendor holds your keys
+
+**Body:**
+
+If you want to run autonomous AI agents but do not want a SaaS vendor holding
+your API keys and your conversation data, this is built for that. IronClaw is a
+self-hosted agent runtime where the isolation is the product, not an afterthought.
+
+**What you actually run:** a control plane on your box plus a CLI (`ironctl`).
+Each conversation spins up its own gVisor (`runsc`) sandbox with `network=none`,
+a seccomp syscall allowlist, all Linux capabilities dropped, a non-root user
+namespace, and a read-only rootfs. Nothing the agent does reaches your host
+kernel directly, and by default it has no network path out.
+
+**Why self-hosters like it:**
+
+- Your keys and your data never leave your infrastructure. Credentials sit behind
+  an approval gateway, so the agent proposes an action and you hold the grant.
+- Bring your own model, including fully local via Ollama with zero credentials.
+- Deploy how you already deploy: there are templates for Fly, Render, and
+  Railway, a Helm chart for Kubernetes, Docker, and a Homebrew formula.
+- It is AGPLv3 plus commercial, so you can read every line and run it forever.
+
+**The trust part, stated honestly:** the containment boundary ships with a
+red-team escape harness that runs a compromised agent through escape,
+exfiltration, and self-modification attempts, and that harness runs as a CI gate
+on every push. There is also `ironctl scan`, which grades a running container's
+isolation from 0 to 100 across seven dimensions, so you can point it at your own
+setup and see where it stands.
+
+The sandbox overhead is small and measured on a public CI runner: about +13 ms
+warm and +39 ms cold per launch, not per request.
+
+Repo: https://github.com/IronSecCo/ironclaw
+
+I would love feedback from people running this on their own boxes, especially on
+the deployment paths and where the first-run experience has friction.
+
+---
+
+**Comment-reply seeds:**
+
+- *How hard is it to stand up?* One control plane plus the CLI. There are one
+  command deployment templates for the common PaaS options and a Helm chart for
+  k8s. If you hit friction, tell me exactly where and it becomes an issue.
+- *Does it phone home?* No. Self-hosted, and the per-conversation sandbox runs
+  `network=none` by default, so the agent has no egress unless you grant it.
+- *What is the catch with AGPLv3?* If you run a modified version as a network
+  service you share your changes. For most self-hosters running it as-is, it just
+  means you get the full source and can verify everything. A commercial license
+  exists if the AGPL terms do not fit your use.

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -1,0 +1,70 @@
+# Show HN draft
+
+Audience: Hacker News. Rewards technical honesty, reproducibility, and a founder
+who answers hard questions in the thread. Overclaiming gets punished fast here,
+so every line maps to shipped code.
+
+---
+
+**Title (must be 80 characters or fewer):**
+
+`Show HN: IronClaw, run each AI agent in its own gVisor sandbox (AGPLv3)`
+
+Alternate titles if the primary reads too long or too dry:
+
+- `Show HN: A self-hosted AI agent runtime that sandboxes each agent in gVisor`
+- `Show HN: IronClaw, we red-team our own AI agent sandbox as a CI gate`
+
+**First comment (post right after the submission):**
+
+Hi HN. IronClaw is a self-hosted runtime for autonomous AI agents. The premise
+is that the agent itself could be compromised, by prompt injection or a bad tool
+result, so it should run behind a boundary you can verify rather than one you
+have to trust.
+
+Each conversation runs in its own gVisor (`runsc`) sandbox: `network=none`, a
+seccomp syscall allowlist, all Linux capabilities dropped, a non-root user
+namespace, and a read-only rootfs. The agent ships as a compiled Go binary, so
+there is no source inside the box to rewrite. gVisor matters here because a plain
+container shares the host kernel, so a container escape is a host compromise. The
+user-space kernel gives you a second, syscall-level boundary.
+
+Two things I want to be judged on:
+
+1. The containment claim is tested, not asserted. There is a red-team escape
+   harness that hands a fully compromised agent a battery of escape,
+   exfiltration, and self-modification attempts from inside the box: reach the
+   Docker Engine socket, read host paths, break out to siblings, rewrite itself,
+   open egress. Every core assertion holds, and the same script runs as a CI gate
+   on every push, so a regression that weakens the boundary fails the build.
+
+2. The performance numbers are reproducible and measured on a public CI runner,
+   not a machine you cannot inspect. The gVisor cost is about +13 ms on a warm
+   respawn and +39 ms on a cold launch, paid once per sandbox, not per request.
+   The harness is committed so you can run it on your own hardware, and the memory
+   footprint is deliberately reported as not-captured on the locked-down CI runner
+   rather than faked as zero.
+
+It is AGPLv3 plus commercial. It runs fully local (Ollama with zero credentials)
+or with your own model. Credentials sit behind an approval gateway, so the agent
+proposes and you grant. There is also `ironctl scan`, which grades a running
+container's isolation from 0 to 100 so you can measure your own setup.
+
+Repo: https://github.com/IronSecCo/ironclaw
+
+I will be here to answer questions. The one thing I will not do is claim a
+boundary we have not tested, so if you find a gap in the threat model I want to
+hear it.
+
+---
+
+**Notes for the publisher:**
+
+- Verify the chosen title is 80 characters or fewer before submitting. The
+  primary title above is within the limit.
+- HN convention: submit the repo as the URL, then post the first comment
+  immediately so the top of the thread is context, not silence.
+- Do not front-load adjectives. The interesting claim is that the sandbox is
+  red-teamed as a CI gate. Let that carry the post.
+- Be present in the thread for the first two hours. On HN, the founder answering
+  fast and honestly is a bigger signal than the post copy.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ exclude_docs: |
   site/
   docs.json
   reference/openapi.yaml
+  launch/
 
 # docs/hooks.py copies api/openapi.yaml into the build and stamps the version.
 hooks:


### PR DESCRIPTION
## What

Pre-writes launch-ready posts under `docs/launch/` so an approved publisher can post instantly on each board-gated reach channel. Removes friction from the reach lever: copy is written, verified, and guardrail-safe.

## Deliverables (per IRO-426)
- **Reddit drafts**: r/LocalLLaMA, r/programming, r/selfhosted (audience-specific, not cross-posted)
- **Show HN**: title (71 chars, under 80) + first comment + 2 alternate titles
- **README.md**: TL;DR, containment-benchmark hook, link block, publishing guardrails, first-hour checklist

## Guardrails met
- No owner name, no personal GitHub/LinkedIn/Instagram (all links -> `github.com/IronSecCo` org)
- No em-dashes or en-dashes (IRO-254)
- Value-first framing; every capability claim maps to shipped code

## Claims sourced from shipped code
- gVisor (runsc) per-conversation sandbox: network=none, seccomp allowlist, caps dropped, non-root userns, read-only rootfs
- Red-team escape harness as CI gate (`examples/red-team-escape`)
- Reproducible benchmark: +13ms warm / +39ms cold, measured on public CI (`docs/benchmarks.md`)
- `ironctl scan` 0-100 containment grade; AGPLv3 plus commercial

## Build
Drafts are internal launch assets, excluded from the MkDocs build via `exclude_docs: launch/`, so they do not publish to the docs site and do not affect `mkdocs --strict`.

## Acceptance
- [x] PR opened
- [x] Links resolve (org repo + harness path verified)
- [x] Guardrails met (0 dashes, 0 personal identity, title <=80)

Refs IRO-426. Publishing itself remains board-gated; this ships the content so publish is one action.