### PR TITLE
feat(scan): ship ironctl scan as a GitHub Action (PR sandbox scorecard) (IRO-432)

### DIFF
--- a/.github/actions/scan/README.md
+++ b/.github/actions/scan/README.md
@@ -1,0 +1,100 @@
+# IronClaw sandbox scan — GitHub Action
+
+Grade the isolation posture of a container, a `docker-compose` service, or a
+Kubernetes manifest **0-100** on every pull request, post the scorecard as a
+sticky PR comment, and (optionally) fail the check when the score regresses.
+
+It wraps [`ironctl scan`](https://ironsecco.github.io/ironclaw/scan/): a local,
+read-only audit that inspects configuration (`docker inspect` / a compose or k8s
+file) and **never talks to any control-plane or needs credentials**. The only
+network access is downloading the released `ironctl` binary. Fail-closed: any
+dimension it cannot determine is graded as insecure.
+
+## Quick start
+
+```yaml
+name: Sandbox scorecard
+on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write        # needed only for the sticky comment
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start the container you want to grade
+        run: docker run -d --name my-sandbox my-image:latest sleep 3600
+      - uses: IronSecCo/ironclaw/.github/actions/scan@v1
+        with:
+          target: my-sandbox
+          min-score: 90        # omit / 0 = report-only, never blocks the check
+```
+
+That renders a scorecard like:
+
+> ### IronClaw containment scan: `my-sandbox` scored **100/100 (grade A)**
+>
+> | Dimension | Verdict | Score |
+> |---|---|---|
+> | Non-root user (uid != 0) | ✅ PASS | 15/15 |
+> | Dropped capabilities | ✅ PASS | 20/20 |
+> | … | … | … |
+
+## Modes
+
+Grade a **container**, a **compose** service, or a **k8s** manifest:
+
+```yaml
+# compose service (no Docker daemon needed — it reads the file)
+- uses: IronSecCo/ironclaw/.github/actions/scan@v1
+  with:
+    mode: compose
+    target: docker-compose.yml
+    service: app            # required only if the file has >1 service
+
+# kubernetes pod / workload manifest
+- uses: IronSecCo/ironclaw/.github/actions/scan@v1
+  with:
+    mode: k8s
+    target: deploy/pod.yaml
+```
+
+## Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `target` | *(required)* | Container name/id, or path to a compose/k8s file. |
+| `mode` | `container` | `container` \| `compose` \| `k8s`. |
+| `service` | `""` | Compose service name (when the file has more than one). |
+| `min-score` | `0` | Fail the check below this score. `0` = report-only. |
+| `comment` | `true` | Post the scorecard as a sticky PR comment. |
+| `badge` | `false` | Write and upload the SVG badge as a build artifact. |
+| `version` | `latest` | ironctl release to use (`latest` or a tag like `v0.1.252`). |
+| `github-token` | `${{ github.token }}` | Token for the comment + release lookup. |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `score` | Overall containment score (0-100). |
+| `grade` | Letter grade (A-F). |
+| `scorecard` | Path to the rendered markdown scorecard. |
+| `badge-path` | Path to the SVG badge (when `badge: true`). |
+| `passed` | `true` when the score met `min-score`. |
+
+## What it grades
+
+Seven boundaries whose breach is a full host compromise — non-root user, dropped
+capabilities, seccomp, `network=none`, read-only rootfs, no `docker.sock`
+exposure, and no shared host namespaces. See the
+[scan docs](https://ironsecco.github.io/ironclaw/scan/) for the weights and the
+grade bands.
+
+## Notes
+
+- The sticky comment updates in place (keyed by mode+target), so re-runs never
+  spam the PR. Multiple targets in one PR each get their own comment.
+- On non-PR events (push, dispatch) the scorecard is written to the job summary
+  instead of a comment.
+- Grant `pull-requests: write` if you want the comment; without it the action
+  still runs and gates, it just skips commenting.

--- a/.github/actions/scan/action.yml
+++ b/.github/actions/scan/action.yml
@@ -1,0 +1,104 @@
+# IronClaw scan — sandbox containment scorecard in CI.
+#
+# Grades the isolation posture of a running container, a docker-compose service,
+# or a Kubernetes manifest 0-100 with `ironctl scan`, posts the scorecard as a
+# sticky pull-request comment (create-or-update, never spam), and optionally
+# fails the check when the score drops below a threshold.
+#
+# It is LOCAL and read-only: it inspects configuration (docker inspect / a
+# compose or k8s file), never talks to any control-plane, and needs no
+# credentials. The only network access is downloading the released `ironctl`
+# binary from GitHub Releases. Fail-closed: any dimension it cannot determine is
+# graded as insecure.
+#
+# Usage (in a consumer repo):
+#
+#   - uses: IronSecCo/ironclaw/.github/actions/scan@v1
+#     with:
+#       target: my-container          # container name/id, or file path for compose/k8s
+#       mode: container               # container | compose | k8s
+#       min-score: 0                  # 0 = report-only; >0 fails the check below it
+#
+# See docs/scan-action.md for the full guide.
+name: 'IronClaw sandbox scan'
+description: 'Grade a container / compose / k8s sandbox isolation posture 0-100 and post a sticky PR scorecard.'
+author: 'IronSec Co.'
+branding:
+  icon: 'shield'
+  color: 'blue'
+
+inputs:
+  target:
+    description: 'What to scan: a running container name/id (mode=container), or a path to a compose/k8s file (mode=compose|k8s).'
+    required: true
+  mode:
+    description: 'Scan mode: container | compose | k8s.'
+    required: false
+    default: 'container'
+  service:
+    description: 'Compose service name (required only when mode=compose and the file has more than one service).'
+    required: false
+    default: ''
+  min-score:
+    description: 'Fail the check when the containment score is below this (0-100). 0 = report-only (default).'
+    required: false
+    default: '0'
+  comment:
+    description: 'Post the scorecard as a sticky comment on the pull request (true/false).'
+    required: false
+    default: 'true'
+  badge:
+    description: 'Write and upload the shareable SVG badge as a build artifact (true/false).'
+    required: false
+    default: 'false'
+  version:
+    description: 'ironctl release to use: a tag like v0.1.252, or "latest" (default).'
+    required: false
+    default: 'latest'
+  github-token:
+    description: 'Token used to post the PR comment and resolve the latest release. Defaults to the workflow token.'
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  score:
+    description: 'The overall containment score (0-100).'
+    value: ${{ steps.scan.outputs.score }}
+  grade:
+    description: 'The letter grade (A-F).'
+    value: ${{ steps.scan.outputs.grade }}
+  scorecard:
+    description: 'Path to the rendered markdown scorecard.'
+    value: ${{ steps.scan.outputs.scorecard }}
+  badge-path:
+    description: 'Path to the SVG badge (only when badge=true).'
+    value: ${{ steps.scan.outputs.badge-path }}
+  passed:
+    description: 'true when the score met min-score (or min-score was 0).'
+    value: ${{ steps.scan.outputs.passed }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: scan
+      shell: bash
+      env:
+        IC_TARGET: ${{ inputs.target }}
+        IC_MODE: ${{ inputs.mode }}
+        IC_SERVICE: ${{ inputs.service }}
+        IC_MIN_SCORE: ${{ inputs.min-score }}
+        IC_COMMENT: ${{ inputs.comment }}
+        IC_BADGE: ${{ inputs.badge }}
+        IC_VERSION: ${{ inputs.version }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: bash "${GITHUB_ACTION_PATH}/scan.sh"
+
+    # Uploaded as a separate composite step, with always(), so the artifact
+    # survives even when the scan step fails the min-score gate after the badge
+    # file is already written.
+    - if: ${{ always() && inputs.badge == 'true' && steps.scan.outputs.badge-path != '' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ironclaw-scan-badge
+        path: ${{ steps.scan.outputs.badge-path }}
+        if-no-files-found: warn

--- a/.github/actions/scan/scan.sh
+++ b/.github/actions/scan/scan.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# IronClaw scan action — install ironctl, grade the target, post a sticky PR
+# scorecard, and gate on min-score. Read-only and credential-free; the only
+# egress is the ironctl release download.
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Inputs (from action.yml env).
+# ---------------------------------------------------------------------------
+MODE="${IC_MODE:-container}"
+TARGET="${IC_TARGET:-}"
+SERVICE="${IC_SERVICE:-}"
+MIN_SCORE="${IC_MIN_SCORE:-0}"
+COMMENT="${IC_COMMENT:-true}"
+BADGE="${IC_BADGE:-false}"
+VERSION="${IC_VERSION:-latest}"
+
+REPO="IronSecCo/ironclaw"
+WORK="${RUNNER_TEMP:-/tmp}/ironclaw-scan"
+mkdir -p "$WORK"
+
+out() { echo "$1=$2" >>"${GITHUB_OUTPUT:-/dev/stdout}"; }
+die() { echo "::error::$*" >&2; exit 1; }
+
+[ -n "$TARGET" ] || die "input 'target' is required"
+case "$MODE" in
+  container|compose|k8s) : ;;
+  *) die "input 'mode' must be one of: container | compose | k8s (got '$MODE')" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 1. Install ironctl from GitHub Releases (linux/amd64 or arm64).
+# ---------------------------------------------------------------------------
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$(uname -m)" in
+  x86_64|amd64) arch="amd64" ;;
+  aarch64|arm64) arch="arm64" ;;
+  *) die "unsupported CPU architecture: $(uname -m)" ;;
+esac
+
+# Resolve the tag (vX.Y.Z) and the version (X.Y.Z) used in the archive name.
+tag="$VERSION"
+if [ -z "$tag" ] || [ "$tag" = "latest" ]; then
+  tag="$(gh api "repos/${REPO}/releases/latest" --jq .tag_name 2>/dev/null || true)"
+  [ -n "$tag" ] || tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
+fi
+[ -n "$tag" ] || die "could not resolve the latest ironctl release tag"
+ver="${tag#v}"
+
+archive="ironclaw_${ver}_${os}_${arch}.tar.gz"
+url="https://github.com/${REPO}/releases/download/${tag}/${archive}"
+echo "==> installing ironctl ${tag} (${os}/${arch})"
+echo "    ${url}"
+curl -fsSL "$url" -o "${WORK}/${archive}" || die "download failed: ${url}"
+tar -xzf "${WORK}/${archive}" -C "${WORK}" || die "could not extract ${archive}"
+IRONCTL="$(find "${WORK}" -maxdepth 2 -type f -name ironctl | head -1)"
+[ -n "$IRONCTL" ] || die "archive ${archive} did not contain an 'ironctl' binary"
+chmod +x "$IRONCTL"
+"$IRONCTL" version || true
+
+# ---------------------------------------------------------------------------
+# 2. Build the scan arguments for the requested mode.
+# ---------------------------------------------------------------------------
+scorecard="${WORK}/scorecard.md"
+badge_path=""
+scan_args=()
+case "$MODE" in
+  container)
+    scan_args+=("$TARGET")
+    ;;
+  compose)
+    scan_args+=(--compose "$TARGET")
+    [ -n "$SERVICE" ] && scan_args+=(--service "$SERVICE")
+    ;;
+  k8s)
+    scan_args+=(--k8s "$TARGET")
+    ;;
+esac
+scan_args+=(--md)
+if [ "$BADGE" = "true" ]; then
+  badge_path="${WORK}/scan-badge.svg"
+  scan_args+=(--badge "$badge_path")
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Run the scan. Capture the full output; we do NOT pass --min-score so the
+#    binary always exits 0 here — the gate runs in bash after we comment, so a
+#    failing score still gets a scorecard posted.
+# ---------------------------------------------------------------------------
+raw="${WORK}/scan.out"
+set +e
+"$IRONCTL" scan "${scan_args[@]}" >"$raw" 2>&1
+rc=$?
+set -e
+cat "$raw"
+if [ "$rc" -ne 0 ]; then
+  die "ironctl scan failed (exit $rc). See output above."
+fi
+
+# The markdown block starts at the RenderMarkdown header line; slice from there.
+sed -n '/^### IronClaw containment scan:/,$p' "$raw" >"$scorecard"
+[ -s "$scorecard" ] || die "could not extract the markdown scorecard from scan output"
+
+# Parse the score/grade from the header: "... scored **NN/100 (grade X)**".
+score="$(sed -nE 's/.*scored \*\*([0-9]+)\/100.*/\1/p' "$scorecard" | head -1)"
+grade="$(sed -nE 's/.*\(grade ([A-F])\).*/\1/p' "$scorecard" | head -1)"
+[ -n "$score" ] || die "could not parse the containment score"
+echo "==> containment score: ${score}/100 (grade ${grade:-?})"
+
+out score "$score"
+out grade "${grade:-?}"
+out scorecard "$scorecard"
+[ -n "$badge_path" ] && out badge-path "$badge_path"
+
+# ---------------------------------------------------------------------------
+# 4. Sticky PR comment (create-or-update). A stable marker keyed by mode+target
+#    lets one PR carry several scorecards without clobbering each other.
+# ---------------------------------------------------------------------------
+pr=""
+if [ -f "${GITHUB_EVENT_PATH:-/nonexistent}" ]; then
+  pr="$(jq -r '.pull_request.number // .issue.number // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"
+fi
+if [ "$COMMENT" = "true" ] && [ -n "$pr" ] && [ -n "${GH_TOKEN:-}" ]; then
+  marker="<!-- ironclaw-scan-scorecard:${MODE}:${TARGET} -->"
+  body="${WORK}/comment.md"
+  { echo "$marker"; cat "$scorecard"; } >"$body"
+
+  # Find an existing comment carrying our marker and update it; else create one.
+  existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" --paginate \
+      --jq "map(select(.body | contains(\"${marker}\"))) | .[0].id // empty" 2>/dev/null || true)"
+  if [ -n "$existing" ]; then
+    gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" \
+      -f body="$(cat "$body")" >/dev/null \
+      && echo "==> updated sticky scorecard comment (#${existing})" \
+      || echo "::warning::could not update the scorecard comment"
+  else
+    gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" \
+      -f body="$(cat "$body")" >/dev/null \
+      && echo "==> posted scorecard comment on PR #${pr}" \
+      || echo "::warning::could not post the scorecard comment"
+  fi
+elif [ "$COMMENT" = "true" ]; then
+  echo "==> not a pull-request event (or no token); skipping the sticky comment"
+fi
+
+# Job summary is always useful, PR or not.
+{ echo "## IronClaw sandbox scan"; echo; cat "$scorecard"; } >>"${GITHUB_STEP_SUMMARY:-/dev/null}" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# 5. Gate: fail the check when below min-score (0 = report-only).
+# ---------------------------------------------------------------------------
+if [ "$MIN_SCORE" -gt 0 ] && [ "$score" -lt "$MIN_SCORE" ]; then
+  out passed "false"
+  die "containment score ${score}/100 is below the required ${MIN_SCORE}"
+fi
+out passed "true"
+echo "==> scan passed (score ${score} >= min-score ${MIN_SCORE})"

--- a/.github/workflows/scan-scorecard.yml
+++ b/.github/workflows/scan-scorecard.yml
@@ -1,0 +1,80 @@
+name: Sandbox scan scorecard (dogfood)
+
+# Green-run proof + live example for the reusable `IronClaw sandbox scan` action
+# (.github/actions/scan). It runs the exact thing an external adopter runs —
+# `uses: <the action>` against real containers — so a broken action surfaces here
+# before an adopter hits it, and this PR itself renders the scorecard comments.
+#
+# Two contrasting targets prove the grader both ways:
+#   * a HARDENED container  -> ~100/A, gated at min-score 90 (must pass)
+#   * a WEAK container       -> ~0/F,  report-only (min-score 0, never blocks)
+#
+# Credential-free: ubuntu ships Docker; the action downloads the released ironctl
+# binary. Additive and non-gating (not a required check) so it can never block a
+# release.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/actions/scan/**"
+      - ".github/workflows/scan-scorecard.yml"
+  pull_request:
+    paths:
+      - ".github/actions/scan/**"
+      - ".github/workflows/scan-scorecard.yml"
+  workflow_dispatch:
+
+# Least-privilege: read the repo, and write PR comments for the sticky scorecard.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Start a HARDENED sandbox container
+        run: |
+          docker run -d --name hardened-sandbox \
+            --user 65532:65532 \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --network none \
+            --read-only \
+            alpine:3 sleep 3600
+
+      - name: Start a WEAK sandbox container (contrast)
+        run: |
+          docker run -d --name weak-sandbox \
+            --privileged \
+            --network host \
+            alpine:3 sleep 3600
+
+      - name: Scan the hardened sandbox (gated at 90)
+        id: hardened
+        uses: ./.github/actions/scan
+        with:
+          target: hardened-sandbox
+          mode: container
+          min-score: 90
+          badge: true
+
+      - name: Scan the weak sandbox (report-only)
+        uses: ./.github/actions/scan
+        with:
+          target: weak-sandbox
+          mode: container
+          min-score: 0
+
+      - name: Assert the hardened container graded A
+        env:
+          SCORE: ${{ steps.hardened.outputs.score }}
+          GRADE: ${{ steps.hardened.outputs.grade }}
+        run: |
+          echo "hardened score=${SCORE} grade=${GRADE}"
+          test "${GRADE}" = "A" \
+            || { echo "::error::expected the hardened container to grade A"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Each one runs sealed in a sandbox that provably cannot phone home, read your hos
 [![Signed releases (cosign)](https://img.shields.io/badge/releases-cosign%20signed-0a7bbb.svg)](#verifying-a-release)
 [![SBOM: SPDX + CycloneDX](https://img.shields.io/badge/SBOM-SPDX%20%2B%20CycloneDX-44883e.svg)](#verifying-a-release)
 [![SLSA provenance](https://img.shields.io/badge/SLSA-build%20provenance-44883e.svg)](#verifying-a-release)
+[![Sandbox scan: PR scorecard](https://img.shields.io/badge/sandbox%20scan-PR%20scorecard-0a7bbb.svg)](https://ironsecco.github.io/ironclaw/scan-action/)
 
 [![Documentation](https://img.shields.io/badge/docs-ironsecco.github.io-0a7bbb.svg)](https://ironsecco.github.io/ironclaw/)
 [![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#project-status)

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -22,6 +22,7 @@ nav:
       - Troubleshooting: troubleshooting.md
       - FAQ: faq.md
   - Scan any container: scan.md
+  - Scan in CI (GitHub Action): scan-action.md
   - Model providers: providers
   - Tutorials: tutorials
   - Examples & use cases: examples.md

--- a/docs/scan-action.md
+++ b/docs/scan-action.md
@@ -1,0 +1,102 @@
+# Scan in CI: a sandbox scorecard on every pull request
+
+The [`ironctl scan`](scan.md) audit also ships as a **GitHub Action**, so every
+repository can render an IronClaw containment scorecard right in its pull
+requests and gate merges on isolation posture. It is the same local, read-only,
+credential-free grader; the action just installs `ironctl`, runs it against your
+target, and posts the result as a sticky PR comment.
+
+## Add it to your workflow
+
+```yaml
+name: Sandbox scorecard
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: write        # only needed for the sticky comment
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start the container you want to grade
+        run: docker run -d --name my-sandbox my-image:latest sleep 3600
+
+      - uses: IronSecCo/ironclaw/.github/actions/scan@v1
+        with:
+          target: my-sandbox
+          min-score: 90        # omit / 0 = report-only, never blocks the check
+```
+
+On the pull request you get a scorecard comment that updates in place on every
+push:
+
+> ### IronClaw containment scan: `my-sandbox` scored **100/100 (grade A)**
+>
+> | Dimension | Verdict | Score |
+> |---|---|---|
+> | Non-root user (uid != 0) | :white_check_mark: PASS | 15/15 |
+> | Dropped capabilities | :white_check_mark: PASS | 20/20 |
+> | Seccomp profile | :white_check_mark: PASS | 15/15 |
+> | Network isolation / egress | :white_check_mark: PASS | 15/15 |
+> | Read-only root filesystem | :white_check_mark: PASS | 10/10 |
+> | No docker.sock exposure | :white_check_mark: PASS | 15/15 |
+> | No shared host namespaces | :white_check_mark: PASS | 10/10 |
+
+## Grade a compose service or a k8s manifest
+
+The file modes need no Docker daemon — the action reads the file directly:
+
+```yaml
+# a docker-compose service
+- uses: IronSecCo/ironclaw/.github/actions/scan@v1
+  with:
+    mode: compose
+    target: docker-compose.yml
+    service: app            # required only if the file has >1 service
+
+# a Kubernetes pod / workload manifest
+- uses: IronSecCo/ironclaw/.github/actions/scan@v1
+  with:
+    mode: k8s
+    target: deploy/pod.yaml
+```
+
+## Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `target` | *(required)* | Container name/id, or path to a compose/k8s file. |
+| `mode` | `container` | `container`, `compose`, or `k8s`. |
+| `service` | `""` | Compose service name (when the file has more than one). |
+| `min-score` | `0` | Fail the check below this score. `0` = report-only. |
+| `comment` | `true` | Post the scorecard as a sticky PR comment. |
+| `badge` | `false` | Write and upload the SVG badge as a build artifact. |
+| `version` | `latest` | ironctl release (`latest` or a tag like `v0.1.252`). |
+| `github-token` | `${{ github.token }}` | Token for the comment + release lookup. |
+
+Outputs: `score`, `grade`, `scorecard` (path), `badge-path`, and `passed`.
+
+## Report-only vs. gating
+
+- Leave `min-score` at `0` (the default) to run **report-only**: the scorecard
+  is posted and the check always passes. Good for adopting the action without
+  risk, or watching a score trend before you enforce it.
+- Set `min-score` (for example `90` for an A) to **gate**: the check fails when
+  the posture regresses below the bar. The comment is still posted first, so
+  reviewers see exactly which dimension slipped.
+
+## How it works
+
+The action downloads the released `ironctl` binary, runs `ironctl scan` against
+your target, extracts the markdown scorecard, and posts it. The sticky comment
+is keyed by mode + target, so re-runs update in place instead of spamming, and
+multiple targets in one PR each keep their own comment. On non-PR events the
+scorecard goes to the job summary instead.
+
+Everything the [scan](scan.md) command guarantees still holds: it is local and
+read-only, it never talks to a control-plane, it needs no credentials, and it is
+fail-closed. See [`.github/actions/scan`](https://github.com/IronSecCo/ironclaw/tree/main/.github/actions/scan)
+for the action source, and the [scan reference](scan.md) for the dimension
+weights and grade bands.

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -88,6 +88,10 @@ Grades map to bands: A is 90 or above, B is 75 to 89, C is 50 to 74, D is 25 to
 ironctl scan my-sandbox --min-score 90
 ```
 
+On GitHub, the [scan GitHub Action](scan-action.md) does this for you: it posts
+the scorecard as a sticky pull-request comment and fails the check below your
+`min-score`, so every PR carries an IronClaw containment grade.
+
 ## What a hardened target looks like
 
 An IronClaw `ic-sbx-*` sandbox scores a clean 100:


### PR DESCRIPTION
## What

Turns `ironctl scan` (IRO-425) into a **no-account distribution vector**: a composite GitHub Action that renders an IronClaw isolation scorecard in every adopter's pull requests. Zero board dependency — the one reach lever agents can pull.

### Deliverable
- **`.github/actions/scan`** — composite action (`action.yml` + `scan.sh` + `README.md`):
  - runs `ironctl scan` against a **container / `--compose` / `--k8s`** target
  - posts the `--md` scorecard as a **sticky PR comment** (create-or-update, keyed by mode+target — never spams; multiple targets each keep their own comment)
  - **fails the check** when score < `min-score` (default `0` = report-only)
  - optionally uploads the `--badge` SVG artifact
  - installs the released `ironctl` binary; local, read-only, credential-free, fail-closed
  - inputs: `target`, `mode`, `service`, `min-score`, `comment`, `badge`, `version`, `github-token`; outputs: `score`, `grade`, `scorecard`, `badge-path`, `passed`
- **`.github/workflows/scan-scorecard.yml`** — dogfood + live example: scans a **hardened** container (gated at 90, must grade A) and a **weak** one (report-only), so this PR itself shows both a passing and a failing scorecard. Additive, non-gating.
- **`docs/scan-action.md`** (+ nav) and a cross-link from `scan.md`; README badge.

## Verification
- `ironctl scan --md` parse pipeline validated on real hardened (100/A) + weak (0/F) targets
- gate logic: hardened passes @ min-score 90; weak correctly fails @ 90; report-only (0) passes
- `shellcheck` clean on `scan.sh`; `actionlint` clean on the workflow; `action.yml` valid YAML
- **live green smoke** comes from the dogfood workflow on this PR: weak → low-score comment, hardened → high-score comment

## Security lenses
- **Egress least-privilege**: only network access is the ironctl release download; scan is read-only config inspection, no control-plane, no credentials.
- **Trust boundary**: nothing sandbox-facing changes; this is host-side CI tooling.
- Workflow uses `permissions: contents: read` + `pull-requests: write` (only for the comment); untrusted inputs kept out of `run:` eval.

Self-contained on scan code already on `main`. No contract changes.

Closes IRO-432.