### PR TITLE
feat(scan): Podman + nerdctl/containerd runtime coverage + hardened-runtime detection (IRO-435)

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -36,7 +36,10 @@ func cmdScan(args []string) error {
 	compose := fs.String("compose", "", "grade a service in this docker-compose file")
 	service := fs.String("service", "", "compose service name (required if the file has >1 service)")
 	k8s := fs.String("k8s", "", "grade the first container in this Kubernetes pod/workload manifest")
+	runtime := fs.String("runtime", envOrDefault("IRONCTL_SCAN_RUNTIME", "auto"), "container runtime: auto|docker|podman|nerdctl")
 	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker inspect`")
+	podmanBin := fs.String("podman-bin", envOrDefault("PODMAN", "podman"), "podman binary used for `podman inspect`")
+	nerdctlBin := fs.String("nerdctl-bin", envOrDefault("NERDCTL", "nerdctl"), "nerdctl binary used for `nerdctl inspect`")
 	minScore := fs.Int("min-score", 0, "exit non-zero if the score is below this threshold (CI gate)")
 	fs.Usage = func() { scanUsage(os.Stdout) }
 	// Go's flag package stops at the first positional, so `scan <target> --json`
@@ -82,7 +85,8 @@ func cmdScan(args []string) error {
 		if len(positional) > 1 {
 			return fmt.Errorf("scan grades one target at a time; got %d: %s", len(positional), strings.Join(positional, " "))
 		}
-		spec, err = dockerSpec(*dockerBin, positional[0])
+		bins := runtimeBins{docker: *dockerBin, podman: *podmanBin, nerdctl: *nerdctlBin}
+		spec, err = containerSpec(*runtime, bins, positional[0])
 	}
 	if err != nil {
 		return err
@@ -131,32 +135,110 @@ func cmdScan(args []string) error {
 	return nil
 }
 
-// dockerSpec runs `docker inspect <target>` and parses the result into a Spec.
-func dockerSpec(dockerBin, target string) (scan.Spec, error) {
-	cmd := exec.Command(dockerBin, "inspect", target)
-	out, err := cmd.Output()
+// runtimeBins carries the resolved binary name for each supported runtime.
+type runtimeBins struct{ docker, podman, nerdctl string }
+
+// containerSpec inspects a running container with the selected (or auto-detected)
+// OCI runtime and parses the result into a Spec. It fails closed: an unknown or
+// unreachable runtime returns a clear error rather than a silent empty scan.
+func containerSpec(runtime string, bins runtimeBins, target string) (scan.Spec, error) {
+	rt := strings.ToLower(strings.TrimSpace(runtime))
+	if rt == "" || rt == "auto" {
+		detected, err := detectRuntime(bins)
+		if err != nil {
+			return scan.Spec{}, err
+		}
+		rt = detected
+	}
+
+	switch rt {
+	case "docker":
+		out, err := runInspect(bins.docker, "docker", target)
+		if err != nil {
+			return scan.Spec{}, err
+		}
+		return scan.SpecFromDockerInspect(out)
+	case "podman":
+		out, err := runInspect(bins.podman, "podman", target)
+		if err != nil {
+			return scan.Spec{}, err
+		}
+		return scan.SpecFromPodmanInspect(out, podmanRootless(bins.podman))
+	case "nerdctl":
+		out, err := runInspect(bins.nerdctl, "nerdctl", target)
+		if err != nil {
+			return scan.Spec{}, err
+		}
+		return scan.SpecFromNerdctlInspect(out)
+	default:
+		return scan.Spec{}, fmt.Errorf("unknown --runtime %q: expected auto|docker|podman|nerdctl", runtime)
+	}
+}
+
+// detectRuntime picks the first runtime whose CLI is on PATH, preferring docker,
+// then podman, then nerdctl. Fails closed with actionable guidance when none is
+// found so a missing runtime never masquerades as a clean scan.
+func detectRuntime(bins runtimeBins) (string, error) {
+	for _, c := range []struct{ name, bin string }{
+		{"docker", bins.docker},
+		{"podman", bins.podman},
+		{"nerdctl", bins.nerdctl},
+	} {
+		if _, err := exec.LookPath(c.bin); err == nil {
+			return c.name, nil
+		}
+	}
+	return "", fmt.Errorf("no container runtime found (looked for docker, podman, nerdctl on PATH); install one or pass --runtime and the matching --<runtime>-bin")
+}
+
+// runInspect runs `<bin> inspect <target>` and returns its stdout, surfacing the
+// runtime's own stderr on failure.
+func runInspect(bin, runtime, target string) ([]byte, error) {
+	if _, err := exec.LookPath(bin); err != nil {
+		return nil, fmt.Errorf("%s runtime selected but %q is not on PATH: %w", runtime, bin, err)
+	}
+	out, err := exec.Command(bin, "inspect", target).Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
 			msg := strings.TrimSpace(string(ee.Stderr))
 			if msg == "" {
 				msg = err.Error()
 			}
-			return scan.Spec{}, fmt.Errorf("docker inspect %s: %s", target, msg)
+			return nil, fmt.Errorf("%s inspect %s: %s", runtime, target, msg)
 		}
-		return scan.Spec{}, fmt.Errorf("run %s inspect: %w (is Docker installed and the container running?)", dockerBin, err)
+		return nil, fmt.Errorf("run %s inspect: %w (is %s running and the container up?)", bin, err, runtime)
 	}
-	return scan.SpecFromDockerInspect(out)
+	return out, nil
+}
+
+// podmanRootless probes `podman info` for the daemon-level rootless flag. On any
+// error it returns Unknown; the podman adapter then falls back to the per-container
+// uid-map evidence, so this is best-effort corroboration, not a hard dependency.
+func podmanRootless(bin string) scan.Tristate {
+	out, err := exec.Command(bin, "info", "--format", "{{.Host.Security.Rootless}}").Output()
+	if err != nil {
+		return scan.Unknown
+	}
+	switch strings.TrimSpace(string(out)) {
+	case "true":
+		return scan.Yes
+	case "false":
+		return scan.No
+	default:
+		return scan.Unknown
+	}
 }
 
 func scanUsage(w *os.File) {
 	fmt.Fprint(w, `ironctl scan — grade a container's containment posture (0-100)
 
 USAGE:
-  ironctl scan <container>                    grade a running docker container
+  ironctl scan <container>                    grade a running container (docker|podman|nerdctl)
   ironctl scan --compose FILE [--service N]   grade a docker-compose service
   ironctl scan --k8s FILE                     grade a Kubernetes pod/workload manifest
 
 FLAGS:
+  --runtime NAME      container runtime: auto|docker|podman|nerdctl (default: auto)
   --json              emit the scorecard as JSON
   --fix               emit concrete remediation config for each failed dimension
   --remediate         alias for --fix
@@ -165,6 +247,14 @@ FLAGS:
   --min-score N       exit non-zero if the score is below N (CI gate)
   --service NAME      compose service to grade (if the file has >1)
   --docker-bin BIN    docker binary for `+"`docker inspect`"+` (default: docker)
+  --podman-bin BIN    podman binary for `+"`podman inspect`"+` (default: podman)
+  --nerdctl-bin BIN   nerdctl binary for `+"`nerdctl inspect`"+` (default: nerdctl)
+
+Runtime is auto-detected (docker, then podman, then nerdctl on PATH); override
+with --runtime. Rootless podman is credited: a userns remap of container-uid 0
+to an unprivileged host uid earns credit on the non-root dimension. A recognized
+hardened runtime (gVisor/Kata/Firecracker) is surfaced informationally, but per
+IRO-429 scoring stays runtime-agnostic (no points for a runtime name).
 
 Dimensions graded: non-root user, dropped capabilities, seccomp, network
 isolation, read-only rootfs, docker.sock exposure, shared host namespaces.

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -37,7 +37,56 @@ ironctl scan --compose docker-compose.yml --service web
 
 # grade a Kubernetes pod or workload manifest (Deployment, StatefulSet, ...)
 ironctl scan --k8s pod.yaml
+
+# force a specific runtime (default is auto-detect)
+ironctl scan --runtime podman my-container
 ```
+
+## Supported runtimes
+
+`ironctl scan` audits any OCI container, not just Docker. It auto-detects the
+available runtime (in order: docker, then podman, then nerdctl on your PATH) and
+picks the matching adapter; override it with `--runtime`. It grades host-side
+inspect data, so probe-masking from inside the container cannot change the score.
+
+| Runtime | How it is graded | Notes |
+|---|---|---|
+| `docker` | `docker inspect` | the default; also covers Docker-compatible engines |
+| `podman` | `podman inspect` | rootless is detected and credited (see below) |
+| `nerdctl` / containerd | `nerdctl inspect` | Docker-compatible schema; containerd runtime handlers (for example `io.containerd.runsc.v1`) are recognized |
+| compose | `--compose FILE` | grades a service from the file, no runtime needed |
+| Kubernetes | `--k8s FILE` | grades a pod or workload manifest, no runtime needed |
+
+Selection and binaries:
+
+```bash
+ironctl scan --runtime auto CONTAINER      # auto-detect (default)
+ironctl scan --runtime podman CONTAINER    # force podman
+ironctl scan --podman-bin /usr/bin/podman CONTAINER
+```
+
+The runtime is resolved fail-closed: if the selected (or auto-detected) runtime
+is not on your PATH or cannot reach a running container, the scan errors with a
+clear message instead of returning a misleadingly clean report. `--docker-bin`,
+`--podman-bin`, and `--nerdctl-bin` (or the `DOCKER`, `PODMAN`, `NERDCTL`
+environment variables) point at a non-default binary.
+
+### Rootless Podman is credited
+
+A rootless container runs inside a user namespace that remaps container-uid 0 to
+an unprivileged host uid, so a container-root escape lands as an unprivileged
+host user rather than host root. That is a real isolation win, so a rootless
+Podman container earns credit on the non-root dimension even when the process
+inside the container is uid 0. Rootless mode is detected from `podman info` and,
+when present, from the container's user-namespace uid map.
+
+### Hardened runtimes are surfaced, not scored
+
+When a container runs under a recognized strong-isolation runtime (gVisor /
+`runsc`, Kata Containers, or Firecracker), the scorecard names it as an
+informational line. Scoring stays runtime-agnostic on purpose: a container can
+name a hardened runtime and still be misconfigured, so no points are awarded for
+the runtime name. The dimension scorers remain the authority on the score.
 
 ## Output formats
 

--- a/internal/host/scan/docker.go
+++ b/internal/host/scan/docker.go
@@ -7,7 +7,8 @@ import (
 )
 
 // dockerInspect is the subset of `docker inspect <container>` we grade. Docker
-// serializes an ARRAY of these (one per queried container).
+// serializes an ARRAY of these (one per queried container). nerdctl emits a
+// Docker-compatible schema, so its adapter reuses this type too.
 type dockerInspect struct {
 	ID     string `json:"Id"`
 	Name   string `json:"Name"`
@@ -33,69 +34,132 @@ type dockerInspect struct {
 	} `json:"Mounts"`
 }
 
+// dockerLikeFields is the normalized, source-agnostic subset that the Docker,
+// Podman, and nerdctl inspect schemas all reduce to. Extracting it lets a single
+// grading body (specFromDockerLike) serve all three OCI runtimes; each adapter
+// only has to fill this struct from its own JSON shape.
+type dockerLikeFields struct {
+	id, name, user, image, runtime string
+	networkMode, pidMode, ipcMode  string
+	privileged, readonlyRootfs     bool
+	capAdd, capDrop, securityOpt   []string
+	binds                          []string
+	mounts                         []mountPair
+	// rootless is the userns-remap posture (rootless Podman / explicit userns);
+	// Unknown for plain Docker unless the adapter determines it.
+	rootless      Tristate
+	userNSHostUID string
+}
+
+// mountPair is one host->container bind, source and destination.
+type mountPair struct{ src, dst string }
+
+// fieldsFromDockerInspect reduces a dockerInspect to the shared normalized form.
+func (d dockerInspect) fields() dockerLikeFields {
+	f := dockerLikeFields{
+		id:             d.ID,
+		name:           d.Name,
+		user:           d.Config.User,
+		image:          d.Config.Image,
+		runtime:        d.HostConfig.Runtime,
+		networkMode:    d.HostConfig.NetworkMode,
+		pidMode:        d.HostConfig.PidMode,
+		ipcMode:        d.HostConfig.IpcMode,
+		privileged:     d.HostConfig.Privileged,
+		readonlyRootfs: d.HostConfig.ReadonlyRootfs,
+		capAdd:         d.HostConfig.CapAdd,
+		capDrop:        d.HostConfig.CapDrop,
+		securityOpt:    d.HostConfig.SecurityOpt,
+		binds:          d.HostConfig.Binds,
+		rootless:       Unknown,
+	}
+	for _, m := range d.Mounts {
+		f.mounts = append(f.mounts, mountPair{m.Source, m.Destination})
+	}
+	return f
+}
+
 // SpecFromDockerInspect parses the JSON emitted by `docker inspect <container>`
 // (an array) into a Spec for the first entry. It is pure: give it the bytes and
 // it grades them, so it is unit-testable without a Docker daemon.
 func SpecFromDockerInspect(raw []byte) (Spec, error) {
+	f, err := firstDockerInspect(raw)
+	if err != nil {
+		return Spec{}, err
+	}
+	return specFromDockerLike(f, "docker"), nil
+}
+
+// firstDockerInspect unmarshals a docker/nerdctl inspect blob (array or single
+// object) and returns the normalized fields of the first entry.
+func firstDockerInspect(raw []byte) (dockerLikeFields, error) {
 	var arr []dockerInspect
 	if err := json.Unmarshal(raw, &arr); err != nil {
 		// Tolerate a single (non-array) object too.
 		var one dockerInspect
 		if err2 := json.Unmarshal(raw, &one); err2 != nil {
-			return Spec{}, fmt.Errorf("parse docker inspect: %w", err)
+			return dockerLikeFields{}, fmt.Errorf("parse inspect: %w", err)
 		}
 		arr = []dockerInspect{one}
 	}
 	if len(arr) == 0 {
-		return Spec{}, fmt.Errorf("docker inspect returned no containers")
+		return dockerLikeFields{}, fmt.Errorf("inspect returned no containers")
 	}
-	d := arr[0]
+	return arr[0].fields(), nil
+}
 
+// specFromDockerLike grades the shared normalized fields into a Spec. It is the
+// single source of truth for the Docker-family (docker/podman/nerdctl) posture
+// extraction; each adapter fills dockerLikeFields from its own JSON and stamps
+// the source label.
+func specFromDockerLike(f dockerLikeFields, source string) Spec {
 	s := Spec{
-		Source:  "docker",
-		Target:  strings.TrimPrefix(d.Name, "/"),
-		Image:   strings.TrimSpace(d.Config.Image),
-		Runtime: d.HostConfig.Runtime,
+		Source:        source,
+		Target:        strings.TrimPrefix(f.name, "/"),
+		Image:         strings.TrimSpace(f.image),
+		Runtime:       f.runtime,
+		Rootless:      f.rootless,
+		UserNSHostUID: f.userNSHostUID,
 	}
 	if s.Target == "" {
-		s.Target = shortID(d.ID)
+		s.Target = shortID(f.id)
 	}
 
 	// --- user / uid ---------------------------------------------------------
-	// Docker's default (empty User) is uid 0. A non-empty user that is not
+	// The Docker default (empty User) is uid 0. A non-empty user that is not
 	// "0"/"root" runs as a non-root uid.
-	u := strings.TrimSpace(d.Config.User)
+	u := strings.TrimSpace(f.user)
 	s.User = u
 	switch {
 	case u == "" || u == "0" || strings.HasPrefix(u, "0:") || u == "root" || strings.HasPrefix(u, "root:"):
 		s.RunAsNonRoot = No
 		if u == "" {
-			s.User = "0 (docker default)"
+			s.User = "0 (default)"
 		}
 	default:
 		s.RunAsNonRoot = Yes
 	}
 
 	// --- capabilities -------------------------------------------------------
-	s.Privileged = boolTri(d.HostConfig.Privileged)
+	s.Privileged = boolTri(f.privileged)
 	s.CapDropAll = No
-	for _, c := range d.HostConfig.CapDrop {
+	for _, c := range f.capDrop {
 		if strings.EqualFold(strings.TrimSpace(c), "ALL") {
 			s.CapDropAll = Yes
 		}
 	}
-	for _, c := range d.HostConfig.CapAdd {
+	for _, c := range f.capAdd {
 		if c = strings.TrimSpace(c); c != "" {
 			s.CapAdd = append(s.CapAdd, strings.ToUpper(c))
 		}
 	}
 
 	// --- seccomp ------------------------------------------------------------
-	// Docker applies its DEFAULT seccomp profile unless SecurityOpt overrides it
-	// (or the container is privileged). So absence of a seccomp opt means the
-	// default profile is active — a determinable, confined posture.
+	// Docker/Podman apply their DEFAULT seccomp profile unless SecurityOpt
+	// overrides it (or the container is privileged). So absence of a seccomp opt
+	// means the default profile is active — a determinable, confined posture.
 	s.Seccomp = "confined"
-	for _, opt := range d.HostConfig.SecurityOpt {
+	for _, opt := range f.securityOpt {
 		low := strings.ToLower(strings.TrimSpace(opt))
 		switch {
 		case low == "no-new-privileges" || low == "no-new-privileges:true":
@@ -114,11 +178,11 @@ func SpecFromDockerInspect(raw []byte) (Spec, error) {
 	}
 
 	// --- network ------------------------------------------------------------
-	s.NetworkMode = d.HostConfig.NetworkMode
-	s.HostNetwork = boolTri(strings.EqualFold(d.HostConfig.NetworkMode, "host"))
+	s.NetworkMode = f.networkMode
+	s.HostNetwork = boolTri(strings.EqualFold(f.networkMode, "host"))
 
 	// --- filesystem ---------------------------------------------------------
-	s.ReadonlyRoot = boolTri(d.HostConfig.ReadonlyRootfs)
+	s.ReadonlyRoot = boolTri(f.readonlyRootfs)
 
 	// --- docker.sock / host mounts ------------------------------------------
 	s.DockerSock = No
@@ -135,10 +199,10 @@ func SpecFromDockerInspect(raw []byte) (Spec, error) {
 			s.HostPathMounts = append(s.HostPathMounts, src)
 		}
 	}
-	for _, m := range d.Mounts {
-		consider(m.Source, m.Destination)
+	for _, m := range f.mounts {
+		consider(m.src, m.dst)
 	}
-	for _, b := range d.HostConfig.Binds {
+	for _, b := range f.binds {
 		// Binds are "src:dst[:opts]".
 		parts := strings.SplitN(b, ":", 3)
 		src := parts[0]
@@ -150,10 +214,10 @@ func SpecFromDockerInspect(raw []byte) (Spec, error) {
 	}
 
 	// --- namespaces ---------------------------------------------------------
-	s.HostPID = boolTri(strings.EqualFold(d.HostConfig.PidMode, "host"))
-	s.HostIPC = boolTri(strings.EqualFold(d.HostConfig.IpcMode, "host"))
+	s.HostPID = boolTri(strings.EqualFold(f.pidMode, "host"))
+	s.HostIPC = boolTri(strings.EqualFold(f.ipcMode, "host"))
 
-	return s, nil
+	return s
 }
 
 // isControlSocket reports whether a path is a container-runtime control socket,
@@ -163,6 +227,7 @@ func isControlSocket(p string) bool {
 	return strings.HasSuffix(p, "docker.sock") ||
 		strings.HasSuffix(p, "containerd.sock") ||
 		strings.HasSuffix(p, "crio.sock") ||
+		strings.HasSuffix(p, "podman.sock") ||
 		strings.Contains(p, "docker.sock")
 }
 

--- a/internal/host/scan/nerdctl.go
+++ b/internal/host/scan/nerdctl.go
@@ -1,0 +1,22 @@
+package scan
+
+// SpecFromNerdctlInspect parses `nerdctl inspect <container>` output into a Spec.
+// nerdctl targets Docker CLI compatibility and emits a Docker-compatible inspect
+// schema, so the shared Docker-family grading body handles it verbatim; only the
+// source label differs.
+//
+// containerd runtime handlers surface in HostConfig.Runtime as reverse-DNS names
+// (e.g. "io.containerd.runc.v2", "io.containerd.runsc.v1" for gVisor,
+// "io.containerd.kata.v2" for Kata); StrongIsolationRuntime recognizes those, so
+// a hardened runtime under nerdctl is surfaced informationally like any other.
+//
+// Fail-closed: nerdctl's inspect has historically been less complete than
+// Docker's; any field it omits stays at its zero value and is graded as insecure
+// by the scorers rather than silently passed.
+func SpecFromNerdctlInspect(raw []byte) (Spec, error) {
+	f, err := firstDockerInspect(raw)
+	if err != nil {
+		return Spec{}, err
+	}
+	return specFromDockerLike(f, "nerdctl"), nil
+}

--- a/internal/host/scan/nerdctl_test.go
+++ b/internal/host/scan/nerdctl_test.go
@@ -1,0 +1,96 @@
+package scan
+
+import "testing"
+
+// nerdctl inspect is Docker-compatible. A hardened nerdctl container running under
+// the containerd gVisor shim (io.containerd.runsc.v1) must grade identically to the
+// Docker path and surface the hardened runtime informationally.
+const nerdctlHardenedInspect = `[{
+  "Id": "nerd0011223344",
+  "Name": "/hardened-nerd",
+  "Config": { "User": "65532" },
+  "HostConfig": {
+    "NetworkMode": "none",
+    "Privileged": false,
+    "ReadonlyRootfs": true,
+    "CapAdd": null,
+    "CapDrop": ["ALL"],
+    "SecurityOpt": ["no-new-privileges"],
+    "PidMode": "",
+    "IpcMode": "private",
+    "Runtime": "io.containerd.runsc.v1",
+    "Binds": []
+  },
+  "Mounts": []
+}]`
+
+func TestSpecFromNerdctlInspect_Hardened(t *testing.T) {
+	s, err := SpecFromNerdctlInspect([]byte(nerdctlHardenedInspect))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Source != "nerdctl" {
+		t.Errorf("source=%q want nerdctl", s.Source)
+	}
+	if s.Target != "hardened-nerd" {
+		t.Errorf("target=%q", s.Target)
+	}
+	if s.RunAsNonRoot != Yes || s.CapDropAll != Yes {
+		t.Error("hardened posture not parsed")
+	}
+	r := Score(s)
+	if r.Score != 100 || r.Grade != "A" {
+		t.Fatalf("hardened nerdctl scored %d/%s, want 100/A", r.Score, r.Grade)
+	}
+	// containerd gVisor shim recognized as a hardened runtime (informational).
+	if r.HardenedRuntime != "gVisor (runsc)" {
+		t.Errorf("hardenedRuntime=%q want gVisor (runsc)", r.HardenedRuntime)
+	}
+}
+
+func TestStrongIsolationRuntime(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantName string
+		wantOK   bool
+	}{
+		{"runsc", "gVisor (runsc)", true},
+		{"io.containerd.runsc.v1", "gVisor (runsc)", true},
+		{"gvisor", "gVisor (runsc)", true},
+		{"kata-runtime", "Kata Containers", true},
+		{"io.containerd.kata.v2", "Kata Containers", true},
+		{"kata-qemu", "Kata Containers", true},
+		{"firecracker", "Firecracker", true},
+		{"runc-fc", "Firecracker", true},
+		{"runc", "", false},
+		{"crun", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		name, ok := StrongIsolationRuntime(c.in)
+		if name != c.wantName || ok != c.wantOK {
+			t.Errorf("StrongIsolationRuntime(%q)=(%q,%v) want (%q,%v)", c.in, name, ok, c.wantName, c.wantOK)
+		}
+	}
+}
+
+// A hardened runtime name never awards points on its own (IRO-429): a misconfigured
+// container under runsc still scores low.
+func TestHardenedRuntime_NoScoreBonus(t *testing.T) {
+	const weakUnderRunsc = `[{
+	  "Name": "/weak-runsc",
+	  "Config": { "User": "0" },
+	  "HostConfig": { "NetworkMode": "host", "Privileged": true, "Runtime": "io.containerd.runsc.v1" }
+	}]`
+	s, err := SpecFromNerdctlInspect([]byte(weakUnderRunsc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := Score(s)
+	if r.HardenedRuntime != "gVisor (runsc)" {
+		t.Errorf("hardenedRuntime=%q want gVisor (runsc)", r.HardenedRuntime)
+	}
+	if r.Grade != "F" {
+		t.Fatalf("privileged host-network container under runsc must still grade F, got %s (%d)", r.Grade, r.Score)
+	}
+}

--- a/internal/host/scan/podman.go
+++ b/internal/host/scan/podman.go
@@ -1,0 +1,202 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// podmanInspect is the subset of `podman inspect <container>` we grade. Podman's
+// Config/HostConfig mirror Docker's for CLI compatibility, but two fields matter
+// specifically here and live OUTSIDE the Docker-compatible shape:
+//
+//   - OCIRuntime is the ACTUAL low-level runtime ("crun", "runc", "runsc",
+//     "kata"…). Podman's HostConfig.Runtime is a generic "oci" string, so the
+//     hardened-runtime detection must read OCIRuntime instead.
+//   - HostConfig.IDMappings carries the user-namespace uid/gid maps. A non-zero
+//     host base in the uid map means container-uid 0 is remapped to an
+//     unprivileged host uid — i.e. rootless / userns isolation, a real posture
+//     win that the scorer credits.
+type podmanInspect struct {
+	ID         string `json:"Id"`
+	Name       string `json:"Name"`
+	OCIRuntime string `json:"OCIRuntime"`
+	Config     struct {
+		User  string `json:"User"`
+		Image string `json:"Image"`
+	} `json:"Config"`
+	HostConfig struct {
+		NetworkMode    string   `json:"NetworkMode"`
+		Privileged     bool     `json:"Privileged"`
+		ReadonlyRootfs bool     `json:"ReadonlyRootfs"`
+		CapAdd         []string `json:"CapAdd"`
+		CapDrop        []string `json:"CapDrop"`
+		SecurityOpt    []string `json:"SecurityOpt"`
+		PidMode        string   `json:"PidMode"`
+		IpcMode        string   `json:"IpcMode"`
+		Runtime        string   `json:"Runtime"`
+		Binds          []string `json:"Binds"`
+		IDMappings     struct {
+			UidMap []string `json:"UidMap"`
+			GidMap []string `json:"GidMap"`
+		} `json:"IDMappings"`
+	} `json:"HostConfig"`
+	// EffectiveCaps/BoundingCaps are the ACTUAL granted capability set (podman
+	// top-level). A non-nil-but-empty set is the authoritative "no caps" signal;
+	// null means podman did not report it and we fall back to the drop list.
+	EffectiveCaps []string `json:"EffectiveCaps"`
+	BoundingCaps  []string `json:"BoundingCaps"`
+	Mounts        []struct {
+		Source      string `json:"Source"`
+		Destination string `json:"Destination"`
+	} `json:"Mounts"`
+}
+
+// podmanDefaultCaps is the standard containers.conf default_capabilities set that
+// podman grants when nothing is dropped. Podman expands `--cap-drop ALL` into
+// exactly these named caps in HostConfig.CapDrop rather than emitting the "ALL"
+// sentinel that Docker uses, so a drop list that COVERS this whole set leaves an
+// empty effective capability set — semantically identical to cap_drop=[ALL].
+var podmanDefaultCaps = []string{
+	"CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "NET_BIND_SERVICE",
+	"SETFCAP", "SETGID", "SETPCAP", "SETUID", "SYS_CHROOT",
+}
+
+// normCap upper-cases a capability and strips the CAP_ prefix for comparison.
+func normCap(c string) string {
+	return strings.TrimPrefix(strings.ToUpper(strings.TrimSpace(c)), "CAP_")
+}
+
+// podmanDropsAll reports whether a podman container has effectively dropped ALL
+// capabilities, accounting for podman's habit of expanding `--cap-drop ALL` into
+// the explicit default set. Signals, strongest first: the literal ALL sentinel;
+// a non-nil-but-empty EffectiveCaps/BoundingCaps set; or a drop list that covers
+// the entire default capability set. Fail-closed: partial coverage is NOT "all".
+func podmanDropsAll(capDrop, effectiveCaps, boundingCaps []string) bool {
+	dropped := map[string]bool{}
+	for _, c := range capDrop {
+		n := normCap(c)
+		if n == "ALL" {
+			return true
+		}
+		dropped[n] = true
+	}
+	// An explicitly reported empty granted set is authoritative.
+	if boundingCaps != nil && len(boundingCaps) == 0 {
+		return true
+	}
+	if effectiveCaps != nil && len(effectiveCaps) == 0 {
+		return true
+	}
+	if len(dropped) == 0 {
+		return false
+	}
+	for _, def := range podmanDefaultCaps {
+		if !dropped[def] {
+			return false
+		}
+	}
+	return true
+}
+
+// SpecFromPodmanInspect parses `podman inspect <container>` into a Spec.
+//
+// rootlessHint carries the daemon-level rootless signal the CLI obtains from
+// `podman info` (Yes/No), or Unknown when it was not probed. It is OR-combined
+// with the per-container evidence in HostConfig.IDMappings so the adapter still
+// detects userns remapping from the inspect JSON alone (which keeps it pure and
+// unit-testable with fixtures).
+func SpecFromPodmanInspect(raw []byte, rootlessHint Tristate) (Spec, error) {
+	var arr []podmanInspect
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		var one podmanInspect
+		if err2 := json.Unmarshal(raw, &one); err2 != nil {
+			return Spec{}, fmt.Errorf("parse podman inspect: %w", err)
+		}
+		arr = []podmanInspect{one}
+	}
+	if len(arr) == 0 {
+		return Spec{}, fmt.Errorf("podman inspect returned no containers")
+	}
+	p := arr[0]
+
+	// Build the shared Docker-family fields, then layer podman specifics on top.
+	f := dockerLikeFields{
+		id:             p.ID,
+		name:           p.Name,
+		user:           p.Config.User,
+		image:          p.Config.Image,
+		runtime:        firstNonEmpty(p.OCIRuntime, p.HostConfig.Runtime),
+		networkMode:    p.HostConfig.NetworkMode,
+		pidMode:        p.HostConfig.PidMode,
+		ipcMode:        p.HostConfig.IpcMode,
+		privileged:     p.HostConfig.Privileged,
+		readonlyRootfs: p.HostConfig.ReadonlyRootfs,
+		capAdd:         p.HostConfig.CapAdd,
+		capDrop:        p.HostConfig.CapDrop,
+		securityOpt:    p.HostConfig.SecurityOpt,
+		// (capDrop is normalized to the "ALL" sentinel just below when podman
+		// expanded a cap-drop-all into the explicit default set.)
+		binds: p.HostConfig.Binds,
+	}
+	for _, m := range p.Mounts {
+		f.mounts = append(f.mounts, mountPair{m.Source, m.Destination})
+	}
+
+	// Normalize podman's expanded cap-drop back to the canonical "ALL" sentinel
+	// the shared grader understands, so a rootless/hardened podman container is
+	// credited for dropping every capability. Preserve any explicit CapAdd so the
+	// grader still applies the "dropped ALL but re-added N" partial-credit path.
+	if podmanDropsAll(p.HostConfig.CapDrop, p.EffectiveCaps, p.BoundingCaps) {
+		f.capDrop = []string{"ALL"}
+	}
+
+	// Rootless / userns: prefer the explicit hint, fall back to the uid-map.
+	hostUID, remapped := userNSHostUID(p.HostConfig.IDMappings.UidMap)
+	switch {
+	case rootlessHint == Yes || remapped:
+		f.rootless = Yes
+		f.userNSHostUID = hostUID
+	case rootlessHint == No:
+		f.rootless = No
+	default:
+		f.rootless = Unknown
+	}
+
+	s := specFromDockerLike(f, "podman")
+	if s.Rootless == Yes {
+		s.Notes = append(s.Notes, "rootless podman: container-uid 0 is remapped to an unprivileged host uid via a user namespace")
+	}
+	return s, nil
+}
+
+// userNSHostUID inspects a podman uid map (entries "containerID:hostID:size",
+// e.g. "0:100000:65536") and reports the host uid that container-uid 0 maps to,
+// plus whether that mapping is a real remap (host base != 0). An empty map, or a
+// 0:0 identity map, means no remap (not rootless).
+func userNSHostUID(uidMap []string) (string, bool) {
+	for _, e := range uidMap {
+		parts := strings.Split(strings.TrimSpace(e), ":")
+		if len(parts) != 3 {
+			continue
+		}
+		containerID := strings.TrimSpace(parts[0])
+		hostID := strings.TrimSpace(parts[1])
+		if containerID != "0" {
+			continue
+		}
+		if hostID != "" && hostID != "0" {
+			return hostID, true
+		}
+	}
+	return "", false
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/host/scan/podman_test.go
+++ b/internal/host/scan/podman_test.go
@@ -1,0 +1,130 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+// A rootless podman container: runs as root INSIDE the container, but the uid map
+// remaps container-uid 0 to host uid 100000 (userns), all caps dropped, seccomp
+// default, no docker.sock. OCIRuntime is crun. The rootless remap must earn credit
+// on the non-root dimension even though Config.User is root.
+const podmanRootlessInspect = `[{
+  "Id": "pod0011223344",
+  "Name": "rootless-app",
+  "OCIRuntime": "crun",
+  "Config": { "User": "0", "Image": "docker.io/library/alpine" },
+  "HostConfig": {
+    "NetworkMode": "slirp4netns",
+    "Privileged": false,
+    "ReadonlyRootfs": true,
+    "CapAdd": null,
+    "CapDrop": ["ALL"],
+    "SecurityOpt": [],
+    "PidMode": "private",
+    "IpcMode": "private",
+    "Runtime": "oci",
+    "Binds": [],
+    "IDMappings": { "UidMap": ["0:100000:65536"], "GidMap": ["0:100000:65536"] }
+  },
+  "Mounts": []
+}]`
+
+func TestSpecFromPodmanInspect_RootlessCredit(t *testing.T) {
+	s, err := SpecFromPodmanInspect([]byte(podmanRootlessInspect), Unknown)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Source != "podman" {
+		t.Errorf("source=%q want podman", s.Source)
+	}
+	if s.Rootless != Yes {
+		t.Fatal("rootless not inferred from uid map")
+	}
+	if s.UserNSHostUID != "100000" {
+		t.Errorf("userns host uid=%q want 100000", s.UserNSHostUID)
+	}
+	// Runtime must come from OCIRuntime, not the generic HostConfig.Runtime "oci".
+	if s.Runtime != "crun" {
+		t.Errorf("runtime=%q want crun (OCIRuntime)", s.Runtime)
+	}
+	r := Score(s)
+	nr := dimByKey(r, "user.nonroot")
+	if nr.Verdict != VerdictWarn || nr.Score == 0 {
+		t.Fatalf("rootless root container should earn partial non-root credit, got %s %d/%d", nr.Verdict, nr.Score, nr.Max)
+	}
+	// Rootless note surfaced.
+	found := false
+	for _, n := range r.Notes {
+		if strings.Contains(n, "rootless") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected a rootless note in the report")
+	}
+}
+
+// Rootful podman (identity uid map, root user) must NOT get rootless credit.
+func TestSpecFromPodmanInspect_RootfulNoCredit(t *testing.T) {
+	const rootful = `[{
+	  "Name": "rootful",
+	  "OCIRuntime": "runc",
+	  "Config": { "User": "0" },
+	  "HostConfig": { "NetworkMode": "bridge", "Runtime": "oci", "IDMappings": { "UidMap": ["0:0:4294967295"] } }
+	}]`
+	s, err := SpecFromPodmanInspect([]byte(rootful), No)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Rootless == Yes {
+		t.Error("identity uid map + rootless=No must not grade as rootless")
+	}
+	if dimByKey(Score(s), "user.nonroot").Verdict != VerdictFail {
+		t.Error("rootful root container should FAIL the non-root dimension")
+	}
+}
+
+// The daemon-level hint alone (no informative uid map) is enough to credit rootless.
+func TestSpecFromPodmanInspect_HintCredits(t *testing.T) {
+	const noMap = `[{"Name":"x","OCIRuntime":"crun","Config":{"User":"0"},"HostConfig":{"NetworkMode":"slirp4netns","CapDrop":["ALL"]}}]`
+	s, err := SpecFromPodmanInspect([]byte(noMap), Yes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Rootless != Yes {
+		t.Fatal("rootless hint should mark the spec rootless")
+	}
+}
+
+func TestSpecFromPodmanInspect_Errors(t *testing.T) {
+	if _, err := SpecFromPodmanInspect([]byte("nope"), Unknown); err == nil {
+		t.Error("expected parse error")
+	}
+	if _, err := SpecFromPodmanInspect([]byte("[]"), Unknown); err == nil {
+		t.Error("expected empty-array error")
+	}
+}
+
+func TestUserNSHostUID(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      []string
+		wantUID string
+		wantOK  bool
+	}{
+		{"rootless remap", []string{"0:100000:65536"}, "100000", true},
+		{"identity map", []string{"0:0:4294967295"}, "", false},
+		{"empty", nil, "", false},
+		{"malformed", []string{"garbage"}, "", false},
+		{"non-zero container id skipped", []string{"1000:200000:1"}, "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			uid, ok := userNSHostUID(c.in)
+			if uid != c.wantUID || ok != c.wantOK {
+				t.Errorf("userNSHostUID(%v)=(%q,%v) want (%q,%v)", c.in, uid, ok, c.wantUID, c.wantOK)
+			}
+		})
+	}
+}

--- a/internal/host/scan/render.go
+++ b/internal/host/scan/render.go
@@ -16,6 +16,9 @@ func RenderTable(w io.Writer, r Report) {
 	if r.Runtime != "" {
 		fmt.Fprintf(w, "  runtime: %s\n", r.Runtime)
 	}
+	if r.HardenedRuntime != "" {
+		fmt.Fprintf(w, "  isolation: %s (hardened runtime; informational, no score bonus)\n", r.HardenedRuntime)
+	}
 	fmt.Fprintf(w, "  score:   %d/%d  grade %s  %s\n\n", r.Score, r.Max, r.Grade, gradeBanner(r.Grade))
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)

--- a/internal/host/scan/score.go
+++ b/internal/host/scan/score.go
@@ -28,14 +28,19 @@ type Dimension struct {
 
 // Report is the full scorecard for one Spec.
 type Report struct {
-	Source     string      `json:"source"`
-	Target     string      `json:"target"`
-	Runtime    string      `json:"runtime,omitempty"`
-	Score      int         `json:"score"` // 0..100
-	Max        int         `json:"max"`   // always 100
-	Grade      string      `json:"grade"` // A..F
-	Dimensions []Dimension `json:"dimensions"`
-	Notes      []string    `json:"notes,omitempty"`
+	Source  string `json:"source"`
+	Target  string `json:"target"`
+	Runtime string `json:"runtime,omitempty"`
+	// HardenedRuntime names a recognized strong-isolation runtime (gVisor, Kata,
+	// Firecracker) when one is detected. Informational ONLY: scoring stays
+	// runtime-agnostic (IRO-429), so this awards no points; it surfaces the fact
+	// that a userspace-kernel / microVM boundary is in play.
+	HardenedRuntime string      `json:"hardenedRuntime,omitempty"`
+	Score           int         `json:"score"` // 0..100
+	Max             int         `json:"max"`   // always 100
+	Grade           string      `json:"grade"` // A..F
+	Dimensions      []Dimension `json:"dimensions"`
+	Notes           []string    `json:"notes,omitempty"`
 	// GeneratedAt is set by the caller (injected for deterministic tests); the
 	// pure scorer never reads the clock.
 	GeneratedAt string `json:"generatedAt,omitempty"`
@@ -94,7 +99,40 @@ func Score(s Spec) Report {
 	}
 	r.Score = sum
 	r.Grade = grade(sum)
+
+	// Strong-isolation runtime is informational only (IRO-429: scoring is
+	// runtime-agnostic). We never award points for a runtime NAME, but we DO
+	// surface when a recognized hardened runtime (gVisor/Kata/Firecracker) wraps
+	// the workload, since it materially changes the escape story.
+	if name, ok := StrongIsolationRuntime(s.Runtime); ok {
+		r.HardenedRuntime = name
+		r.Notes = append(r.Notes, fmt.Sprintf(
+			"hardened runtime detected: %s (userspace-kernel / microVM isolation). Informational only; scoring is runtime-agnostic, so no points are awarded for the runtime name.",
+			name))
+	}
 	return r
+}
+
+// StrongIsolationRuntime classifies an OCI runtime identifier (a docker
+// HostConfig.Runtime, a podman OCIRuntime, a containerd runtime handler like
+// "io.containerd.runsc.v1", or a Kubernetes runtimeClassName) as a recognized
+// strong-isolation technology and returns a display name. It is a NAME match
+// only and never affects the score — a container can name a hardened runtime and
+// still be misconfigured, so the dimension scorers remain authoritative.
+func StrongIsolationRuntime(runtime string) (string, bool) {
+	r := strings.ToLower(strings.TrimSpace(runtime))
+	if r == "" {
+		return "", false
+	}
+	switch {
+	case strings.Contains(r, "runsc") || strings.Contains(r, "gvisor"):
+		return "gVisor (runsc)", true
+	case strings.Contains(r, "kata"):
+		return "Kata Containers", true
+	case strings.Contains(r, "firecracker") || strings.Contains(r, "fc-runtime") || r == "runc-fc":
+		return "Firecracker", true
+	}
+	return "", false
 }
 
 // grade maps a 0..100 score to a letter band.
@@ -127,8 +165,22 @@ func gradeNonRoot(s Spec) (int, Verdict, string) {
 		}
 		return 15, VerdictPass, fmt.Sprintf("runs as %s (uid != 0)", u)
 	case No:
+		// Rootless / userns remap: even a container-uid-0 process maps to an
+		// UNPRIVILEGED host uid, so an escape does not yield host root. That is the
+		// single strongest mitigation for this dimension, so it earns near-full
+		// credit even though the in-container user is 0.
+		if s.Rootless == Yes {
+			return 12, VerdictWarn, fmt.Sprintf(
+				"runs as root INSIDE the container, but a rootless userns remaps container-uid 0 to unprivileged host uid %s; an escape lands unprivileged",
+				nz(s.UserNSHostUID, "!= 0"))
+		}
 		return 0, VerdictFail, fmt.Sprintf("runs as root (user %q); a container escape starts with host-uid 0", nz(s.User, "0"))
 	default:
+		if s.Rootless == Yes {
+			return 12, VerdictWarn, fmt.Sprintf(
+				"in-container user not reported, but a rootless userns remaps container-uid 0 to unprivileged host uid %s; an escape lands unprivileged",
+				nz(s.UserNSHostUID, "!= 0"))
+		}
 		return 0, VerdictUnknown, "user not reported; assuming root (fail-closed)"
 	}
 }

--- a/internal/host/scan/spec.go
+++ b/internal/host/scan/spec.go
@@ -74,6 +74,15 @@ type Spec struct {
 	// User is the raw user spec observed ("65532", "nobody", "0:0", ""), shown
 	// as evidence in the detail column.
 	User string
+	// Rootless is Yes when the container runs in a user namespace that remaps
+	// container-uid 0 to an UNPRIVILEGED host uid (rootless Podman, or an explicit
+	// userns). This is a genuine posture win independent of the runtime name: a
+	// container-root escape lands as an unprivileged host user, not host root. It
+	// credits the non-root dimension even when the in-container user is 0.
+	Rootless Tristate
+	// UserNSHostUID is the host uid that container-uid 0 maps to, when known
+	// (evidence for the rootless credit; e.g. "100000").
+	UserNSHostUID string
 
 	// --- capabilities --------------------------------------------------------
 	// CapDropAll is Yes when ALL capabilities are dropped (cap_drop: [ALL] or an


### PR DESCRIPTION
## Summary
Makes `ironctl scan` a universal container-isolation auditor across OCI runtimes, not just Docker/Compose/K8s. Scan is our top-of-funnel wedge (it works without adopting IronClaw's runtime), so widening runtime coverage is direct organic reach with zero account/board gating.

## What changed
- **Shared grading core**: refactored the Docker grading body into `specFromDockerLike(fields, source)` so docker/podman/nerdctl reuse one model over a normalized field set.
- **Podman adapter**: reads `OCIRuntime` (real runtime, not the generic `HostConfig.Runtime="oci"`); detects rootless from `podman info` + the userns uid map; normalizes podman's expanded cap-drop-all (podman lists the default caps and reports empty `EffectiveCaps`/`BoundingCaps` instead of the `ALL` sentinel).
- **nerdctl/containerd adapter**: Docker-compatible inspect; containerd runtime handlers (`io.containerd.runsc.v1`, ...) recognized.
- **Rootless credit**: a userns remap of container-uid 0 to an unprivileged host uid earns partial credit on the non-root dimension (an escape lands unprivileged). A real posture win, not a runtime name.
- **Hardened runtimes**: `StrongIsolationRuntime` classifies gVisor/Kata/Firecracker and surfaces an informational `HardenedRuntime` line. Per IRO-429 scoring stays runtime-agnostic: **no points for a runtime name**; dimension scorers remain authoritative.
- **CLI**: `--runtime auto|docker|podman|nerdctl` with auto-detect + `--podman-bin`/`--nerdctl-bin`. Fail-closed on unknown/unreachable runtime.
- **Docs**: `docs/scan.md` gains a supported-runtimes matrix + rootless/hardened-runtime sections.

## Acceptance criteria
- [x] Auto-detects runtime and picks the adapter; `--runtime` override
- [x] Fail-closed on unknown/unreachable runtime with a clear message
- [x] Unit tests per adapter using fixture inspect JSON (82 tests in the scan package)
- [x] Live smoke on Podman rootless
- [x] `docs/scan.md` updated with the runtimes matrix

## Verification
`CGO_ENABLED=1 go test ./internal/host/scan/... ./cmd/ironctl/...` green; `go vet` clean; docs free of em/en-dashes.

Live smoke on the macOS podman machine:
- hardened container = **100/A**
- weak (root, host net, docker.sock) = **19/F**
- true rootless container (root inside, cap-drop ALL, read-only, net none) = **97/A** (rootless credit gives non-root 12/15 WARN; empty `BoundingCaps` drove caps 20/20)

## Security lenses
- **Isolation / trust boundary**: grades host-side inspect data (not in-container `/sys`), so probe-masking cannot recur (IRO-429). Read-only, local command; no control-plane mutation, no new egress path.
- Rootless credit reflects a real userns boundary; hardened-runtime detection is informational only, so a named-but-misconfigured runtime still scores low.

Parent: IRO-434. Follow-on to IRO-425 (#407).