### PR TITLE
feat(examples): reproducible isolation-survey harness + committed dataset (IRO-436)

### DIFF
--- a/examples/isolation-survey/README.md
+++ b/examples/isolation-survey/README.md
@@ -1,0 +1,112 @@
+# isolation-survey — a reproducible State of Container Isolation dataset
+
+This example runs [`ironctl scan`](../../docs/scan.md) over a curated set of
+popular **public** container images and their common run configurations, and
+emits a combined machine-readable [`results.json`](./results.json) plus a
+rendered [`results.md`](./results.md) table (image -> score -> grade -> top
+failed dimensions).
+
+It is the reproducible harness behind the "State of Container Isolation"
+writeup: a defensible, repeatable measurement that anyone can rerun from a clean
+checkout with nothing but Docker. No credentials, no cloud, no account.
+
+```bash
+# from the repo root, with a Docker daemon running:
+examples/isolation-survey/survey.sh
+# -> writes examples/isolation-survey/results.json and results.md
+```
+
+## What it measures
+
+`ironctl scan` grades a workload's containment posture 0-100 across seven
+dimensions, each weighted by how much of the host it hands over when it fails:
+
+| Dimension | Weight | Fails when |
+|-----------|:------:|------------|
+| Dropped capabilities | 20 | the default Linux capability set is retained |
+| Non-root user | 15 | the container runs as uid 0 |
+| Seccomp profile | 15 | the syscall filter is disabled (`seccomp=unconfined`) |
+| Network isolation | 15 | egress is possible (anything but `--network none`) |
+| No docker.sock exposure | 15 | the host Docker/OCI socket is bind-mounted |
+| Read-only root filesystem | 10 | the root fs is writable |
+| No shared host namespaces | 10 | `--pid host` / `--network host` / `--ipc host` |
+
+Grading is **fail-closed**: any dimension the scanner cannot determine is scored
+as insecure, never silently passed. Grades map A (>=90) down to F (<50).
+
+## The curated set
+
+The scenarios are captured in a versioned manifest,
+[`images.txt`](./images.txt), in three families:
+
+1. **`default-*`** — a popular image (nginx, postgres, redis, mysql, mongo,
+   node, python, golang, httpd, rabbitmq, memcached, wordpress) run with a plain
+   `docker run` and **zero hardening flags**. This is the baseline the survey is
+   about: what you get from a copy-pasted run command.
+2. **`naive-*`** — a common but dangerous CI / ops pattern applied to a popular
+   base image: a bind-mounted `docker.sock` ("build images in CI"), `--privileged`
+   ("docker-in-docker"), and shared host namespaces ("a monitoring sidecar").
+3. **`hardened-reference`** — the target every workload should aim for:
+   `--user 65532 --cap-drop ALL --security-opt no-new-privileges --read-only
+   --tmpfs /tmp --network none`.
+
+Every image is pinned by its **multi-arch manifest-list digest**, so
+`docker pull` resolves byte-identical bits on amd64 and arm64. Digests were
+captured with:
+
+```bash
+docker buildx imagetools inspect <tag> --format '{{.Manifest.Digest}}'
+```
+
+## Methodology (so the numbers are defensible)
+
+* **Read-only, config-based.** `ironctl scan` inspects a container's declared
+  configuration via `docker inspect`; it never executes the image's real
+  workload. To keep each container alive long enough to inspect, the survey
+  overrides the entrypoint with `sleep`. This does **not** change any graded
+  dimension — user, capabilities, seccomp, network, rootfs, docker.sock and host
+  namespaces all come from the image config and the `docker run` flags, not from
+  the entrypoint.
+* **Declared config, not runtime drops.** The scan sees the *declared* posture.
+  An image whose entrypoint drops privileges at runtime (e.g. `gosu`/`su-exec`
+  from a root-configured entrypoint, as postgres/mysql do) is still graded on its
+  declared root user, because a compromised process reaches the boundary before
+  that drop. This is intentional and fail-closed.
+* **Runtime-agnostic scores.** The score reflects the container's *config*, not
+  the host runtime under it. Running the same config under gVisor (`runsc`) or
+  Kata adds real defense-in-depth but does not change these numbers — the survey
+  measures the posture the workload declares for itself.
+* **Deterministic output.** Rows in `results.md` are sorted by score, so a re-run
+  over the same pinned manifest produces a byte-identical table apart from the
+  tool-version / timestamp stamp recorded once at the top.
+
+## Reproducing it
+
+Prerequisites: a running Docker daemon. The harness will build `ironctl` from
+this repo (needs Go 1.23+ and `CGO_ENABLED=1`) unless you point it at a prebuilt
+binary, and uses `python3` (stdlib only) to render the results.
+
+```bash
+examples/isolation-survey/survey.sh                 # scan all scenarios
+IRONCTL=/path/to/ironctl examples/isolation-survey/survey.sh   # use a prebuilt ironctl
+examples/isolation-survey/survey.sh --keep          # leave containers up for poking
+```
+
+**Docker Hub rate limits.** Pulling ~12 public images anonymously can hit Docker
+Hub's unauthenticated pull-rate limit (HTTP 429). The harness skips the pull for
+any digest already cached locally and backs off/retries on a 429, but if you hit
+it repeatedly, run `docker login` first (a free account lifts the anonymous
+limit). Nothing in the survey needs a paid or private registry.
+
+## Files
+
+| File | What it is |
+|------|-----------|
+| [`images.txt`](./images.txt) | the pinned, versioned manifest of scenarios |
+| [`survey.sh`](./survey.sh) | the harness: pull -> run -> `ironctl scan --json` -> aggregate |
+| [`render.py`](./render.py) | stdlib aggregation of scan JSON into `results.{json,md}` |
+| [`results.json`](./results.json) | the committed machine-readable dataset |
+| [`results.md`](./results.md) | the committed rendered table |
+
+Handing off to Growth for the "State of Container Isolation" writeup that builds
+on `results.md`.

--- a/examples/isolation-survey/images.txt
+++ b/examples/isolation-survey/images.txt
@@ -1,0 +1,58 @@
+# isolation-survey manifest — the curated, pinned dataset for `survey.sh`.
+#
+# Each non-comment line is ONE survey scenario:
+#
+#     label | image:tag@sha256:<digest> | run-flags...
+#
+#   label       stable, filesystem-safe id; the container is named ic-survey-<label>.
+#   image       a PUBLIC Docker Hub image pinned by its multi-arch MANIFEST-LIST
+#               digest, so `docker pull` resolves the identical bits on amd64 and
+#               arm64. Digests were captured with:
+#                   docker buildx imagetools inspect <tag> --format '{{.Manifest.Digest}}'
+#   run-flags   the `docker run` security flags that define this scenario's
+#               posture (may be empty = a plain `docker run` with all defaults).
+#
+# Every scenario is launched as:
+#     docker run -d --name ic-survey-<label> <run-flags> --entrypoint sleep <image> 86400
+# The `--entrypoint sleep` override only keeps the container alive for inspection;
+# it does NOT alter any graded dimension (user, caps, seccomp, network, rootfs,
+# docker.sock, host namespaces all come from the image config + run flags). See
+# README.md "Methodology".
+#
+# THREE scenario families:
+#   1. default-*  : a popular image run with ZERO hardening flags — what you get
+#                   from a copy-pasted `docker run <image>`. This is the baseline
+#                   the report is about.
+#   2. naive-*    : a common but dangerous CI / ops pattern applied to a popular
+#                   image (bind-mounted docker.sock, --privileged, host namespaces).
+#   3. hardened   : the reference target every workload should aim for.
+#
+# ---------------------------------------------------------------------------
+# family 1 — popular images, plain `docker run` defaults (no hardening flags)
+# ---------------------------------------------------------------------------
+default-nginx     | nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10          |
+default-postgres  | postgres:17-alpine@sha256:67f624a4ad70edba8d65c82341124fab7054b277b4f7dea4b04be6f939ce2314        |
+default-redis     | redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99            |
+default-mysql     | mysql:8.4@sha256:d36d39a64cd12a5c1cc9e6aa2bfb5f8d4c81a2f6586e0a04a9ae13939db02209                 |
+default-mongo     | mongo:7@sha256:d5b3ca8c3f3cdce78d44870dc0871b76d5235e9b2ad4ea6bea5d1fbff8027703                   |
+default-node      | node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2            |
+default-python    | python:3.13-alpine@sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0        |
+default-golang    | golang:1.23-alpine@sha256:383395b794dffa5b53012a212365d40c8e37109a626ca30d6151c8348d380b5f        |
+default-httpd     | httpd:2.4-alpine@sha256:1b766f17b84026429b7cb243317b142921b24432336e798bc881c43f45ed9567           |
+default-rabbitmq  | rabbitmq:4-alpine@sha256:835cbc6fabceedef7a3b0ce3195a17adccb753a3ba645bdd61c5557b6e4bf580         |
+default-memcached | memcached:1.6-alpine@sha256:dfacdbd93e7a6f1ad63801753a1fc959dc678a5a1d2141ff438d57e6d8793fc3      |
+default-wordpress | wordpress:6-php8.3-apache@sha256:5d2c212561c4b5442ebc4d98933a9cbadcf3dee8888ed3fd9ed44667c27cc905 |
+# ---------------------------------------------------------------------------
+# family 2 — common but dangerous CI / ops patterns on popular base images
+# ---------------------------------------------------------------------------
+# A CI runner that bind-mounts the host docker.sock to "build images" — one API
+# call from full host root.
+naive-ci-docker-sock | node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 | -v /var/run/docker.sock:/var/run/docker.sock
+# A "docker-in-docker" build agent started --privileged.
+naive-privileged     | python:3.13-alpine@sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0 | --privileged
+# A monitoring/agent sidecar wired into the host network and PID namespaces.
+naive-host-ns        | redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99 | --network host --pid host
+# ---------------------------------------------------------------------------
+# family 3 — the hardened reference every workload should target
+# ---------------------------------------------------------------------------
+hardened-reference   | nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10 | --user 65532:65532 --cap-drop ALL --security-opt no-new-privileges --read-only --tmpfs /tmp --network none

--- a/examples/isolation-survey/render.py
+++ b/examples/isolation-survey/render.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""render.py — aggregate per-scenario `ironctl scan --json` blobs into the
+combined results.json + a human-readable results.md table.
+
+Pure stdlib (json only). Reads a JSON array of records on stdin, each:
+
+    {"label": ..., "image": ..., "runFlags": ..., "report": <scan-json>}
+
+Writes results.json to argv[1] and results.md to argv[2]. Deterministic: rows
+are sorted by (score asc, label asc) so a re-run over the same manifest yields a
+byte-identical table (minus the generatedAt/version stamps, which are recorded
+once at the dataset level).
+"""
+import json
+import sys
+
+
+def failed_dims(report):
+    """Titles of dimensions the scanner graded FAIL or UNKNOWN (fail-closed),
+    worst-weighted first — the 'top failed dimensions' column."""
+    dims = [d for d in report.get("dimensions", [])
+            if d.get("verdict") in ("FAIL", "UNKNOWN")]
+    dims.sort(key=lambda d: -d.get("max", 0))
+    return [d.get("title", d.get("key", "?")) for d in dims]
+
+
+def main():
+    out_json, out_md = sys.argv[1], sys.argv[2]
+    records = json.load(sys.stdin)
+
+    rows = []
+    for rec in records:
+        rep = rec["report"]
+        rows.append({
+            "label": rec["label"],
+            "image": rec["image"],
+            "runFlags": rec.get("runFlags", "").strip(),
+            "score": rep.get("score", 0),
+            "grade": rep.get("grade", "?"),
+            "failedDimensions": failed_dims(rep),
+            "report": rep,
+        })
+    rows.sort(key=lambda r: (r["score"], r["label"]))
+
+    # A dataset-level stamp: take the tool version + generatedAt from the first
+    # report (they are identical across a single run).
+    stamp = records[0]["report"] if records else {}
+    dataset = {
+        "report": "ironclaw-isolation-survey",
+        "schemaVersion": "1.0",
+        "generatedAt": stamp.get("generatedAt", ""),
+        "ironctlVersion": stamp.get("version", ""),
+        "scenarioCount": len(rows),
+        "scenarios": rows,
+    }
+    with open(out_json, "w") as f:
+        json.dump(dataset, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+    # Markdown table.
+    lines = []
+    lines.append("# State of Container Isolation — survey results")
+    lines.append("")
+    lines.append(f"Scanned **{len(rows)} scenarios** with "
+                 f"`ironctl scan` {dataset['ironctlVersion']} "
+                 f"on {dataset['generatedAt']}.")
+    lines.append("")
+    lines.append("Each row is one popular public image run with a specific "
+                 "configuration, graded 0-100 across seven containment "
+                 "dimensions (non-root user, dropped capabilities, seccomp, "
+                 "network isolation, read-only rootfs, no docker.sock, no host "
+                 "namespaces). Higher is safer. See "
+                 "[README.md](./README.md) for the exact method and "
+                 "[images.txt](./images.txt) for the pinned manifest.")
+    lines.append("")
+    lines.append("| Scenario | Image | Score | Grade | Top failed dimensions |")
+    lines.append("|----------|-------|------:|:-----:|-----------------------|")
+    for r in rows:
+        failed = ", ".join(r["failedDimensions"][:3]) or "none"
+        img = r["image"].split("@")[0]  # drop the digest for readability
+        lines.append(f"| `{r['label']}` | `{img}` | {r['score']}/100 "
+                     f"| **{r['grade']}** | {failed} |")
+    lines.append("")
+
+    # A compact grade-distribution summary.
+    dist = {}
+    for r in rows:
+        dist[r["grade"]] = dist.get(r["grade"], 0) + 1
+    summary = ", ".join(f"{dist[g]}×{g}" for g in sorted(dist))
+    lines.append(f"**Grade distribution:** {summary}.")
+    lines.append("")
+    lines.append("Regenerate this file from a clean checkout with "
+                 "`examples/isolation-survey/survey.sh` (Docker required).")
+    lines.append("")
+    with open(out_md, "w") as f:
+        f.write("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/isolation-survey/results.json
+++ b/examples/isolation-survey/results.json
@@ -1,0 +1,1321 @@
+{
+  "generatedAt": "2026-07-08T11:27:08Z",
+  "ironctlVersion": "dev",
+  "report": "ironclaw-isolation-survey",
+  "scenarioCount": 16,
+  "scenarios": [
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Seccomp profile",
+        "Read-only root filesystem",
+        "No shared host namespaces"
+      ],
+      "grade": "F",
+      "image": "python:3.13-alpine@sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0",
+      "label": "naive-privileged",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "privileged: the full capability set is granted",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 0,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "privileged: seccomp is disabled",
+            "key": "seccomp",
+            "max": 15,
+            "score": 0,
+            "title": "Seccomp profile",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "privileged: host devices and namespaces are reachable",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 0,
+            "title": "No shared host namespaces",
+            "verdict": "FAIL"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:29Z",
+        "grade": "F",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 19,
+        "source": "docker",
+        "target": "ic-survey-naive-privileged",
+        "version": "dev"
+      },
+      "runFlags": "--privileged",
+      "score": 19
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "No docker.sock exposure",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2",
+      "label": "naive-ci-docker-sock",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "docker.sock is mounted: trivial host-root escape (docker run --privileged -v /:/host)",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 0,
+            "title": "No docker.sock exposure",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:28Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 33,
+        "source": "docker",
+        "target": "ic-survey-naive-ci-docker-sock",
+        "version": "dev"
+      },
+      "runFlags": "-v /var/run/docker.sock:/var/run/docker.sock",
+      "score": 33
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Network isolation / egress",
+        "Read-only root filesystem",
+        "No shared host namespaces"
+      ],
+      "grade": "D",
+      "image": "redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99",
+      "label": "naive-host-ns",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "host network namespace: full host network reachability",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 0,
+            "title": "Network isolation / egress",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "shares host namespace(s): PID, network",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 0,
+            "title": "No shared host namespaces",
+            "verdict": "FAIL"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:31Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 34,
+        "source": "docker",
+        "target": "ic-survey-naive-host-ns",
+        "version": "dev"
+      },
+      "runFlags": "--network host --pid host",
+      "score": 34
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "golang:1.23-alpine@sha256:383395b794dffa5b53012a212365d40c8e37109a626ca30d6151c8348d380b5f",
+      "label": "default-golang",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:19Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-golang",
+        "version": "dev"
+      },
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "httpd:2.4-alpine@sha256:1b766f17b84026429b7cb243317b142921b24432336e798bc881c43f45ed9567",
+      "label": "default-httpd",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:21Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-httpd",
+        "version": "dev"
+      },
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "mongo:7@sha256:d5b3ca8c3f3cdce78d44870dc0871b76d5235e9b2ad4ea6bea5d1fbff8027703",
+      "label": "default-mongo",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:14Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-mongo",
+        "version": "dev"
+      },
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "mysql:8.4@sha256:d36d39a64cd12a5c1cc9e6aa2bfb5f8d4c81a2f6586e0a04a9ae13939db02209",
+      "label": "default-mysql",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:13Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-mysql",
+        "version": "dev"
+      },
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10",
+      "label": "default-nginx",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:08Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-nginx",
+        "version": "dev"
+      },
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2",
+      "label": "default-node",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:16Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-node",
+        "version": "dev"
+      },
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "postgres:17-alpine@sha256:67f624a4ad70edba8d65c82341124fab7054b277b4f7dea4b04be6f939ce2314",
+      "label": "default-postgres",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:10Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-postgres",
+        "version": "dev"
+      },
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "python:3.13-alpine@sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0",
+      "label": "default-python",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:18Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-python",
+        "version": "dev"
+      },
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "rabbitmq:4-alpine@sha256:835cbc6fabceedef7a3b0ce3195a17adccb753a3ba645bdd61c5557b6e4bf580",
+      "label": "default-rabbitmq",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:23Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-rabbitmq",
+        "version": "dev"
+      },
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99",
+      "label": "default-redis",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:11Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-redis",
+        "version": "dev"
+      },
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "wordpress:6-php8.3-apache@sha256:5d2c212561c4b5442ebc4d98933a9cbadcf3dee8888ed3fd9ed44667c27cc905",
+      "label": "default-wordpress",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:26Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-wordpress",
+        "version": "dev"
+      },
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Read-only root filesystem"
+      ],
+      "grade": "C",
+      "image": "memcached:1.6-alpine@sha256:dfacdbd93e7a6f1ad63801753a1fc959dc678a5a1d2141ff438d57e6d8793fc3",
+      "label": "default-memcached",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as memcache (uid != 0)",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 15,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:24Z",
+        "grade": "C",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 63,
+        "source": "docker",
+        "target": "ic-survey-default-memcached",
+        "version": "dev"
+      },
+      "runFlags": "",
+      "score": 63
+    },
+    {
+      "failedDimensions": [],
+      "grade": "A",
+      "image": "nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10",
+      "label": "hardened-reference",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as 65532:65532 (uid != 0)",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 15,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "all capabilities dropped, none added back",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 20,
+            "title": "Dropped capabilities",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=none: no NIC but loopback, no egress",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 15,
+            "title": "Network isolation / egress",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "root filesystem is read-only",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 10,
+            "title": "Read-only root filesystem",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-08T11:27:33Z",
+        "grade": "A",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "runc",
+        "schemaVersion": "1.0",
+        "score": 100,
+        "source": "docker",
+        "target": "ic-survey-hardened-reference",
+        "version": "dev"
+      },
+      "runFlags": "--user 65532:65532 --cap-drop ALL --security-opt no-new-privileges --read-only --tmpfs /tmp --network none",
+      "score": 100
+    }
+  ],
+  "schemaVersion": "1.0"
+}

--- a/examples/isolation-survey/results.md
+++ b/examples/isolation-survey/results.md
@@ -1,0 +1,28 @@
+# State of Container Isolation — survey results
+
+Scanned **16 scenarios** with `ironctl scan` dev on 2026-07-08T11:27:08Z.
+
+Each row is one popular public image run with a specific configuration, graded 0-100 across seven containment dimensions (non-root user, dropped capabilities, seccomp, network isolation, read-only rootfs, no docker.sock, no host namespaces). Higher is safer. See [README.md](./README.md) for the exact method and [images.txt](./images.txt) for the pinned manifest.
+
+| Scenario | Image | Score | Grade | Top failed dimensions |
+|----------|-------|------:|:-----:|-----------------------|
+| `naive-privileged` | `python:3.13-alpine` | 19/100 | **F** | Dropped capabilities, Non-root user (uid != 0), Seccomp profile |
+| `naive-ci-docker-sock` | `node:22-alpine` | 33/100 | **D** | Dropped capabilities, Non-root user (uid != 0), No docker.sock exposure |
+| `naive-host-ns` | `redis:7-alpine` | 34/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| `default-golang` | `golang:1.23-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-httpd` | `httpd:2.4-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-mongo` | `mongo:7` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-mysql` | `mysql:8.4` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-nginx` | `nginx:1.27-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-node` | `node:22-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-postgres` | `postgres:17-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-python` | `python:3.13-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-rabbitmq` | `rabbitmq:4-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-redis` | `redis:7-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-wordpress` | `wordpress:6-php8.3-apache` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-memcached` | `memcached:1.6-alpine` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
+| `hardened-reference` | `nginx:1.27-alpine` | 100/100 | **A** | none |
+
+**Grade distribution:** 1×A, 1×C, 13×D, 1×F.
+
+Regenerate this file from a clean checkout with `examples/isolation-survey/survey.sh` (Docker required).

--- a/examples/isolation-survey/survey.sh
+++ b/examples/isolation-survey/survey.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# isolation-survey — run `ironctl scan` over a curated, pinned set of popular
+# PUBLIC container images and their common run configurations, and emit a
+# combined results.json + a rendered results.md table.
+#
+# This is the reproducible harness behind the "State of Container Isolation"
+# dataset (IRO-436): it turns `ironctl scan` from a per-user tool into a
+# defensible, shareable artifact. No credentials, no cloud, no account — only a
+# working Docker daemon (plus Go to build ironctl, and python3 to render, both
+# standard on any dev box / CI runner).
+#
+#   examples/isolation-survey/survey.sh              # scan every scenario, write results.*
+#   examples/isolation-survey/survey.sh --keep       # leave containers running afterwards
+#   IRONCTL=/path/to/ironctl examples/isolation-survey/survey.sh   # use a prebuilt binary
+#
+# Determinism / reproducibility:
+#   * Every image is pinned by its multi-arch manifest-list digest in images.txt,
+#     so `docker pull` resolves identical bits on amd64 and arm64.
+#   * The scan is read-only config inspection (docker inspect); it never runs the
+#     image's real workload — the entrypoint is overridden with `sleep` purely to
+#     keep the container alive for inspection.
+#   * Rows in results.md are sorted by score, so a re-run is byte-identical modulo
+#     the tool-version / timestamp stamp.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MANIFEST="$SCRIPT_DIR/images.txt"
+RESULTS_JSON="$SCRIPT_DIR/results.json"
+RESULTS_MD="$SCRIPT_DIR/results.md"
+NAME_PREFIX="ic-survey-"
+
+KEEP=0
+[ "${1:-}" = "--keep" ] && KEEP=1
+
+DOCKER="${DOCKER:-docker}"
+
+die() { echo "error: $*" >&2; exit 1; }
+log() { echo ">> $*" >&2; }
+
+command -v "$DOCKER" >/dev/null 2>&1 || die "docker not found (set \$DOCKER)"
+"$DOCKER" info >/dev/null 2>&1 || die "docker daemon not reachable (is it running?)"
+command -v python3 >/dev/null 2>&1 || die "python3 not found (needed to render results)"
+
+# Resolve ironctl: prefer $IRONCTL, else a repo-local build, else build it.
+IRONCTL="${IRONCTL:-}"
+if [ -z "$IRONCTL" ]; then
+  if [ -x "$REPO_ROOT/bin/ironctl" ]; then
+    IRONCTL="$REPO_ROOT/bin/ironctl"
+  else
+    log "building ironctl (CGO_ENABLED=1)…"
+    ( cd "$REPO_ROOT" && CGO_ENABLED=1 go build -o "$REPO_ROOT/bin/ironctl" ./cmd/ironctl )
+    IRONCTL="$REPO_ROOT/bin/ironctl"
+  fi
+fi
+[ -x "$IRONCTL" ] || die "ironctl not executable: $IRONCTL"
+log "ironctl: $IRONCTL ($("$IRONCTL" scan --help >/dev/null 2>&1 && echo ok))"
+
+# Track containers we create so we can always tear them down.
+CREATED=()
+cleanup() {
+  [ "$KEEP" -eq 1 ] && { log "--keep: leaving ${#CREATED[@]} container(s) running"; return; }
+  for c in "${CREATED[@]:-}"; do
+    [ -n "$c" ] && "$DOCKER" rm -f "$c" >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT
+
+# Accumulate per-scenario records as a JSON array on a temp file.
+RECORDS="$(mktemp)"
+trap 'rm -f "$RECORDS"' RETURN 2>/dev/null || true
+echo "[]" > "$RECORDS"
+
+append_record() { # label image runFlags scanjson-file
+  local label="$1" image="$2" flags="$3" scanfile="$4"
+  python3 - "$RECORDS" "$label" "$image" "$flags" "$scanfile" <<'PY'
+import json, sys
+recfile, label, image, flags, scanfile = sys.argv[1:6]
+with open(recfile) as f:
+    recs = json.load(f)
+with open(scanfile) as f:
+    report = json.load(f)
+recs.append({"label": label, "image": image, "runFlags": flags, "report": report})
+with open(recfile, "w") as f:
+    json.dump(recs, f)
+PY
+}
+
+n=0
+while IFS= read -r line; do
+  # strip comments / blanks
+  line="${line%%$'\r'}"
+  case "$line" in ''|'#'*) continue;; esac
+  # split on '|'
+  IFS='|' read -r label image flags <<<"$line"
+  label="$(echo "$label" | xargs)"
+  image="$(echo "$image" | xargs)"
+  flags="$(echo "${flags:-}" | xargs || true)"
+  [ -z "$label" ] && continue
+  n=$((n+1))
+  cname="${NAME_PREFIX}${label}"
+
+  # Pull only if the pinned digest is not already present locally. This makes
+  # re-runs fast and lets the survey complete from cache even when Docker Hub's
+  # anonymous pull-rate limit is exhausted. On a 429, back off and retry a few
+  # times; if you hit this often, `docker login` (a free account) lifts the
+  # anonymous limit — see README.md.
+  if "$DOCKER" image inspect "$image" >/dev/null 2>&1; then
+    log "[$n] $label — cached $image"
+  else
+    log "[$n] $label — pulling $image"
+    tries=0
+    until "$DOCKER" pull -q "$image" >/dev/null 2>pull.err; do
+      tries=$((tries+1))
+      if grep -qi "rate limit" pull.err && [ "$tries" -lt 5 ]; then
+        wait=$((tries*30))
+        log "[$n] $label — rate limited, retrying in ${wait}s (try $tries/5)"
+        sleep "$wait"
+        continue
+      fi
+      cat pull.err >&2; rm -f pull.err
+      die "pull failed for $image (see above; 'docker login' lifts anon rate limits)"
+    done
+    rm -f pull.err
+  fi
+
+  "$DOCKER" rm -f "$cname" >/dev/null 2>&1 || true
+  log "[$n] $label — docker run $flags --entrypoint sleep <image>"
+  # shellcheck disable=SC2086
+  "$DOCKER" run -d --name "$cname" $flags --entrypoint sleep "$image" 86400 >/dev/null
+  CREATED+=("$cname")
+
+  scanfile="$(mktemp)"
+  "$IRONCTL" scan "$cname" --json > "$scanfile"
+  score="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["score"])' "$scanfile")"
+  grade="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["grade"])' "$scanfile")"
+  log "[$n] $label — ${score}/100 grade ${grade}"
+  append_record "$label" "$image" "$flags" "$scanfile"
+  rm -f "$scanfile"
+
+  if [ "$KEEP" -eq 0 ]; then
+    "$DOCKER" rm -f "$cname" >/dev/null 2>&1 || true
+    CREATED=("${CREATED[@]/$cname}")
+  fi
+done < "$MANIFEST"
+
+[ "$n" -gt 0 ] || die "no scenarios found in $MANIFEST"
+
+log "rendering results.json + results.md ($n scenarios)…"
+python3 "$SCRIPT_DIR/render.py" "$RESULTS_JSON" "$RESULTS_MD" < "$RECORDS"
+
+log "done: $RESULTS_JSON"
+log "done: $RESULTS_MD"


### PR DESCRIPTION
## What

`examples/isolation-survey/` — a reproducible harness that runs `ironctl scan` over a curated, digest-pinned set of popular **public** container images and their common run configs, emitting a combined machine-readable `results.json` + a rendered `results.md` table (image → score → grade → top failed dimensions).

Turns `ironctl scan` (IRO-425) from a per-user tool into a defensible, shareable **State of Container Isolation** dataset. No credentials, no cloud, no account — only Docker. Hands off to Growth for the writeup.

## One command

```bash
examples/isolation-survey/survey.sh   # -> results.json + results.md
```

## Files

| File | What |
|------|------|
| `images.txt` | versioned manifest; every image pinned by multi-arch manifest-list digest; 3 families (plain defaults, naive CI/ops misconfigs, hardened reference) |
| `survey.sh` | pull (cache-skip + 429 backoff) → `docker run` → `ironctl scan --json` → aggregate; read-only; tears down every container it creates |
| `render.py` | stdlib aggregation into deterministic, score-sorted `results.{json,md}` |
| `README.md` | full methodology so results are defensible/repeatable by outsiders |
| `results.json` / `results.md` | the committed initial dataset (16 scenarios) |

## Initial dataset (this branch, real run)

16 scenarios, **19/F** (`--privileged`) → **100/A** (hardened reference). Highlights: 13 plain defaults land at **48/D** (root + full caps + writable rootfs + bridge egress); `memcached` **63/C** (ships a non-root default user); docker.sock mount **33/D**; `--privileged` **19/F**.

## Acceptance criteria

- [x] One command produces `results.json` + `results.md` from a clean checkout with only Docker present
- [x] Curated list captured in a versioned manifest with pinned digests (`images.txt`)
- [x] At least one real run committed as the initial dataset (16 scenarios)

## Security lenses

Read-only: uses `ironctl scan` (local `docker inspect` only), never touches the control-plane, queues, keys, or egress. Creates throwaway containers with an overridden `sleep` entrypoint (posture-neutral) and force-removes them. No trust boundary widened.

## Verification

Ran `survey.sh` end-to-end under colima (amd64, runc): all 16 scenarios scanned green, containers cleaned up (0 leftover), `results.json` validates, `results.md` renders. Docker Hub anon pull limits were hit mid-run — the harness's cache-skip + 429 backoff handled it; README documents `docker login` as the fix for outsiders.