### PR TITLE
feat(scan): shields.io Sandbox Isolation Score badge (--badge-json) + dogfood (IRO-438)

### DIFF
--- a/.ironclaw/sandbox-isolation.json
+++ b/.ironclaw/sandbox-isolation.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "sandbox isolation",
+  "message": "100/100 A",
+  "color": "3fb950"
+}

--- a/.ironclaw/sandbox-posture.yml
+++ b/.ironclaw/sandbox-posture.yml
@@ -1,0 +1,14 @@
+# IronClaw sandbox reference posture (what the isolation launcher applies to every
+# per-session sandbox): non-root nonroot uid, all caps dropped, no new privileges,
+# read-only rootfs, seccomp confined, network=none (egress only via host-mediated
+# socket, never a NIC), no shared host namespaces. See internal/host/isolation.
+services:
+  ironclaw-sandbox:
+    image: gcr.io/distroless/static:nonroot
+    user: "65532:65532"
+    cap_drop:
+      - ALL
+    network_mode: none
+    read_only: true
+    security_opt:
+      - no-new-privileges:true

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Each one runs sealed in a sandbox that provably cannot phone home, read your hos
 [![SBOM: SPDX + CycloneDX](https://img.shields.io/badge/SBOM-SPDX%20%2B%20CycloneDX-44883e.svg)](#verifying-a-release)
 [![SLSA provenance](https://img.shields.io/badge/SLSA-build%20provenance-44883e.svg)](#verifying-a-release)
 [![Sandbox scan: PR scorecard](https://img.shields.io/badge/sandbox%20scan-PR%20scorecard-0a7bbb.svg)](https://ironsecco.github.io/ironclaw/scan-action/)
+[![Sandbox Isolation Score](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/IronSecCo/ironclaw/main/.ironclaw/sandbox-isolation.json)](https://ironsecco.github.io/ironclaw/scan/#sandbox-isolation-score-badge)
 
 [![Documentation](https://img.shields.io/badge/docs-ironsecco.github.io-0a7bbb.svg)](https://ironsecco.github.io/ironclaw/)
 [![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#project-status)

--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -30,6 +30,7 @@ func cmdScan(args []string) error {
 	fs := flag.NewFlagSet("scan", flag.ContinueOnError)
 	asJSON := fs.Bool("json", false, "emit the scorecard as JSON")
 	badge := fs.String("badge", "", "write a shareable SVG badge to this path")
+	badgeJSON := fs.String("badge-json", "", "write a shields.io endpoint JSON badge to this path (embed a live README badge)")
 	md := fs.Bool("md", false, "print a shareable markdown block (README/blog section)")
 	fix := fs.Bool("fix", false, "emit concrete remediation config for each failed dimension")
 	remediate := fs.Bool("remediate", false, "alias for --fix")
@@ -125,6 +126,14 @@ func cmdScan(args []string) error {
 		}
 		if !*asJSON {
 			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", *badge)
+		}
+	}
+	if *badgeJSON != "" {
+		if err := os.WriteFile(*badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !*asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", *badgeJSON)
 		}
 	}
 
@@ -243,6 +252,7 @@ FLAGS:
   --fix               emit concrete remediation config for each failed dimension
   --remediate         alias for --fix
   --badge PATH        write a shareable SVG badge to PATH
+  --badge-json PATH   write a shields.io endpoint JSON badge to PATH (live README badge)
   --md                print a shareable markdown block
   --min-score N       exit non-zero if the score is below N (CI gate)
   --service NAME      compose service to grade (if the file has >1)

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -96,8 +96,46 @@ the runtime name. The dimension scorers remain the authority on the score.
 | `--json` | the full report as JSON (schemaVersion 1.0), for pipelines and dashboards |
 | `--fix` | print the concrete remediation for every failed dimension, plus a copy-pasteable hardened config (`--remediate` is an alias) |
 | `--badge scan.svg` | a self-contained SVG badge you can drop into a README |
+| `--badge-json badge.json` | a [shields.io endpoint](https://shields.io/badges/endpoint-badge) JSON file for a live, self-updating README badge |
 | `--md` | a shareable markdown block for a README or blog post |
 | `--min-score N` | exit non-zero when the score is below N (a CI gate) |
+
+## Sandbox Isolation Score badge
+
+Show your container's containment grade in your README, the same way a coverage or
+build badge advertises code health. Two ways to do it, both free and static (no
+server scans your image on every badge hit):
+
+**1. A pinned static badge (zero infrastructure).** Point a plain
+[shields.io static badge](https://shields.io/badges/static-badge) at your grade:
+
+```markdown
+![Sandbox Isolation](https://img.shields.io/badge/sandbox%20isolation-100%2F100%20A-3fb950)
+```
+
+**2. A live badge that updates itself.** Commit a small JSON file to your repo and
+let shields.io render it. Regenerate the file whenever your container config
+changes and the badge follows along:
+
+```bash
+# grade your container (or --compose FILE / --k8s FILE) and write the badge file
+ironctl scan my-container --badge-json .ironclaw/sandbox-isolation.json
+git add .ironclaw/sandbox-isolation.json && git commit -m "chore: refresh sandbox isolation badge"
+```
+
+Then embed it, swapping in your `OWNER/REPO/BRANCH/PATH`:
+
+```markdown
+[![Sandbox Isolation Score](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OWNER/REPO/main/.ironclaw/sandbox-isolation.json)](https://ironsecco.github.io/ironclaw/scan/)
+```
+
+The score is pinned in the committed file at generation time, so a badge hit never
+triggers a scan of a remote target. Grade to color follows the scorecard palette:
+A is green, B and C are amber, D and F are red.
+
+IronClaw dogfoods its own badge in the project README, generated from the sandbox
+reference posture the isolation launcher applies to every session
+(`.ironclaw/sandbox-posture.yml`, graded 100/100 A).
 
 ## Fix it, do not just grade it
 

--- a/internal/host/scan/render.go
+++ b/internal/host/scan/render.go
@@ -152,6 +152,37 @@ func RenderBadgeSVG(r Report) string {
 		llx, label, llx, label, rx, right, rx, right)
 }
 
+// BadgeEndpoint is the shields.io endpoint response schema (schemaVersion 1).
+// See https://shields.io/badges/endpoint-badge.
+type BadgeEndpoint struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	Label         string `json:"label"`
+	Message       string `json:"message"`
+	Color         string `json:"color"`
+}
+
+// RenderBadgeEndpointJSON returns the shields.io endpoint JSON for r. Commit the
+// output into your repo and point a shields endpoint badge at its raw URL to get
+// a live, self-updating Sandbox Isolation Score badge in your README:
+//
+//	![Sandbox Isolation](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/OWNER/REPO/BRANCH/PATH.json)
+//
+// The score is pinned at generation time; this file triggers no live scan (no
+// server-side DoS surface). Regenerate with `ironctl scan --badge-json` whenever
+// your container config changes.
+func RenderBadgeEndpointJSON(r Report) string {
+	b := BadgeEndpoint{
+		SchemaVersion: 1,
+		Label:         "sandbox isolation",
+		Message:       fmt.Sprintf("%d/100 %s", r.Score, r.Grade),
+		// shields accepts a bare 6-hex color; drop the leading '#'. Same palette
+		// as the committed SVG so both surfaces agree.
+		Color: strings.TrimPrefix(gradeColor(r.Grade), "#"),
+	}
+	out, _ := json.MarshalIndent(b, "", "  ")
+	return string(out) + "\n"
+}
+
 // gradeColor maps a letter grade to the shields flat-badge palette.
 func gradeColor(g string) string {
 	switch g {

--- a/internal/host/scan/render_test.go
+++ b/internal/host/scan/render_test.go
@@ -98,6 +98,35 @@ func TestRenderBadgeSVG(t *testing.T) {
 	}
 }
 
+func TestRenderBadgeEndpointJSON(t *testing.T) {
+	var pass BadgeEndpoint
+	if err := json.Unmarshal([]byte(RenderBadgeEndpointJSON(sampleReport())), &pass); err != nil {
+		t.Fatalf("badge JSON is not valid: %v", err)
+	}
+	if pass.SchemaVersion != 1 {
+		t.Errorf("schemaVersion = %d, want 1", pass.SchemaVersion)
+	}
+	if pass.Label != "sandbox isolation" {
+		t.Errorf("label = %q", pass.Label)
+	}
+	if pass.Message != "100/100 A" {
+		t.Errorf("message = %q, want 100/100 A", pass.Message)
+	}
+	// Color is the bare hex (no '#') so shields accepts it, and matches the SVG.
+	if want := strings.TrimPrefix(gradeColor("A"), "#"); pass.Color != want {
+		t.Errorf("color = %q, want %q", pass.Color, want)
+	}
+
+	// A failing report must render red, not green.
+	var fail BadgeEndpoint
+	if err := json.Unmarshal([]byte(RenderBadgeEndpointJSON(Score(Spec{}))), &fail); err != nil {
+		t.Fatalf("failing badge JSON invalid: %v", err)
+	}
+	if want := strings.TrimPrefix(gradeColor("F"), "#"); fail.Color != want {
+		t.Errorf("failing badge color = %q, want %q (red)", fail.Color, want)
+	}
+}
+
 func TestRenderMarkdown(t *testing.T) {
 	md := RenderMarkdown(sampleReport())
 	for _, want := range []string{"ic-sbx-demo", "100/100", "| Dimension |", "ironctl scan"} {


### PR DESCRIPTION
## What

Ships an embeddable **Sandbox Isolation Score** badge so any repo can display its `ironctl scan` grade in its README. Badges are the #1 organic OSS distribution mechanic: every embed is a backlink and a brand impression that pulls maintainers into the scan funnel.

## How (cheapest correct host: no server, no board gate, no DoS surface)

- New `ironctl scan --badge-json PATH` emits a [shields.io endpoint](https://shields.io/badges/endpoint-badge) JSON (`schemaVersion:1`, `label`, `message`, `color`). Commit the file, point a shields endpoint badge at its raw URL, and the badge renders live and self-updates on regen.
- **No server-side scanning.** The score is pinned in the committed file at generation time, so a badge hit never scans a remote target. Zero DoS surface, no rate-limiting needed. A plain shields *static* badge is also documented for zero-infra users.
- Grade to color map (A green, B/C amber, D/F red) reuses the existing `gradeColor` palette, so the JSON badge and the `--badge` SVG always agree.

## Dogfood

- `.ironclaw/sandbox-posture.yml` captures the reference posture the isolation launcher applies to every session (non-root uid 65532, drop-all caps, `network=none`, read-only rootfs, no-new-privileges, seccomp).
- `.ironclaw/sandbox-isolation.json` is the badge `ironctl scan` grades it to: **100/100 A**. Embedded in the README trust cluster.
- Reproduce: `ironctl scan --compose .ironclaw/sandbox-posture.yml --badge-json .ironclaw/sandbox-isolation.json`

## Docs

`docs/scan.md` gains a **Sandbox Isolation Score badge** section (static + live embed snippets, DoS note, palette).

## Verification

- `CGO_ENABLED=1 go build ./...` green.
- `go test ./internal/host/scan/ ./cmd/ironctl/` — 186 pass (new `TestRenderBadgeEndpointJSON` covers schema, message, palette, and fail-closed red).
- Badge JSON generated end-to-end by the tool from the committed posture (100/100 A).
- No em/en-dashes in added public copy.

## Security lenses

Touches **egress least-privilege / DoS surface**: deliberately avoids any scan-on-request path (score is pinned in a committed file, not scanned live per badge hit). No trust-boundary, isolation, encryption, or secret changes. Out of scope (deferred to the scan wave): public web checker and image leaderboard.

## Scope note

Did **not** touch the docker adapter cap-detection. On this colima CLI, `docker --cap-drop ALL` expands into 11 named caps with empty CapAdd, which the literal-`ALL` check on `main` misses (false negative 84/B for a fully hardened container). That is the same expansion IRO-435 (#417, in_review) already handles via `specFromDockerLike`; folding a competing fix here would conflict at merge. Dogfood uses the compose adapter, which reads `cap_drop: [ALL]` literally and is unaffected. Flagging for QA once #417 lands.

Closes IRO-438.