### PR TITLE
feat(scan): ironctl scan --sarif + GitHub code-scanning upload (IRO-440)

### DIFF
--- a/.github/actions/scan/README.md
+++ b/.github/actions/scan/README.md
@@ -69,6 +69,7 @@ Grade a **container**, a **compose** service, or a **k8s** manifest:
 | `min-score` | `0` | Fail the check below this score. `0` = report-only. |
 | `comment` | `true` | Post the scorecard as a sticky PR comment. |
 | `badge` | `false` | Write and upload the SVG badge as a build artifact. |
+| `upload-sarif` | `false` | Emit SARIF and upload to GitHub code scanning (Security tab). Requires `security-events: write`. |
 | `version` | `latest` | ironctl release to use (`latest` or a tag like `v0.1.252`). |
 | `github-token` | `${{ github.token }}` | Token for the comment + release lookup. |
 
@@ -80,6 +81,7 @@ Grade a **container**, a **compose** service, or a **k8s** manifest:
 | `grade` | Letter grade (A-F). |
 | `scorecard` | Path to the rendered markdown scorecard. |
 | `badge-path` | Path to the SVG badge (when `badge: true`). |
+| `sarif-path` | Path to the SARIF log (when `upload-sarif: true`). |
 | `passed` | `true` when the score met `min-score`. |
 
 ## What it grades

--- a/.github/actions/scan/action.yml
+++ b/.github/actions/scan/action.yml
@@ -51,6 +51,10 @@ inputs:
     description: 'Write and upload the shareable SVG badge as a build artifact (true/false).'
     required: false
     default: 'false'
+  upload-sarif:
+    description: 'Emit SARIF and upload it to GitHub code scanning so failed dimensions appear in the Security tab (true/false). Requires `permissions: security-events: write` in the calling workflow. Default false so the action needs no extra permission unless you opt in.'
+    required: false
+    default: 'false'
   version:
     description: 'ironctl release to use: a tag like v0.1.252, or "latest" (default).'
     required: false
@@ -73,6 +77,9 @@ outputs:
   badge-path:
     description: 'Path to the SVG badge (only when badge=true).'
     value: ${{ steps.scan.outputs.badge-path }}
+  sarif-path:
+    description: 'Path to the SARIF log (only when upload-sarif=true).'
+    value: ${{ steps.scan.outputs.sarif-path }}
   passed:
     description: 'true when the score met min-score (or min-score was 0).'
     value: ${{ steps.scan.outputs.passed }}
@@ -89,9 +96,21 @@ runs:
         IC_MIN_SCORE: ${{ inputs.min-score }}
         IC_COMMENT: ${{ inputs.comment }}
         IC_BADGE: ${{ inputs.badge }}
+        IC_UPLOAD_SARIF: ${{ inputs.upload-sarif }}
         IC_VERSION: ${{ inputs.version }}
         GH_TOKEN: ${{ inputs.github-token }}
       run: bash "${GITHUB_ACTION_PATH}/scan.sh"
+
+    # Opt-in SARIF upload: surfaces failed isolation dimensions in the repo's
+    # Security > Code scanning tab. Gated on upload-sarif so the action needs no
+    # security-events permission unless the consumer opts in. always() so a SARIF
+    # written before a min-score gate failure still uploads. codeql-action pinned
+    # by commit SHA (supply-chain).
+    - if: ${{ always() && inputs.upload-sarif == 'true' && steps.scan.outputs.sarif-path != '' }}
+      uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
+      with:
+        sarif_file: ${{ steps.scan.outputs.sarif-path }}
+        category: ironclaw-scan
 
     # Uploaded as a separate composite step, with always(), so the artifact
     # survives even when the scan step fails the min-score gate after the badge

--- a/.github/actions/scan/scan.sh
+++ b/.github/actions/scan/scan.sh
@@ -13,6 +13,7 @@ SERVICE="${IC_SERVICE:-}"
 MIN_SCORE="${IC_MIN_SCORE:-0}"
 COMMENT="${IC_COMMENT:-true}"
 BADGE="${IC_BADGE:-false}"
+UPLOAD_SARIF="${IC_UPLOAD_SARIF:-false}"
 VERSION="${IC_VERSION:-latest}"
 
 REPO="IronSecCo/ironclaw"
@@ -64,6 +65,7 @@ chmod +x "$IRONCTL"
 # ---------------------------------------------------------------------------
 scorecard="${WORK}/scorecard.md"
 badge_path=""
+sarif_path=""
 scan_args=()
 case "$MODE" in
   container)
@@ -81,6 +83,10 @@ scan_args+=(--md)
 if [ "$BADGE" = "true" ]; then
   badge_path="${WORK}/scan-badge.svg"
   scan_args+=(--badge "$badge_path")
+fi
+if [ "$UPLOAD_SARIF" = "true" ]; then
+  sarif_path="${WORK}/ironclaw-scan.sarif"
+  scan_args+=(--sarif "$sarif_path")
 fi
 
 # ---------------------------------------------------------------------------
@@ -112,6 +118,9 @@ out score "$score"
 out grade "${grade:-?}"
 out scorecard "$scorecard"
 [ -n "$badge_path" ] && out badge-path "$badge_path"
+# Only advertise the SARIF path when the file was actually written, so the
+# upload step's guard is precise and never uploads a missing file.
+[ -n "$sarif_path" ] && [ -s "$sarif_path" ] && out sarif-path "$sarif_path"
 
 # ---------------------------------------------------------------------------
 # 4. Sticky PR comment (create-or-update). A stable marker keyed by mode+target

--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -25,12 +25,13 @@ import (
 //	ironctl scan <container>                 grade a running docker container
 //	ironctl scan --compose FILE [--service N]  grade a compose service
 //	ironctl scan --k8s FILE                    grade a pod/workload manifest
-//	  [--json] [--badge scan.svg] [--md] [--min-score N]
+//	  [--json] [--badge scan.svg] [--sarif scan.sarif] [--md] [--min-score N]
 func cmdScan(args []string) error {
 	fs := flag.NewFlagSet("scan", flag.ContinueOnError)
 	asJSON := fs.Bool("json", false, "emit the scorecard as JSON")
 	badge := fs.String("badge", "", "write a shareable SVG badge to this path")
 	badgeJSON := fs.String("badge-json", "", "write a shields.io endpoint JSON badge to this path (embed a live README badge)")
+	sarif := fs.String("sarif", "", "write a SARIF 2.1.0 log to this path (GitHub code-scanning upload)")
 	md := fs.Bool("md", false, "print a shareable markdown block (README/blog section)")
 	fix := fs.Bool("fix", false, "emit concrete remediation config for each failed dimension")
 	remediate := fs.Bool("remediate", false, "alias for --fix")
@@ -60,10 +61,14 @@ func cmdScan(args []string) error {
 		rest = rest[1:]
 	}
 
-	// Resolve the source and build a normalized Spec.
+	// Resolve the source and build a normalized Spec. configFile/configRaw carry
+	// the scanned file (compose/k8s) so SARIF results anchor at the config; both
+	// stay empty for a live-container scan (no file to point at).
 	var (
-		spec scan.Spec
-		err  error
+		spec       scan.Spec
+		err        error
+		configFile string
+		configRaw  []byte
 	)
 	switch {
 	case *compose != "":
@@ -71,12 +76,14 @@ func cmdScan(args []string) error {
 		if rerr != nil {
 			return fmt.Errorf("read compose file: %w", rerr)
 		}
+		configFile, configRaw = *compose, raw
 		spec, err = scan.SpecFromCompose(raw, *service)
 	case *k8s != "":
 		raw, rerr := os.ReadFile(*k8s)
 		if rerr != nil {
 			return fmt.Errorf("read manifest: %w", rerr)
 		}
+		configFile, configRaw = *k8s, raw
 		spec, err = scan.SpecFromK8s(raw)
 	default:
 		if len(positional) < 1 {
@@ -137,11 +144,40 @@ func cmdScan(args []string) error {
 		}
 	}
 
+	if *sarif != "" {
+		// SARIF is a best-effort side artifact: an emit error must never block the
+		// scan itself (fail-open), and never affects the min-score gate below.
+		opts := scan.SARIFOptions{ConfigFile: configFile}
+		if configRaw != nil {
+			opts.AnchorLine = scan.AnchorLine(configRaw, spec.Target)
+		}
+		if err := writeSARIF(*sarif, report, spec, opts); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !*asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", *sarif)
+		}
+	}
+
 	// CI gate: fail-closed below the requested threshold.
 	if *minScore > 0 && report.Score < *minScore {
 		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, *minScore)
 	}
 	return nil
+}
+
+// writeSARIF renders the SARIF log for report r to path. It is separated so the
+// caller can fail-open on any error without leaking a half-written file into a
+// later step.
+func writeSARIF(path string, r scan.Report, s scan.Spec, opts scan.SARIFOptions) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	if err := scan.RenderSARIF(f, r, s, opts); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 // runtimeBins carries the resolved binary name for each supported runtime.
@@ -253,6 +289,7 @@ FLAGS:
   --remediate         alias for --fix
   --badge PATH        write a shareable SVG badge to PATH
   --badge-json PATH   write a shields.io endpoint JSON badge to PATH (live README badge)
+  --sarif PATH        write a SARIF 2.1.0 log to PATH (GitHub code-scanning upload)
   --md                print a shareable markdown block
   --min-score N       exit non-zero if the score is below N (CI gate)
   --service NAME      compose service to grade (if the file has >1)

--- a/docs/scan-action.md
+++ b/docs/scan-action.md
@@ -73,10 +73,42 @@ The file modes need no Docker daemon — the action reads the file directly:
 | `min-score` | `0` | Fail the check below this score. `0` = report-only. |
 | `comment` | `true` | Post the scorecard as a sticky PR comment. |
 | `badge` | `false` | Write and upload the SVG badge as a build artifact. |
+| `upload-sarif` | `false` | Emit SARIF and upload it to GitHub code scanning (Security tab). Requires `security-events: write`. |
 | `version` | `latest` | ironctl release (`latest` or a tag like `v0.1.252`). |
 | `github-token` | `${{ github.token }}` | Token for the comment + release lookup. |
 
-Outputs: `score`, `grade`, `scorecard` (path), `badge-path`, and `passed`.
+Outputs: `score`, `grade`, `scorecard` (path), `badge-path`, `sarif-path`, and `passed`.
+
+## Surface findings in the Security tab (SARIF)
+
+Set `upload-sarif: true` and grant `security-events: write`, and the action
+uploads a [SARIF 2.1.0](scan.md#github-code-scanning-security-tab) log so every
+failed isolation dimension shows up in your repo's **Security > Code scanning**
+tab, deduped across runs, alongside CodeQL and any other scanner:
+
+```yaml
+permissions:
+  contents: read
+  security-events: write      # required to upload SARIF
+  pull-requests: write        # only if you also keep the sticky comment
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: IronSecCo/ironclaw/.github/actions/scan@v1
+        with:
+          mode: compose
+          target: docker-compose.yml
+          upload-sarif: true
+```
+
+`upload-sarif` defaults to `false`, so the action asks for **no** new permission
+unless you opt in. Results are anchored at the scanned config file (with a line
+region when derivable), and a clean 100/A target uploads zero findings. SARIF
+emit is fail-open: a write failure never blocks the scan or its `min-score` gate.
+The upload uses `github/codeql-action/upload-sarif`, pinned by commit SHA.
 
 ## Report-only vs. gating
 

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -97,6 +97,7 @@ the runtime name. The dimension scorers remain the authority on the score.
 | `--fix` | print the concrete remediation for every failed dimension, plus a copy-pasteable hardened config (`--remediate` is an alias) |
 | `--badge scan.svg` | a self-contained SVG badge you can drop into a README |
 | `--badge-json badge.json` | a [shields.io endpoint](https://shields.io/badges/endpoint-badge) JSON file for a live, self-updating README badge |
+| `--sarif scan.sarif` | a SARIF 2.1.0 log you can upload to GitHub code scanning (findings land in the repo Security tab) |
 | `--md` | a shareable markdown block for a README or blog post |
 | `--min-score N` | exit non-zero when the score is below N (a CI gate) |
 
@@ -140,6 +141,44 @@ reference posture the isolation launcher applies to every session
 For a step-by-step walkthrough, including hosting the file, wiring it into CI, and the
 reasoning behind the committed-file design, see the blog post
 [Add a live Sandbox Isolation Score badge to your repo](blog/add-a-sandbox-isolation-score-badge-to-your-repo.md).
+
+## GitHub code scanning (Security tab)
+
+Emit [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html)
+and upload it so every failed isolation dimension appears in your repo's
+**Security > Code scanning** tab, right next to the findings from CodeQL and any
+other scanner, with no IronClaw account required:
+
+```bash
+ironctl scan --compose docker-compose.yml --sarif ironclaw-scan.sarif
+```
+
+- One SARIF **rule** per graded dimension (non-root user, dropped capabilities,
+  seccomp, network isolation, read-only rootfs, docker.sock, host namespaces),
+  each carrying the concrete remediation as `help` text.
+- One SARIF **result** per FAILED dimension, at `error` or `warning` level from
+  the dimension's severity, anchored at the scanned config file (with a line
+  region when derivable). A clean 100/A target emits **zero** results.
+- A stable `partialFingerprints` value per (rule, file) so GitHub dedupes the
+  same finding across runs instead of re-alerting.
+
+The easiest way to upload is the [scan Action](scan-action.md) with
+`upload-sarif: true`; it runs the scan and hands the SARIF to
+`github/codeql-action/upload-sarif` for you. To upload from your own workflow,
+grant `permissions: security-events: write` and call the same action:
+
+```yaml
+permissions:
+  security-events: write   # required to upload SARIF
+steps:
+  - uses: github/codeql-action/upload-sarif@v3
+    with:
+      sarif_file: ironclaw-scan.sarif
+      category: ironclaw-scan
+```
+
+SARIF emit is fail-open: if writing the file ever fails, the scan itself (and its
+`--min-score` gate) is unaffected.
 
 ## Fix it, do not just grade it
 

--- a/internal/host/scan/render.go
+++ b/internal/host/scan/render.go
@@ -1,12 +1,18 @@
 package scan
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
 	"text/tabwriter"
 )
+
+// scanDocsURL is the published hardening guide, used as the SARIF driver's
+// informationUri and the fallback remediation pointer.
+const scanDocsURL = "https://ironsecco.github.io/ironclaw/scan/"
 
 // RenderTable writes the human-readable scorecard to w: a header line with the
 // overall score + grade, then one row per dimension.
@@ -181,6 +187,249 @@ func RenderBadgeEndpointJSON(r Report) string {
 	}
 	out, _ := json.MarshalIndent(b, "", "  ")
 	return string(out) + "\n"
+}
+
+// --------------------------------------------------------------------------- //
+// SARIF 2.1.0 — GitHub code-scanning integration.
+//
+// RenderSARIF emits a Static Analysis Results Interchange Format log so failed
+// isolation dimensions surface in a repo's Security > Code scanning tab (upload
+// via github/codeql-action/upload-sarif). One rule per graded dimension; one
+// result per non-PASS dimension. A clean 100/A target produces zero results.
+// --------------------------------------------------------------------------- //
+
+// SARIFOptions carries the source-location context RenderSARIF needs to anchor
+// results at the scanned artifact. Both fields are optional: with no ConfigFile
+// (a live container scan) results anchor at a logical location naming the
+// workload; with ConfigFile but AnchorLine 0 they anchor at file level.
+type SARIFOptions struct {
+	// ConfigFile is the repo-relative path to the scanned config (a
+	// docker-compose.yml, k8s manifest, or posture file). "" for a live
+	// container scan, which has no file to point at.
+	ConfigFile string
+	// AnchorLine is the 1-based line the results point at (the workload's
+	// declaration), when derivable. 0 means file-level.
+	AnchorLine int
+}
+
+type sarifLog struct {
+	Schema  string     `json:"$schema"`
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name           string      `json:"name"`
+	Version        string      `json:"version,omitempty"`
+	InformationURI string      `json:"informationUri,omitempty"`
+	Rules          []sarifRule `json:"rules"`
+}
+
+type sarifRule struct {
+	ID                   string          `json:"id"`
+	Name                 string          `json:"name"`
+	ShortDescription     sarifText       `json:"shortDescription"`
+	FullDescription      sarifText       `json:"fullDescription"`
+	Help                 sarifMsg        `json:"help"`
+	DefaultConfiguration sarifRuleConfig `json:"defaultConfiguration"`
+	Properties           sarifRuleProps  `json:"properties,omitempty"`
+}
+
+type sarifText struct {
+	Text string `json:"text"`
+}
+
+type sarifMsg struct {
+	Text     string `json:"text"`
+	Markdown string `json:"markdown,omitempty"`
+}
+
+type sarifRuleConfig struct {
+	Level string `json:"level"`
+}
+
+type sarifRuleProps struct {
+	Tags []string `json:"tags,omitempty"`
+}
+
+type sarifResult struct {
+	RuleID              string            `json:"ruleId"`
+	RuleIndex           int               `json:"ruleIndex"`
+	Level               string            `json:"level"`
+	Message             sarifText         `json:"message"`
+	Locations           []sarifLocation   `json:"locations"`
+	PartialFingerprints map[string]string `json:"partialFingerprints,omitempty"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation *sarifPhysical `json:"physicalLocation,omitempty"`
+	LogicalLocations []sarifLogical `json:"logicalLocations,omitempty"`
+}
+
+type sarifPhysical struct {
+	ArtifactLocation sarifArtifact `json:"artifactLocation"`
+	Region           *sarifRegion  `json:"region,omitempty"`
+}
+
+type sarifArtifact struct {
+	URI string `json:"uri"`
+}
+
+type sarifRegion struct {
+	StartLine int `json:"startLine"`
+}
+
+type sarifLogical struct {
+	Name               string `json:"name"`
+	FullyQualifiedName string `json:"fullyQualifiedName,omitempty"`
+}
+
+// RenderSARIF writes a SARIF 2.1.0 log for report r (graded from spec s) to w.
+// Every graded dimension becomes a rule (with remediation reused from
+// remediate.go as help text); every non-PASS dimension becomes a result whose
+// level derives from the dimension's severity, anchored at the scanned config
+// via opts. Deterministic for a given (report, spec, opts): no clock, no
+// randomness, and fingerprints are stable per (rule, file) so GitHub dedupes
+// findings across runs.
+func RenderSARIF(w io.Writer, r Report, s Spec, opts SARIFOptions) error {
+	driver := sarifDriver{
+		Name:           "ironctl-scan",
+		Version:        r.Version,
+		InformationURI: scanDocsURL,
+	}
+	ruleIndex := make(map[string]int, len(scorers))
+	for i, sc := range scorers {
+		ruleIndex[sc.key] = i
+		fix, expl := dimFix(s, sc.key)
+		driver.Rules = append(driver.Rules, sarifRule{
+			ID:               sc.key,
+			Name:             sarifRuleName(sc.key),
+			ShortDescription: sarifText{Text: sc.title},
+			FullDescription:  sarifText{Text: expl},
+			Help: sarifMsg{
+				Text:     fmt.Sprintf("%s\n\nFix: %s\nMore: %s", expl, fix, scanDocsURL),
+				Markdown: fmt.Sprintf("%s\n\n**Fix:** `%s`\n\n[Hardening guide](%s)", expl, fix, scanDocsURL),
+			},
+			DefaultConfiguration: sarifRuleConfig{Level: sarifSeverity(sc.max)},
+			Properties:           sarifRuleProps{Tags: []string{"security", "containment", "ironclaw"}},
+		})
+	}
+
+	// results must marshal as [] (not null) even when empty: SARIF requires the
+	// array present, and a clean 100/A scan legitimately has zero results.
+	results := []sarifResult{}
+	for _, d := range r.Dimensions {
+		if d.Verdict == VerdictPass {
+			continue
+		}
+		idx := ruleIndex[d.Key]
+		fix, _ := dimFix(s, d.Key)
+		results = append(results, sarifResult{
+			RuleID:    d.Key,
+			RuleIndex: idx,
+			Level:     sarifResultLevel(d.Verdict, scorers[idx].max),
+			Message: sarifText{Text: fmt.Sprintf("%s (%s): %s. Fix: %s",
+				d.Title, d.Verdict, d.Detail, fix)},
+			Locations:           []sarifLocation{sarifLoc(opts, s)},
+			PartialFingerprints: map[string]string{"ironclawScan/v1": sarifFingerprint(d.Key, opts.ConfigFile)},
+		})
+	}
+
+	out, err := json.MarshalIndent(sarifLog{
+		Schema:  "https://json.schemastore.org/sarif-2.1.0.json",
+		Version: "2.1.0",
+		Runs:    []sarifRun{{Tool: sarifTool{Driver: driver}, Results: results}},
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(append(out, '\n'))
+	return err
+}
+
+// sarifLoc builds the location for a result: a physicalLocation at the scanned
+// file (with a region when the workload's line is derivable) when a config file
+// was scanned, else a logicalLocation naming the container.
+func sarifLoc(opts SARIFOptions, s Spec) sarifLocation {
+	if opts.ConfigFile != "" {
+		pl := &sarifPhysical{ArtifactLocation: sarifArtifact{URI: opts.ConfigFile}}
+		if opts.AnchorLine > 0 {
+			pl.Region = &sarifRegion{StartLine: opts.AnchorLine}
+		}
+		return sarifLocation{PhysicalLocation: pl}
+	}
+	name := nz(s.Target, "container")
+	return sarifLocation{LogicalLocations: []sarifLogical{{
+		Name:               name,
+		FullyQualifiedName: nz(s.Source, "container") + "/" + name,
+	}}}
+}
+
+// sarifSeverity maps a dimension's weight to a SARIF level: the heavier
+// boundaries (>=15 pts, each a full host-compromise primitive when breached)
+// are errors, the rest warnings.
+func sarifSeverity(maxWeight int) string {
+	if maxWeight >= 15 {
+		return "error"
+	}
+	return "warning"
+}
+
+// sarifResultLevel is the level for one result: a WARN (partial/weakened)
+// posture never escalates past warning; a FAIL/UNKNOWN inherits the rule's
+// severity.
+func sarifResultLevel(v Verdict, maxWeight int) string {
+	if v == VerdictWarn {
+		return "warning"
+	}
+	return sarifSeverity(maxWeight)
+}
+
+// sarifRuleName converts a dotted dimension key ("user.nonroot") to a
+// PascalCase rule name ("UserNonroot") for the SARIF rule.name field.
+func sarifRuleName(key string) string {
+	parts := strings.FieldsFunc(key, func(r rune) bool { return r == '.' || r == '_' || r == '-' })
+	var b strings.Builder
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		b.WriteString(strings.ToUpper(p[:1]) + p[1:])
+	}
+	return b.String()
+}
+
+// sarifFingerprint is a stable partial fingerprint per (rule, file) so GitHub
+// dedupes the same finding across runs and only alerts on genuinely new ones.
+func sarifFingerprint(ruleID, file string) string {
+	sum := sha256.Sum256([]byte(ruleID + "\x00" + file))
+	return hex.EncodeToString(sum[:8])
+}
+
+// AnchorLine returns the 1-based line number of the first line in raw that
+// mentions target (a compose service or k8s container/pod name) so SARIF
+// results anchor at the workload's declaration. Returns 0 (file-level) when
+// target is empty or not found.
+func AnchorLine(raw []byte, target string) int {
+	t := strings.TrimSpace(target)
+	if t == "" {
+		return 0
+	}
+	for i, line := range strings.Split(string(raw), "\n") {
+		if strings.Contains(line, t) {
+			return i + 1
+		}
+	}
+	return 0
 }
 
 // gradeColor maps a letter grade to the shields flat-badge palette.

--- a/internal/host/scan/sarif_test.go
+++ b/internal/host/scan/sarif_test.go
@@ -1,0 +1,269 @@
+package scan
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// updateGolden regenerates the committed golden SARIF fixture: `go test
+// ./internal/host/scan/ -run Golden -update`.
+var updateGolden = flag.Bool("update", false, "update the golden SARIF fixture")
+
+// goldenSpec is a fixed weak compose service used for the golden fixture: root,
+// default caps, seccomp=unconfined, bridge egress, writable rootfs, docker.sock
+// mounted, host PID shared. Every dimension is non-PASS, so it exercises the
+// full result set with a stable, deterministic shape.
+func goldenSpec() Spec {
+	return Spec{
+		Source: "compose", Target: "web", Image: "nginx:latest",
+		RunAsNonRoot: No, User: "0",
+		CapDropAll: No, Seccomp: "unconfined",
+		NetworkMode: "bridge", ReadonlyRoot: No,
+		DockerSock: Yes, HostPathMounts: []string{"/var/run/docker.sock"},
+		HostPID: Yes,
+	}
+}
+
+// TestRenderSARIF_Golden pins the exact SARIF byte output for a fixed spec so
+// any accidental shape/field change is caught in review. Regenerate with
+// -update after an intentional change.
+func TestRenderSARIF_Golden(t *testing.T) {
+	s := goldenSpec()
+	r := Score(s)
+	r.Version = "v0.0.0-golden"
+	var b bytes.Buffer
+	if err := RenderSARIF(&b, r, s, SARIFOptions{ConfigFile: "docker-compose.yml", AnchorLine: 3}); err != nil {
+		t.Fatal(err)
+	}
+	golden := filepath.Join("testdata", "weak_compose.sarif.json")
+	if *updateGolden {
+		if err := os.WriteFile(golden, b.Bytes(), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	want, err := os.ReadFile(golden)
+	if err != nil {
+		t.Fatalf("read golden (run with -update to create): %v", err)
+	}
+	if !bytes.Equal(b.Bytes(), want) {
+		t.Errorf("SARIF output drifted from golden. Run: go test ./internal/host/scan/ -run Golden -update\n--- got ---\n%s", b.String())
+	}
+}
+
+// decodeSARIF renders r/s/opts to SARIF and unmarshals it, failing on malformed
+// JSON so every test gets a typed tree to assert against.
+func decodeSARIF(t *testing.T, r Report, s Spec, opts SARIFOptions) sarifLog {
+	t.Helper()
+	var b bytes.Buffer
+	if err := RenderSARIF(&b, r, s, opts); err != nil {
+		t.Fatalf("RenderSARIF: %v", err)
+	}
+	var log sarifLog
+	if err := json.Unmarshal(b.Bytes(), &log); err != nil {
+		t.Fatalf("SARIF is not valid JSON: %v\n%s", err, b.String())
+	}
+	return log
+}
+
+// TestRenderSARIF_Shape asserts the top-level 2.1.0 envelope and driver metadata
+// required by the schema and by GitHub's code-scanning ingest.
+func TestRenderSARIF_Shape(t *testing.T) {
+	s := weakDockerSpec()
+	log := decodeSARIF(t, Score(s), s, SARIFOptions{})
+
+	if log.Version != "2.1.0" {
+		t.Errorf("version = %q, want 2.1.0", log.Version)
+	}
+	if !strings.Contains(log.Schema, "sarif-2.1.0") {
+		t.Errorf("$schema = %q, missing sarif-2.1.0", log.Schema)
+	}
+	if len(log.Runs) != 1 {
+		t.Fatalf("runs = %d, want 1", len(log.Runs))
+	}
+	d := log.Runs[0].Tool.Driver
+	if d.Name != "ironctl-scan" {
+		t.Errorf("driver.name = %q, want ironctl-scan", d.Name)
+	}
+	if d.InformationURI == "" {
+		t.Error("driver.informationUri is empty")
+	}
+	// One rule per graded dimension, indices aligned with results.
+	if len(d.Rules) != len(scorers) {
+		t.Fatalf("rules = %d, want %d (one per dimension)", len(d.Rules), len(scorers))
+	}
+	for i, rule := range d.Rules {
+		if rule.ID != scorers[i].key {
+			t.Errorf("rule[%d].id = %q, want %q", i, rule.ID, scorers[i].key)
+		}
+		if rule.ShortDescription.Text == "" || rule.FullDescription.Text == "" {
+			t.Errorf("rule %q missing descriptions", rule.ID)
+		}
+		if rule.Help.Text == "" || rule.Help.Markdown == "" {
+			t.Errorf("rule %q missing help", rule.ID)
+		}
+		if rule.DefaultConfiguration.Level != "error" && rule.DefaultConfiguration.Level != "warning" {
+			t.Errorf("rule %q level = %q, want error|warning", rule.ID, rule.DefaultConfiguration.Level)
+		}
+	}
+}
+
+// TestRenderSARIF_CleanTargetZeroResults is the core acceptance: a hardened
+// 100/A workload emits rules but ZERO results (nothing shows in the Security tab).
+func TestRenderSARIF_CleanTargetZeroResults(t *testing.T) {
+	s := Spec{
+		Source: "docker", Target: "ic-sbx-demo",
+		RunAsNonRoot: Yes, User: "65532", CapDropAll: Yes, Seccomp: "confined",
+		NetworkMode: "none", ReadonlyRoot: Yes, DockerSock: No,
+		HostPID: No, HostIPC: No, HostNetwork: No,
+	}
+	r := Score(s)
+	if r.Score != 100 {
+		t.Fatalf("precondition: score = %d, want 100", r.Score)
+	}
+	log := decodeSARIF(t, r, s, SARIFOptions{})
+	if got := len(log.Runs[0].Results); got != 0 {
+		t.Errorf("clean target produced %d results, want 0", got)
+	}
+	// results must still marshal as [] (not null) for schema validity.
+	var b bytes.Buffer
+	_ = RenderSARIF(&b, r, s, SARIFOptions{})
+	if !strings.Contains(b.String(), `"results": []`) {
+		t.Error("empty results must marshal as [], not null")
+	}
+}
+
+// TestRenderSARIF_FailingDims asserts every non-PASS dimension yields exactly one
+// result, with a valid level, a rule-aligned index, a location, and a fingerprint.
+func TestRenderSARIF_FailingDims(t *testing.T) {
+	s := weakDockerSpec()
+	r := Score(s)
+	log := decodeSARIF(t, r, s, SARIFOptions{ConfigFile: "docker-compose.yml", AnchorLine: 4})
+	results := log.Runs[0].Results
+
+	// Count non-PASS dimensions; every one must produce a result.
+	wantN := 0
+	for _, d := range r.Dimensions {
+		if d.Verdict != VerdictPass {
+			wantN++
+		}
+	}
+	if len(results) != wantN {
+		t.Fatalf("results = %d, want %d (one per non-PASS dim)", len(results), wantN)
+	}
+
+	seen := map[string]bool{}
+	for _, res := range results {
+		seen[res.RuleID] = true
+		if res.Level != "error" && res.Level != "warning" {
+			t.Errorf("result %q level = %q, want error|warning", res.RuleID, res.Level)
+		}
+		if res.RuleIndex < 0 || res.RuleIndex >= len(scorers) || scorers[res.RuleIndex].key != res.RuleID {
+			t.Errorf("result %q ruleIndex %d does not point at its rule", res.RuleID, res.RuleIndex)
+		}
+		if len(res.Locations) == 0 {
+			t.Errorf("result %q has no location", res.RuleID)
+		}
+		if res.Message.Text == "" {
+			t.Errorf("result %q has empty message", res.RuleID)
+		}
+		if res.PartialFingerprints["ironclawScan/v1"] == "" {
+			t.Errorf("result %q missing partialFingerprint", res.RuleID)
+		}
+		// File-anchored results point at the config with the derived region.
+		pl := res.Locations[0].PhysicalLocation
+		if pl == nil || pl.ArtifactLocation.URI != "docker-compose.yml" {
+			t.Errorf("result %q not anchored at the config file: %+v", res.RuleID, res.Locations[0])
+		}
+		if pl.Region == nil || pl.Region.StartLine != 4 {
+			t.Errorf("result %q region = %+v, want startLine 4", res.RuleID, pl.Region)
+		}
+	}
+	// docker.sock exposure is a headline failure; it must be present as an error.
+	if !seen["docker.sock"] {
+		t.Error("expected a docker.sock result on the weak spec")
+	}
+}
+
+// TestRenderSARIF_LogicalLocationForContainer: a live-container scan (no config
+// file) anchors results at a logical location naming the workload, not a bogus
+// physical path.
+func TestRenderSARIF_LogicalLocationForContainer(t *testing.T) {
+	s := weakDockerSpec()
+	log := decodeSARIF(t, Score(s), s, SARIFOptions{})
+	loc := log.Runs[0].Results[0].Locations[0]
+	if loc.PhysicalLocation != nil {
+		t.Error("container scan should not fabricate a physicalLocation")
+	}
+	if len(loc.LogicalLocations) == 0 || loc.LogicalLocations[0].Name != "weak" {
+		t.Errorf("logicalLocation = %+v, want name 'weak'", loc.LogicalLocations)
+	}
+}
+
+// TestSARIF_FingerprintStable: the partial fingerprint is deterministic per
+// (rule, file) so GitHub dedupes across runs and differs when the file differs.
+func TestSARIF_FingerprintStable(t *testing.T) {
+	a := sarifFingerprint("caps.dropped", "docker-compose.yml")
+	if a != sarifFingerprint("caps.dropped", "docker-compose.yml") {
+		t.Error("fingerprint is not deterministic")
+	}
+	if a == sarifFingerprint("caps.dropped", "k8s.yaml") {
+		t.Error("fingerprint should vary with the file")
+	}
+	if a == sarifFingerprint("seccomp", "docker-compose.yml") {
+		t.Error("fingerprint should vary with the rule")
+	}
+}
+
+func TestSARIFLevelMapping(t *testing.T) {
+	if sarifSeverity(20) != "error" || sarifSeverity(15) != "error" {
+		t.Error("weight >= 15 should be error")
+	}
+	if sarifSeverity(10) != "warning" {
+		t.Error("weight < 15 should be warning")
+	}
+	// WARN never escalates past warning even on a heavy dimension.
+	if sarifResultLevel(VerdictWarn, 20) != "warning" {
+		t.Error("WARN must map to warning")
+	}
+	if sarifResultLevel(VerdictFail, 20) != "error" {
+		t.Error("FAIL on a heavy dim must map to error")
+	}
+	if sarifResultLevel(VerdictUnknown, 20) != "error" {
+		t.Error("UNKNOWN (fail-closed) must map to error")
+	}
+}
+
+func TestAnchorLine(t *testing.T) {
+	raw := []byte("version: '3'\nservices:\n  web:\n    image: nginx\n  db:\n    image: postgres\n")
+	if got := AnchorLine(raw, "db"); got != 5 {
+		t.Errorf("AnchorLine(db) = %d, want 5", got)
+	}
+	if got := AnchorLine(raw, "missing"); got != 0 {
+		t.Errorf("AnchorLine(missing) = %d, want 0", got)
+	}
+	if got := AnchorLine(raw, ""); got != 0 {
+		t.Errorf("AnchorLine(empty) = %d, want 0", got)
+	}
+}
+
+func TestSarifRuleName(t *testing.T) {
+	cases := map[string]string{
+		"user.nonroot":     "UserNonroot",
+		"caps.dropped":     "CapsDropped",
+		"namespaces.host":  "NamespacesHost",
+		"docker.sock":      "DockerSock",
+		"rootfs.readonly":  "RootfsReadonly",
+		"network.isolated": "NetworkIsolated",
+	}
+	for in, want := range cases {
+		if got := sarifRuleName(in); got != want {
+			t.Errorf("sarifRuleName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/host/scan/testdata/weak_compose.sarif.json
+++ b/internal/host/scan/testdata/weak_compose.sarif.json
@@ -1,0 +1,348 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "ironctl-scan",
+          "version": "v0.0.0-golden",
+          "informationUri": "https://ironsecco.github.io/ironclaw/scan/",
+          "rules": [
+            {
+              "id": "user.nonroot",
+              "name": "UserNonroot",
+              "shortDescription": {
+                "text": "Non-root user (uid != 0)"
+              },
+              "fullDescription": {
+                "text": "Pin a non-root uid so a container escape does not begin as host uid 0."
+              },
+              "help": {
+                "text": "Pin a non-root uid so a container escape does not begin as host uid 0.\n\nFix: user: \"65532:65532\"\nMore: https://ironsecco.github.io/ironclaw/scan/",
+                "markdown": "Pin a non-root uid so a container escape does not begin as host uid 0.\n\n**Fix:** `user: \"65532:65532\"`\n\n[Hardening guide](https://ironsecco.github.io/ironclaw/scan/)"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "containment",
+                  "ironclaw"
+                ]
+              }
+            },
+            {
+              "id": "caps.dropped",
+              "name": "CapsDropped",
+              "shortDescription": {
+                "text": "Dropped capabilities"
+              },
+              "fullDescription": {
+                "text": "Drop every Linux capability; add back only what the workload provably needs."
+              },
+              "help": {
+                "text": "Drop every Linux capability; add back only what the workload provably needs.\n\nFix: cap_drop: [ALL]\nMore: https://ironsecco.github.io/ironclaw/scan/",
+                "markdown": "Drop every Linux capability; add back only what the workload provably needs.\n\n**Fix:** `cap_drop: [ALL]`\n\n[Hardening guide](https://ironsecco.github.io/ironclaw/scan/)"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "containment",
+                  "ironclaw"
+                ]
+              }
+            },
+            {
+              "id": "seccomp",
+              "name": "Seccomp",
+              "shortDescription": {
+                "text": "Seccomp profile"
+              },
+              "fullDescription": {
+                "text": "Keep a seccomp profile active to shrink the reachable syscall surface."
+              },
+              "help": {
+                "text": "Keep a seccomp profile active to shrink the reachable syscall surface.\n\nFix: security_opt: [no-new-privileges:true]  (and remove any seccomp=unconfined)\nMore: https://ironsecco.github.io/ironclaw/scan/",
+                "markdown": "Keep a seccomp profile active to shrink the reachable syscall surface.\n\n**Fix:** `security_opt: [no-new-privileges:true]  (and remove any seccomp=unconfined)`\n\n[Hardening guide](https://ironsecco.github.io/ironclaw/scan/)"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "containment",
+                  "ironclaw"
+                ]
+              }
+            },
+            {
+              "id": "network.isolated",
+              "name": "NetworkIsolated",
+              "shortDescription": {
+                "text": "Network isolation / egress"
+              },
+              "fullDescription": {
+                "text": "Cut egress so a compromised workload cannot reach the network or exfiltrate."
+              },
+              "help": {
+                "text": "Cut egress so a compromised workload cannot reach the network or exfiltrate.\n\nFix: network_mode: none\nMore: https://ironsecco.github.io/ironclaw/scan/",
+                "markdown": "Cut egress so a compromised workload cannot reach the network or exfiltrate.\n\n**Fix:** `network_mode: none`\n\n[Hardening guide](https://ironsecco.github.io/ironclaw/scan/)"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "containment",
+                  "ironclaw"
+                ]
+              }
+            },
+            {
+              "id": "rootfs.readonly",
+              "name": "RootfsReadonly",
+              "shortDescription": {
+                "text": "Read-only root filesystem"
+              },
+              "fullDescription": {
+                "text": "Make the root filesystem read-only to remove the tamper/persistence surface."
+              },
+              "help": {
+                "text": "Make the root filesystem read-only to remove the tamper/persistence surface.\n\nFix: read_only: true\nMore: https://ironsecco.github.io/ironclaw/scan/",
+                "markdown": "Make the root filesystem read-only to remove the tamper/persistence surface.\n\n**Fix:** `read_only: true`\n\n[Hardening guide](https://ironsecco.github.io/ironclaw/scan/)"
+              },
+              "defaultConfiguration": {
+                "level": "warning"
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "containment",
+                  "ironclaw"
+                ]
+              }
+            },
+            {
+              "id": "docker.sock",
+              "name": "DockerSock",
+              "shortDescription": {
+                "text": "No docker.sock exposure"
+              },
+              "fullDescription": {
+                "text": "Mounting the container-runtime socket is a one-command host-root escape."
+              },
+              "help": {
+                "text": "Mounting the container-runtime socket is a one-command host-root escape.\n\nFix: remove the docker.sock entry from the service's volumes:\nMore: https://ironsecco.github.io/ironclaw/scan/",
+                "markdown": "Mounting the container-runtime socket is a one-command host-root escape.\n\n**Fix:** `remove the docker.sock entry from the service's volumes:`\n\n[Hardening guide](https://ironsecco.github.io/ironclaw/scan/)"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "containment",
+                  "ironclaw"
+                ]
+              }
+            },
+            {
+              "id": "namespaces.host",
+              "name": "NamespacesHost",
+              "shortDescription": {
+                "text": "No shared host namespaces"
+              },
+              "fullDescription": {
+                "text": "Do not share host namespaces; each shared namespace erases an isolation boundary."
+              },
+              "help": {
+                "text": "Do not share host namespaces; each shared namespace erases an isolation boundary.\n\nFix: remove pid: host\nMore: https://ironsecco.github.io/ironclaw/scan/",
+                "markdown": "Do not share host namespaces; each shared namespace erases an isolation boundary.\n\n**Fix:** `remove pid: host`\n\n[Hardening guide](https://ironsecco.github.io/ironclaw/scan/)"
+              },
+              "defaultConfiguration": {
+                "level": "warning"
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "containment",
+                  "ironclaw"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "user.nonroot",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "Non-root user (uid != 0) (FAIL): runs as root (user \"0\"); a container escape starts with host-uid 0. Fix: user: \"65532:65532\""
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "docker-compose.yml"
+                },
+                "region": {
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "ironclawScan/v1": "48330939b59526e4"
+          }
+        },
+        {
+          "ruleId": "caps.dropped",
+          "ruleIndex": 1,
+          "level": "error",
+          "message": {
+            "text": "Dropped capabilities (FAIL): default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …). Fix: cap_drop: [ALL]"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "docker-compose.yml"
+                },
+                "region": {
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "ironclawScan/v1": "a8cf0ca19dcf3eaf"
+          }
+        },
+        {
+          "ruleId": "seccomp",
+          "ruleIndex": 2,
+          "level": "error",
+          "message": {
+            "text": "Seccomp profile (FAIL): seccomp=unconfined: the full syscall surface is exposed. Fix: security_opt: [no-new-privileges:true]  (and remove any seccomp=unconfined)"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "docker-compose.yml"
+                },
+                "region": {
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "ironclawScan/v1": "f5272f010045cc40"
+          }
+        },
+        {
+          "ruleId": "network.isolated",
+          "ruleIndex": 3,
+          "level": "warning",
+          "message": {
+            "text": "Network isolation / egress (WARN): network=bridge: outbound egress is possible; prefer network=none. Fix: network_mode: none"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "docker-compose.yml"
+                },
+                "region": {
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "ironclawScan/v1": "b9532d876273bc28"
+          }
+        },
+        {
+          "ruleId": "rootfs.readonly",
+          "ruleIndex": 4,
+          "level": "warning",
+          "message": {
+            "text": "Read-only root filesystem (FAIL): root filesystem is writable: tamper/persistence surface. Fix: read_only: true"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "docker-compose.yml"
+                },
+                "region": {
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "ironclawScan/v1": "131b561f1c1c4dda"
+          }
+        },
+        {
+          "ruleId": "docker.sock",
+          "ruleIndex": 5,
+          "level": "error",
+          "message": {
+            "text": "No docker.sock exposure (FAIL): docker.sock is mounted: trivial host-root escape (docker run --privileged -v /:/host). Fix: remove the docker.sock entry from the service's volumes:"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "docker-compose.yml"
+                },
+                "region": {
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "ironclawScan/v1": "9cea47edf2bca8d4"
+          }
+        },
+        {
+          "ruleId": "namespaces.host",
+          "ruleIndex": 6,
+          "level": "warning",
+          "message": {
+            "text": "No shared host namespaces (FAIL): shares host namespace(s): PID. Fix: remove pid: host"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "docker-compose.yml"
+                },
+                "region": {
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "ironclawScan/v1": "48696dfb137ef63a"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds SARIF 2.1.0 output to `ironctl scan` and an opt-in GitHub code-scanning upload so failed isolation dimensions surface in a repo's **Security > Code scanning** tab. This is the biggest untapped distribution lever for our only no-account adoption wedge: every repo that adds the scan Action gets IronClaw findings in GitHub-native UI, no account required.

## Changes

- **`internal/host/scan/render.go` — `RenderSARIF`** (alongside `RenderJSON`/`RenderBadgeEndpointJSON`):
  - one **rule** per graded dimension (7): `shortDescription`, `fullDescription`, `help` (reuses remediation text from `remediate.go`), `defaultConfiguration.level` from severity.
  - one **result** per non-PASS dimension, `error`/`warning` per severity (WARN never escalates past warning), message with the finding + fix, anchored at the scanned config file with a derived line region when available, else a logical location for live-container scans.
  - `tool.driver`: name `ironctl-scan`, version from build, `informationUri` to the scan docs, `rules[]`.
  - stable `partialFingerprints` per (rule, file) so GitHub dedupes across runs.
  - **A clean 100/A target emits zero results.**
- **`cmd/ironctl/scan.go`** — `--sarif PATH` flag; captures the compose/k8s config path + line anchor. **Fail-open**: an emit error never blocks the scan or the `--min-score` gate.
- **Action** (`.github/actions/scan/`) — opt-in `upload-sarif` input (default `false`, so no `security-events` permission is required unless opted in); uploads via `github/codeql-action/upload-sarif` **pinned by commit SHA** (`v3.37.0`). New `always()` step so a SARIF written before a min-score gate failure still uploads.
- **Docs** — `docs/scan.md` + `docs/scan-action.md` + action README document the Security-tab flow and the required `permissions: security-events: write`.

## Tests / verification

- `go test ./internal/host/scan/ ./cmd/ironctl/` → **195 pass** (`CGO_ENABLED=1`); `gofmt`/`go vet` clean.
- SARIF unit tests: envelope shape, one-rule-per-dimension, per-verdict levels, fingerprint stability, anchor-line derivation, rule-name mapping, **golden fixture** (`testdata/weak_compose.sarif.json`).
- E2E: `ironctl scan --compose <weak> --sarif` -> valid SARIF, 7 rules / 7 results (error+warning); hardened compose -> **0 results**.
- `shellcheck` clean on `scan.sh`; `actionlint` clean on the scorecard workflow.

## Security lenses

- **Supply-chain**: codeql-action pinned by commit SHA, not a moving tag.
- **Least privilege**: upload defaults off; the Action asks for no new permission unless `upload-sarif: true`.
- **Trust boundary**: scan stays local, read-only, no control-plane; SARIF is a side artifact, fail-open.

Closes IRO-440.