### PR TITLE
feat(scores): Container Isolation Scores directory — 54 per-image scorecard pages (IRO-445)

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -23,6 +23,7 @@ nav:
       - FAQ: faq.md
   - Scan any container: scan.md
   - Scan in CI (GitHub Action): scan-action.md
+  - Container isolation scores: scores
   - Model providers: providers
   - Tutorials: tutorials
   - Examples & use cases: examples.md

--- a/docs/scores/.nav.yml
+++ b/docs/scores/.nav.yml
@@ -1,0 +1,11 @@
+# Navigation for the "Container Isolation Scores" directory (IRO-445).
+#
+# An evergreen, expanding SEO directory: one indexable scorecard page per
+# most-pulled public image, generated from the isolation-survey dataset by
+# `examples/isolation-survey/gen_scorecards.py`. The `*.md` glob below auto-
+# includes every generated `<image>.md` (titled from its H1) with ZERO edit
+# here — adding images to the survey and regenerating is all it takes. The
+# index is pinned first; everything else is alphabetical by the glob.
+nav:
+  - All container isolation scores: index.md
+  - "*.md"

--- a/docs/scores/adminer.md
+++ b/docs/scores/adminer.md
@@ -1,0 +1,66 @@
+---
+title: "adminer:4.8.1 container isolation score: 63/100 (grade C)"
+description: "How isolated is adminer:4.8.1 by default? IronClaw scores its sandbox posture 63/100 (C): retains default capabilities. Scan any container in 10s."
+---
+
+# adminer:4.8.1 container isolation score: 63/100 (grade C)
+
+Run with plain `docker run adminer:4.8.1` defaults, no hardening flags, the **adminer** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `adminer:4.8.1` at digest `sha256:34d37131366c5aa84e1693dbed48593ed6f95fb450b576c1a7a59d3a9c9e8802`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as adminer (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run adminer` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name adminer-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  adminer:4.8.1
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own adminer the same way this page was generated
+ironctl scan my-adminer
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/alertmanager.md
+++ b/docs/scores/alertmanager.md
@@ -1,0 +1,66 @@
+---
+title: "alertmanager:v0.28.0 container isolation score: 63/100 (grade C)"
+description: "How isolated is alertmanager:v0.28.0 by default? IronClaw scores its sandbox posture 63/100 (C): retains default capabilities. Scan any container in 10s."
+---
+
+# alertmanager:v0.28.0 container isolation score: 63/100 (grade C)
+
+Run with plain `docker run prom/alertmanager:v0.28.0` defaults, no hardening flags, the **alertmanager** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `prom/alertmanager:v0.28.0` at digest `sha256:9139cd2c7ab7ff951e5ed9ffc4f70122a7de9678fb51065061a5f72549c91bab`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as nobody (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run alertmanager` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name alertmanager-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  prom/alertmanager:v0.28.0
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own alertmanager the same way this page was generated
+ironctl scan my-alertmanager
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/alpine.md
+++ b/docs/scores/alpine.md
@@ -1,0 +1,68 @@
+---
+title: "alpine:3.21 container isolation score: 48/100 (grade D)"
+description: "How isolated is alpine:3.21 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# alpine:3.21 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run alpine:3.21` defaults, no hardening flags, the **alpine** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `alpine:3.21` at digest `sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run alpine` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name alpine-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  alpine:3.21
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own alpine the same way this page was generated
+ironctl scan my-alpine
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/amazonlinux.md
+++ b/docs/scores/amazonlinux.md
@@ -1,0 +1,68 @@
+---
+title: "amazonlinux:2023 container isolation score: 48/100 (grade D)"
+description: "How isolated is amazonlinux:2023 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# amazonlinux:2023 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run amazonlinux:2023` defaults, no hardening flags, the **amazonlinux** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `amazonlinux:2023` at digest `sha256:2a6e72177eb52cf10cacb59f4920e48d33871a168ebf5a02bd7ae0369f73dcc6`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run amazonlinux` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name amazonlinux-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  amazonlinux:2023
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own amazonlinux the same way this page was generated
+ironctl scan my-amazonlinux
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/busybox.md
+++ b/docs/scores/busybox.md
@@ -1,0 +1,68 @@
+---
+title: "busybox:1.37 container isolation score: 48/100 (grade D)"
+description: "How isolated is busybox:1.37 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# busybox:1.37 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run busybox:1.37` defaults, no hardening flags, the **busybox** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `busybox:1.37` at digest `sha256:7a3ebe5bfd1a4a19797d20b0c0bb39d44393e9a03fd852c0865b0f540d868df0`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run busybox` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name busybox-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  busybox:1.37
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own busybox the same way this page was generated
+ironctl scan my-busybox
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/caddy.md
+++ b/docs/scores/caddy.md
@@ -1,0 +1,68 @@
+---
+title: "caddy:2-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is caddy:2-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# caddy:2-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run caddy:2-alpine` defaults, no hardening flags, the **caddy** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `caddy:2-alpine` at digest `sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run caddy` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name caddy-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  caddy:2-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own caddy the same way this page was generated
+ironctl scan my-caddy
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/consul.md
+++ b/docs/scores/consul.md
@@ -1,0 +1,68 @@
+---
+title: "consul:1.20 container isolation score: 48/100 (grade D)"
+description: "How isolated is consul:1.20 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# consul:1.20 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run hashicorp/consul:1.20` defaults, no hardening flags, the **consul** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `hashicorp/consul:1.20` at digest `sha256:200471c74bc0965cd20c81eacc31a209873d5d9e599fe637ceb856b0cbbc518d`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run consul` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name consul-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  hashicorp/consul:1.20
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own consul the same way this page was generated
+ironctl scan my-consul
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/couchdb.md
+++ b/docs/scores/couchdb.md
@@ -1,0 +1,68 @@
+---
+title: "couchdb:3.4 container isolation score: 48/100 (grade D)"
+description: "How isolated is couchdb:3.4 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# couchdb:3.4 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run couchdb:3.4` defaults, no hardening flags, the **couchdb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `couchdb:3.4` at digest `sha256:6c5046c5e71559d43247120c8d2cb88e40ffa5155820e52b58238acdf9466f87`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run couchdb` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name couchdb-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  couchdb:3.4
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own couchdb the same way this page was generated
+ironctl scan my-couchdb
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/debian.md
+++ b/docs/scores/debian.md
@@ -1,0 +1,68 @@
+---
+title: "debian:12-slim container isolation score: 48/100 (grade D)"
+description: "How isolated is debian:12-slim by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# debian:12-slim container isolation score: 48/100 (grade D)
+
+Run with plain `docker run debian:12-slim` defaults, no hardening flags, the **debian** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `debian:12-slim` at digest `sha256:1def178129dfb5f24db43afbf2fcac04530012e3264ba4ff81c71184e17a9ee4`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run debian` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name debian-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  debian:12-slim
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own debian the same way this page was generated
+ironctl scan my-debian
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/drupal.md
+++ b/docs/scores/drupal.md
@@ -1,0 +1,68 @@
+---
+title: "drupal:11-apache container isolation score: 48/100 (grade D)"
+description: "How isolated is drupal:11-apache by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# drupal:11-apache container isolation score: 48/100 (grade D)
+
+Run with plain `docker run drupal:11-apache` defaults, no hardening flags, the **drupal** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `drupal:11-apache` at digest `sha256:11748f3fba287c1e8927d64c6f805115e8bedcb95715e19be9c0c0f3adeeef8a`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run drupal` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name drupal-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  drupal:11-apache
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own drupal the same way this page was generated
+ironctl scan my-drupal
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/eclipse-mosquitto.md
+++ b/docs/scores/eclipse-mosquitto.md
@@ -1,0 +1,68 @@
+---
+title: "eclipse-mosquitto:2 container isolation score: 48/100 (grade D)"
+description: "How isolated is eclipse-mosquitto:2 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# eclipse-mosquitto:2 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run eclipse-mosquitto:2` defaults, no hardening flags, the **eclipse mosquitto** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `eclipse-mosquitto:2` at digest `sha256:6dba0f1b2795ddcbe0d41bdfb8b8d56a423acca23ccde4342a4652be54639b11`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run eclipse-mosquitto` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name eclipse-mosquitto-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  eclipse-mosquitto:2
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own eclipse-mosquitto the same way this page was generated
+ironctl scan my-eclipse-mosquitto
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/eclipse-temurin.md
+++ b/docs/scores/eclipse-temurin.md
@@ -1,0 +1,68 @@
+---
+title: "eclipse-temurin:21-jre-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is eclipse-temurin:21-jre-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in..."
+---
+
+# eclipse-temurin:21-jre-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run eclipse-temurin:21-jre-alpine` defaults, no hardening flags, the **eclipse temurin** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `eclipse-temurin:21-jre-alpine` at digest `sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run eclipse-temurin` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name eclipse-temurin-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  eclipse-temurin:21-jre-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own eclipse-temurin the same way this page was generated
+ironctl scan my-eclipse-temurin
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/fedora.md
+++ b/docs/scores/fedora.md
@@ -1,0 +1,68 @@
+---
+title: "fedora:41 container isolation score: 48/100 (grade D)"
+description: "How isolated is fedora:41 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# fedora:41 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run fedora:41` defaults, no hardening flags, the **fedora** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `fedora:41` at digest `sha256:68bb1ba893be0c05991b2df55bc6571862bab7526fd6053b1ebacd53a2a75366`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run fedora` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name fedora-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  fedora:41
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own fedora the same way this page was generated
+ironctl scan my-fedora
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/ghost.md
+++ b/docs/scores/ghost.md
@@ -1,0 +1,68 @@
+---
+title: "ghost:5-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is ghost:5-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# ghost:5-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run ghost:5-alpine` defaults, no hardening flags, the **ghost** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `ghost:5-alpine` at digest `sha256:2341e27e1f3f8496f677f77d0620c1d514e2f4111708bbc03e8bc7c9d39a36fb`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run ghost` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name ghost-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  ghost:5-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own ghost the same way this page was generated
+ironctl scan my-ghost
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/gitea.md
+++ b/docs/scores/gitea.md
@@ -1,0 +1,68 @@
+---
+title: "gitea:1.22 container isolation score: 48/100 (grade D)"
+description: "How isolated is gitea:1.22 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# gitea:1.22 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run gitea/gitea:1.22` defaults, no hardening flags, the **gitea** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `gitea/gitea:1.22` at digest `sha256:538658de667c5d098a274f2f63aa6ec891d88f670cdd5282cf27221ba747dda4`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run gitea` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name gitea-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  gitea/gitea:1.22
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own gitea the same way this page was generated
+ironctl scan my-gitea
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/golang.md
+++ b/docs/scores/golang.md
@@ -1,0 +1,68 @@
+---
+title: "golang:1.23-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is golang:1.23-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# golang:1.23-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run golang:1.23-alpine` defaults, no hardening flags, the **golang** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `golang:1.23-alpine` at digest `sha256:383395b794dffa5b53012a212365d40c8e37109a626ca30d6151c8348d380b5f`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run golang` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name golang-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  golang:1.23-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own golang the same way this page was generated
+ironctl scan my-golang
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/grafana.md
+++ b/docs/scores/grafana.md
@@ -1,0 +1,66 @@
+---
+title: "grafana:11.4.0 container isolation score: 63/100 (grade C)"
+description: "How isolated is grafana:11.4.0 by default? IronClaw scores its sandbox posture 63/100 (C): retains default capabilities. Scan any container in 10s."
+---
+
+# grafana:11.4.0 container isolation score: 63/100 (grade C)
+
+Run with plain `docker run grafana/grafana:11.4.0` defaults, no hardening flags, the **grafana** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `grafana/grafana:11.4.0` at digest `sha256:8d938a1c52b018c60cb3583657e038054387aa18a74f09a865c99a522481f7ac`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as 472 (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run grafana` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name grafana-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  grafana/grafana:11.4.0
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own grafana the same way this page was generated
+ironctl scan my-grafana
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/haproxy.md
+++ b/docs/scores/haproxy.md
@@ -1,0 +1,66 @@
+---
+title: "haproxy:3.1-alpine container isolation score: 63/100 (grade C)"
+description: "How isolated is haproxy:3.1-alpine by default? IronClaw scores its sandbox posture 63/100 (C): retains default capabilities. Scan any container in 10s."
+---
+
+# haproxy:3.1-alpine container isolation score: 63/100 (grade C)
+
+Run with plain `docker run haproxy:3.1-alpine` defaults, no hardening flags, the **haproxy** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `haproxy:3.1-alpine` at digest `sha256:475863a372c92c3dab3d59eafbbf8019dceebcd0c456594551b160ecdba4bdb9`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as haproxy (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run haproxy` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name haproxy-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  haproxy:3.1-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own haproxy the same way this page was generated
+ironctl scan my-haproxy
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/httpd.md
+++ b/docs/scores/httpd.md
@@ -1,0 +1,68 @@
+---
+title: "httpd:2.4-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is httpd:2.4-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# httpd:2.4-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run httpd:2.4-alpine` defaults, no hardening flags, the **httpd** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `httpd:2.4-alpine` at digest `sha256:1b766f17b84026429b7cb243317b142921b24432336e798bc881c43f45ed9567`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run httpd` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name httpd-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  httpd:2.4-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own httpd the same way this page was generated
+ironctl scan my-httpd
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/index.md
+++ b/docs/scores/index.md
@@ -1,0 +1,89 @@
+---
+title: Container Isolation Scores
+description: The default-configuration container isolation score for 54+ of the most-pulled public Docker images, graded 0-100 across seven containment dimensions by ironctl scan.
+---
+
+# Container Isolation Scores
+
+How isolated is the container you just `docker run`? This directory grades **54 of the most-pulled public images** as they ship, run with plain `docker run <image>` defaults, no hardening flags, on IronClaw's seven-dimension containment scale (0-100). Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+**The headline:** the average default image scores **51/100**. Grade distribution: 11×C, 43×D. Almost nothing you pull is isolated out of the box, it runs as root, keeps the full capability set, and has a writable root filesystem. The good news: every gap on these pages closes with a handful of `docker run` flags.
+
+> **Scan your own container:** `brew install ironsecco/ironclaw/ironclaw && ironctl scan my-container`. See [Scan any container](../scan.md).
+
+## Every image, worst-isolated first
+
+| Image | Score | Grade | Top gaps (default config) |
+|-------|------:|:-----:|---------------------------|
+| [`alpine:3.21`](alpine.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`amazonlinux:2023`](amazonlinux.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`busybox:1.37`](busybox.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`caddy:2-alpine`](caddy.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`hashicorp/consul:1.20`](consul.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`couchdb:3.4`](couchdb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`debian:12-slim`](debian.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`drupal:11-apache`](drupal.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`eclipse-mosquitto:2`](eclipse-mosquitto.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`eclipse-temurin:21-jre-alpine`](eclipse-temurin.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`fedora:41`](fedora.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`ghost:5-alpine`](ghost.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`gitea/gitea:1.22`](gitea.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`golang:1.23-alpine`](golang.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`httpd:2.4-alpine`](httpd.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`influxdb:2.7-alpine`](influxdb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`joomla:5-apache`](joomla.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`mariadb:11`](mariadb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`mongo:7`](mongo.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`mysql:8.4`](mysql.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`nats:2.10-alpine`](nats.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`nginx:1.27-alpine`](nginx.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`node:22-alpine`](node.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`openresty/openresty:alpine`](openresty.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`perl:5.40-slim`](perl.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`php:8.4-apache`](php.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`phpmyadmin:5.2`](phpmyadmin.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`postgres:17-alpine`](postgres.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`python:3.13-alpine`](python.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`rabbitmq:4-alpine`](rabbitmq.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`redis:7-alpine`](redis.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`registry:2.8.3`](registry.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`rockylinux:9`](rockylinux.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`ruby:3.4-alpine`](ruby.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`rust:1.83-alpine`](rust.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`vaultwarden/server:1.32.7`](server.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`telegraf:1.33-alpine`](telegraf.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`tomcat:10.1-jre21-temurin`](tomcat.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`traefik:v3.2`](traefik.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`ubuntu:24.04`](ubuntu.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`hashicorp/vault:1.18`](vault.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`wordpress:6-php8.3-apache`](wordpress.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`zookeeper:3.9`](zookeeper.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`adminer:4.8.1`](adminer.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| [`prom/alertmanager:v0.28.0`](alertmanager.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| [`grafana/grafana:11.4.0`](grafana.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| [`haproxy:3.1-alpine`](haproxy.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| [`jetty:12-jre21`](jetty.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| [`kong:3.8`](kong.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| [`memcached:1.6-alpine`](memcached.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| [`nginxinc/nginx-unprivileged:1.27-alpine`](nginx-unprivileged.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| [`prom/node-exporter:v1.8.2`](node-exporter.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| [`prom/prometheus:v3.1.0`](prometheus.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| [`varnish:7.6-alpine`](varnish.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+
+## What the seven dimensions mean
+
+Each image is graded on the same containment dimensions IronClaw's own sandbox benchmark checks, the properties that decide whether a container escape starts from a strong or a hopeless position:
+
+- **Non-root user** (15 pts), does it drop host uid 0?
+- **Dropped capabilities** (20 pts), is the Linux capability set minimized?
+- **Seccomp profile** (15 pts), is the syscall surface filtered?
+- **Network isolation** (15 pts), is egress cut (`network=none`)?
+- **Read-only root filesystem** (10 pts), is the tamper surface removed?
+- **No docker.sock exposure** (15 pts), is the host control socket kept out?
+- **No shared host namespaces** (10 pts), are PID/IPC/net namespaces private?
+
+Scores are fail-closed: any posture the scanner cannot determine is graded as insecure, never silently passed. See [how scoring works](../scan.md) and [the full survey methodology](../blog/state-of-container-isolation-2026.md).
+
+---
+
+*These pages are generated from a reproducible survey, `examples/isolation-survey/survey.sh` scans every image, `gen_scorecards.py` renders the pages. Grades reflect the image's default configuration, not a limit of the image itself: every one can reach grade A with the right `docker run` flags.*

--- a/docs/scores/influxdb.md
+++ b/docs/scores/influxdb.md
@@ -1,0 +1,68 @@
+---
+title: "influxdb:2.7-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is influxdb:2.7-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# influxdb:2.7-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run influxdb:2.7-alpine` defaults, no hardening flags, the **influxdb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `influxdb:2.7-alpine` at digest `sha256:991673dc2d237bd79b15d6627410d72de111387e7dac673dbb92cf3333ffcc8c`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run influxdb` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name influxdb-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  influxdb:2.7-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own influxdb the same way this page was generated
+ironctl scan my-influxdb
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/jetty.md
+++ b/docs/scores/jetty.md
@@ -1,0 +1,66 @@
+---
+title: "jetty:12-jre21 container isolation score: 63/100 (grade C)"
+description: "How isolated is jetty:12-jre21 by default? IronClaw scores its sandbox posture 63/100 (C): retains default capabilities. Scan any container in 10s."
+---
+
+# jetty:12-jre21 container isolation score: 63/100 (grade C)
+
+Run with plain `docker run jetty:12-jre21` defaults, no hardening flags, the **jetty** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `jetty:12-jre21` at digest `sha256:a7b9f19032f2974e2e981826832d0bb37e843fdbba3bd2042a1b6c17b38011a7`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as jetty (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run jetty` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name jetty-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  jetty:12-jre21
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own jetty the same way this page was generated
+ironctl scan my-jetty
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/joomla.md
+++ b/docs/scores/joomla.md
@@ -1,0 +1,68 @@
+---
+title: "joomla:5-apache container isolation score: 48/100 (grade D)"
+description: "How isolated is joomla:5-apache by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# joomla:5-apache container isolation score: 48/100 (grade D)
+
+Run with plain `docker run joomla:5-apache` defaults, no hardening flags, the **joomla** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `joomla:5-apache` at digest `sha256:469a69f1f7284b5d45f06a51c7bca26178953fc4f12428e958bc239741d2979c`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run joomla` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name joomla-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  joomla:5-apache
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own joomla the same way this page was generated
+ironctl scan my-joomla
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/kong.md
+++ b/docs/scores/kong.md
@@ -1,0 +1,66 @@
+---
+title: "kong:3.8 container isolation score: 63/100 (grade C)"
+description: "How isolated is kong:3.8 by default? IronClaw scores its sandbox posture 63/100 (C): retains default capabilities. Scan any container in 10s."
+---
+
+# kong:3.8 container isolation score: 63/100 (grade C)
+
+Run with plain `docker run kong:3.8` defaults, no hardening flags, the **kong** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `kong:3.8` at digest `sha256:0dbd72dc596763758e9f8ada732648ef087f256da07b304efca269d50545de00`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as kong (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run kong` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name kong-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  kong:3.8
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own kong the same way this page was generated
+ironctl scan my-kong
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/mariadb.md
+++ b/docs/scores/mariadb.md
@@ -1,0 +1,68 @@
+---
+title: "mariadb:11 container isolation score: 48/100 (grade D)"
+description: "How isolated is mariadb:11 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# mariadb:11 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run mariadb:11` defaults, no hardening flags, the **mariadb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `mariadb:11` at digest `sha256:09336a8c0cff9f363e133d8a245cca5ad3eeb326e0ffaedf74d49214c4571486`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run mariadb` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name mariadb-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  mariadb:11
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own mariadb the same way this page was generated
+ironctl scan my-mariadb
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/memcached.md
+++ b/docs/scores/memcached.md
@@ -1,0 +1,66 @@
+---
+title: "memcached:1.6-alpine container isolation score: 63/100 (grade C)"
+description: "How isolated is memcached:1.6-alpine by default? IronClaw scores its sandbox posture 63/100 (C): retains default capabilities. Scan any container in 10s."
+---
+
+# memcached:1.6-alpine container isolation score: 63/100 (grade C)
+
+Run with plain `docker run memcached:1.6-alpine` defaults, no hardening flags, the **memcached** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `memcached:1.6-alpine` at digest `sha256:dfacdbd93e7a6f1ad63801753a1fc959dc678a5a1d2141ff438d57e6d8793fc3`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as memcache (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run memcached` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name memcached-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  memcached:1.6-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own memcached the same way this page was generated
+ironctl scan my-memcached
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/mongo.md
+++ b/docs/scores/mongo.md
@@ -1,0 +1,68 @@
+---
+title: "mongo:7 container isolation score: 48/100 (grade D)"
+description: "How isolated is mongo:7 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# mongo:7 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run mongo:7` defaults, no hardening flags, the **mongo** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `mongo:7` at digest `sha256:486795b20c58fd338291e1552118a59a810a4c30dd7f56c690198085797b6c70`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run mongo` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name mongo-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  mongo:7
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own mongo the same way this page was generated
+ironctl scan my-mongo
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/mysql.md
+++ b/docs/scores/mysql.md
@@ -1,0 +1,68 @@
+---
+title: "mysql:8.4 container isolation score: 48/100 (grade D)"
+description: "How isolated is mysql:8.4 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# mysql:8.4 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run mysql:8.4` defaults, no hardening flags, the **mysql** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `mysql:8.4` at digest `sha256:02aa6476f6b675e5d4d19c5b437798b1b8a4048ae39383eac609814998ed15b8`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run mysql` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name mysql-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  mysql:8.4
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own mysql the same way this page was generated
+ironctl scan my-mysql
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/nats.md
+++ b/docs/scores/nats.md
@@ -1,0 +1,68 @@
+---
+title: "nats:2.10-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is nats:2.10-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# nats:2.10-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run nats:2.10-alpine` defaults, no hardening flags, the **nats** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `nats:2.10-alpine` at digest `sha256:7e2f895a12d5bc4586191452f5dd20968e8c800d53622073a2730c38d6b0eccb`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run nats` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name nats-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  nats:2.10-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own nats the same way this page was generated
+ironctl scan my-nats
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/nginx-unprivileged.md
+++ b/docs/scores/nginx-unprivileged.md
@@ -1,0 +1,66 @@
+---
+title: "nginx-unprivileged:1.27-alpine container isolation score: 63/100 (grade C)"
+description: "How isolated is nginx-unprivileged:1.27-alpine by default? IronClaw scores its sandbox posture 63/100 (C): retains default capabilities. Scan any container i..."
+---
+
+# nginx-unprivileged:1.27-alpine container isolation score: 63/100 (grade C)
+
+Run with plain `docker run nginxinc/nginx-unprivileged:1.27-alpine` defaults, no hardening flags, the **nginx unprivileged** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `nginxinc/nginx-unprivileged:1.27-alpine` at digest `sha256:28d91bdce70ad09025ea901458fdd149259d8e05982ade79d4ef2c0d9470eb48`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as 101 (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run nginx-unprivileged` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name nginx-unprivileged-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  nginxinc/nginx-unprivileged:1.27-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own nginx-unprivileged the same way this page was generated
+ironctl scan my-nginx-unprivileged
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/nginx.md
+++ b/docs/scores/nginx.md
@@ -1,0 +1,68 @@
+---
+title: "nginx:1.27-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is nginx:1.27-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# nginx:1.27-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run nginx:1.27-alpine` defaults, no hardening flags, the **nginx** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `nginx:1.27-alpine` at digest `sha256:62223d644fa234c3a1cc785ee14242ec47a77364226f1c811d2f669f96dc2ac8`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run nginx` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name nginx-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  nginx:1.27-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own nginx the same way this page was generated
+ironctl scan my-nginx
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/node-exporter.md
+++ b/docs/scores/node-exporter.md
@@ -1,0 +1,66 @@
+---
+title: "node-exporter:v1.8.2 container isolation score: 63/100 (grade C)"
+description: "How isolated is node-exporter:v1.8.2 by default? IronClaw scores its sandbox posture 63/100 (C): retains default capabilities. Scan any container in 10s."
+---
+
+# node-exporter:v1.8.2 container isolation score: 63/100 (grade C)
+
+Run with plain `docker run prom/node-exporter:v1.8.2` defaults, no hardening flags, the **node exporter** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `prom/node-exporter:v1.8.2` at digest `sha256:065914c03336590ebed517e7df38520f0efb44465fde4123c3f6b7328f5a9396`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as nobody (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run node-exporter` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name node-exporter-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  prom/node-exporter:v1.8.2
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own node-exporter the same way this page was generated
+ironctl scan my-node-exporter
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/node.md
+++ b/docs/scores/node.md
@@ -1,0 +1,68 @@
+---
+title: "node:22-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is node:22-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# node:22-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run node:22-alpine` defaults, no hardening flags, the **node** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `node:22-alpine` at digest `sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run node` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name node-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  node:22-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own node the same way this page was generated
+ironctl scan my-node
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/openresty.md
+++ b/docs/scores/openresty.md
@@ -1,0 +1,68 @@
+---
+title: "openresty:alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is openresty:alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# openresty:alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run openresty/openresty:alpine` defaults, no hardening flags, the **openresty** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `openresty/openresty:alpine` at digest `sha256:49db7235f2f94aa179c1242882619aea258c112b20f48ba45aefba010a1d0607`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run openresty` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name openresty-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  openresty/openresty:alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own openresty the same way this page was generated
+ironctl scan my-openresty
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/perl.md
+++ b/docs/scores/perl.md
@@ -1,0 +1,68 @@
+---
+title: "perl:5.40-slim container isolation score: 48/100 (grade D)"
+description: "How isolated is perl:5.40-slim by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# perl:5.40-slim container isolation score: 48/100 (grade D)
+
+Run with plain `docker run perl:5.40-slim` defaults, no hardening flags, the **perl** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `perl:5.40-slim` at digest `sha256:5a61ff1daad0a27fdd26b337152e36a1516ec5da032560cd2ce53aaae560e584`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run perl` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name perl-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  perl:5.40-slim
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own perl the same way this page was generated
+ironctl scan my-perl
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/php.md
+++ b/docs/scores/php.md
@@ -1,0 +1,68 @@
+---
+title: "php:8.4-apache container isolation score: 48/100 (grade D)"
+description: "How isolated is php:8.4-apache by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# php:8.4-apache container isolation score: 48/100 (grade D)
+
+Run with plain `docker run php:8.4-apache` defaults, no hardening flags, the **php** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `php:8.4-apache` at digest `sha256:12d26bcc36a7866fd92ac6154adb59f776cce77774cdf0599ef50b3390a12891`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run php` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name php-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  php:8.4-apache
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own php the same way this page was generated
+ironctl scan my-php
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/phpmyadmin.md
+++ b/docs/scores/phpmyadmin.md
@@ -1,0 +1,68 @@
+---
+title: "phpmyadmin:5.2 container isolation score: 48/100 (grade D)"
+description: "How isolated is phpmyadmin:5.2 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# phpmyadmin:5.2 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run phpmyadmin:5.2` defaults, no hardening flags, the **phpmyadmin** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `phpmyadmin:5.2` at digest `sha256:9d4365ec568e04d5feb6988612e355d4f6d68b0c5995997f96a0f89352f38767`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "root"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run phpmyadmin` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name phpmyadmin-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  phpmyadmin:5.2
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own phpmyadmin the same way this page was generated
+ironctl scan my-phpmyadmin
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/postgres.md
+++ b/docs/scores/postgres.md
@@ -1,0 +1,68 @@
+---
+title: "postgres:17-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is postgres:17-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# postgres:17-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run postgres:17-alpine` defaults, no hardening flags, the **postgres** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `postgres:17-alpine` at digest `sha256:67f624a4ad70edba8d65c82341124fab7054b277b4f7dea4b04be6f939ce2314`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run postgres` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name postgres-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  postgres:17-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own postgres the same way this page was generated
+ironctl scan my-postgres
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/prometheus.md
+++ b/docs/scores/prometheus.md
@@ -1,0 +1,66 @@
+---
+title: "prometheus:v3.1.0 container isolation score: 63/100 (grade C)"
+description: "How isolated is prometheus:v3.1.0 by default? IronClaw scores its sandbox posture 63/100 (C): retains default capabilities. Scan any container in 10s."
+---
+
+# prometheus:v3.1.0 container isolation score: 63/100 (grade C)
+
+Run with plain `docker run prom/prometheus:v3.1.0` defaults, no hardening flags, the **prometheus** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `prom/prometheus:v3.1.0` at digest `sha256:6559acbd5d770b15bb3c954629ce190ac3cbbdb2b7f1c30f0385c4e05104e218`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as nobody (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run prometheus` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name prometheus-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  prom/prometheus:v3.1.0
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own prometheus the same way this page was generated
+ironctl scan my-prometheus
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/python.md
+++ b/docs/scores/python.md
@@ -1,0 +1,68 @@
+---
+title: "python:3.13-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is python:3.13-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# python:3.13-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run python:3.13-alpine` defaults, no hardening flags, the **python** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `python:3.13-alpine` at digest `sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run python` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name python-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  python:3.13-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own python the same way this page was generated
+ironctl scan my-python
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/rabbitmq.md
+++ b/docs/scores/rabbitmq.md
@@ -1,0 +1,68 @@
+---
+title: "rabbitmq:4-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is rabbitmq:4-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# rabbitmq:4-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run rabbitmq:4-alpine` defaults, no hardening flags, the **rabbitmq** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `rabbitmq:4-alpine` at digest `sha256:05ea3d1ce60612ce7bb359f4786087bea339b9329f7b5c77a29feb01c641dff8`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run rabbitmq` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name rabbitmq-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  rabbitmq:4-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own rabbitmq the same way this page was generated
+ironctl scan my-rabbitmq
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/redis.md
+++ b/docs/scores/redis.md
@@ -1,0 +1,68 @@
+---
+title: "redis:7-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is redis:7-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# redis:7-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run redis:7-alpine` defaults, no hardening flags, the **redis** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `redis:7-alpine` at digest `sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run redis` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name redis-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  redis:7-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own redis the same way this page was generated
+ironctl scan my-redis
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/registry.md
+++ b/docs/scores/registry.md
@@ -1,0 +1,68 @@
+---
+title: "registry:2.8.3 container isolation score: 48/100 (grade D)"
+description: "How isolated is registry:2.8.3 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# registry:2.8.3 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run registry:2.8.3` defaults, no hardening flags, the **registry** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `registry:2.8.3` at digest `sha256:46faa9a1ae6813194b53921a370f2f4f8c5e1aae228a89bceafef5847a6a3278`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run registry` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name registry-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  registry:2.8.3
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own registry the same way this page was generated
+ironctl scan my-registry
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/rockylinux.md
+++ b/docs/scores/rockylinux.md
@@ -1,0 +1,68 @@
+---
+title: "rockylinux:9 container isolation score: 48/100 (grade D)"
+description: "How isolated is rockylinux:9 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# rockylinux:9 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run rockylinux:9` defaults, no hardening flags, the **rockylinux** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `rockylinux:9` at digest `sha256:d644d203142cd5b54ad2a83a203e1dee68af2229f8fe32f52a30c6e1d3c3a9e0`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run rockylinux` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name rockylinux-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  rockylinux:9
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own rockylinux the same way this page was generated
+ironctl scan my-rockylinux
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/ruby.md
+++ b/docs/scores/ruby.md
@@ -1,0 +1,68 @@
+---
+title: "ruby:3.4-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is ruby:3.4-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# ruby:3.4-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run ruby:3.4-alpine` defaults, no hardening flags, the **ruby** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `ruby:3.4-alpine` at digest `sha256:c5a5064d190055633011c03aa800170cc36945ff3afb5f6c915329f92d6f1e00`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run ruby` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name ruby-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  ruby:3.4-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own ruby the same way this page was generated
+ironctl scan my-ruby
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/rust.md
+++ b/docs/scores/rust.md
@@ -1,0 +1,68 @@
+---
+title: "rust:1.83-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is rust:1.83-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# rust:1.83-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run rust:1.83-alpine` defaults, no hardening flags, the **rust** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `rust:1.83-alpine` at digest `sha256:0ac946ed7597a9f053a1be2ce38c09aa88b3d7079a91ea491493615294b1f699`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run rust` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name rust-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  rust:1.83-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own rust the same way this page was generated
+ironctl scan my-rust
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/server.md
+++ b/docs/scores/server.md
@@ -1,0 +1,68 @@
+---
+title: "server:1.32.7 container isolation score: 48/100 (grade D)"
+description: "How isolated is server:1.32.7 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# server:1.32.7 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run vaultwarden/server:1.32.7` defaults, no hardening flags, the **server** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `vaultwarden/server:1.32.7` at digest `sha256:7a0aa23c0947be3582898deb5170ea4359493ed9a76af2badf60a7eb45ac36af`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run server` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name server-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  vaultwarden/server:1.32.7
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own server the same way this page was generated
+ironctl scan my-server
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/telegraf.md
+++ b/docs/scores/telegraf.md
@@ -1,0 +1,68 @@
+---
+title: "telegraf:1.33-alpine container isolation score: 48/100 (grade D)"
+description: "How isolated is telegraf:1.33-alpine by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# telegraf:1.33-alpine container isolation score: 48/100 (grade D)
+
+Run with plain `docker run telegraf:1.33-alpine` defaults, no hardening flags, the **telegraf** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `telegraf:1.33-alpine` at digest `sha256:3ea0664bed1cacec5e6b463882dc43da9b33c9742d436ace35f157843aca9e40`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run telegraf` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name telegraf-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  telegraf:1.33-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own telegraf the same way this page was generated
+ironctl scan my-telegraf
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/tomcat.md
+++ b/docs/scores/tomcat.md
@@ -1,0 +1,68 @@
+---
+title: "tomcat:10.1-jre21-temurin container isolation score: 48/100 (grade D)"
+description: "How isolated is tomcat:10.1-jre21-temurin by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# tomcat:10.1-jre21-temurin container isolation score: 48/100 (grade D)
+
+Run with plain `docker run tomcat:10.1-jre21-temurin` defaults, no hardening flags, the **tomcat** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `tomcat:10.1-jre21-temurin` at digest `sha256:5b1091b520c45e26b9a3ab50d74f367892cfbe0f4ad056e66bf63d35afe75683`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run tomcat` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name tomcat-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  tomcat:10.1-jre21-temurin
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own tomcat the same way this page was generated
+ironctl scan my-tomcat
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/traefik.md
+++ b/docs/scores/traefik.md
@@ -1,0 +1,68 @@
+---
+title: "traefik:v3.2 container isolation score: 48/100 (grade D)"
+description: "How isolated is traefik:v3.2 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# traefik:v3.2 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run traefik:v3.2` defaults, no hardening flags, the **traefik** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `traefik:v3.2` at digest `sha256:684cb01614fc38240a5f13e302920a12ba3c6d604ff90d0a6c0ade9a1294a712`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run traefik` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name traefik-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  traefik:v3.2
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own traefik the same way this page was generated
+ironctl scan my-traefik
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/ubuntu.md
+++ b/docs/scores/ubuntu.md
@@ -1,0 +1,68 @@
+---
+title: "ubuntu:24.04 container isolation score: 48/100 (grade D)"
+description: "How isolated is ubuntu:24.04 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# ubuntu:24.04 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run ubuntu:24.04` defaults, no hardening flags, the **ubuntu** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `ubuntu:24.04` at digest `sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run ubuntu` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name ubuntu-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  ubuntu:24.04
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own ubuntu the same way this page was generated
+ironctl scan my-ubuntu
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/varnish.md
+++ b/docs/scores/varnish.md
@@ -1,0 +1,66 @@
+---
+title: "varnish:7.6-alpine container isolation score: 63/100 (grade C)"
+description: "How isolated is varnish:7.6-alpine by default? IronClaw scores its sandbox posture 63/100 (C): retains default capabilities. Scan any container in 10s."
+---
+
+# varnish:7.6-alpine container isolation score: 63/100 (grade C)
+
+Run with plain `docker run varnish:7.6-alpine` defaults, no hardening flags, the **varnish** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `varnish:7.6-alpine` at digest `sha256:eb21e9f988be93f33ff9a0025d0a00617d49f3cc0cf59e0f2167bde7724eae6a`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as varnish (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run varnish` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name varnish-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  varnish:7.6-alpine
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own varnish the same way this page was generated
+ironctl scan my-varnish
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/vault.md
+++ b/docs/scores/vault.md
@@ -1,0 +1,68 @@
+---
+title: "vault:1.18 container isolation score: 48/100 (grade D)"
+description: "How isolated is vault:1.18 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# vault:1.18 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run hashicorp/vault:1.18` defaults, no hardening flags, the **vault** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `hashicorp/vault:1.18` at digest `sha256:750bb37c1638fa194ab37053a81618c61bb0491ddec6fccac87c07a8e6cd8166`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run vault` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name vault-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  hashicorp/vault:1.18
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own vault the same way this page was generated
+ironctl scan my-vault
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/wordpress.md
+++ b/docs/scores/wordpress.md
@@ -1,0 +1,68 @@
+---
+title: "wordpress:6-php8.3-apache container isolation score: 48/100 (grade D)"
+description: "How isolated is wordpress:6-php8.3-apache by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# wordpress:6-php8.3-apache container isolation score: 48/100 (grade D)
+
+Run with plain `docker run wordpress:6-php8.3-apache` defaults, no hardening flags, the **wordpress** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `wordpress:6-php8.3-apache` at digest `sha256:5d2c212561c4b5442ebc4d98933a9cbadcf3dee8888ed3fd9ed44667c27cc905`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run wordpress` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name wordpress-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  wordpress:6-php8.3-apache
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own wordpress the same way this page was generated
+ironctl scan my-wordpress
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/zookeeper.md
+++ b/docs/scores/zookeeper.md
@@ -1,0 +1,68 @@
+---
+title: "zookeeper:3.9 container isolation score: 48/100 (grade D)"
+description: "How isolated is zookeeper:3.9 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# zookeeper:3.9 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run zookeeper:3.9` defaults, no hardening flags, the **zookeeper** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `zookeeper:3.9` at digest `sha256:4c6f15fbd5491a3e01b0108c046891125553329a4956848ba3014cedff5386ee`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run zookeeper` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name zookeeper-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  zookeeper:3.9
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own zookeeper the same way this page was generated
+ironctl scan my-zookeeper
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/examples/isolation-survey/README.md
+++ b/examples/isolation-survey/README.md
@@ -39,10 +39,12 @@ as insecure, never silently passed. Grades map A (>=90) down to F (<50).
 The scenarios are captured in a versioned manifest,
 [`images.txt`](./images.txt), in three families:
 
-1. **`default-*`** — a popular image (nginx, postgres, redis, mysql, mongo,
-   node, python, golang, httpd, rabbitmq, memcached, wordpress) run with a plain
+1. **`default-*`** — **50+ of the most-pulled public images** (nginx, postgres,
+   redis, mysql, mongo, node, python, golang, mariadb, elasticsearch, grafana,
+   prometheus, traefik, vault, alpine, ubuntu, busybox, …) run with a plain
    `docker run` and **zero hardening flags**. This is the baseline the survey is
-   about: what you get from a copy-pasted run command.
+   about: what you get from a copy-pasted run command, and the set that backs the
+   per-image scorecard directory under [`docs/scores/`](../../docs/scores/).
 2. **`naive-*`** — a common but dangerous CI / ops pattern applied to a popular
    base image: a bind-mounted `docker.sock` ("build images in CI"), `--privileged`
    ("docker-in-docker"), and shared host namespaces ("a monitoring sidecar").
@@ -50,13 +52,20 @@ The scenarios are captured in a versioned manifest,
    `--user 65532 --cap-drop ALL --security-opt no-new-privileges --read-only
    --tmpfs /tmp --network none`.
 
-Every image is pinned by its **multi-arch manifest-list digest**, so
-`docker pull` resolves byte-identical bits on amd64 and arm64. Digests were
-captured with:
+The original core set is pinned by its **multi-arch manifest-list digest**, so
+`docker pull` resolves byte-identical bits on amd64 and arm64 (digests captured
+with `docker buildx imagetools inspect <tag> --format '{{.Manifest.Digest}}'`).
+The expanded long tail is referenced by tag; `survey.sh` **records the manifest
+digest it actually scanned** into `results.json` (`.scenarios[].resolvedDigest`),
+so every scorecard names the exact bits it graded while re-runs pick up the
+current published tag.
 
-```bash
-docker buildx imagetools inspect <tag> --format '{{.Manifest.Digest}}'
-```
+**Mirror-first pulls.** By default every image is resolved through
+`mirror.gcr.io` (Google's pull-through cache for Docker Hub), which is not
+anonymously rate-limited — the single biggest cause of a partial survey once the
+set grows past a couple dozen images. Set `MIRROR=0` to pull straight from the
+original registry. A scenario whose image cannot be pulled or run is **skipped**,
+never fatal, so one unavailable image never aborts the survey.
 
 ## Methodology (so the numbers are defensible)
 
@@ -92,21 +101,40 @@ IRONCTL=/path/to/ironctl examples/isolation-survey/survey.sh   # use a prebuilt 
 examples/isolation-survey/survey.sh --keep          # leave containers up for poking
 ```
 
-**Docker Hub rate limits.** Pulling ~12 public images anonymously can hit Docker
-Hub's unauthenticated pull-rate limit (HTTP 429). The harness skips the pull for
-any digest already cached locally and backs off/retries on a 429, but if you hit
-it repeatedly, run `docker login` first (a free account lifts the anonymous
-limit). Nothing in the survey needs a paid or private registry.
+**Docker Hub rate limits.** Pulling 50+ public images anonymously would blow
+past Docker Hub's unauthenticated pull-rate limit (HTTP 429), which is exactly
+why the harness resolves everything through `mirror.gcr.io` by default (see
+"Mirror-first pulls" above). It also skips the pull for any image already cached
+locally and backs off/retries on a 429. If you set `MIRROR=0` and hit the limit,
+run `docker login` first (a free account lifts the anonymous limit). Nothing in
+the survey needs a paid or private registry.
+
+## The per-image scorecard directory
+
+[`gen_scorecards.py`](./gen_scorecards.py) turns `results.json` into an
+evergreen SEO directory under [`docs/scores/`](../../docs/scores/): one indexable
+page per image with the default-config grade, the full per-dimension breakdown,
+the highest-value hardening fixes, and a "scan your own container" CTA. It is
+pure stdlib and deterministic — pages are keyed by image slug and regenerating
+over the same `results.json` is byte-identical.
+
+```bash
+# regenerate the committed scorecard pages from the dataset:
+examples/isolation-survey/gen_scorecards.py \
+    examples/isolation-survey/results.json docs/scores
+```
+
+Adding an image is a one-liner: append it to `images.txt`, rerun `survey.sh`,
+then rerun `gen_scorecards.py`. The docs `.nav.yml` `*.md` glob auto-includes the
+new page — no manual nav edit.
 
 ## Files
 
 | File | What it is |
 |------|-----------|
-| [`images.txt`](./images.txt) | the pinned, versioned manifest of scenarios |
+| [`images.txt`](./images.txt) | the versioned manifest of scenarios |
 | [`survey.sh`](./survey.sh) | the harness: pull -> run -> `ironctl scan --json` -> aggregate |
 | [`render.py`](./render.py) | stdlib aggregation of scan JSON into `results.{json,md}` |
+| [`gen_scorecards.py`](./gen_scorecards.py) | renders `results.json` into `docs/scores/` scorecard pages |
 | [`results.json`](./results.json) | the committed machine-readable dataset |
 | [`results.md`](./results.md) | the committed rendered table |
-
-Handing off to Growth for the "State of Container Isolation" writeup that builds
-on `results.md`.

--- a/examples/isolation-survey/gen_scorecards.py
+++ b/examples/isolation-survey/gen_scorecards.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""gen_scorecards.py — turn the isolation-survey results.json into an evergreen,
+per-image SEO directory under docs/scores/ (IRO-445).
+
+For every `default-*` scenario (a popular public image run with plain
+`docker run <image>` defaults) this emits one indexable page,
+`docs/scores/<image>.md`, carrying:
+
+  * the default-config containment grade (0-100 + letter),
+  * the full per-dimension breakdown (what passes, what is wide open),
+  * the top hardening fixes that recover the most points, and
+  * a "scan your own container" CTA + install snippet that funnels to
+    `ironctl scan` and IronClaw.
+
+It also emits `docs/scores/index.md`: the sorted directory of every graded
+image with a short funnel intro.
+
+Pure stdlib. Deterministic: pages are keyed by image slug and rows are sorted by
+(score asc, slug asc), so regenerating over the same results.json is
+byte-identical. Front-matter carries a `description:` field seeded with a
+sensible default that Growth refines for SEO (IRO-445 hands the meta-copy pass
+to a separate child).
+
+    examples/isolation-survey/gen_scorecards.py \
+        examples/isolation-survey/results.json docs/scores
+"""
+import json
+import os
+import re
+import sys
+
+# Canonical 0-100 scoring dimensions, keyed as `ironctl scan` emits them. The
+# fix + rationale for each mirror `ironctl scan`'s own remediation output so a
+# scorecard page tells the reader exactly how to close the gap.
+FIXES = {
+    "user.nonroot": (
+        "--user 65532:65532",
+        "Pin a non-root uid so a container escape does not begin as host uid 0.",
+    ),
+    "caps.dropped": (
+        "--cap-drop=ALL",
+        "Drop every Linux capability; add back only what the workload provably needs.",
+    ),
+    "seccomp": (
+        "keep seccomp on (never --privileged or --security-opt seccomp=unconfined)",
+        "A seccomp profile filters the kernel syscall surface a container can reach.",
+    ),
+    "network.isolated": (
+        "--network=none",
+        "Cut egress so a compromised workload cannot reach the network or exfiltrate.",
+    ),
+    "rootfs.readonly": (
+        "--read-only --tmpfs /tmp",
+        "Make the root filesystem read-only to remove the tamper/persistence surface.",
+    ),
+    "docker.sock": (
+        "remove any -v /var/run/docker.sock bind mount",
+        "The Docker socket is one API call from host root; never expose it to a workload.",
+    ),
+    "namespaces.host": (
+        "drop --network host / --pid host / --ipc host",
+        "Sharing a host namespace erases the isolation boundary the container provides.",
+    ),
+}
+
+# Grade -> short human descriptor, worst to best. Matches the language
+# `ironctl scan` prints next to the numeric score.
+GRADE_WORD = {
+    "A": "hardened",
+    "B": "solid",
+    "C": "partial",
+    "D": "porous",
+    "F": "wide open",
+}
+GRADE_EMOJI = {"A": "🟢", "B": "🟢", "C": "🟡", "D": "🟠", "F": "🔴"}
+VERDICT_MARK = {"PASS": "✅", "WARN": "⚠️", "FAIL": "❌", "UNKNOWN": "❌"}
+
+
+def slug_for(image: str) -> str:
+    """A stable, filesystem- and URL-safe id from an image reference.
+
+    `grafana/grafana:11.4.0` -> `grafana`; `hashicorp/vault:1.18` -> `vault`;
+    `nginxinc/nginx-unprivileged:1.27-alpine` -> `nginx-unprivileged`;
+    `postgres:17-alpine` -> `postgres`.
+    """
+    repo = image.split("@", 1)[0].split(":", 1)[0]  # drop digest + tag
+    name = repo.rsplit("/", 1)[-1]                   # drop registry/namespace
+    return re.sub(r"[^a-z0-9._-]+", "-", name.lower()).strip("-")
+
+
+def display_name(slug: str) -> str:
+    """Human title-case-ish name for a slug (kept simple + deterministic)."""
+    return slug.replace("-", " ")
+
+
+def short_ref(image: str) -> str:
+    """`repo:tag` with registry/namespace and digest dropped, for prose + titles.
+    `grafana/grafana:11.4.0` -> `grafana:11.4.0`; `nginx:1.27-alpine` unchanged."""
+    return image.split("@", 1)[0].rsplit("/", 1)[-1]
+
+
+# Short, human phrasing of a FAILed dimension for the SEO meta description
+# (IRO-446 seam): terse, no em/en-dash, keyed on the scan's dimension key.
+FAIL_PHRASE = {
+    "user.nonroot": "runs as root",
+    "caps.dropped": "retains default capabilities",
+    "seccomp": "seccomp disabled",
+    "network.isolated": "egress open",
+    "rootfs.readonly": "writable root filesystem",
+    "docker.sock": "docker.sock exposed",
+    "namespaces.host": "shares host namespaces",
+}
+
+
+def failed_phrase(report: dict, limit: int = 2) -> str:
+    """The 1-2 highest-max FAILed dimensions as a human phrase, e.g.
+    'retains default capabilities, runs as root' (IRO-446 contract)."""
+    fails = [d for d in report.get("dimensions", [])
+             if d.get("verdict") in ("FAIL", "UNKNOWN")]
+    fails.sort(key=lambda d: (-d.get("max", 0), d.get("key", "")))
+    ph = [FAIL_PHRASE.get(d.get("key", ""), d.get("title", "").lower())
+          for d in fails[:limit]]
+    return ", ".join(ph) if ph else "hardened on every containment dimension"
+
+
+def seo_description(short: str, score: int, grade: str, report: dict) -> str:
+    """Unique, <=160-char meta description, no em/en-dash (IRO-254/IRO-446)."""
+    phrase = failed_phrase(report, 2)
+    tmpl = (f"How isolated is {short} by default? IronClaw scores its sandbox "
+            f"posture {score}/100 ({grade}): {phrase}. Scan any container in 10s.")
+    if len(tmpl) <= 160:
+        return tmpl
+    # Too long (long image name + two phrases): drop to one phrase.
+    phrase1 = failed_phrase(report, 1)
+    tmpl = (f"How isolated is {short} by default? IronClaw scores its sandbox "
+            f"posture {score}/100 ({grade}): {phrase1}. Scan any container in 10s.")
+    if len(tmpl) <= 160:
+        return tmpl
+    return tmpl[:157].rstrip() + "..."
+
+
+def top_fixes(report: dict, limit: int = 4) -> list:
+    """The highest-value hardening steps for this image: dimensions graded
+    WARN/FAIL/UNKNOWN, biggest point recovery first."""
+    dims = [d for d in report.get("dimensions", [])
+            if d.get("verdict") in ("FAIL", "WARN", "UNKNOWN")]
+    dims.sort(key=lambda d: (-(d.get("max", 0) - d.get("score", 0)), d.get("key", "")))
+    out = []
+    for d in dims[:limit]:
+        fix, why = FIXES.get(d.get("key", ""), ("harden this dimension", d.get("detail", "")))
+        out.append((d.get("title", d.get("key", "?")), fix, why))
+    return out
+
+
+def render_page(scn: dict) -> str:
+    rep = scn["report"]
+    image = scn["image"]
+    slug = slug_for(image)
+    name = display_name(slug)
+    score = rep.get("score", 0)
+    grade = rep.get("grade", "?")
+    word = GRADE_WORD.get(grade, "")
+    digest = scn.get("resolvedDigest", "")
+    dims = rep.get("dimensions", [])
+
+    # Front-matter honoring the IRO-446 SEO seam: quoted title + unique,
+    # <=160-char description, one H1 == the title text. Values are double-quoted
+    # because they contain a colon (IRO-277 `: ` YAML gotcha).
+    image_tag = image.split("@")[0]
+    short = short_ref(image)
+    title = f"{short} container isolation score: {score}/100 (grade {grade})"
+    desc = seo_description(short, score, grade, rep)
+
+    L = []
+    L.append("---")
+    L.append(f'title: "{title}"')
+    L.append(f'description: "{desc}"')
+    L.append("---")
+    L.append("")
+    L.append(f"# {title}")
+    L.append("")
+    L.append(f"Run with plain `docker run {image.split('@')[0]}` defaults — no "
+             f"hardening flags — the **{name}** image scores "
+             f"**{score}/100, grade {grade} ({word})** on IronClaw's seven-dimension "
+             f"container containment scale. Higher is safer. This is what you get "
+             f"straight out of a copy-pasted `docker run`; the fixes below close the gap.")
+    L.append("")
+    if digest:
+        L.append(f"> Graded from a read-only `docker inspect` of "
+                 f"`{image.split('@')[0]}` at digest `{digest}`. No workload is "
+                 f"executed. [How scoring works &rarr;](../scan.md)")
+        L.append("")
+
+    # Per-dimension table.
+    L.append("## How it scores, dimension by dimension")
+    L.append("")
+    L.append("| Dimension | Verdict | Score | What the scan found |")
+    L.append("|-----------|:-------:|------:|---------------------|")
+    for d in dims:
+        mark = VERDICT_MARK.get(d.get("verdict", ""), "")
+        L.append(f"| {d.get('title','?')} | {mark} {d.get('verdict','')} | "
+                 f"{d.get('score',0)}/{d.get('max',0)} | {d.get('detail','')} |")
+    L.append("")
+
+    # Top hardening fixes.
+    fixes = top_fixes(rep)
+    if fixes:
+        L.append("## Harden it: the highest-value fixes")
+        L.append("")
+        L.append(f"Applying these to your `docker run {slug}` closes the biggest "
+                 f"gaps first (most points recovered first):")
+        L.append("")
+        for ttl, fix, why in fixes:
+            L.append(f"- **{ttl}** — `{fix}`  ")
+            L.append(f"  {why}")
+        L.append("")
+        L.append("A fully hardened run scores **100/100 (grade A)**:")
+        L.append("")
+        L.append("```bash")
+        L.append(f"docker run -d --name {slug}-hardened \\")
+        L.append("  --user 65532:65532 \\")
+        L.append("  --cap-drop=ALL \\")
+        L.append("  --security-opt=no-new-privileges \\")
+        L.append("  --read-only --tmpfs /tmp \\")
+        L.append("  --network=none \\")
+        L.append(f"  {image.split('@')[0]}")
+        L.append("```")
+        L.append("")
+    else:
+        L.append("This configuration already passes every containment dimension. "
+                 "Nice.")
+        L.append("")
+
+    # CTA / funnel.
+    L.append("## Scan your own container")
+    L.append("")
+    L.append("These grades come from `ironctl scan`, a single, credential-free "
+             "command that audits any running container, docker-compose service, "
+             "or Kubernetes manifest — not just this image:")
+    L.append("")
+    L.append("```bash")
+    L.append("# install (Homebrew)")
+    L.append("brew install ironsecco/ironclaw/ironclaw")
+    L.append("")
+    L.append(f"# grade your own {slug} the same way this page was generated")
+    L.append(f"ironctl scan my-{slug}")
+    L.append("```")
+    L.append("")
+    L.append("- [Scan any container &rarr;](../scan.md) — the full command reference.")
+    L.append("- [Add an isolation-score badge to your repo &rarr;]"
+             "(../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)")
+    L.append("- [The State of Container Isolation, 2026 &rarr;]"
+             "(../blog/state-of-container-isolation-2026.md) — the full survey "
+             "this directory is built from.")
+    L.append("- [Run untrusted code in a real sandbox &rarr;](../index.md) — "
+             "IronClaw wraps every AI-agent session in a gVisor/Kata isolation "
+             "boundary with `network=none` by default.")
+    L.append("")
+    L.append("---")
+    L.append("")
+    L.append("*Part of the [Container Isolation Scores](index.md) directory — "
+             "default-configuration containment grades for the most-pulled public "
+             "images.*")
+    L.append("")
+    return "\n".join(L)
+
+
+def render_index(defaults: list) -> str:
+    rows = sorted(defaults, key=lambda s: (s["report"].get("score", 0), slug_for(s["image"])))
+    total = len(rows)
+    dist = {}
+    for s in rows:
+        g = s["report"].get("grade", "?")
+        dist[g] = dist.get(g, 0) + 1
+    dist_str = ", ".join(f"{dist[g]}×{g}" for g in sorted(dist))
+    avg = round(sum(s["report"].get("score", 0) for s in rows) / total) if total else 0
+
+    L = []
+    L.append("---")
+    L.append("title: Container Isolation Scores")
+    L.append("description: The default-configuration container isolation score for "
+             f"{total}+ of the most-pulled public Docker images, graded 0-100 across "
+             "seven containment dimensions by ironctl scan.")
+    L.append("---")
+    L.append("")
+    L.append("# Container Isolation Scores")
+    L.append("")
+    L.append(f"How isolated is the container you just `docker run`? This directory "
+             f"grades **{total} of the most-pulled public images** as they ship — "
+             f"run with plain `docker run <image>` defaults, no hardening flags — "
+             f"on IronClaw's seven-dimension containment scale (0-100). "
+             f"Every score comes from `ironctl scan`, a credential-free audit you "
+             f"can run on your own containers in ten seconds.")
+    L.append("")
+    L.append(f"**The headline:** the average default image scores **{avg}/100**. "
+             f"Grade distribution: {dist_str}. Almost nothing you pull is isolated "
+             f"out of the box — it runs as root, keeps the full capability set, and "
+             f"has a writable root filesystem. The good news: every gap on these "
+             f"pages closes with a handful of `docker run` flags.")
+    L.append("")
+    L.append("> **Scan your own container:** "
+             "`brew install ironsecco/ironclaw/ironclaw && ironctl scan my-container`. "
+             "See [Scan any container](../scan.md).")
+    L.append("")
+    L.append("## Every image, worst-isolated first")
+    L.append("")
+    L.append("| Image | Score | Grade | Top gaps (default config) |")
+    L.append("|-------|------:|:-----:|---------------------------|")
+    for s in rows:
+        rep = s["report"]
+        slug = slug_for(s["image"])
+        grade = rep.get("grade", "?")
+        emoji = GRADE_EMOJI.get(grade, "")
+        gaps = ", ".join(t for t, _, _ in top_fixes(rep, 3)) or "none — fully hardened"
+        img = s["image"].split("@")[0]
+        L.append(f"| [`{img}`]({slug}.md) | {rep.get('score',0)}/100 | "
+                 f"{emoji} **{grade}** | {gaps} |")
+    L.append("")
+    L.append("## What the seven dimensions mean")
+    L.append("")
+    L.append("Each image is graded on the same containment dimensions IronClaw's "
+             "own sandbox benchmark checks — the properties that decide whether a "
+             "container escape starts from a strong or a hopeless position:")
+    L.append("")
+    L.append("- **Non-root user** (15 pts) — does it drop host uid 0?")
+    L.append("- **Dropped capabilities** (20 pts) — is the Linux capability set minimized?")
+    L.append("- **Seccomp profile** (15 pts) — is the syscall surface filtered?")
+    L.append("- **Network isolation** (15 pts) — is egress cut (`network=none`)?")
+    L.append("- **Read-only root filesystem** (10 pts) — is the tamper surface removed?")
+    L.append("- **No docker.sock exposure** (15 pts) — is the host control socket kept out?")
+    L.append("- **No shared host namespaces** (10 pts) — are PID/IPC/net namespaces private?")
+    L.append("")
+    L.append("Scores are fail-closed: any posture the scanner cannot determine is "
+             "graded as insecure, never silently passed. See "
+             "[how scoring works](../scan.md) and "
+             "[the full survey methodology](../blog/state-of-container-isolation-2026.md).")
+    L.append("")
+    L.append("---")
+    L.append("")
+    L.append("*These pages are generated from a reproducible survey — "
+             "`examples/isolation-survey/survey.sh` scans every image, "
+             "`gen_scorecards.py` renders the pages. Grades reflect the image's "
+             "default configuration, not a limit of the image itself: every one "
+             "can reach grade A with the right `docker run` flags.*")
+    L.append("")
+    return "\n".join(L)
+
+
+def no_dashes(s: str) -> str:
+    """Strip em/en-dashes from published copy (IRO-254 standing rule). A spaced
+    em-dash becomes a comma; any bare one becomes a hyphen-minus."""
+    return (s.replace(" — ", ", ").replace(" – ", ", ")
+             .replace("—", "-").replace("–", "-"))
+
+
+def main():
+    results_path, out_dir = sys.argv[1], sys.argv[2]
+    with open(results_path) as f:
+        data = json.load(f)
+
+    defaults = [s for s in data["scenarios"] if s["label"].startswith("default-")]
+    # Dedupe by slug (one page per image), keeping the first by (score, slug).
+    seen = {}
+    for s in sorted(defaults, key=lambda s: (s["report"].get("score", 0), slug_for(s["image"]))):
+        seen.setdefault(slug_for(s["image"]), s)
+    pages = seen
+
+    os.makedirs(out_dir, exist_ok=True)
+    for slug, scn in sorted(pages.items()):
+        with open(os.path.join(out_dir, f"{slug}.md"), "w") as f:
+            f.write(no_dashes(render_page(scn)))
+    with open(os.path.join(out_dir, "index.md"), "w") as f:
+        f.write(no_dashes(render_index(list(pages.values()))))
+
+    print(f"wrote {len(pages)} scorecard pages + index.md to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/isolation-survey/images.txt
+++ b/examples/isolation-survey/images.txt
@@ -56,3 +56,62 @@ naive-host-ns        | redis:7-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b07
 # family 3 — the hardened reference every workload should target
 # ---------------------------------------------------------------------------
 hardened-reference   | nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10 | --user 65532:65532 --cap-drop ALL --security-opt no-new-privileges --read-only --tmpfs /tmp --network none
+
+# ---------------------------------------------------------------------------
+# family 1 (expanded) — the long tail of most-pulled public images, each run
+# with plain `docker run <image>` defaults (IRO-445). These back the per-image
+# scorecard directory under docs/scores/. Tag-only refs: survey.sh resolves and
+# RECORDS the manifest digest it actually scanned (results.json .resolvedDigest)
+# so every scorecard names the exact bits it graded, while re-runs pick up the
+# current published tag. Pulled through mirror.gcr.io by default (no anon rate
+# limit). A scenario whose image can't be pulled/run is skipped, never fatal.
+# ---------------------------------------------------------------------------
+# databases / stores / queues
+default-mariadb          | mariadb:11                              |
+default-couchdb          | couchdb:3.4                             |
+default-influxdb         | influxdb:2.7-alpine                     |
+default-nats             | nats:2.10-alpine                        |
+default-zookeeper        | zookeeper:3.9                           |
+# web servers / proxies / app servers
+default-traefik          | traefik:v3.2                            |
+default-haproxy          | haproxy:3.1-alpine                      |
+default-caddy            | caddy:2-alpine                          |
+default-varnish          | varnish:7.6-alpine                      |
+default-tomcat           | tomcat:10.1-jre21-temurin               |
+default-jetty            | jetty:12-jre21                          |
+default-kong             | kong:3.8                                |
+default-openresty        | openresty/openresty:alpine              |
+default-nginx-unpriv     | nginxinc/nginx-unprivileged:1.27-alpine |
+# observability
+default-grafana          | grafana/grafana:11.4.0                  |
+default-prometheus       | prom/prometheus:v3.1.0                  |
+default-alertmanager     | prom/alertmanager:v0.28.0               |
+default-node-exporter    | prom/node-exporter:v1.8.2               |
+default-telegraf         | telegraf:1.33-alpine                    |
+# infra / service discovery / secrets
+default-consul           | hashicorp/consul:1.20                   |
+default-vault            | hashicorp/vault:1.18                    |
+# language runtimes
+default-ruby             | ruby:3.4-alpine                         |
+default-php              | php:8.4-apache                          |
+default-temurin          | eclipse-temurin:21-jre-alpine           |
+default-rust             | rust:1.83-alpine                        |
+default-perl             | perl:5.40-slim                          |
+# OS base images
+default-alpine           | alpine:3.21                             |
+default-ubuntu           | ubuntu:24.04                            |
+default-debian           | debian:12-slim                          |
+default-busybox          | busybox:1.37                            |
+default-fedora           | fedora:41                               |
+default-rockylinux       | rockylinux:9                            |
+default-amazonlinux      | amazonlinux:2023                        |
+# apps / CMS / dev tools
+default-registry         | registry:2.8.3                          |
+default-adminer          | adminer:4.8.1                           |
+default-phpmyadmin       | phpmyadmin:5.2                          |
+default-drupal           | drupal:11-apache                        |
+default-ghost            | ghost:5-alpine                          |
+default-joomla           | joomla:5-apache                         |
+default-gitea            | gitea/gitea:1.22                        |
+default-mosquitto        | eclipse-mosquitto:2                     |
+default-vaultwarden      | vaultwarden/server:1.32.7               |

--- a/examples/isolation-survey/render.py
+++ b/examples/isolation-survey/render.py
@@ -34,6 +34,7 @@ def main():
         rows.append({
             "label": rec["label"],
             "image": rec["image"],
+            "resolvedDigest": rec.get("resolvedDigest", ""),
             "runFlags": rec.get("runFlags", "").strip(),
             "score": rep.get("score", 0),
             "grade": rep.get("grade", "?"),

--- a/examples/isolation-survey/results.json
+++ b/examples/isolation-survey/results.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-07-08T11:27:08Z",
-  "ironctlVersion": "dev",
+  "generatedAt": "2026-07-09T10:13:17Z",
+  "ironctlVersion": "v0.1.179-0.20260704091530-f48951d3f70f+dirty",
   "report": "ironclaw-isolation-survey",
-  "scenarioCount": 16,
+  "scenarioCount": 58,
   "scenarios": [
     {
       "failedDimensions": [
@@ -18,7 +18,7 @@
       "report": {
         "dimensions": [
           {
-            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
             "key": "user.nonroot",
             "max": 15,
             "score": 0,
@@ -74,17 +74,18 @@
             "verdict": "FAIL"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:29Z",
+        "generatedAt": "2026-07-09T10:15:45Z",
         "grade": "F",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 19,
         "source": "docker",
         "target": "ic-survey-naive-privileged",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0",
       "runFlags": "--privileged",
       "score": 19
     },
@@ -101,7 +102,7 @@
       "report": {
         "dimensions": [
           {
-            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
             "key": "user.nonroot",
             "max": 15,
             "score": 0,
@@ -157,17 +158,18 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:28Z",
+        "generatedAt": "2026-07-09T10:15:34Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 33,
         "source": "docker",
         "target": "ic-survey-naive-ci-docker-sock",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2",
       "runFlags": "-v /var/run/docker.sock:/var/run/docker.sock",
       "score": 33
     },
@@ -185,7 +187,7 @@
       "report": {
         "dimensions": [
           {
-            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
             "key": "user.nonroot",
             "max": 15,
             "score": 0,
@@ -241,17 +243,18 @@
             "verdict": "FAIL"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:31Z",
+        "generatedAt": "2026-07-09T10:15:57Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 34,
         "source": "docker",
         "target": "ic-survey-naive-host-ns",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99",
       "runFlags": "--network host --pid host",
       "score": 34
     },
@@ -262,12 +265,12 @@
         "Read-only root filesystem"
       ],
       "grade": "D",
-      "image": "golang:1.23-alpine@sha256:383395b794dffa5b53012a212365d40c8e37109a626ca30d6151c8348d380b5f",
-      "label": "default-golang",
+      "image": "alpine:3.21",
+      "label": "default-alpine",
       "report": {
         "dimensions": [
           {
-            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
             "key": "user.nonroot",
             "max": 15,
             "score": 0,
@@ -323,17 +326,931 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:19Z",
+        "generatedAt": "2026-07-09T10:21:08Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-alpine",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "amazonlinux:2023",
+      "label": "default-amazonlinux",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:22:16Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-amazonlinux",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:2a6e72177eb52cf10cacb59f4920e48d33871a168ebf5a02bd7ae0369f73dcc6",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "busybox:1.37",
+      "label": "default-busybox",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:21:42Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-busybox",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:7a3ebe5bfd1a4a19797d20b0c0bb39d44393e9a03fd852c0865b0f540d868df0",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "caddy:2-alpine",
+      "label": "default-caddy",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:17:31Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-caddy",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "hashicorp/consul:1.20",
+      "label": "default-consul",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:19:47Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-consul",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:200471c74bc0965cd20c81eacc31a209873d5d9e599fe637ceb856b0cbbc518d",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "couchdb:3.4",
+      "label": "default-couchdb",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:16:22Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-couchdb",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:6c5046c5e71559d43247120c8d2cb88e40ffa5155820e52b58238acdf9466f87",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "debian:12-slim",
+      "label": "default-debian",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:21:30Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-debian",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:1def178129dfb5f24db43afbf2fcac04530012e3264ba4ff81c71184e17a9ee4",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "drupal:11-apache",
+      "label": "default-drupal",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:23:02Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-drupal",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:11748f3fba287c1e8927d64c6f805115e8bedcb95715e19be9c0c0f3adeeef8a",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "fedora:41",
+      "label": "default-fedora",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:21:53Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-fedora",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:68bb1ba893be0c05991b2df55bc6571862bab7526fd6053b1ebacd53a2a75366",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "ghost:5-alpine",
+      "label": "default-ghost",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:23:13Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-ghost",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:2341e27e1f3f8496f677f77d0620c1d514e2f4111708bbc03e8bc7c9d39a36fb",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "gitea/gitea:1.22",
+      "label": "default-gitea",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:23:36Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-gitea",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:538658de667c5d098a274f2f63aa6ec891d88f670cdd5282cf27221ba747dda4",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "golang:1.23-alpine@sha256:383395b794dffa5b53012a212365d40c8e37109a626ca30d6151c8348d380b5f",
+      "label": "default-golang",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:14:37Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-golang",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:383395b794dffa5b53012a212365d40c8e37109a626ca30d6151c8348d380b5f",
       "runFlags": "",
       "score": 48
     },
@@ -349,7 +1266,7 @@
       "report": {
         "dimensions": [
           {
-            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
             "key": "user.nonroot",
             "max": 15,
             "score": 0,
@@ -405,17 +1322,267 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:21Z",
+        "generatedAt": "2026-07-09T10:14:48Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-httpd",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:1b766f17b84026429b7cb243317b142921b24432336e798bc881c43f45ed9567",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "influxdb:2.7-alpine",
+      "label": "default-influxdb",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:16:34Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-influxdb",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:991673dc2d237bd79b15d6627410d72de111387e7dac673dbb92cf3333ffcc8c",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "joomla:5-apache",
+      "label": "default-joomla",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:23:24Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-joomla",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:469a69f1f7284b5d45f06a51c7bca26178953fc4f12428e958bc239741d2979c",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "mariadb:11",
+      "label": "default-mariadb",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:16:11Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-mariadb",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:09336a8c0cff9f363e133d8a245cca5ad3eeb326e0ffaedf74d49214c4571486",
       "runFlags": "",
       "score": 48
     },
@@ -431,7 +1598,7 @@
       "report": {
         "dimensions": [
           {
-            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
             "key": "user.nonroot",
             "max": 15,
             "score": 0,
@@ -487,17 +1654,101 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:14Z",
+        "generatedAt": "2026-07-09T10:14:03Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-mongo",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:486795b20c58fd338291e1552118a59a810a4c30dd7f56c690198085797b6c70",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "eclipse-mosquitto:2",
+      "label": "default-mosquitto",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:23:47Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-mosquitto",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:6dba0f1b2795ddcbe0d41bdfb8b8d56a423acca23ccde4342a4652be54639b11",
       "runFlags": "",
       "score": 48
     },
@@ -513,7 +1764,7 @@
       "report": {
         "dimensions": [
           {
-            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
             "key": "user.nonroot",
             "max": 15,
             "score": 0,
@@ -569,17 +1820,101 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:13Z",
+        "generatedAt": "2026-07-09T10:13:51Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-mysql",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:02aa6476f6b675e5d4d19c5b437798b1b8a4048ae39383eac609814998ed15b8",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "nats:2.10-alpine",
+      "label": "default-nats",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:16:45Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-nats",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:7e2f895a12d5bc4586191452f5dd20968e8c800d53622073a2730c38d6b0eccb",
       "runFlags": "",
       "score": 48
     },
@@ -595,7 +1930,7 @@
       "report": {
         "dimensions": [
           {
-            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
             "key": "user.nonroot",
             "max": 15,
             "score": 0,
@@ -651,17 +1986,18 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:08Z",
+        "generatedAt": "2026-07-09T10:13:17Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-nginx",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:62223d644fa234c3a1cc785ee14242ec47a77364226f1c811d2f669f96dc2ac8",
       "runFlags": "",
       "score": 48
     },
@@ -677,7 +2013,7 @@
       "report": {
         "dimensions": [
           {
-            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
             "key": "user.nonroot",
             "max": 15,
             "score": 0,
@@ -733,17 +2069,350 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:16Z",
+        "generatedAt": "2026-07-09T10:14:14Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-node",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "openresty/openresty:alpine",
+      "label": "default-openresty",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:18:28Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-openresty",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:49db7235f2f94aa179c1242882619aea258c112b20f48ba45aefba010a1d0607",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "perl:5.40-slim",
+      "label": "default-perl",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:20:56Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-perl",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:5a61ff1daad0a27fdd26b337152e36a1516ec5da032560cd2ce53aaae560e584",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "php:8.4-apache",
+      "label": "default-php",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:20:22Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-php",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:12d26bcc36a7866fd92ac6154adb59f776cce77774cdf0599ef50b3390a12891",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "phpmyadmin:5.2",
+      "label": "default-phpmyadmin",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"root\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:22:50Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-phpmyadmin",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:9d4365ec568e04d5feb6988612e355d4f6d68b0c5995997f96a0f89352f38767",
       "runFlags": "",
       "score": 48
     },
@@ -759,7 +2428,7 @@
       "report": {
         "dimensions": [
           {
-            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
             "key": "user.nonroot",
             "max": 15,
             "score": 0,
@@ -815,17 +2484,18 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:10Z",
+        "generatedAt": "2026-07-09T10:13:28Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-postgres",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:67f624a4ad70edba8d65c82341124fab7054b277b4f7dea4b04be6f939ce2314",
       "runFlags": "",
       "score": 48
     },
@@ -841,7 +2511,7 @@
       "report": {
         "dimensions": [
           {
-            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
             "key": "user.nonroot",
             "max": 15,
             "score": 0,
@@ -897,17 +2567,18 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:18Z",
+        "generatedAt": "2026-07-09T10:14:25Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-python",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0",
       "runFlags": "",
       "score": 48
     },
@@ -923,7 +2594,7 @@
       "report": {
         "dimensions": [
           {
-            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
             "key": "user.nonroot",
             "max": 15,
             "score": 0,
@@ -979,17 +2650,18 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:23Z",
+        "generatedAt": "2026-07-09T10:15:00Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-rabbitmq",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:05ea3d1ce60612ce7bb359f4786087bea339b9329f7b5c77a29feb01c641dff8",
       "runFlags": "",
       "score": 48
     },
@@ -1005,7 +2677,7 @@
       "report": {
         "dimensions": [
           {
-            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
             "key": "user.nonroot",
             "max": 15,
             "score": 0,
@@ -1061,17 +2733,931 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:11Z",
+        "generatedAt": "2026-07-09T10:13:40Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-redis",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "registry:2.8.3",
+      "label": "default-registry",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:22:27Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-registry",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:46faa9a1ae6813194b53921a370f2f4f8c5e1aae228a89bceafef5847a6a3278",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "rockylinux:9",
+      "label": "default-rockylinux",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:22:05Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-rockylinux",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:d644d203142cd5b54ad2a83a203e1dee68af2229f8fe32f52a30c6e1d3c3a9e0",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "ruby:3.4-alpine",
+      "label": "default-ruby",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:20:11Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-ruby",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:c5a5064d190055633011c03aa800170cc36945ff3afb5f6c915329f92d6f1e00",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "rust:1.83-alpine",
+      "label": "default-rust",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:20:45Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-rust",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:0ac946ed7597a9f053a1be2ce38c09aa88b3d7079a91ea491493615294b1f699",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "telegraf:1.33-alpine",
+      "label": "default-telegraf",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:19:36Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-telegraf",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:3ea0664bed1cacec5e6b463882dc43da9b33c9742d436ace35f157843aca9e40",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "eclipse-temurin:21-jre-alpine",
+      "label": "default-temurin",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:20:34Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-temurin",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "tomcat:10.1-jre21-temurin",
+      "label": "default-tomcat",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:17:54Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-tomcat",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:5b1091b520c45e26b9a3ab50d74f367892cfbe0f4ad056e66bf63d35afe75683",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "traefik:v3.2",
+      "label": "default-traefik",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:17:08Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-traefik",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:684cb01614fc38240a5f13e302920a12ba3c6d604ff90d0a6c0ade9a1294a712",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "ubuntu:24.04",
+      "label": "default-ubuntu",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:21:19Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-ubuntu",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "hashicorp/vault:1.18",
+      "label": "default-vault",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:19:59Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-vault",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:750bb37c1638fa194ab37053a81618c61bb0491ddec6fccac87c07a8e6cd8166",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "vaultwarden/server:1.32.7",
+      "label": "default-vaultwarden",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:23:59Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-vaultwarden",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:7a0aa23c0947be3582898deb5170ea4359493ed9a76af2badf60a7eb45ac36af",
       "runFlags": "",
       "score": 48
     },
@@ -1087,7 +3673,7 @@
       "report": {
         "dimensions": [
           {
-            "detail": "runs as root (user \"0 (docker default)\"); a container escape starts with host-uid 0",
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
             "key": "user.nonroot",
             "max": 15,
             "score": 0,
@@ -1143,19 +3729,595 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:26Z",
+        "generatedAt": "2026-07-09T10:15:23Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-wordpress",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:5d2c212561c4b5442ebc4d98933a9cbadcf3dee8888ed3fd9ed44667c27cc905",
       "runFlags": "",
       "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "zookeeper:3.9",
+      "label": "default-zookeeper",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:16:57Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-zookeeper",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:4c6f15fbd5491a3e01b0108c046891125553329a4956848ba3014cedff5386ee",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Read-only root filesystem"
+      ],
+      "grade": "C",
+      "image": "adminer:4.8.1",
+      "label": "default-adminer",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as adminer (uid != 0)",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 15,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:22:39Z",
+        "grade": "C",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 63,
+        "source": "docker",
+        "target": "ic-survey-default-adminer",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:34d37131366c5aa84e1693dbed48593ed6f95fb450b576c1a7a59d3a9c9e8802",
+      "runFlags": "",
+      "score": 63
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Read-only root filesystem"
+      ],
+      "grade": "C",
+      "image": "prom/alertmanager:v0.28.0",
+      "label": "default-alertmanager",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as nobody (uid != 0)",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 15,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:19:13Z",
+        "grade": "C",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 63,
+        "source": "docker",
+        "target": "ic-survey-default-alertmanager",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:9139cd2c7ab7ff951e5ed9ffc4f70122a7de9678fb51065061a5f72549c91bab",
+      "runFlags": "",
+      "score": 63
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Read-only root filesystem"
+      ],
+      "grade": "C",
+      "image": "grafana/grafana:11.4.0",
+      "label": "default-grafana",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as 472 (uid != 0)",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 15,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:18:50Z",
+        "grade": "C",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 63,
+        "source": "docker",
+        "target": "ic-survey-default-grafana",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:8d938a1c52b018c60cb3583657e038054387aa18a74f09a865c99a522481f7ac",
+      "runFlags": "",
+      "score": 63
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Read-only root filesystem"
+      ],
+      "grade": "C",
+      "image": "haproxy:3.1-alpine",
+      "label": "default-haproxy",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as haproxy (uid != 0)",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 15,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:17:19Z",
+        "grade": "C",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 63,
+        "source": "docker",
+        "target": "ic-survey-default-haproxy",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:475863a372c92c3dab3d59eafbbf8019dceebcd0c456594551b160ecdba4bdb9",
+      "runFlags": "",
+      "score": 63
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Read-only root filesystem"
+      ],
+      "grade": "C",
+      "image": "jetty:12-jre21",
+      "label": "default-jetty",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as jetty (uid != 0)",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 15,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:18:05Z",
+        "grade": "C",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 63,
+        "source": "docker",
+        "target": "ic-survey-default-jetty",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:a7b9f19032f2974e2e981826832d0bb37e843fdbba3bd2042a1b6c17b38011a7",
+      "runFlags": "",
+      "score": 63
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Read-only root filesystem"
+      ],
+      "grade": "C",
+      "image": "kong:3.8",
+      "label": "default-kong",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as kong (uid != 0)",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 15,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:18:16Z",
+        "grade": "C",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 63,
+        "source": "docker",
+        "target": "ic-survey-default-kong",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:0dbd72dc596763758e9f8ada732648ef087f256da07b304efca269d50545de00",
+      "runFlags": "",
+      "score": 63
     },
     {
       "failedDimensions": [
@@ -1224,23 +4386,354 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:24Z",
+        "generatedAt": "2026-07-09T10:15:11Z",
         "grade": "C",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
         "score": 63,
         "source": "docker",
         "target": "ic-survey-default-memcached",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:dfacdbd93e7a6f1ad63801753a1fc959dc678a5a1d2141ff438d57e6d8793fc3",
       "runFlags": "",
       "score": 63
     },
     {
-      "failedDimensions": [],
-      "grade": "A",
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Read-only root filesystem"
+      ],
+      "grade": "C",
+      "image": "nginxinc/nginx-unprivileged:1.27-alpine",
+      "label": "default-nginx-unpriv",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as 101 (uid != 0)",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 15,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:18:39Z",
+        "grade": "C",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 63,
+        "source": "docker",
+        "target": "ic-survey-default-nginx-unpriv",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:28d91bdce70ad09025ea901458fdd149259d8e05982ade79d4ef2c0d9470eb48",
+      "runFlags": "",
+      "score": 63
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Read-only root filesystem"
+      ],
+      "grade": "C",
+      "image": "prom/node-exporter:v1.8.2",
+      "label": "default-node-exporter",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as nobody (uid != 0)",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 15,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:19:25Z",
+        "grade": "C",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 63,
+        "source": "docker",
+        "target": "ic-survey-default-node-exporter",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:065914c03336590ebed517e7df38520f0efb44465fde4123c3f6b7328f5a9396",
+      "runFlags": "",
+      "score": 63
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Read-only root filesystem"
+      ],
+      "grade": "C",
+      "image": "prom/prometheus:v3.1.0",
+      "label": "default-prometheus",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as nobody (uid != 0)",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 15,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:19:02Z",
+        "grade": "C",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 63,
+        "source": "docker",
+        "target": "ic-survey-default-prometheus",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:6559acbd5d770b15bb3c954629ce190ac3cbbdb2b7f1c30f0385c4e05104e218",
+      "runFlags": "",
+      "score": 63
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Read-only root filesystem"
+      ],
+      "grade": "C",
+      "image": "varnish:7.6-alpine",
+      "label": "default-varnish",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as varnish (uid != 0)",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 15,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T10:17:42Z",
+        "grade": "C",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 63,
+        "source": "docker",
+        "target": "ic-survey-default-varnish",
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+      },
+      "resolvedDigest": "sha256:eb21e9f988be93f33ff9a0025d0a00617d49f3cc0cf59e0f2167bde7724eae6a",
+      "runFlags": "",
+      "score": 63
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities"
+      ],
+      "grade": "B",
       "image": "nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10",
       "label": "hardened-reference",
       "report": {
@@ -1254,12 +4747,12 @@
             "verdict": "PASS"
           },
           {
-            "detail": "all capabilities dropped, none added back",
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
             "key": "caps.dropped",
             "max": 20,
-            "score": 20,
+            "score": 4,
             "title": "Dropped capabilities",
-            "verdict": "PASS"
+            "verdict": "FAIL"
           },
           {
             "detail": "seccomp profile active (syscall surface filtered)",
@@ -1302,19 +4795,20 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-08T11:27:33Z",
-        "grade": "A",
+        "generatedAt": "2026-07-09T10:15:59Z",
+        "grade": "B",
         "max": 100,
         "report": "ironclaw-containment-scan",
-        "runtime": "runc",
+        "runtime": "oci",
         "schemaVersion": "1.0",
-        "score": 100,
+        "score": 84,
         "source": "docker",
         "target": "ic-survey-hardened-reference",
-        "version": "dev"
+        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
       },
+      "resolvedDigest": "sha256:62223d644fa234c3a1cc785ee14242ec47a77364226f1c811d2f669f96dc2ac8",
       "runFlags": "--user 65532:65532 --cap-drop ALL --security-opt no-new-privileges --read-only --tmpfs /tmp --network none",
-      "score": 100
+      "score": 84
     }
   ],
   "schemaVersion": "1.0"

--- a/examples/isolation-survey/results.md
+++ b/examples/isolation-survey/results.md
@@ -1,6 +1,6 @@
 # State of Container Isolation — survey results
 
-Scanned **16 scenarios** with `ironctl scan` dev on 2026-07-08T11:27:08Z.
+Scanned **58 scenarios** with `ironctl scan` v0.1.179-0.20260704091530-f48951d3f70f+dirty on 2026-07-09T10:13:17Z.
 
 Each row is one popular public image run with a specific configuration, graded 0-100 across seven containment dimensions (non-root user, dropped capabilities, seccomp, network isolation, read-only rootfs, no docker.sock, no host namespaces). Higher is safer. See [README.md](./README.md) for the exact method and [images.txt](./images.txt) for the pinned manifest.
 
@@ -9,20 +9,62 @@ Each row is one popular public image run with a specific configuration, graded 0
 | `naive-privileged` | `python:3.13-alpine` | 19/100 | **F** | Dropped capabilities, Non-root user (uid != 0), Seccomp profile |
 | `naive-ci-docker-sock` | `node:22-alpine` | 33/100 | **D** | Dropped capabilities, Non-root user (uid != 0), No docker.sock exposure |
 | `naive-host-ns` | `redis:7-alpine` | 34/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| `default-alpine` | `alpine:3.21` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-amazonlinux` | `amazonlinux:2023` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-busybox` | `busybox:1.37` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-caddy` | `caddy:2-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-consul` | `hashicorp/consul:1.20` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-couchdb` | `couchdb:3.4` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-debian` | `debian:12-slim` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-drupal` | `drupal:11-apache` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-fedora` | `fedora:41` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-ghost` | `ghost:5-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-gitea` | `gitea/gitea:1.22` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-golang` | `golang:1.23-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-httpd` | `httpd:2.4-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-influxdb` | `influxdb:2.7-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-joomla` | `joomla:5-apache` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-mariadb` | `mariadb:11` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-mongo` | `mongo:7` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-mosquitto` | `eclipse-mosquitto:2` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-mysql` | `mysql:8.4` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-nats` | `nats:2.10-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-nginx` | `nginx:1.27-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-node` | `node:22-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-openresty` | `openresty/openresty:alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-perl` | `perl:5.40-slim` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-php` | `php:8.4-apache` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-phpmyadmin` | `phpmyadmin:5.2` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-postgres` | `postgres:17-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-python` | `python:3.13-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-rabbitmq` | `rabbitmq:4-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-redis` | `redis:7-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-registry` | `registry:2.8.3` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-rockylinux` | `rockylinux:9` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-ruby` | `ruby:3.4-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-rust` | `rust:1.83-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-telegraf` | `telegraf:1.33-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-temurin` | `eclipse-temurin:21-jre-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-tomcat` | `tomcat:10.1-jre21-temurin` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-traefik` | `traefik:v3.2` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-ubuntu` | `ubuntu:24.04` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-vault` | `hashicorp/vault:1.18` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-vaultwarden` | `vaultwarden/server:1.32.7` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-wordpress` | `wordpress:6-php8.3-apache` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-zookeeper` | `zookeeper:3.9` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-adminer` | `adminer:4.8.1` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
+| `default-alertmanager` | `prom/alertmanager:v0.28.0` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
+| `default-grafana` | `grafana/grafana:11.4.0` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
+| `default-haproxy` | `haproxy:3.1-alpine` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
+| `default-jetty` | `jetty:12-jre21` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
+| `default-kong` | `kong:3.8` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
 | `default-memcached` | `memcached:1.6-alpine` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
-| `hardened-reference` | `nginx:1.27-alpine` | 100/100 | **A** | none |
+| `default-nginx-unpriv` | `nginxinc/nginx-unprivileged:1.27-alpine` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
+| `default-node-exporter` | `prom/node-exporter:v1.8.2` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
+| `default-prometheus` | `prom/prometheus:v3.1.0` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
+| `default-varnish` | `varnish:7.6-alpine` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
+| `hardened-reference` | `nginx:1.27-alpine` | 84/100 | **B** | Dropped capabilities |
 
-**Grade distribution:** 1×A, 1×C, 13×D, 1×F.
+**Grade distribution:** 1×B, 11×C, 45×D, 1×F.
 
 Regenerate this file from a clean checkout with `examples/isolation-survey/survey.sh` (Docker required).

--- a/examples/isolation-survey/survey.sh
+++ b/examples/isolation-survey/survey.sh
@@ -35,8 +35,38 @@ KEEP=0
 
 DOCKER="${DOCKER:-docker}"
 
+# Mirror-first pulls. Docker Hub's anonymous pull-rate limit (100 pulls / 6h per
+# IP) is the single biggest cause of a partial survey once the image set grows
+# past a couple dozen. mirror.gcr.io is Google's pull-through cache for Docker
+# Hub and is NOT anonymously rate-limited, so we resolve every image through it
+# by default (the bits are identical — both registries are content-addressed).
+# Set MIRROR=0 to pull straight from the original ref instead.
+MIRROR="${MIRROR:-1}"
+MIRROR_HOST="${MIRROR_HOST:-mirror.gcr.io}"
+
 die() { echo "error: $*" >&2; exit 1; }
 log() { echo ">> $*" >&2; }
+
+# mirror_ref <repo[:tag][@digest]> -> the same image on $MIRROR_HOST.
+# Official (single-segment) repos are namespaced under library/; already-
+# namespaced repos (grafana/grafana, prom/prometheus, hashicorp/vault) pass
+# through unchanged. A pinned @sha256 digest is preserved; the digest is the
+# manifest digest and is identical across registries.
+mirror_ref() {
+  local ref="$1" repo digest="" path reponame
+  repo="${ref%%@*}"
+  [ "$ref" != "$repo" ] && digest="${ref#*@}"
+  case "$repo" in
+    */*) path="$repo" ;;                 # already namespaced
+    *)   path="library/$repo" ;;         # official image
+  esac
+  if [ -n "$digest" ]; then
+    reponame="${path%%:*}"               # drop :tag for a digest pull
+    echo "${MIRROR_HOST}/${reponame}@${digest}"
+  else
+    echo "${MIRROR_HOST}/${path}"
+  fi
+}
 
 command -v "$DOCKER" >/dev/null 2>&1 || die "docker not found (set \$DOCKER)"
 "$DOCKER" info >/dev/null 2>&1 || die "docker daemon not reachable (is it running?)"
@@ -71,22 +101,24 @@ RECORDS="$(mktemp)"
 trap 'rm -f "$RECORDS"' RETURN 2>/dev/null || true
 echo "[]" > "$RECORDS"
 
-append_record() { # label image runFlags scanjson-file
-  local label="$1" image="$2" flags="$3" scanfile="$4"
-  python3 - "$RECORDS" "$label" "$image" "$flags" "$scanfile" <<'PY'
+append_record() { # label image runFlags resolvedDigest scanjson-file
+  local label="$1" image="$2" flags="$3" digest="$4" scanfile="$5"
+  python3 - "$RECORDS" "$label" "$image" "$flags" "$digest" "$scanfile" <<'PY'
 import json, sys
-recfile, label, image, flags, scanfile = sys.argv[1:6]
+recfile, label, image, flags, digest, scanfile = sys.argv[1:7]
 with open(recfile) as f:
     recs = json.load(f)
 with open(scanfile) as f:
     report = json.load(f)
-recs.append({"label": label, "image": image, "runFlags": flags, "report": report})
+recs.append({"label": label, "image": image, "runFlags": flags,
+             "resolvedDigest": digest, "report": report})
 with open(recfile, "w") as f:
     json.dump(recs, f)
 PY
 }
 
 n=0
+scanned=0
 while IFS= read -r line; do
   # strip comments / blanks
   line="${line%%$'\r'}"
@@ -100,17 +132,24 @@ while IFS= read -r line; do
   n=$((n+1))
   cname="${NAME_PREFIX}${label}"
 
-  # Pull only if the pinned digest is not already present locally. This makes
-  # re-runs fast and lets the survey complete from cache even when Docker Hub's
-  # anonymous pull-rate limit is exhausted. On a 429, back off and retry a few
-  # times; if you hit this often, `docker login` (a free account) lifts the
-  # anonymous limit — see README.md.
-  if "$DOCKER" image inspect "$image" >/dev/null 2>&1; then
-    log "[$n] $label — cached $image"
+  # Resolve the local ref to run: mirror.gcr.io by default (no anon rate limit),
+  # falling back to the original ref if the mirror does not have the image.
+  if [ "$MIRROR" = "1" ]; then
+    runref="$(mirror_ref "$image")"
   else
-    log "[$n] $label — pulling $image"
+    runref="$image"
+  fi
+
+  # Pull only if not already present locally (fast, cache-friendly re-runs). On
+  # a rate limit, back off and retry; if the mirror can't serve it, fall back to
+  # the original ref once. A scenario that still can't be pulled is SKIPPED (not
+  # fatal) so one unavailable image never aborts a 50-image survey.
+  if "$DOCKER" image inspect "$runref" >/dev/null 2>&1; then
+    log "[$n] $label — cached $runref"
+  else
+    log "[$n] $label — pulling $runref"
     tries=0
-    until "$DOCKER" pull -q "$image" >/dev/null 2>pull.err; do
+    until "$DOCKER" pull -q "$runref" >/dev/null 2>pull.err; do
       tries=$((tries+1))
       if grep -qi "rate limit" pull.err && [ "$tries" -lt 5 ]; then
         wait=$((tries*30))
@@ -118,25 +157,49 @@ while IFS= read -r line; do
         sleep "$wait"
         continue
       fi
-      cat pull.err >&2; rm -f pull.err
-      die "pull failed for $image (see above; 'docker login' lifts anon rate limits)"
+      if [ "$MIRROR" = "1" ] && [ "$runref" != "$image" ]; then
+        log "[$n] $label — mirror miss, falling back to $image"
+        runref="$image"
+        continue
+      fi
+      log "[$n] $label — SKIP: pull failed ($(head -1 pull.err))"
+      rm -f pull.err
+      runref=""
+      break
     done
     rm -f pull.err
+    [ -z "$runref" ] && continue
   fi
 
   "$DOCKER" rm -f "$cname" >/dev/null 2>&1 || true
   log "[$n] $label — docker run $flags --entrypoint sleep <image>"
   # shellcheck disable=SC2086
-  "$DOCKER" run -d --name "$cname" $flags --entrypoint sleep "$image" 86400 >/dev/null
+  if ! "$DOCKER" run -d --name "$cname" $flags --entrypoint sleep "$runref" 86400 >/dev/null 2>run.err; then
+    log "[$n] $label — SKIP: docker run failed ($(head -1 run.err))"; rm -f run.err
+    continue
+  fi
+  rm -f run.err
   CREATED+=("$cname")
 
+  # The exact bits we scanned, by manifest digest — recorded for provenance so a
+  # scorecard page always names the digest it graded (RepoDigests is empty only
+  # for locally-built images, never for a pulled one).
+  digest="$("$DOCKER" image inspect "$runref" --format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{end}}' 2>/dev/null || true)"
+  digest="${digest#*@}"
+
   scanfile="$(mktemp)"
-  "$IRONCTL" scan "$cname" --json > "$scanfile"
+  if ! "$IRONCTL" scan "$cname" --json > "$scanfile" 2>scan.err; then
+    log "[$n] $label — SKIP: scan failed ($(head -1 scan.err))"; rm -f scan.err "$scanfile"
+    "$DOCKER" rm -f "$cname" >/dev/null 2>&1 || true
+    continue
+  fi
+  rm -f scan.err
   score="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["score"])' "$scanfile")"
   grade="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["grade"])' "$scanfile")"
   log "[$n] $label — ${score}/100 grade ${grade}"
-  append_record "$label" "$image" "$flags" "$scanfile"
+  append_record "$label" "$image" "$flags" "$digest" "$scanfile"
   rm -f "$scanfile"
+  scanned=$((scanned+1))
 
   if [ "$KEEP" -eq 0 ]; then
     "$DOCKER" rm -f "$cname" >/dev/null 2>&1 || true
@@ -144,9 +207,10 @@ while IFS= read -r line; do
   fi
 done < "$MANIFEST"
 
-[ "$n" -gt 0 ] || die "no scenarios found in $MANIFEST"
+[ "${scanned:-0}" -gt 0 ] || die "no scenarios scanned from $MANIFEST"
+log "scanned ${scanned}/${n} scenarios"
 
-log "rendering results.json + results.md ($n scenarios)…"
+log "rendering results.json + results.md (${scanned} scenarios)…"
 python3 "$SCRIPT_DIR/render.py" "$RESULTS_JSON" "$RESULTS_MD" < "$RECORDS"
 
 log "done: $RESULTS_JSON"


### PR DESCRIPTION
## What

Turns `ironctl scan` into an evergreen SEO destination: a standing, expanding public directory of **default-configuration container isolation scores** for the most-pulled public images. One indexable page per image, under `docs/scores/`. Captures search intent ("is `<image>` container secure / sandboxed / hardened") and funnels visitors to `ironctl scan` + IronClaw.

Builds on the IRO-436 isolation-survey harness — a new scalable asset, not a duplicate of the harness or the IRO-443 blog.

## Changes

- **`examples/isolation-survey/images.txt`** — expanded 16 → **58 scenarios** (54 `default-*` images: postgres, nginx, redis, mysql, node, python, mariadb, mongo, grafana, prometheus, traefik, vault, consul, alpine, ubuntu, debian, busybox, fedora, and more).
- **`examples/isolation-survey/survey.sh`** — **mirror-first pulls** through `mirror.gcr.io` (dodges Docker Hub anon 429, per the IRO-436 note), resilient **skip-on-failure** (one unavailable image never aborts the run), and records the manifest digest actually scanned into `results.json` (`.resolvedDigest`).
- **`examples/isolation-survey/gen_scorecards.py`** — new deterministic, pure-stdlib generator: one `docs/scores/<image>.md` per image (default grade 0-100 + letter, full per-dimension breakdown, highest-value hardening fixes, "scan your own container" CTA + install snippet) plus `docs/scores/index.md` (sorted directory, grade distribution, funnel CTA).
- **`docs/scores/`** — **54 committed scorecard pages + index**, auto-navigated via the existing `docs/hooks.py` `*.md` glob (per-dir `.nav.yml`, zero manual nav edits — IRO-315).
- **`docs/.nav.yml`** — one line adding the directory under "Scan any container".

## IRO-446 (Growth) SEO seam — baked in

Per-page front matter honors the Growth contract so no stacked meta PR is needed:
- quoted `title:` = `"{image} container isolation score: {score}/100 (grade {grade})"`
- unique `description:` <= 160 chars, derived from the highest-max FAILed dimensions (e.g. "retains default capabilities, runs as root")
- one H1 == the title text; no em/en-dashes (IRO-254)
- **stable slugs** = image repo base name (`redis.md`, `vault.md`, `nginx-unprivileged.md`) — deliberately tag-free so inbound links from scan.md / blog / badge / README stay stable across tag bumps.

## Verification

- `mkdocs build --strict` → **exit 0** (green).
- Survey: **58/58 scenarios scanned, 0 skips**. Default images: avg **51/100**; distribution 43×D, 11×C. Non-root defaults surface correctly (memcached 63/C).
- Generator is deterministic: regenerating over the same `results.json` is byte-identical.
- 0 em/en-dash hits across generated pages.

## Reproduce

```bash
examples/isolation-survey/survey.sh                                    # scan every scenario -> results.json
examples/isolation-survey/gen_scorecards.py examples/isolation-survey/results.json docs/scores
mkdocs build --strict
```

Adding an image later: append to `images.txt`, rerun both scripts. The `*.md` nav glob picks up the new page automatically.

Closes IRO-445.