### PR TITLE
docs(scores): cross-link the Container Isolation Scores directory into scan, README, and blog (IRO-446)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,10 @@ Every failing line names the specific hole and why it matters. Drop the grade in
 README with `ironctl scan --badge scan.svg`, or gate CI with `ironctl scan --min-score 90`.
 
 See the [scan reference](https://ironsecco.github.io/ironclaw/scan/) for all seven dimensions
-and every flag.
+and every flag. Or browse the
+[Container Isolation Scores directory](https://ironsecco.github.io/ironclaw/scores/): the
+default-config grade for 50+ of the most-pulled public images, so you can see how the
+containers you already run stack up.
 
 ### Show your score
 

--- a/docs/blog/state-of-container-isolation-2026.md
+++ b/docs/blog/state-of-container-isolation-2026.md
@@ -121,6 +121,11 @@ image in the survey is pinned by its multi-arch manifest-list digest, so a
 `docker pull` resolves byte-identical bits on amd64 and arm64. The survey was
 generated on 2026-07-08 with `ironctl` at dev.
 
+Want the per-image breakdown? See the
+[Container Isolation Scores directory](../scores/index.md) for one scorecard page
+per image, each with its full dimension-by-dimension grade and the exact flags
+that close the gap.
+
 Re-run the whole thing from a clean checkout with nothing but a Docker daemon:
 
 ```bash

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -9,6 +9,10 @@ It grades the same dimensions IronClaw's own containment benchmark checks, and
 it is fail-closed: any posture it cannot determine is scored as insecure, never
 silently passed.
 
+Curious how the images you already pull score? Browse the public
+[Container Isolation Scores directory](scores/index.md): the default-config
+grade for 50+ of the most-pulled public images, then scan your own in 10 seconds.
+
 ```
 $ ironctl scan my-container
 IronClaw containment scan
@@ -141,6 +145,10 @@ reference posture the isolation launcher applies to every session
 For a step-by-step walkthrough, including hosting the file, wiring it into CI, and the
 reasoning behind the committed-file design, see the blog post
 [Add a live Sandbox Isolation Score badge to your repo](blog/add-a-sandbox-isolation-score-badge-to-your-repo.md).
+
+Want to see how your grade stacks up? Compare it against the
+[Container Isolation Scores directory](scores/index.md), where 50+ of the most-pulled
+public images are graded in their default configuration.
 
 ## GitHub code scanning (Security tab)
 


### PR DESCRIPTION
## What

SEO + funnel layer for the Container Isolation Scores directory (IRO-446), stacked on the IRO-445 directory now live on `main`.

IRO-445 shipped 54 per-image scorecard pages + index under `docs/scores/` with unique, intent-matched `title:`/`description:` front-matter (the meta-copy seam baked into `gen_scorecards.py`) and index funnel copy + `ironctl scan` CTA. Verified: **55/55 unique meta descriptions**, all titles intent-matched, nav wired via `docs/.nav.yml` + the `docs/scores/.nav.yml` glob, and the sitemap already emits every page.

The one gap: the pages were **orphaned** (no inbound links from the high-traffic docs). This PR closes the funnel.

## Changes (4 inbound cross-links)

- **docs/scan.md** intro: directory pointer right after the pitch.
- **docs/scan.md** badge section: "compare your score against the directory" next to the badge how-to.
- **README.md** audit section: link the directory from the scan funnel.
- **docs/blog/state-of-container-isolation-2026.md**: per-image breakdown pointer from the survey method section.

## Acceptance

- [x] Every scores page has a unique meta description + intent-matched title (eng seam, verified 55/55 unique)
- [x] Index has funnel copy + `ironctl scan` CTA (eng)
- [x] Cross-links land from scan / blog / badge / README
- [x] Sitemap emits all 55 scores pages; nav wired
- [x] `mkdocs build --strict` green (EXIT=0)
- [x] No em/en-dashes (STANDING rule IRO-254)

Follows the IRO-445 directory PR (already merged to main).