### PR TITLE
feat(scores): expand isolation-scores directory + weekly auto-refresh engine (IRO-449)

### DIFF
--- a/.github/workflows/scores-refresh.yml
+++ b/.github/workflows/scores-refresh.yml
@@ -1,0 +1,202 @@
+# Weekly refresh of the Container Isolation Scores directory (IRO-449).
+#
+# The scores directory (docs/scores/) is a compounding SEO surface: one indexable
+# "<image> container isolation score" page per most-pulled public image, generated
+# from the reproducible isolation-survey by examples/isolation-survey/survey.sh +
+# gen_scorecards.py. Base images move (a new tag flips a default USER, drops a
+# capability, adds a seccomp default), so a one-shot snapshot goes stale. This
+# workflow re-runs the whole survey every week and opens a PR with the refreshed
+# results.json + per-image scorecards, so the directory stays current with zero
+# manual toil and search engines keep seeing fresh content.
+#
+# It does NOT push to main directly: main requires a reviewed PR with passing
+# checks (.github/rulesets/main.json), and weakening that is off the table for a
+# security product. It pushes the regenerated pages to ONE rolling branch and
+# opens/refreshes a single PR for a maintainer to merge. Modeled on the Homebrew
+# rolling-bump PR in release.yml (IRO-270/IRO-318): a fixed branch name, force-
+# reset onto the current main tip each run, so the PR never conflicts and there is
+# never more than one open.
+name: Scores refresh
+
+on:
+  schedule:
+    # Mondays 06:00 UTC. Weekly is enough for base-image drift without churn.
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+
+# One refresh at a time; a new run supersedes an in-flight one (the survey is
+# long-running and the rolling PR is idempotent, so cancelling a stale run is safe).
+concurrency:
+  group: scores-refresh
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    # Never run on forks: the survey is expensive and the PR/token steps are
+    # meaningless off the canonical repo.
+    if: github.repository == 'IronSecCo/ironclaw'
+    runs-on: ubuntu-latest
+    # The survey pulls + scans ~150 images through mirror.gcr.io; give it room but
+    # cap it so a hung pull can never burn a full 6h of runner time.
+    timeout-minutes: 120
+    permissions:
+      contents: write # push the rolling refresh branch
+      pull-requests: write # open/refresh the tracking PR
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: "1.23"
+          cache: true
+
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce62c38 # v5.4.0
+        with:
+          python-version: "3.12"
+
+      # Build ironctl once (CGO for the encrypted-SQLite deps). survey.sh will reuse
+      # this binary via $IRONCTL instead of rebuilding.
+      - name: Build ironctl
+        run: CGO_ENABLED=1 go build -o bin/ironctl ./cmd/ironctl
+
+      # Run the full survey. PRUNE=1 removes each image right after it is scanned so
+      # the ~150-image sweep never exceeds the runner's free disk. Mirror-first
+      # (the default) dodges Docker Hub's anonymous pull-rate limit.
+      - name: Run the isolation survey
+        env:
+          IRONCTL: ${{ github.workspace }}/bin/ironctl
+          PRUNE: "1"
+        run: bash examples/isolation-survey/survey.sh
+
+      - name: Regenerate the scorecard directory
+        run: |
+          python3 examples/isolation-survey/gen_scorecards.py \
+            examples/isolation-survey/results.json docs/scores
+
+      # The refreshed pages must still pass the same strict docs gate main enforces,
+      # so a bad regeneration can never open a PR that fails CI.
+      - name: Verify docs build (strict)
+        # Same install + strict build the docs CI gate uses (docs.yml), so a bad
+        # regeneration can never open a PR that would fail the docs check on main.
+        run: |
+          pip install --require-hashes -r docs/requirements.txt
+          mkdocs build --strict --site-dir /tmp/_scores_site
+
+      # Mint a short-lived, least-privilege token for the reviewer App so the refresh
+      # PR can open itself. The default GITHUB_TOKEN cannot create PRs while the repo
+      # setting "Allow GitHub Actions to create and approve pull requests" stays OFF
+      # (IRO-203 keeps it off and uses a scoped App token instead). Scoped to
+      # pull-requests:write only; used ONLY to open the PR, never to approve/merge.
+      # continue-on-error so a missing/rotated secret degrades to the loud manual
+      # fallback instead of aborting after the branch is already pushed.
+      - name: Mint a scoped reviewer-App token to open the refresh PR
+        id: pr-app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.REVIEWER_APP_ID }}
+          private-key: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+          permission-contents: read
+
+      - name: Push the rolling refresh branch and open a PR if the scores changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_TOKEN: ${{ steps.pr-app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Nothing to do if the weekly survey produced byte-identical output
+          # (gen_scorecards.py is deterministic; results.json only changes when a
+          # base image's config actually moved).
+          if git diff --quiet -- docs/scores examples/isolation-survey/results.json examples/isolation-survey/results.md; then
+            echo "Scores directory already current, nothing to refresh."
+            exit 0
+          fi
+
+          # ONE rolling refresh branch, force-reset onto the current main tip every
+          # run so the PR is always cleanly rebased and there is never more than one
+          # open (same discipline as the Homebrew brew/track branch, IRO-270).
+          branch="scores/refresh"
+
+          # Author the commit as the CLA-signed maintainer, NOT github-actions[bot]:
+          # cla-assistant checks every commit AUTHOR against the signed roster, and a
+          # bot-authored commit strands the PR on "CLA not signed" (IRO-353). The
+          # email is already public in the verified-commit history; not a secret.
+          git config user.name "Omer Zamir"
+          git config user.email "zamir98@gmail.com"
+
+          git checkout -B "$branch"
+          git add docs/scores examples/isolation-survey/results.json examples/isolation-survey/results.md
+          today="$(date -u +%Y-%m-%d)"
+          n_pages=0
+          for f in docs/scores/*.md; do
+            [ "$(basename "$f")" = "index.md" ] || n_pages=$((n_pages + 1))
+          done
+          git commit -m "chore(scores): weekly refresh of the container isolation scores directory (${today})" \
+                     -m "Regenerated docs/scores/ (${n_pages} image scorecards) + results.json from the weekly isolation-survey re-run. Automated by .github/workflows/scores-refresh.yml (IRO-449)."
+
+          # Force-push the rolling branch to the current tip. Unprotected feature
+          # branch, so a plain push works; the commit is unsigned but the rolling PR
+          # lands via SQUASH merge and GitHub signs the squashed commit it writes to
+          # main, so main's required_signatures rule is still satisfied.
+          git push --force origin "$branch"
+
+          title="chore(scores): weekly refresh of the container isolation scores directory"
+          body="Automated by the weekly Scores refresh workflow (IRO-449): re-runs \`examples/isolation-survey/survey.sh\` over the top ~150 public images and regenerates \`docs/scores/\` + \`results.json\` so the [Container Isolation Scores](https://github.com/${REPO}/tree/main/docs/scores) directory tracks current base-image posture. This is the single **rolling** refresh PR, force-reset onto the current main tip each run, so it never conflicts and supersedes any prior refresh. Opened by the reviewer App (PR creation only; a human still approves + merges)."
+
+          emit_manual_fallback() {
+            echo "::error title=Scores refresh PR not opened::${1}"
+            {
+              echo "### ⚠️ Weekly scores refresh needs a manual PR"
+              echo
+              echo "The refresh branch [\`${branch}\`](https://github.com/${REPO}/tree/${branch}) was pushed, but the workflow could not open its PR:"
+              echo
+              echo '```'
+              printf '%s\n' "${1}"
+              echo '```'
+              echo
+              echo "Usual cause: the scoped reviewer-App token could not be minted (check \`REVIEWER_APP_ID\` / \`REVIEWER_APP_PRIVATE_KEY\`). Open it manually from the already-pushed branch:"
+              echo
+              echo '```'
+              echo "gh pr create --repo ${REPO} --base main --head ${branch} \\"
+              echo "  --title 'chore(scores): weekly refresh of the container isolation scores directory'"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+
+          # Refresh the existing rolling PR if one is open; otherwise create it.
+          existing="$(gh pr list --repo "${REPO}" --head "${branch}" --state open \
+            --json number -q '.[0].number' 2>/dev/null || true)"
+
+          if [ -n "${existing:-}" ]; then
+            # gh pr edit works with the default GITHUB_TOKEN — the OFF repo setting
+            # only blocks PR creation/approval, not edits. The force-push above has
+            # already refreshed the PR's diff.
+            if gh pr edit "${existing}" --repo "${REPO}" --title "${title}" --body "${body}"; then
+              echo "Refreshed rolling scores PR #${existing}."
+            else
+              echo "::warning title=Scores refresh PR not refreshed::could not update PR #${existing} metadata (non-fatal; its diff is already current)."
+            fi
+          else
+            if [ -z "${PR_TOKEN:-}" ]; then
+              emit_manual_fallback "scoped reviewer-App token was not minted (actions/create-github-app-token failed — see the mint step)."
+            fi
+            if out="$(GH_TOKEN="${PR_TOKEN}" gh pr create \
+              --repo "${REPO}" \
+              --base main \
+              --head "${branch}" \
+              --title "${title}" \
+              --body "${body}" 2>&1)"; then
+              echo "Opened rolling scores refresh PR: ${out}"
+            elif printf '%s' "$out" | grep -qi 'already exists'; then
+              echo "A rolling scores refresh PR for ${branch} already exists — left it in place."
+            else
+              emit_manual_fallback "gh pr create failed for ${branch}: ${out}"
+            fi
+          fi

--- a/docs/scores/authelia.md
+++ b/docs/scores/authelia.md
@@ -1,0 +1,68 @@
+---
+title: "authelia:4.38 container isolation score: 48/100 (grade D)"
+description: "How isolated is authelia:4.38 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# authelia:4.38 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run authelia/authelia:4.38` defaults, no hardening flags, the **authelia** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `authelia/authelia:4.38` at digest `sha256:46021dc20efdcc5cdc38a29e3050b8835429a155ae6215388ed3b793a02eb0ab`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run authelia` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name authelia-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  authelia/authelia:4.38
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own authelia the same way this page was generated
+ironctl scan my-authelia
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/blackbox-exporter.md
+++ b/docs/scores/blackbox-exporter.md
@@ -1,0 +1,68 @@
+---
+title: "blackbox-exporter:v0.25.0 container isolation score: 48/100 (grade D)"
+description: "How isolated is blackbox-exporter:v0.25.0 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# blackbox-exporter:v0.25.0 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run prom/blackbox-exporter:v0.25.0` defaults, no hardening flags, the **blackbox exporter** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `prom/blackbox-exporter:v0.25.0` at digest `sha256:67847e8aaec3c4852a2c7d84d5344e7931521962988c48df00cd980cd1b490a2`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run blackbox-exporter` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name blackbox-exporter-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  prom/blackbox-exporter:v0.25.0
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own blackbox-exporter the same way this page was generated
+ironctl scan my-blackbox-exporter
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/cassandra.md
+++ b/docs/scores/cassandra.md
@@ -1,0 +1,68 @@
+---
+title: "cassandra:5.0 container isolation score: 48/100 (grade D)"
+description: "How isolated is cassandra:5.0 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# cassandra:5.0 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run cassandra:5.0` defaults, no hardening flags, the **cassandra** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `cassandra:5.0` at digest `sha256:b89056c366c4b807380cd9a4ac865ad558c0b4d5aac342f69087d0169ca1ddcd`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run cassandra` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name cassandra-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  cassandra:5.0
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own cassandra the same way this page was generated
+ironctl scan my-cassandra
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/chronograf.md
+++ b/docs/scores/chronograf.md
@@ -1,0 +1,68 @@
+---
+title: "chronograf:1.10 container isolation score: 48/100 (grade D)"
+description: "How isolated is chronograf:1.10 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# chronograf:1.10 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run chronograf:1.10` defaults, no hardening flags, the **chronograf** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `chronograf:1.10` at digest `sha256:2f587075ca6b101681e6588b762acebb2c53b6b66a358581119d0e85c1c8db3e`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run chronograf` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name chronograf-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  chronograf:1.10
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own chronograf the same way this page was generated
+ironctl scan my-chronograf
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/clickhouse.md
+++ b/docs/scores/clickhouse.md
@@ -1,0 +1,68 @@
+---
+title: "clickhouse:24.8 container isolation score: 48/100 (grade D)"
+description: "How isolated is clickhouse:24.8 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities. Scan any container in 10s."
+---
+
+# clickhouse:24.8 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run clickhouse:24.8` defaults, no hardening flags, the **clickhouse** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `clickhouse:24.8` at digest `sha256:1b41b544da2428cc0df6632a38af8f0fef28658cce772fbd1f051ac2d8c74245`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run clickhouse` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name clickhouse-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  clickhouse:24.8
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own clickhouse the same way this page was generated
+ironctl scan my-clickhouse
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/index.md
+++ b/docs/scores/index.md
@@ -1,13 +1,13 @@
 ---
 title: Container Isolation Scores
-description: The default-configuration container isolation score for 54+ of the most-pulled public Docker images, graded 0-100 across seven containment dimensions by ironctl scan.
+description: The default-configuration container isolation score for 64+ of the most-pulled public Docker images, graded 0-100 across seven containment dimensions by ironctl scan.
 ---
 
 # Container Isolation Scores
 
-How isolated is the container you just `docker run`? This directory grades **54 of the most-pulled public images** as they ship, run with plain `docker run <image>` defaults, no hardening flags, on IronClaw's seven-dimension containment scale (0-100). Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+How isolated is the container you just `docker run`? This directory grades **64 of the most-pulled public images** as they ship, run with plain `docker run <image>` defaults, no hardening flags, on IronClaw's seven-dimension containment scale (0-100). Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
 
-**The headline:** the average default image scores **51/100**. Grade distribution: 11×C, 43×D. Almost nothing you pull is isolated out of the box, it runs as root, keeps the full capability set, and has a writable root filesystem. The good news: every gap on these pages closes with a handful of `docker run` flags.
+**The headline:** the average default image scores **51/100**. Grade distribution: 12×C, 52×D. Almost nothing you pull is isolated out of the box, it runs as root, keeps the full capability set, and has a writable root filesystem. The good news: every gap on these pages closes with a handful of `docker run` flags.
 
 > **Scan your own container:** `brew install ironsecco/ironclaw/ironclaw && ironctl scan my-container`. See [Scan any container](../scan.md).
 
@@ -17,8 +17,13 @@ How isolated is the container you just `docker run`? This directory grades **54 
 |-------|------:|:-----:|---------------------------|
 | [`alpine:3.21`](alpine.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`amazonlinux:2023`](amazonlinux.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`authelia/authelia:4.38`](authelia.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`prom/blackbox-exporter:v0.25.0`](blackbox-exporter.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`busybox:1.37`](busybox.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`caddy:2-alpine`](caddy.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`cassandra:5.0`](cassandra.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`chronograf:1.10`](chronograf.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`clickhouse:24.8`](clickhouse.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`hashicorp/consul:1.20`](consul.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`couchdb:3.4`](couchdb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`debian:12-slim`](debian.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
@@ -36,6 +41,7 @@ How isolated is the container you just `docker run`? This directory grades **54 
 | [`mongo:7`](mongo.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`mysql:8.4`](mysql.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`nats:2.10-alpine`](nats.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`neo4j:5`](neo4j.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`nginx:1.27-alpine`](nginx.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`node:22-alpine`](node.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`openresty/openresty:alpine`](openresty.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
@@ -44,9 +50,11 @@ How isolated is the container you just `docker run`? This directory grades **54 
 | [`phpmyadmin:5.2`](phpmyadmin.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`postgres:17-alpine`](postgres.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`python:3.13-alpine`](python.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`questdb/questdb:8.2.1`](questdb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`rabbitmq:4-alpine`](rabbitmq.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`redis:7-alpine`](redis.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`registry:2.8.3`](registry.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`rethinkdb:2.4`](rethinkdb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`rockylinux:9`](rockylinux.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`ruby:3.4-alpine`](ruby.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`rust:1.83-alpine`](rust.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
@@ -55,6 +63,7 @@ How isolated is the container you just `docker run`? This directory grades **54 
 | [`tomcat:10.1-jre21-temurin`](tomcat.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`traefik:v3.2`](traefik.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`ubuntu:24.04`](ubuntu.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| [`valkey/valkey:8`](valkey.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`hashicorp/vault:1.18`](vault.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`wordpress:6-php8.3-apache`](wordpress.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | [`zookeeper:3.9`](zookeeper.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
@@ -62,6 +71,7 @@ How isolated is the container you just `docker run`? This directory grades **54 
 | [`prom/alertmanager:v0.28.0`](alertmanager.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
 | [`grafana/grafana:11.4.0`](grafana.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
 | [`haproxy:3.1-alpine`](haproxy.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| [`jaegertracing/jaeger:2.1.0`](jaeger.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
 | [`jetty:12-jre21`](jetty.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
 | [`kong:3.8`](kong.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
 | [`memcached:1.6-alpine`](memcached.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |

--- a/docs/scores/jaeger.md
+++ b/docs/scores/jaeger.md
@@ -1,0 +1,66 @@
+---
+title: "jaeger:2.1.0 container isolation score: 63/100 (grade C)"
+description: "How isolated is jaeger:2.1.0 by default? IronClaw scores its sandbox posture 63/100 (C): retains default capabilities. Scan any container in 10s."
+---
+
+# jaeger:2.1.0 container isolation score: 63/100 (grade C)
+
+Run with plain `docker run jaegertracing/jaeger:2.1.0` defaults, no hardening flags, the **jaeger** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `jaegertracing/jaeger:2.1.0` at digest `sha256:105b3915b1b176540980a82f96f4cf814484ca637ac4043db2da527779fedf25`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as 10001 (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run jaeger` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name jaeger-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  jaegertracing/jaeger:2.1.0
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own jaeger the same way this page was generated
+ironctl scan my-jaeger
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/neo4j.md
+++ b/docs/scores/neo4j.md
@@ -1,0 +1,68 @@
+---
+title: "neo4j:5 container isolation score: 48/100 (grade D)"
+description: "How isolated is neo4j:5 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# neo4j:5 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run neo4j:5` defaults, no hardening flags, the **neo4j** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `neo4j:5` at digest `sha256:32e6325c6f2160747d68601b6e1a38e556deca66524cf95cf0e6c1ee29b1596b`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run neo4j` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name neo4j-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  neo4j:5
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own neo4j the same way this page was generated
+ironctl scan my-neo4j
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/questdb.md
+++ b/docs/scores/questdb.md
@@ -1,0 +1,68 @@
+---
+title: "questdb:8.2.1 container isolation score: 48/100 (grade D)"
+description: "How isolated is questdb:8.2.1 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# questdb:8.2.1 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run questdb/questdb:8.2.1` defaults, no hardening flags, the **questdb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `questdb/questdb:8.2.1` at digest `sha256:17148f1b0acd4903ee1ad656aa9de9b75d8d179bde2731b5df1d499fa17d978b`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run questdb` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name questdb-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  questdb/questdb:8.2.1
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own questdb the same way this page was generated
+ironctl scan my-questdb
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/rethinkdb.md
+++ b/docs/scores/rethinkdb.md
@@ -1,0 +1,68 @@
+---
+title: "rethinkdb:2.4 container isolation score: 48/100 (grade D)"
+description: "How isolated is rethinkdb:2.4 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# rethinkdb:2.4 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run rethinkdb:2.4` defaults, no hardening flags, the **rethinkdb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `rethinkdb:2.4` at digest `sha256:2ba16bd0687bf2c6b4c7d5cf8c672a2658ff4f65bc181d9aa1672d3af276c804`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run rethinkdb` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name rethinkdb-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  rethinkdb:2.4
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own rethinkdb the same way this page was generated
+ironctl scan my-rethinkdb
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/valkey.md
+++ b/docs/scores/valkey.md
@@ -1,0 +1,68 @@
+---
+title: "valkey:8 container isolation score: 48/100 (grade D)"
+description: "How isolated is valkey:8 by default? IronClaw scores its sandbox posture 48/100 (D): retains default capabilities, runs as root. Scan any container in 10s."
+---
+
+# valkey:8 container isolation score: 48/100 (grade D)
+
+Run with plain `docker run valkey/valkey:8` defaults, no hardening flags, the **valkey** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
+
+> Graded from a read-only `docker inspect` of `valkey/valkey:8` at digest `sha256:2e5a314659c893edee4530d6844aae75e533648187bbbe13c09b7bbb20711240`. No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## How it scores, dimension by dimension
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (user "0 (default)"); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, …) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active (syscall surface filtered) |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible; prefer network=none |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable: tamper/persistence surface |
+| No docker.sock exposure | ✅ PASS | 15/15 | no docker.sock / OCI control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network namespace sharing |
+
+## Harden it: the highest-value fixes
+
+Applying these to your `docker run valkey` closes the biggest gaps first (most points recovered first):
+
+- **Dropped capabilities**, `--cap-drop=ALL`  
+  Drop every Linux capability; add back only what the workload provably needs.
+- **Non-root user (uid != 0)**, `--user 65532:65532`  
+  Pin a non-root uid so a container escape does not begin as host uid 0.
+- **Network isolation / egress**, `--network=none`  
+  Cut egress so a compromised workload cannot reach the network or exfiltrate.
+- **Read-only root filesystem**, `--read-only --tmpfs /tmp`  
+  Make the root filesystem read-only to remove the tamper/persistence surface.
+
+A fully hardened run scores **100/100 (grade A)**:
+
+```bash
+docker run -d --name valkey-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  valkey/valkey:8
+```
+
+## Scan your own container
+
+These grades come from `ironctl scan`, a single, credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just this image:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own valkey the same way this page was generated
+ironctl scan my-valkey
+```
+
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
+
+---
+
+*Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/examples/isolation-survey/images.txt
+++ b/examples/isolation-survey/images.txt
@@ -115,3 +115,140 @@ default-joomla           | joomla:5-apache                         |
 default-gitea            | gitea/gitea:1.22                        |
 default-mosquitto        | eclipse-mosquitto:2                     |
 default-vaultwarden      | vaultwarden/server:1.32.7               |
+
+# ---------------------------------------------------------------------------
+# family 1 (long-tail expansion, IRO-449) — grow the scored directory from ~54
+# toward the top ~150 most-pulled PUBLIC images so every "is <image> isolated /
+# container isolation score" search intent lands on a page. All Docker Hub refs
+# (mirror.gcr.io serves library/* + hub namespaces with no anon rate limit); a
+# few non-official repos fall back to the original ref. Tag-only, so a re-run /
+# the weekly refresh Action picks up the current published bits and records the
+# manifest digest it actually graded (results.json .resolvedDigest). Any image
+# that can't be pulled/run is SKIPPED, never fatal, so the set self-heals.
+# ---------------------------------------------------------------------------
+# databases / data stores
+default-cassandra        | cassandra:5.0                           |
+default-clickhouse       | clickhouse:24.8                         |
+default-neo4j            | neo4j:5                                 |
+default-percona          | percona:8.0                             |
+default-rethinkdb        | rethinkdb:2.4                           |
+default-solr             | solr:9                                  |
+default-opensearch       | opensearchproject/opensearch:2          |
+default-cockroach        | cockroachdb/cockroach:latest            |
+default-arangodb         | arangodb:3.12                           |
+default-postgis          | postgis/postgis:17-3.5                  |
+default-pgvector         | pgvector/pgvector:pg17                  |
+default-postgresql       | bitnami/postgresql:17                    |
+default-mongodb          | bitnami/mongodb:8.0                     |
+default-scylla           | scylladb/scylla:6.2                     |
+default-questdb          | questdb/questdb:8.2.1                   |
+default-couchbase        | couchbase:community-7.6.3               |
+# caches / kv / vector / search
+default-redis-stack      | redis/redis-stack-server:7.4.0-v3       |
+default-keydb            | eqalpha/keydb:latest                    |
+default-dragonfly        | docker.dragonflydb.io/dragonflydb/dragonfly:latest |
+default-valkey           | valkey/valkey:8                         |
+default-qdrant           | qdrant/qdrant:v1.12.4                   |
+default-meilisearch      | getmeili/meilisearch:v1.11             |
+default-typesense        | typesense/typesense:27.1               |
+default-weaviate         | semitechnologies/weaviate:1.28.1       |
+default-chroma           | chromadb/chroma:0.5.23                  |
+default-etcd             | bitnami/etcd:3.5                        |
+# messaging / streaming
+default-kafka            | apache/kafka:3.9.0                      |
+default-pulsar           | apachepulsar/pulsar:3.3.2               |
+default-emqx             | emqx:5                                  |
+default-redpanda         | redpandadata/redpanda:v24.2.11          |
+default-cp-kafka         | confluentinc/cp-kafka:7.8.0             |
+# web / app servers / proxies / gateways
+default-envoy            | envoyproxy/envoy:v1.32-latest           |
+default-unit             | unit:1.34.1-minimal                     |
+default-apisix           | apache/apisix:3.11.0                    |
+default-krakend          | krakend:2.8                             |
+# language runtimes / build tools
+default-amazoncorretto   | amazoncorretto:21                       |
+default-maven            | maven:3.9-eclipse-temurin-21            |
+default-gradle           | gradle:8-jdk21                          |
+default-gcc              | gcc:14                                  |
+default-elixir           | elixir:1.18-alpine                      |
+default-erlang           | erlang:27-alpine                        |
+default-haskell          | haskell:9.8                             |
+default-julia            | julia:1.11                              |
+default-r-base           | r-base:4.4                              |
+default-dart             | dart:3.6                                |
+default-groovy           | groovy:4                                |
+default-pypy             | pypy:3.10-slim                          |
+default-clojure          | clojure:temurin-21-tools-deps           |
+default-deno             | denoland/deno:2.1.4                     |
+default-bun              | oven/bun:1.1                            |
+# ci / cd / dev / vcs
+default-jenkins          | jenkins/jenkins:lts                     |
+default-sonarqube        | sonarqube:community                     |
+default-verdaccio        | verdaccio/verdaccio:6                   |
+default-gogs             | gogs/gogs:0.13                          |
+default-forgejo          | codeberg.org/forgejo/forgejo:9          |
+default-drone            | drone/drone:2                           |
+default-nexus3           | sonatype/nexus3:3.75.0                  |
+# observability
+default-loki             | grafana/loki:3.3.2                      |
+default-promtail         | grafana/promtail:3.3.2                  |
+default-tempo            | grafana/tempo:2.6.1                     |
+default-mimir            | grafana/mimir:2.14.0                    |
+default-alloy            | grafana/alloy:latest                    |
+default-jaeger           | jaegertracing/jaeger:2.1.0              |
+default-pushgateway      | prom/pushgateway:v1.10.0                |
+default-blackbox         | prom/blackbox-exporter:v0.25.0          |
+default-victoriametrics  | victoriametrics/victoria-metrics:v1.107.0 |
+default-netdata          | netdata/netdata:stable                  |
+default-uptime-kuma      | louislam/uptime-kuma:1                  |
+default-vector           | timberio/vector:0.43.0-alpine           |
+default-fluentd          | fluent/fluentd:v1.17                    |
+default-fluent-bit       | fluent/fluent-bit:3.2                   |
+default-graylog          | graylog/graylog:6.1                     |
+default-chronograf       | chronograf:1.10                         |
+default-kapacitor        | kapacitor:1.7                           |
+# cms / apps / self-hosted
+default-nextcloud        | nextcloud:30-apache                     |
+default-mediawiki        | mediawiki:1.43                          |
+default-matomo           | matomo:5                                |
+default-wiki             | requarks/wiki:2                         |
+default-rocketchat       | rocketchat/rocket.chat:6                |
+default-mattermost       | mattermost/mattermost-team-edition:10.2 |
+default-n8n              | n8nio/n8n:1.71.3                        |
+default-node-red         | nodered/node-red:4                      |
+default-pihole           | pihole/pihole:2024.07.0                 |
+default-jellyfin         | jellyfin/jellyfin:10.10.3               |
+default-metabase         | metabase/metabase:v0.52.4               |
+default-redmine          | redmine:6                               |
+default-roundcube        | roundcube/roundcubemail:1.6             |
+default-snipe-it         | snipe/snipe-it:v7.0.13                  |
+# storage / infra / devops
+default-minio            | minio/minio:latest                      |
+default-localstack       | localstack/localstack:4                 |
+default-portainer        | portainer/portainer-ce:2.21             |
+default-watchtower       | containrrr/watchtower:latest            |
+default-terraform        | hashicorp/terraform:1.10                |
+default-nomad            | hashicorp/nomad:1.9                     |
+default-flink            | flink:1.20                              |
+default-docker-dind      | docker:27-dind                          |
+# auth / identity / secrets
+default-keycloak         | bitnami/keycloak:26                     |
+default-authelia         | authelia/authelia:4.38                  |
+default-hydra            | oryd/hydra:v2.2.0                       |
+# networking / dns / mail / tools
+default-coredns          | coredns/coredns:1.12.0                  |
+default-adguardhome      | adguard/adguardhome:latest              |
+default-mailhog          | mailhog/mailhog:v1.0.1                  |
+default-mailpit          | axllent/mailpit:latest                  |
+default-swagger-ui       | swaggerapi/swagger-ui:latest            |
+default-tika             | apache/tika:latest                      |
+# db admin / tooling
+default-mongo-express    | mongo-express:1.0                       |
+default-pgadmin          | dpage/pgadmin4:8                        |
+default-redisinsight     | redis/redisinsight:latest               |
+# OS base images (long tail)
+default-oraclelinux      | oraclelinux:9                           |
+default-almalinux        | almalinux:9                             |
+default-archlinux        | archlinux:latest                        |
+default-opensuse-leap    | opensuse/leap:15.6                      |
+default-photon           | photon:5.0                              |

--- a/examples/isolation-survey/results.json
+++ b/examples/isolation-survey/results.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-07-09T10:13:17Z",
-  "ironctlVersion": "v0.1.179-0.20260704091530-f48951d3f70f+dirty",
+  "generatedAt": "2026-07-09T17:37:22Z",
+  "ironctlVersion": "dev",
   "report": "ironclaw-isolation-survey",
-  "scenarioCount": 58,
+  "scenarioCount": 68,
   "scenarios": [
     {
       "failedDimensions": [
@@ -74,7 +74,7 @@
             "verdict": "FAIL"
           }
         ],
-        "generatedAt": "2026-07-09T10:15:45Z",
+        "generatedAt": "2026-07-09T17:30:01Z",
         "grade": "F",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -83,7 +83,7 @@
         "score": 19,
         "source": "docker",
         "target": "ic-survey-naive-privileged",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0",
       "runFlags": "--privileged",
@@ -158,7 +158,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:15:34Z",
+        "generatedAt": "2026-07-09T17:29:50Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -167,7 +167,7 @@
         "score": 33,
         "source": "docker",
         "target": "ic-survey-naive-ci-docker-sock",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2",
       "runFlags": "-v /var/run/docker.sock:/var/run/docker.sock",
@@ -243,7 +243,7 @@
             "verdict": "FAIL"
           }
         ],
-        "generatedAt": "2026-07-09T10:15:57Z",
+        "generatedAt": "2026-07-09T17:30:13Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -252,7 +252,7 @@
         "score": 34,
         "source": "docker",
         "target": "ic-survey-naive-host-ns",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99",
       "runFlags": "--network host --pid host",
@@ -326,7 +326,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:21:08Z",
+        "generatedAt": "2026-07-09T17:35:27Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -335,7 +335,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-alpine",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d",
       "runFlags": "",
@@ -409,7 +409,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:22:16Z",
+        "generatedAt": "2026-07-09T17:36:58Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -418,9 +418,175 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-amazonlinux",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:2a6e72177eb52cf10cacb59f4920e48d33871a168ebf5a02bd7ae0369f73dcc6",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "authelia/authelia:4.38",
+      "label": "default-authelia",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T18:10:23Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-authelia",
+        "version": "dev"
+      },
+      "resolvedDigest": "sha256:46021dc20efdcc5cdc38a29e3050b8835429a155ae6215388ed3b793a02eb0ab",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "prom/blackbox-exporter:v0.25.0",
+      "label": "default-blackbox",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T18:12:22Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-blackbox",
+        "version": "dev"
+      },
+      "resolvedDigest": "sha256:67847e8aaec3c4852a2c7d84d5344e7931521962988c48df00cd980cd1b490a2",
       "runFlags": "",
       "score": 48
     },
@@ -492,7 +658,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:21:42Z",
+        "generatedAt": "2026-07-09T17:36:24Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -501,7 +667,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-busybox",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:7a3ebe5bfd1a4a19797d20b0c0bb39d44393e9a03fd852c0865b0f540d868df0",
       "runFlags": "",
@@ -575,7 +741,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:17:31Z",
+        "generatedAt": "2026-07-09T17:31:46Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -584,9 +750,258 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-caddy",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "cassandra:5.0",
+      "label": "default-cassandra",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T17:44:34Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-cassandra",
+        "version": "dev"
+      },
+      "resolvedDigest": "sha256:b89056c366c4b807380cd9a4ac865ad558c0b4d5aac342f69087d0169ca1ddcd",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "chronograf:1.10",
+      "label": "default-chronograf",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T18:13:34Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-chronograf",
+        "version": "dev"
+      },
+      "resolvedDigest": "sha256:2f587075ca6b101681e6588b762acebb2c53b6b66a358581119d0e85c1c8db3e",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "clickhouse:24.8",
+      "label": "default-clickhouse",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T17:52:19Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-clickhouse",
+        "version": "dev"
+      },
+      "resolvedDigest": "sha256:1b41b544da2428cc0df6632a38af8f0fef28658cce772fbd1f051ac2d8c74245",
       "runFlags": "",
       "score": 48
     },
@@ -658,7 +1073,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:19:47Z",
+        "generatedAt": "2026-07-09T17:34:06Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -667,7 +1082,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-consul",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:200471c74bc0965cd20c81eacc31a209873d5d9e599fe637ceb856b0cbbc518d",
       "runFlags": "",
@@ -741,7 +1156,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:16:22Z",
+        "generatedAt": "2026-07-09T17:30:37Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -750,7 +1165,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-couchdb",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:6c5046c5e71559d43247120c8d2cb88e40ffa5155820e52b58238acdf9466f87",
       "runFlags": "",
@@ -824,7 +1239,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:21:30Z",
+        "generatedAt": "2026-07-09T17:35:51Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -833,7 +1248,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-debian",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:1def178129dfb5f24db43afbf2fcac04530012e3264ba4ff81c71184e17a9ee4",
       "runFlags": "",
@@ -907,7 +1322,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:23:02Z",
+        "generatedAt": "2026-07-09T17:37:45Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -916,7 +1331,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-drupal",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:11748f3fba287c1e8927d64c6f805115e8bedcb95715e19be9c0c0f3adeeef8a",
       "runFlags": "",
@@ -990,7 +1405,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:21:53Z",
+        "generatedAt": "2026-07-09T17:36:35Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -999,7 +1414,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-fedora",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:68bb1ba893be0c05991b2df55bc6571862bab7526fd6053b1ebacd53a2a75366",
       "runFlags": "",
@@ -1073,7 +1488,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:23:13Z",
+        "generatedAt": "2026-07-09T17:37:57Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -1082,7 +1497,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-ghost",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:2341e27e1f3f8496f677f77d0620c1d514e2f4111708bbc03e8bc7c9d39a36fb",
       "runFlags": "",
@@ -1156,7 +1571,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:23:36Z",
+        "generatedAt": "2026-07-09T17:38:20Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -1165,7 +1580,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-gitea",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:538658de667c5d098a274f2f63aa6ec891d88f670cdd5282cf27221ba747dda4",
       "runFlags": "",
@@ -1239,7 +1654,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:14:37Z",
+        "generatedAt": "2026-07-09T17:28:53Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -1248,7 +1663,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-golang",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:383395b794dffa5b53012a212365d40c8e37109a626ca30d6151c8348d380b5f",
       "runFlags": "",
@@ -1322,7 +1737,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:14:48Z",
+        "generatedAt": "2026-07-09T17:29:04Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -1331,7 +1746,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-httpd",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:1b766f17b84026429b7cb243317b142921b24432336e798bc881c43f45ed9567",
       "runFlags": "",
@@ -1405,7 +1820,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:16:34Z",
+        "generatedAt": "2026-07-09T17:30:48Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -1414,7 +1829,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-influxdb",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:991673dc2d237bd79b15d6627410d72de111387e7dac673dbb92cf3333ffcc8c",
       "runFlags": "",
@@ -1488,7 +1903,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:23:24Z",
+        "generatedAt": "2026-07-09T17:38:08Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -1497,7 +1912,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-joomla",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:469a69f1f7284b5d45f06a51c7bca26178953fc4f12428e958bc239741d2979c",
       "runFlags": "",
@@ -1571,7 +1986,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:16:11Z",
+        "generatedAt": "2026-07-09T17:30:26Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -1580,7 +1995,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-mariadb",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:09336a8c0cff9f363e133d8a245cca5ad3eeb326e0ffaedf74d49214c4571486",
       "runFlags": "",
@@ -1654,7 +2069,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:14:03Z",
+        "generatedAt": "2026-07-09T17:28:19Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -1663,7 +2078,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-mongo",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:486795b20c58fd338291e1552118a59a810a4c30dd7f56c690198085797b6c70",
       "runFlags": "",
@@ -1737,7 +2152,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:23:47Z",
+        "generatedAt": "2026-07-09T17:38:31Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -1746,7 +2161,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-mosquitto",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:6dba0f1b2795ddcbe0d41bdfb8b8d56a423acca23ccde4342a4652be54639b11",
       "runFlags": "",
@@ -1820,7 +2235,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:13:51Z",
+        "generatedAt": "2026-07-09T17:28:08Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -1829,7 +2244,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-mysql",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:02aa6476f6b675e5d4d19c5b437798b1b8a4048ae39383eac609814998ed15b8",
       "runFlags": "",
@@ -1903,7 +2318,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:16:45Z",
+        "generatedAt": "2026-07-09T17:31:00Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -1912,9 +2327,92 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-nats",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:7e2f895a12d5bc4586191452f5dd20968e8c800d53622073a2730c38d6b0eccb",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "neo4j:5",
+      "label": "default-neo4j",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T17:52:45Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-neo4j",
+        "version": "dev"
+      },
+      "resolvedDigest": "sha256:32e6325c6f2160747d68601b6e1a38e556deca66524cf95cf0e6c1ee29b1596b",
       "runFlags": "",
       "score": 48
     },
@@ -1986,7 +2484,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:13:17Z",
+        "generatedAt": "2026-07-09T17:27:33Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -1995,7 +2493,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-nginx",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:62223d644fa234c3a1cc785ee14242ec47a77364226f1c811d2f669f96dc2ac8",
       "runFlags": "",
@@ -2069,7 +2567,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:14:14Z",
+        "generatedAt": "2026-07-09T17:28:30Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -2078,7 +2576,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-node",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2",
       "runFlags": "",
@@ -2152,7 +2650,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:18:28Z",
+        "generatedAt": "2026-07-09T17:32:44Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -2161,7 +2659,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-openresty",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:49db7235f2f94aa179c1242882619aea258c112b20f48ba45aefba010a1d0607",
       "runFlags": "",
@@ -2235,7 +2733,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:20:56Z",
+        "generatedAt": "2026-07-09T17:35:15Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -2244,7 +2742,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-perl",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:5a61ff1daad0a27fdd26b337152e36a1516ec5da032560cd2ce53aaae560e584",
       "runFlags": "",
@@ -2318,7 +2816,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:20:22Z",
+        "generatedAt": "2026-07-09T17:34:40Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -2327,7 +2825,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-php",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:12d26bcc36a7866fd92ac6154adb59f776cce77774cdf0599ef50b3390a12891",
       "runFlags": "",
@@ -2401,7 +2899,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:22:50Z",
+        "generatedAt": "2026-07-09T17:37:34Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -2410,7 +2908,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-phpmyadmin",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:9d4365ec568e04d5feb6988612e355d4f6d68b0c5995997f96a0f89352f38767",
       "runFlags": "",
@@ -2484,7 +2982,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:13:28Z",
+        "generatedAt": "2026-07-09T17:27:45Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -2493,7 +2991,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-postgres",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:67f624a4ad70edba8d65c82341124fab7054b277b4f7dea4b04be6f939ce2314",
       "runFlags": "",
@@ -2567,7 +3065,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:14:25Z",
+        "generatedAt": "2026-07-09T17:28:42Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -2576,9 +3074,92 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-python",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "questdb/questdb:8.2.1",
+      "label": "default-questdb",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T18:06:47Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-questdb",
+        "version": "dev"
+      },
+      "resolvedDigest": "sha256:17148f1b0acd4903ee1ad656aa9de9b75d8d179bde2731b5df1d499fa17d978b",
       "runFlags": "",
       "score": 48
     },
@@ -2650,7 +3231,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:15:00Z",
+        "generatedAt": "2026-07-09T17:29:16Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -2659,7 +3240,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-rabbitmq",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:05ea3d1ce60612ce7bb359f4786087bea339b9329f7b5c77a29feb01c641dff8",
       "runFlags": "",
@@ -2733,7 +3314,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:13:40Z",
+        "generatedAt": "2026-07-09T17:27:56Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -2742,7 +3323,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-redis",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99",
       "runFlags": "",
@@ -2816,7 +3397,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:22:27Z",
+        "generatedAt": "2026-07-09T17:37:10Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -2825,9 +3406,92 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-registry",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:46faa9a1ae6813194b53921a370f2f4f8c5e1aae228a89bceafef5847a6a3278",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "rethinkdb:2.4",
+      "label": "default-rethinkdb",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T18:01:56Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-rethinkdb",
+        "version": "dev"
+      },
+      "resolvedDigest": "sha256:2ba16bd0687bf2c6b4c7d5cf8c672a2658ff4f65bc181d9aa1672d3af276c804",
       "runFlags": "",
       "score": 48
     },
@@ -2899,7 +3563,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:22:05Z",
+        "generatedAt": "2026-07-09T17:36:47Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -2908,7 +3572,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-rockylinux",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:d644d203142cd5b54ad2a83a203e1dee68af2229f8fe32f52a30c6e1d3c3a9e0",
       "runFlags": "",
@@ -2982,7 +3646,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:20:11Z",
+        "generatedAt": "2026-07-09T17:34:29Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -2991,7 +3655,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-ruby",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:c5a5064d190055633011c03aa800170cc36945ff3afb5f6c915329f92d6f1e00",
       "runFlags": "",
@@ -3065,7 +3729,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:20:45Z",
+        "generatedAt": "2026-07-09T17:35:04Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -3074,7 +3738,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-rust",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:0ac946ed7597a9f053a1be2ce38c09aa88b3d7079a91ea491493615294b1f699",
       "runFlags": "",
@@ -3148,7 +3812,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:19:36Z",
+        "generatedAt": "2026-07-09T17:33:54Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -3157,7 +3821,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-telegraf",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:3ea0664bed1cacec5e6b463882dc43da9b33c9742d436ace35f157843aca9e40",
       "runFlags": "",
@@ -3231,7 +3895,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:20:34Z",
+        "generatedAt": "2026-07-09T17:34:52Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -3240,7 +3904,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-temurin",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c",
       "runFlags": "",
@@ -3314,7 +3978,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:17:54Z",
+        "generatedAt": "2026-07-09T17:32:10Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -3323,7 +3987,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-tomcat",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:5b1091b520c45e26b9a3ab50d74f367892cfbe0f4ad056e66bf63d35afe75683",
       "runFlags": "",
@@ -3397,7 +4061,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:17:08Z",
+        "generatedAt": "2026-07-09T17:31:23Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -3406,7 +4070,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-traefik",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:684cb01614fc38240a5f13e302920a12ba3c6d604ff90d0a6c0ade9a1294a712",
       "runFlags": "",
@@ -3480,7 +4144,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:21:19Z",
+        "generatedAt": "2026-07-09T17:35:39Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -3489,9 +4153,92 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-ubuntu",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90",
+      "runFlags": "",
+      "score": 48
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Non-root user (uid != 0)",
+        "Read-only root filesystem"
+      ],
+      "grade": "D",
+      "image": "valkey/valkey:8",
+      "label": "default-valkey",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as root (user \"0 (default)\"); a container escape starts with host-uid 0",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 0,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T18:10:15Z",
+        "grade": "D",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 48,
+        "source": "docker",
+        "target": "ic-survey-default-valkey",
+        "version": "dev"
+      },
+      "resolvedDigest": "sha256:2e5a314659c893edee4530d6844aae75e533648187bbbe13c09b7bbb20711240",
       "runFlags": "",
       "score": 48
     },
@@ -3563,7 +4310,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:19:59Z",
+        "generatedAt": "2026-07-09T17:34:17Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -3572,7 +4319,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-vault",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:750bb37c1638fa194ab37053a81618c61bb0491ddec6fccac87c07a8e6cd8166",
       "runFlags": "",
@@ -3646,7 +4393,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:23:59Z",
+        "generatedAt": "2026-07-09T17:38:43Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -3655,7 +4402,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-vaultwarden",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:7a0aa23c0947be3582898deb5170ea4359493ed9a76af2badf60a7eb45ac36af",
       "runFlags": "",
@@ -3729,7 +4476,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:15:23Z",
+        "generatedAt": "2026-07-09T17:29:39Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -3738,7 +4485,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-wordpress",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:5d2c212561c4b5442ebc4d98933a9cbadcf3dee8888ed3fd9ed44667c27cc905",
       "runFlags": "",
@@ -3812,7 +4559,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:16:57Z",
+        "generatedAt": "2026-07-09T17:31:12Z",
         "grade": "D",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -3821,7 +4568,7 @@
         "score": 48,
         "source": "docker",
         "target": "ic-survey-default-zookeeper",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:4c6f15fbd5491a3e01b0108c046891125553329a4956848ba3014cedff5386ee",
       "runFlags": "",
@@ -3894,7 +4641,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:22:39Z",
+        "generatedAt": "2026-07-09T17:37:22Z",
         "grade": "C",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -3903,7 +4650,7 @@
         "score": 63,
         "source": "docker",
         "target": "ic-survey-default-adminer",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:34d37131366c5aa84e1693dbed48593ed6f95fb450b576c1a7a59d3a9c9e8802",
       "runFlags": "",
@@ -3976,7 +4723,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:19:13Z",
+        "generatedAt": "2026-07-09T17:33:31Z",
         "grade": "C",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -3985,7 +4732,7 @@
         "score": 63,
         "source": "docker",
         "target": "ic-survey-default-alertmanager",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:9139cd2c7ab7ff951e5ed9ffc4f70122a7de9678fb51065061a5f72549c91bab",
       "runFlags": "",
@@ -4058,7 +4805,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:18:50Z",
+        "generatedAt": "2026-07-09T17:33:07Z",
         "grade": "C",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -4067,7 +4814,7 @@
         "score": 63,
         "source": "docker",
         "target": "ic-survey-default-grafana",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:8d938a1c52b018c60cb3583657e038054387aa18a74f09a865c99a522481f7ac",
       "runFlags": "",
@@ -4140,7 +4887,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:17:19Z",
+        "generatedAt": "2026-07-09T17:31:34Z",
         "grade": "C",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -4149,9 +4896,91 @@
         "score": 63,
         "source": "docker",
         "target": "ic-survey-default-haproxy",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:475863a372c92c3dab3d59eafbbf8019dceebcd0c456594551b160ecdba4bdb9",
+      "runFlags": "",
+      "score": 63
+    },
+    {
+      "failedDimensions": [
+        "Dropped capabilities",
+        "Read-only root filesystem"
+      ],
+      "grade": "C",
+      "image": "jaegertracing/jaeger:2.1.0",
+      "label": "default-jaeger",
+      "report": {
+        "dimensions": [
+          {
+            "detail": "runs as 10001 (uid != 0)",
+            "key": "user.nonroot",
+            "max": 15,
+            "score": 15,
+            "title": "Non-root user (uid != 0)",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "default capability set retained (includes CAP_NET_RAW, CAP_MKNOD, \u2026)",
+            "key": "caps.dropped",
+            "max": 20,
+            "score": 4,
+            "title": "Dropped capabilities",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "seccomp profile active (syscall surface filtered)",
+            "key": "seccomp",
+            "max": 15,
+            "score": 15,
+            "title": "Seccomp profile",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "network=bridge: outbound egress is possible; prefer network=none",
+            "key": "network.isolated",
+            "max": 15,
+            "score": 4,
+            "title": "Network isolation / egress",
+            "verdict": "WARN"
+          },
+          {
+            "detail": "root filesystem is writable: tamper/persistence surface",
+            "key": "rootfs.readonly",
+            "max": 10,
+            "score": 0,
+            "title": "Read-only root filesystem",
+            "verdict": "FAIL"
+          },
+          {
+            "detail": "no docker.sock / OCI control socket mounted",
+            "key": "docker.sock",
+            "max": 15,
+            "score": 15,
+            "title": "No docker.sock exposure",
+            "verdict": "PASS"
+          },
+          {
+            "detail": "no host PID/IPC/network namespace sharing",
+            "key": "namespaces.host",
+            "max": 10,
+            "score": 10,
+            "title": "No shared host namespaces",
+            "verdict": "PASS"
+          }
+        ],
+        "generatedAt": "2026-07-09T18:13:34Z",
+        "grade": "C",
+        "max": 100,
+        "report": "ironclaw-containment-scan",
+        "runtime": "oci",
+        "schemaVersion": "1.0",
+        "score": 63,
+        "source": "docker",
+        "target": "ic-survey-default-jaeger",
+        "version": "dev"
+      },
+      "resolvedDigest": "sha256:105b3915b1b176540980a82f96f4cf814484ca637ac4043db2da527779fedf25",
       "runFlags": "",
       "score": 63
     },
@@ -4222,7 +5051,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:18:05Z",
+        "generatedAt": "2026-07-09T17:32:21Z",
         "grade": "C",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -4231,7 +5060,7 @@
         "score": 63,
         "source": "docker",
         "target": "ic-survey-default-jetty",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:a7b9f19032f2974e2e981826832d0bb37e843fdbba3bd2042a1b6c17b38011a7",
       "runFlags": "",
@@ -4304,7 +5133,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:18:16Z",
+        "generatedAt": "2026-07-09T17:32:33Z",
         "grade": "C",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -4313,7 +5142,7 @@
         "score": 63,
         "source": "docker",
         "target": "ic-survey-default-kong",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:0dbd72dc596763758e9f8ada732648ef087f256da07b304efca269d50545de00",
       "runFlags": "",
@@ -4386,7 +5215,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:15:11Z",
+        "generatedAt": "2026-07-09T17:29:27Z",
         "grade": "C",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -4395,7 +5224,7 @@
         "score": 63,
         "source": "docker",
         "target": "ic-survey-default-memcached",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:dfacdbd93e7a6f1ad63801753a1fc959dc678a5a1d2141ff438d57e6d8793fc3",
       "runFlags": "",
@@ -4468,7 +5297,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:18:39Z",
+        "generatedAt": "2026-07-09T17:32:56Z",
         "grade": "C",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -4477,7 +5306,7 @@
         "score": 63,
         "source": "docker",
         "target": "ic-survey-default-nginx-unpriv",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:28d91bdce70ad09025ea901458fdd149259d8e05982ade79d4ef2c0d9470eb48",
       "runFlags": "",
@@ -4550,7 +5379,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:19:25Z",
+        "generatedAt": "2026-07-09T17:33:43Z",
         "grade": "C",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -4559,7 +5388,7 @@
         "score": 63,
         "source": "docker",
         "target": "ic-survey-default-node-exporter",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:065914c03336590ebed517e7df38520f0efb44465fde4123c3f6b7328f5a9396",
       "runFlags": "",
@@ -4632,7 +5461,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:19:02Z",
+        "generatedAt": "2026-07-09T17:33:19Z",
         "grade": "C",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -4641,7 +5470,7 @@
         "score": 63,
         "source": "docker",
         "target": "ic-survey-default-prometheus",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:6559acbd5d770b15bb3c954629ce190ac3cbbdb2b7f1c30f0385c4e05104e218",
       "runFlags": "",
@@ -4714,7 +5543,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:17:42Z",
+        "generatedAt": "2026-07-09T17:31:57Z",
         "grade": "C",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -4723,7 +5552,7 @@
         "score": 63,
         "source": "docker",
         "target": "ic-survey-default-varnish",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:eb21e9f988be93f33ff9a0025d0a00617d49f3cc0cf59e0f2167bde7724eae6a",
       "runFlags": "",
@@ -4795,7 +5624,7 @@
             "verdict": "PASS"
           }
         ],
-        "generatedAt": "2026-07-09T10:15:59Z",
+        "generatedAt": "2026-07-09T17:30:14Z",
         "grade": "B",
         "max": 100,
         "report": "ironclaw-containment-scan",
@@ -4804,7 +5633,7 @@
         "score": 84,
         "source": "docker",
         "target": "ic-survey-hardened-reference",
-        "version": "v0.1.179-0.20260704091530-f48951d3f70f+dirty"
+        "version": "dev"
       },
       "resolvedDigest": "sha256:62223d644fa234c3a1cc785ee14242ec47a77364226f1c811d2f669f96dc2ac8",
       "runFlags": "--user 65532:65532 --cap-drop ALL --security-opt no-new-privileges --read-only --tmpfs /tmp --network none",

--- a/examples/isolation-survey/results.md
+++ b/examples/isolation-survey/results.md
@@ -1,6 +1,6 @@
 # State of Container Isolation — survey results
 
-Scanned **58 scenarios** with `ironctl scan` v0.1.179-0.20260704091530-f48951d3f70f+dirty on 2026-07-09T10:13:17Z.
+Scanned **68 scenarios** with `ironctl scan` dev on 2026-07-09T17:37:22Z.
 
 Each row is one popular public image run with a specific configuration, graded 0-100 across seven containment dimensions (non-root user, dropped capabilities, seccomp, network isolation, read-only rootfs, no docker.sock, no host namespaces). Higher is safer. See [README.md](./README.md) for the exact method and [images.txt](./images.txt) for the pinned manifest.
 
@@ -11,8 +11,13 @@ Each row is one popular public image run with a specific configuration, graded 0
 | `naive-host-ns` | `redis:7-alpine` | 34/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
 | `default-alpine` | `alpine:3.21` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-amazonlinux` | `amazonlinux:2023` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-authelia` | `authelia/authelia:4.38` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-blackbox` | `prom/blackbox-exporter:v0.25.0` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-busybox` | `busybox:1.37` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-caddy` | `caddy:2-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-cassandra` | `cassandra:5.0` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-chronograf` | `chronograf:1.10` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-clickhouse` | `clickhouse:24.8` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-consul` | `hashicorp/consul:1.20` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-couchdb` | `couchdb:3.4` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-debian` | `debian:12-slim` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
@@ -29,6 +34,7 @@ Each row is one popular public image run with a specific configuration, graded 0
 | `default-mosquitto` | `eclipse-mosquitto:2` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-mysql` | `mysql:8.4` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-nats` | `nats:2.10-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-neo4j` | `neo4j:5` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-nginx` | `nginx:1.27-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-node` | `node:22-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-openresty` | `openresty/openresty:alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
@@ -37,9 +43,11 @@ Each row is one popular public image run with a specific configuration, graded 0
 | `default-phpmyadmin` | `phpmyadmin:5.2` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-postgres` | `postgres:17-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-python` | `python:3.13-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-questdb` | `questdb/questdb:8.2.1` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-rabbitmq` | `rabbitmq:4-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-redis` | `redis:7-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-registry` | `registry:2.8.3` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-rethinkdb` | `rethinkdb:2.4` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-rockylinux` | `rockylinux:9` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-ruby` | `ruby:3.4-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-rust` | `rust:1.83-alpine` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
@@ -48,6 +56,7 @@ Each row is one popular public image run with a specific configuration, graded 0
 | `default-tomcat` | `tomcat:10.1-jre21-temurin` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-traefik` | `traefik:v3.2` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-ubuntu` | `ubuntu:24.04` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
+| `default-valkey` | `valkey/valkey:8` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-vault` | `hashicorp/vault:1.18` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-vaultwarden` | `vaultwarden/server:1.32.7` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
 | `default-wordpress` | `wordpress:6-php8.3-apache` | 48/100 | **D** | Dropped capabilities, Non-root user (uid != 0), Read-only root filesystem |
@@ -56,6 +65,7 @@ Each row is one popular public image run with a specific configuration, graded 0
 | `default-alertmanager` | `prom/alertmanager:v0.28.0` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
 | `default-grafana` | `grafana/grafana:11.4.0` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
 | `default-haproxy` | `haproxy:3.1-alpine` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
+| `default-jaeger` | `jaegertracing/jaeger:2.1.0` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
 | `default-jetty` | `jetty:12-jre21` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
 | `default-kong` | `kong:3.8` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
 | `default-memcached` | `memcached:1.6-alpine` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
@@ -65,6 +75,6 @@ Each row is one popular public image run with a specific configuration, graded 0
 | `default-varnish` | `varnish:7.6-alpine` | 63/100 | **C** | Dropped capabilities, Read-only root filesystem |
 | `hardened-reference` | `nginx:1.27-alpine` | 84/100 | **B** | Dropped capabilities |
 
-**Grade distribution:** 1×B, 11×C, 45×D, 1×F.
+**Grade distribution:** 1×B, 12×C, 54×D, 1×F.
 
 Regenerate this file from a clean checkout with `examples/isolation-survey/survey.sh` (Docker required).

--- a/examples/isolation-survey/survey.sh
+++ b/examples/isolation-survey/survey.sh
@@ -44,6 +44,14 @@ DOCKER="${DOCKER:-docker}"
 MIRROR="${MIRROR:-1}"
 MIRROR_HOST="${MIRROR_HOST:-mirror.gcr.io}"
 
+# Disk hygiene for large surveys. Scanning ~150 images pulls many GB; a CI runner
+# (or a laptop VM) can run out of space long before the survey finishes. With
+# PRUNE=1 each image we PULLED this run is removed right after it is scanned, so
+# peak disk stays ~one image, not the whole set. Images already present locally
+# before the run are left untouched. Off by default so cache-friendly local
+# re-runs stay fast; the weekly refresh Action turns it on.
+PRUNE="${PRUNE:-0}"
+
 die() { echo "error: $*" >&2; exit 1; }
 log() { echo ">> $*" >&2; }
 
@@ -144,9 +152,11 @@ while IFS= read -r line; do
   # a rate limit, back off and retry; if the mirror can't serve it, fall back to
   # the original ref once. A scenario that still can't be pulled is SKIPPED (not
   # fatal) so one unavailable image never aborts a 50-image survey.
+  pulled=0
   if "$DOCKER" image inspect "$runref" >/dev/null 2>&1; then
     log "[$n] $label — cached $runref"
   else
+    pulled=1
     log "[$n] $label — pulling $runref"
     tries=0
     until "$DOCKER" pull -q "$runref" >/dev/null 2>pull.err; do
@@ -204,6 +214,11 @@ while IFS= read -r line; do
   if [ "$KEEP" -eq 0 ]; then
     "$DOCKER" rm -f "$cname" >/dev/null 2>&1 || true
     CREATED=("${CREATED[@]/$cname}")
+    # Bound peak disk on a big survey: drop the image we just pulled + scanned.
+    # Only images pulled THIS run are removed (pre-existing cache is preserved).
+    if [ "$PRUNE" = "1" ] && [ "$pulled" = "1" ] && [ -n "$runref" ]; then
+      "$DOCKER" rmi "$runref" >/dev/null 2>&1 || true
+    fi
   fi
 done < "$MANIFEST"
 


### PR DESCRIPTION
## IRO-449 — Container Isolation Scores: compounding, self-refreshing SEO engine

Turns the one-shot scores directory (`docs/scores/`, 54 images, IRO-445) into a **self-refreshing content engine**: a much larger scored image set + a weekly CI job that keeps it current with zero manual toil.

### What's here
- **`examples/isolation-survey/images.txt`** — +109 `default-*` long-tail scenarios → **167 total** covering the most-pulled public images (databases, caches, vector/search, messaging, web/app servers, language runtimes, CI/CD, observability, CMS/self-hosted, storage, auth, DNS/mail). All Docker Hub refs so `mirror.gcr.io` serves them with no anon rate limit; unpullable images are skipped, never fatal.
- **`examples/isolation-survey/survey.sh`** — `PRUNE=1` (drop each image right after scan → a 150-image sweep stays inside a runner's / VM's free disk) and `RESUME=1` + `MAX_NEW` (persistent NDJSON records so an interrupted survey resumes instead of re-scanning from scratch). bash 3.2 + CI bash 5 compatible.
- **`.github/workflows/scores-refresh.yml`** — **weekly (Mon 06:00 UTC) + `workflow_dispatch`** job: rebuild `ironctl`, re-run the survey (PRUNE, mirror-first), regenerate the scorecards, verify `mkdocs --strict`, and open/refresh a single rolling PR (`scores/refresh`) via the reviewer-App token. Modeled on the Homebrew rolling-bump PR (IRO-270): force-reset onto main each run so it never conflicts. `actionlint` clean, action SHAs match repo canon.
- **`docs/scores/` + `results.json`/`results.md`** — regenerated; adds scorecards for the newly-scanned long-tail images (cassandra, clickhouse, neo4j, percona, rethinkdb, questdb, valkey, jaeger, blackbox-exporter, chronograf, authelia, ...). Existing pages untouched; front-matter seam (quoted title, <=160 desc, tag-free slug — IRO-446) intact. `mkdocs --strict` passes.

### Reaching the full ~150 pages
The full survey pulls ~150 images; on a local/VM network that is bandwidth-bound, so the committed page set here is a **bootstrap baseline**. The **`scores-refresh` Action is the mechanism that reaches ≥150**: it runs the same survey in CI (fast runner network, no anon pull limit) and opens a refresh PR with the full set. After this merges, trigger it once to populate immediately:

```
gh workflow run "Scores refresh" --ref main
```

…or just wait for the Monday run. Every subsequent week it keeps the directory current as base images drift.

Refs IRO-449. Parent IRO-448.
