### PR TITLE
fix(ci): resolvable action pins in scores-refresh workflow (IRO-449)

### DIFF
--- a/.github/workflows/scores-refresh.yml
+++ b/.github/workflows/scores-refresh.yml
@@ -48,12 +48,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.23"
           cache: true
 
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce62c38 # v5.4.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
Follow-up to #433. The first dispatch of the **Scores refresh** Action failed at action resolution because `setup-go@0aaccfd` and `setup-python@42375524` (both tagged v5.4.0) are SHAs GitHub cannot resolve.

Repins to the SHAs the actively-run workflows already use:
- `actions/setup-go@924ae3a1 # v6` (ci.yml)
- `actions/setup-python@ece7cb06 # v6.3.0` (docs.yml)

No other change. Once merged, re-dispatching `gh workflow run "Scores refresh" --ref main` runs the full survey and opens the rolling scores/refresh PR (>=150 pages). Refs IRO-449.