### PR TITLE
docs(launch): r/devops + r/kubernetes Reddit drafts (scores-data angle) (IRO-447)

### DIFF
--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -19,6 +19,8 @@ docs. No hero numbers from machines you cannot inspect.
 
 | File | Channel | Format |
 | --- | --- | --- |
+| [`reddit-devops.md`](reddit-devops.md) | r/devops | self-post (scores-data angle) |
+| [`reddit-kubernetes.md`](reddit-kubernetes.md) | r/kubernetes | self-post (scores-data angle) |
 | [`reddit-localllama.md`](reddit-localllama.md) | r/LocalLLaMA | self-post |
 | [`reddit-programming.md`](reddit-programming.md) | r/programming | link + comment |
 | [`reddit-selfhosted.md`](reddit-selfhosted.md) | r/selfhosted | self-post |

--- a/docs/launch/reddit-devops.md
+++ b/docs/launch/reddit-devops.md
@@ -1,0 +1,49 @@
+# r/devops draft
+
+Audience: practitioners who ship and operate containers. Rewards a concrete
+finding they can act on Monday, not a product pitch. Lead with the data from the
+Container Isolation Scores directory, keep the tool secondary, invite them to
+measure their own images. Self-post.
+
+---
+
+**Title:** I scored the default isolation posture of 54 popular Docker images. None got above a C.
+
+**Body:**
+
+I got tired of "is this base image secure" being a vibe, so I built a scanner
+that grades a container's runtime isolation from 0 to 100 across seven
+dimensions (user namespace, dropped capabilities, seccomp profile, read-only
+rootfs, network exposure, and more), then ran it against 54 of the most-pulled
+images on their stock `docker run` config.
+
+The results, on defaults:
+
+- 43 of 54 images scored a **D** (48/100). 11 scored a **C**. Nothing scored
+  above a C.
+- nginx, postgres, redis, node, python, mongo, and mysql are all an identical
+  **48/100** out of the box.
+- The only images that did better are the handful that ship non-root by default:
+  memcached, nginx-unprivileged, and node-exporter land at **63/100 (C)**.
+
+The point is not that these images are "insecure." It is that a default
+`docker run` gives you almost none of the isolation the runtime can actually
+enforce, and most pipelines never change it. Dropping to non-root alone is worth
+15 points here. Adding a seccomp profile, dropping capabilities, and a read-only
+rootfs move you a lot further, and none of that requires gVisor or a different
+runtime.
+
+Every image has a full per-dimension scorecard published, so you can see exactly
+which controls each one is missing and what to change. The scan is reproducible
+and the harness is committed, so you can point it at your own images or wire it
+into CI as a gate. It runs against Docker, Compose, Kubernetes manifests,
+Podman, nerdctl, and containerd.
+
+`ironctl scan <image>` grades one container. `ironctl scan --compose` /
+`--k8s` grade a whole stack. There is a GitHub Action that posts the scorecard
+on a PR and can fail the build below a minimum score.
+
+Full scores directory and the scanner: https://github.com/IronSecCo/ironclaw
+
+Happy to defend the rubric. If a dimension is weighted wrong I would rather fix
+it than argue it.

--- a/docs/launch/reddit-kubernetes.md
+++ b/docs/launch/reddit-kubernetes.md
@@ -1,0 +1,48 @@
+# r/kubernetes draft
+
+Audience: cluster operators and platform engineers. Rewards a finding that maps
+to securityContext / Pod Security they already reason about. Lead with the data,
+tie it to workload defaults, keep the tool secondary. Self-post.
+
+---
+
+**Title:** Scored the default isolation of 54 popular container images. The gap maps almost 1:1 to the securityContext fields nobody sets.
+
+**Body:**
+
+I built a scanner that grades a container's runtime isolation from 0 to 100
+across seven dimensions and ran it against 54 of the most-pulled images on their
+stock config. On defaults, 43 of 54 scored a **D** (48/100), 11 scored a **C**,
+and nothing scored above a C. nginx, postgres, redis, node, python, mongo, and
+mysql are all an identical 48/100 out of the box.
+
+What makes this a Kubernetes problem specifically: the points these images are
+losing line up almost exactly with the `securityContext` and Pod Security fields
+that most manifests leave unset.
+
+- `runAsNonRoot` / a non-root UID: the single biggest lever. The only images that
+  beat a D in this set (memcached, nginx-unprivileged, node-exporter at 63/C)
+  are the ones that already drop root.
+- `readOnlyRootFilesystem: true`
+- `capabilities.drop: ["ALL"]`
+- a `seccompProfile` (RuntimeDefault at minimum)
+- `allowPrivilegeEscalation: false`
+
+A cluster running the "restricted" Pod Security Standard already enforces most of
+this, but plenty of workloads run "baseline" or unrestricted, and the base image
+default is what you inherit when you do.
+
+The scanner reads Kubernetes manifests directly (`ironctl scan --k8s`), so you
+can grade a Deployment or a whole namespace's worth of workloads and get a
+per-dimension breakdown of which controls are missing. It also has a `--fix`
+mode that emits the concrete securityContext stanza to close each failed
+dimension, and a GitHub Action that scores manifests on a PR and can gate merges
+below a threshold.
+
+Every one of the 54 images has a published scorecard, and the harness is
+committed so the numbers are reproducible on your own images.
+
+Scores directory and scanner: https://github.com/IronSecCo/ironclaw
+
+If you think a dimension is weighted wrong for real cluster workloads, tell me,
+the rubric is meant to be argued with.


### PR DESCRIPTION
Board resolved reach interaction ce78ef49 → **reddit** (r/devops, r/kubernetes, r/selfhosted; scan tool + Container Isolation Scores directory).

r/selfhosted already had a draft; r/devops and r/kubernetes did not. This adds both, written on the **scores-data angle** the board picked (value-first finding, tool secondary), matching the launch-folder guardrails (no em-dashes, no identity leak, project links only, every claim verifiable against shipped code).

**New drafts:**
- `reddit-devops.md` — 'I scored the default isolation of 54 popular Docker images. None got above a C.'
- `reddit-kubernetes.md` — same data, tied to the securityContext / Pod Security fields most manifests leave unset.

All numbers verified against `docs/scores/index.json` on main (54 images: 43 D, 11 C, none above C; nginx/postgres/redis/node/python/mongo/mysql all 48/D; non-root defaults memcached/nginx-unprivileged/node-exporter at 63/C). Capability claims (`--k8s`, `--fix` securityContext emit, PR-gate Action, Podman/nerdctl/containerd) all map to shipped code.

docs/launch/ is excluded from mkdocs nav (internal), so no --strict impact. Posting remains board-gated (needs Reddit account); these are post-and-go.