### PR TITLE
docs(launch): r/devops + r/kubernetes Reddit drafts (IRO-453)

### DIFF
--- a/docs/launch/reddit-devops.md
+++ b/docs/launch/reddit-devops.md
@@ -1,0 +1,80 @@
+# r/devops draft
+
+Audience: platform and CI/CD engineers who already gate merges on lint, tests,
+and coverage. They think in pipelines, policy-as-code, and blast radius. Lead
+with the CI-gate story and the scored-images data, frame isolation as one more
+gate you can actually enforce, not a vibe. Keep the security depth but speak
+pipeline, not FUD.
+
+---
+
+**Title:** We scored the 54 most-pulled Docker images for container isolation on default settings. 43 of them are a D. Here is the data and the CI gate we built around it.
+
+**Body:**
+
+Most of us gate merges on tests, lint, and coverage, but almost nobody gates on
+how isolated the container actually runs. So we scored it. We took the 54
+most-pulled public images, ran them as they ship (plain defaults, no hardening),
+and graded each one 0 to 100 across seven containment dimensions: user, caps,
+seccomp, filesystem, network, PID, and runtime.
+
+The result is a public directory you can search by image name:
+https://nivardsec.com/scores
+
+The short version: the average default score is 51 out of 100, the most common
+grade is a D (43 of the 54 images), and every one of them jumps to 100 once you
+apply the hardening the scorecard tells you to apply. postgres, nginx, redis,
+node, mongo, all land at 48 out of 100 on their stock config. The gap is not
+exotic, it is the defaults.
+
+The tool that produces those grades is open source and runs in a pipeline:
+
+- `ironctl scan <container>` grades a running container, a compose file, or a k8s
+  manifest 0 to 100 and prints the failed dimensions with the exact fix.
+- `ironctl scan --fix` rewrites the offending stanzas for docker, compose, or k8s
+  so remediation is a diff, not a research project.
+- There is a composite GitHub Action that posts a sticky scorecard comment on the
+  PR and can fail the build below a minimum score, so isolation becomes a gate
+  like any other.
+- `--sarif` emits SARIF 2.1.0 so the findings land in GitHub code scanning next
+  to your other security results.
+- `--badge-json` produces a shields.io endpoint so you can put the score on your
+  README and keep yourself honest.
+
+This all falls out of IronClaw, a self-hosted runtime for AI agents where each
+agent runs in its own gVisor (`runsc`) sandbox with `network=none`, a seccomp
+allowlist, all caps dropped, a non-root user namespace, and a read-only rootfs.
+The containment boundary ships with a red-team escape harness that runs as a CI
+gate on every push, so the claim that a compromised workload stays contained is
+tested, not asserted. But `ironctl scan` works on any container, you do not have
+to adopt the runtime to use the scanner.
+
+Deploy paths are the ones you already use: Fly, Render, and Railway templates, a
+Helm chart for k8s, Docker, and a Homebrew formula. It is AGPLv3 plus commercial.
+
+Repo: https://github.com/IronSecCo/ironclaw
+
+I would like feedback from people who run this kind of gate at scale: is a 0 to
+100 score the right shape for a merge gate, or do you want a pass or fail on
+specific dimensions? And which images surprised you on the directory.
+
+---
+
+**Comment-reply seeds:**
+
+- *How is the score computed?* Seven dimensions, each weighted: user namespace and
+  non-root, dropped capabilities, seccomp profile, read-only and masked
+  filesystem, network egress, PID namespace, and the runtime itself. It grades
+  the container as configured, from `docker inspect` or the manifest, so it sees
+  what will actually run, not what the image README claims.
+- *Does gVisor change the score?* No. The scan is runtime-agnostic by design; it
+  grades the isolation posture you configured, and gVisor is a separate defense
+  layer, not a free bonus point. We did not want a number that flatters our own
+  runtime.
+- *Can I gate without adopting the whole runtime?* Yes. `ironctl scan` and the
+  Action stand alone. Point them at your existing containers and you get the
+  scorecard and the gate without running IronClaw at all.
+- *Why do the defaults score so low?* Because base images ship permissive so they
+  run anywhere. That is a reasonable default for the image author and a bad
+  default for your blast radius. The `--fix` output is the same hardening you
+  would apply by hand, just generated for you.

--- a/docs/launch/reddit-kubernetes.md
+++ b/docs/launch/reddit-kubernetes.md
@@ -1,0 +1,79 @@
+# r/kubernetes draft
+
+Audience: cluster operators and platform teams who already know Pod Security
+Standards, securityContext, and RuntimeClass. They are skeptical of anything
+that sounds like a new admission-controller sales pitch. Lead with the runtime
+isolation gap that PSS does not close, the per-pod gVisor angle, and the Helm
+chart. Frame the scores directory as evidence, and `ironctl scan --k8s` as
+something they can run against their own manifests today.
+
+---
+
+**Title:** Pod Security Standards restrict what a pod requests, not what its kernel shares. We scored 54 popular images on default settings and shipped a per-pod gVisor runtime plus a manifest scanner.
+
+**Body:**
+
+Pod Security Standards and a tight `securityContext` gate what a pod is allowed
+to ask for. They do not change the fact that a `runc` pod shares the host kernel,
+so a single container escape is a node compromise. If you run agents, CI
+runners, or any workload that executes untrusted code, that shared kernel is the
+part of the threat model most manifests quietly ignore.
+
+Two things came out of working on this that are useful on their own.
+
+**1. A manifest scanner you can run today.**
+`ironctl scan --k8s <manifest>` grades a pod or deployment 0 to 100 across seven
+containment dimensions (user, capabilities, seccomp, filesystem, network, PID,
+runtime) and prints each failed dimension with the fix. `--fix` rewrites the
+`securityContext` and pod spec for you. To show what defaults actually look like,
+we scored the 54 most-pulled public images as they ship, no hardening, and put
+it in a searchable directory:
+
+https://nivardsec.com/scores
+
+Average default score is 51 out of 100, the most common grade is a D (43 of 54),
+and every image reaches 100 once hardened. It is a fast way to calibrate what
+"unhardened default" costs you before you argue about it in a design review.
+
+**2. A per-pod gVisor runtime, not a shared sidecar.**
+IronClaw is a self-hosted agent runtime where each workload gets its own gVisor
+(`runsc`) sandbox: `network=none` by default, a seccomp syscall allowlist, all
+Linux capabilities dropped, a non-root user namespace, and a read-only rootfs.
+The isolation is per pod, not a cluster-wide trust boundary you hope holds. The
+containment boundary ships with a red-team escape harness (Engine socket reach,
+host path reads, sibling-container breakout, self-modification, egress) that runs
+as a CI gate on every push, so the boundary is tested on every commit rather than
+asserted once in a README. The measured gVisor cost is about +13 ms warm and
++39 ms cold per sandbox launch, paid once per launch, not per request.
+
+It installs the way you already install things: there is a Helm chart under
+`deploy/helm/ironclaw`, plus Docker, PaaS templates (Fly, Render, Railway), and a
+Homebrew formula. AGPLv3 plus commercial, self-hosted, so nothing about your
+workloads leaves your cluster.
+
+Repo: https://github.com/IronSecCo/ironclaw
+
+I would value feedback from operators on two things: whether a 0 to 100 posture
+score per manifest is useful in an admission or CI gate, and whether per-pod
+gVisor via RuntimeClass fits how you actually schedule untrusted work.
+
+---
+
+**Comment-reply seeds:**
+
+- *How is this different from just setting a RuntimeClass to gVisor myself?* It is
+  not competing with that, it leans on it. IronClaw wires the per-pod `runsc`
+  sandbox plus the seccomp, caps, userns, network, and rootfs posture together
+  and ships a red-team harness that keeps the whole boundary honest as a CI gate.
+  If you already run gVisor via RuntimeClass, `ironctl scan --k8s` will still tell
+  you where the rest of your pod spec leaks.
+- *Does the scanner need the runtime?* No. `ironctl scan --k8s` grades any
+  manifest standalone and `--fix` rewrites the spec. You can adopt the scanner
+  and the CI gate without running IronClaw at all.
+- *What about the gVisor performance hit for real workloads?* The measured cost is
+  per sandbox launch (about +13 ms warm, +39 ms cold), not per syscall or per
+  request, and the harness that produces those numbers is committed so you can
+  reproduce it on your own nodes.
+- *Is the Helm chart production-shaped or a toy?* It is a real chart under
+  `deploy/helm/ironclaw` with the control plane and CLI. If you hit a values gap
+  for your cluster, tell me exactly where and it becomes an issue.


### PR DESCRIPTION
Board-approved Reddit reach lever (ce78ef49). Adds the two remaining approved-sub drafts to `docs/launch/` at the `reddit-selfhosted.md` quality bar.

- **reddit-devops.md** - CI-gate + deploy-templates angle. Leads with the scored-images data (43/54 popular images grade D on defaults) and `ironctl scan` as a merge gate (Action sticky scorecard, min-score fail, SARIF, badge-json).
- **reddit-kubernetes.md** - Helm chart + per-pod gVisor angle. Framed against Pod Security Standards not closing the shared-kernel gap; `ironctl scan --k8s` manifest scoring.

Both link the **live** /scores directory (https://nivardsec.com/scores, confirmed rendering 54 images, avg 51/100, 43x grade D) and the repo.

Guardrail pass (all approved-sub drafts): no personal name/handles, project links only, no em/en-dashes. `docs/launch/` is excluded from nav so mkdocs --strict is unaffected.

Posting stays board-gated (board submits under board identity). Full posting playbook handed back on IRO-453.