### PR TITLE
test: cover OpenRouter provider defaults

### DIFF
--- a/internal/sandbox/provider/openrouter_test.go
+++ b/internal/sandbox/provider/openrouter_test.go
@@ -1,0 +1,52 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOpenRouterFactoryDefaults(t *testing.T) {
+	pv, err := New(Config{Kind: KindOpenRouter})
+	if err != nil {
+		t.Fatalf("openrouter with no host/model: want defaults, got error: %v", err)
+	}
+	if pv == nil {
+		t.Fatal("openrouter provider = nil, want non-nil")
+	}
+	op, ok := pv.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("openrouter kind = %T, want *OpenAIProvider", pv)
+	}
+	if op.cfg.UpstreamHost != openRouterUpstreamHost {
+		t.Fatalf("openrouter default upstream host = %q, want %q", op.cfg.UpstreamHost, openRouterUpstreamHost)
+	}
+	if op.cfg.Model != defaultOpenRouterModel {
+		t.Fatalf("openrouter default model = %q, want %q", op.cfg.Model, defaultOpenRouterModel)
+	}
+	if !strings.Contains(op.url, openRouterUpstreamHost+"/api/v1/chat/completions") {
+		t.Fatalf("openrouter url = %q, want the %s /api/v1 path", op.url, openRouterUpstreamHost)
+	}
+}
+
+func TestOpenRouterFactoryOverrides(t *testing.T) {
+	const host = "gateway.example.test"
+	const model = "meta-llama/llama-3.1-8b-instruct"
+
+	pv, err := New(Config{Kind: "OpenRouter", UpstreamHost: host, Model: model})
+	if err != nil {
+		t.Fatalf("openrouter override: %v", err)
+	}
+	op, ok := pv.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("openrouter kind = %T, want *OpenAIProvider", pv)
+	}
+	if op.cfg.UpstreamHost != host {
+		t.Fatalf("openrouter upstream host = %q, want overridden %q", op.cfg.UpstreamHost, host)
+	}
+	if op.cfg.Model != model {
+		t.Fatalf("openrouter model = %q, want overridden %q", op.cfg.Model, model)
+	}
+	if !strings.Contains(op.url, host+"/v1/chat/completions") {
+		t.Fatalf("openrouter override url = %q, want the overridden host standard /v1 path", op.url)
+	}
+}


### PR DESCRIPTION
## What & why

Add focused unit coverage for the OpenRouter provider backend so its registered factory behavior is locked down.

Closes #395

## Changes

- Add `internal/sandbox/provider/openrouter_test.go`.
- Cover `New(Config{Kind: KindOpenRouter})` returning a non-nil `*OpenAIProvider`.
- Assert OpenRouter default host/model application.
- Assert explicit upstream host/model values are preserved.

## Checklist

- [x] **Tests pass:** `CGO_ENABLED=1 go test ./...` is green (CGO is required — SQLCipher binding).
- [x] **Formatted & vetted:** `gofmt -l .` is empty and `go vet ./...` passes.
- [x] **Frozen contract:** `internal/contract/**` is untouched.
- [x] **Threat model:** no change to the sandbox seal / `network=none` / approval-gateway posture.
- [x] **Docs updated:** not applicable; this is test-only and has no user-facing or behavioral change.
- [x] **No secrets:** no tokens, keys, or credentials in code, tests, fixtures, or logs.

## Validation

```bash
$ CGO_ENABLED=1 go test ./internal/sandbox/provider/...
ok  	github.com/IronSecCo/ironclaw/internal/sandbox/provider	0.461s
```

```bash
$ CGO_ENABLED=1 go test ./...
ok  	github.com/IronSecCo/ironclaw/cmd/controlplane	0.273s
?   	github.com/IronSecCo/ironclaw/cmd/ironclaw-vault-injector	[no test files]
ok  	github.com/IronSecCo/ironclaw/cmd/ironctl	0.318s
?   	github.com/IronSecCo/ironclaw/cmd/mcp-sample	[no test files]
?   	github.com/IronSecCo/ironclaw/cmd/sandbox	[no test files]
ok  	github.com/IronSecCo/ironclaw/internal/contract	0.452s
ok  	github.com/IronSecCo/ironclaw/internal/host/api	1.365s
ok  	github.com/IronSecCo/ironclaw/internal/host/catalog	0.878s
ok  	github.com/IronSecCo/ironclaw/internal/host/channels	1.136s
ok  	github.com/IronSecCo/ironclaw/internal/host/delivery	1.337s
ok  	github.com/IronSecCo/ironclaw/internal/host/egress	1.568s
ok  	github.com/IronSecCo/ironclaw/internal/host/gateway	1.643s
ok  	github.com/IronSecCo/ironclaw/internal/host/isolation	3.715s
ok  	github.com/IronSecCo/ironclaw/internal/host/keys	1.887s
ok  	github.com/IronSecCo/ironclaw/internal/host/mcp	1.659s
ok  	github.com/IronSecCo/ironclaw/internal/host/metrics	1.623s
ok  	github.com/IronSecCo/ironclaw/internal/host/modelproxy	1.667s
ok  	github.com/IronSecCo/ironclaw/internal/host/onboard	1.867s
ok  	github.com/IronSecCo/ironclaw/internal/host/questions	1.860s
ok  	github.com/IronSecCo/ironclaw/internal/host/queue	2.266s
ok  	github.com/IronSecCo/ironclaw/internal/host/registry	1.864s
ok  	github.com/IronSecCo/ironclaw/internal/host/router	1.812s
ok  	github.com/IronSecCo/ironclaw/internal/host/sandboxexec	1.816s
ok  	github.com/IronSecCo/ironclaw/internal/host/scan	1.791s
ok  	github.com/IronSecCo/ironclaw/internal/host/scheduling	1.819s
ok  	github.com/IronSecCo/ironclaw/internal/host/session	1.917s
ok  	github.com/IronSecCo/ironclaw/internal/host/skills	1.277s
ok  	github.com/IronSecCo/ironclaw/internal/host/sweep	1.311s
?   	github.com/IronSecCo/ironclaw/internal/host/types	[no test files]
ok  	github.com/IronSecCo/ironclaw/internal/host/vaultinjector	1.521s
ok  	github.com/IronSecCo/ironclaw/internal/integration	1.594s
ok  	github.com/IronSecCo/ironclaw/internal/obs	1.619s
ok  	github.com/IronSecCo/ironclaw/internal/sandbox/loop	1.793s
ok  	github.com/IronSecCo/ironclaw/internal/sandbox/provider	(cached)
ok  	github.com/IronSecCo/ironclaw/internal/sandbox/queue	1.624s
ok  	github.com/IronSecCo/ironclaw/internal/sandbox/tools	1.295s
ok  	github.com/IronSecCo/ironclaw/internal/smoke	1.443s
?   	github.com/IronSecCo/ironclaw/internal/version	[no test files]
ok  	github.com/IronSecCo/ironclaw/test/e2e	1.467s
ok  	github.com/IronSecCo/ironclaw/test/parity	1.562s
?   	github.com/IronSecCo/ironclaw/test/parity/harness	[no test files]
?   	github.com/IronSecCo/ironclaw/test/wsg/probe	[no test files]
?   	github.com/IronSecCo/ironclaw/tools/icdemo	[no test files]
ok  	github.com/IronSecCo/ironclaw/web	1.746s
```

```bash
$ go vet ./...
# no output

$ gofmt -l .
# no output
```

## AI assistance disclosure

Prepared with AI assistance from OpenAI Codex. Codex did not sign or accept any CLA or legal terms.
