### PR TITLE
docs: surface scan/scores as first-contribution areas (IRO-458)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,26 @@ that's all the setup there is. A maintainer reviews and merges.
 [**Discussions**](https://github.com/IronSecCo/ironclaw/discussions). The rest of this
 guide covers the ground rules, the frozen contract, and the code layout in detail.
 
+### Good places to start
+
+Two subsystems are deliberately self-contained — you can make a real, mergeable change
+in either without loading the whole architecture in your head:
+
+- **`ironctl scan`** (`internal/host/scan/`, `cmd/ironctl/scan.go`) — grades a container's
+  containment posture 0-100 across seven dimensions. Pure, table-testable scoring logic and
+  a small CLI surface. Good for test coverage, new flags, and output polish. See
+  [`docs/scan.md`](https://ironsecco.github.io/ironclaw/scan/).
+- **The isolation scores dataset** (`examples/isolation-survey/`) — the data behind the public
+  [container isolation scores](https://ironsecco.github.io/ironclaw/scores/) directory. Adding
+  images to `images.txt` is a data-only change (no Go, no build); the weekly CI survey grades
+  and publishes them for you.
+
+Filter the open issues for these areas with the
+[**`area:cli`**](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22area%3Acli%22),
+[**`area:sandbox`**](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22area%3Asandbox%22),
+and [**`category:test`**](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22category%3Atest%22)
+labels.
+
 ## Ground rules
 
 - **Open an issue first** for anything non-trivial, so we can agree on the approach

--- a/README.md
+++ b/README.md
@@ -1081,7 +1081,11 @@ home for Q&A, design discussion, and show-and-tell, and it's where maintainers a
   [ready to claim](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3A%22help+wanted%22)
   (`good first issue` + `help wanted`). They are small, self-contained, and mentored, and every one
   carries the standard labels that contributor boards such as [up-for-grabs.net](https://up-for-grabs.net)
-  and [goodfirstissue.dev](https://goodfirstissue.dev) index by. See [Contributing](#contributing) for the workflow.
+  and [goodfirstissue.dev](https://goodfirstissue.dev) index by. The friendliest starting points are the
+  two most self-contained subsystems — [**`ironctl scan`**](https://ironsecco.github.io/ironclaw/scan/)
+  (containment scoring; `internal/host/scan/`) and the
+  [**isolation scores dataset**](https://ironsecco.github.io/ironclaw/scores/) (`examples/isolation-survey/`,
+  a data-only change). See [Contributing](#contributing) for the workflow.
 - **First time here?** Everyone interacting with the project is expected to follow our
   [**Code of Conduct**](CODE_OF_CONDUCT.md) — be excellent to each other.
 


### PR DESCRIPTION
Part of the contributor on-ramp (IRO-458). Own-repo issue creation + labels are our few no-account levers to grow contributors, and external PR #441 proved the good-first-issue funnel works.

## Changes
- **CONTRIBUTING.md** — new **Good places to start** section directing newcomers to the two most self-contained subsystems: `ironctl scan` (`internal/host/scan/`, table-testable scoring + small CLI) and the isolation scores dataset (`examples/isolation-survey/`, data-only, CI grades it). Links the `area:cli` / `area:sandbox` / `category:test` label filters.
- **README.md** — mirror the pointer in the existing contribute callout.

## Companion GFIs opened this batch
#443 (OpenRouter coverage), #444 (scores dataset images), #445 (scan grade legend), #446 (scan --list-dimensions), #447 (scan --min-grade gate), #448 (grade() band tests), #449 (Tristate tests), #450 (docs/scan.md scoring section).

Docs-only; no code or nav changes.