### PR TITLE
feat(scores): leaderboard + embeddable per-image score badges (IRO-459)

### DIFF
--- a/docs/scan.md
+++ b/docs/scan.md
@@ -11,7 +11,9 @@ silently passed.
 
 Curious how the images you already pull score? Browse the public
 [Container Isolation Scores directory](scores/index.md): the default-config
-grade for 50+ of the most-pulled public images, then scan your own in 10 seconds.
+grade for 150+ of the most-pulled public images, then scan your own in 10 seconds.
+See the full ranking, best to worst, on the
+[Container Isolation Leaderboard](scores/leaderboard.md).
 
 ```
 $ ironctl scan my-container
@@ -147,8 +149,9 @@ reasoning behind the committed-file design, see the blog post
 [Add a live Sandbox Isolation Score badge to your repo](blog/add-a-sandbox-isolation-score-badge-to-your-repo.md).
 
 Want to see how your grade stacks up? Compare it against the
-[Container Isolation Scores directory](scores/index.md), where 50+ of the most-pulled
-public images are graded in their default configuration.
+[Container Isolation Scores directory](scores/index.md), where 150+ of the most-pulled
+public images are graded in their default configuration, or the ranked
+[leaderboard](scores/leaderboard.md).
 
 ## GitHub code scanning (Security tab)
 

--- a/docs/scores/.nav.yml
+++ b/docs/scores/.nav.yml
@@ -8,4 +8,5 @@
 # index is pinned first; everything else is alphabetical by the glob.
 nav:
   - All container isolation scores: index.md
+  - Leaderboard: leaderboard.md
   - "*.md"

--- a/docs/scores/adguardhome.md
+++ b/docs/scores/adguardhome.md
@@ -63,6 +63,18 @@ ironctl scan my-adguardhome
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **adguardhome** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/adguardhome/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/adguardhome/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/adminer.md
+++ b/docs/scores/adminer.md
@@ -61,6 +61,18 @@ ironctl scan my-adminer
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **adminer** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/adminer/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/adminer/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/alertmanager.md
+++ b/docs/scores/alertmanager.md
@@ -61,6 +61,18 @@ ironctl scan my-alertmanager
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **alertmanager** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/alertmanager/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/alertmanager/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/alloy.md
+++ b/docs/scores/alloy.md
@@ -63,6 +63,18 @@ ironctl scan my-alloy
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **alloy** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/alloy/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/alloy/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/almalinux.md
+++ b/docs/scores/almalinux.md
@@ -63,6 +63,18 @@ ironctl scan my-almalinux
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **almalinux** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/almalinux/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/almalinux/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/alpine.md
+++ b/docs/scores/alpine.md
@@ -63,6 +63,18 @@ ironctl scan my-alpine
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **alpine** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/alpine/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/alpine/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/amazoncorretto.md
+++ b/docs/scores/amazoncorretto.md
@@ -63,6 +63,18 @@ ironctl scan my-amazoncorretto
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **amazoncorretto** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/amazoncorretto/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/amazoncorretto/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/amazonlinux.md
+++ b/docs/scores/amazonlinux.md
@@ -63,6 +63,18 @@ ironctl scan my-amazonlinux
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **amazonlinux** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/amazonlinux/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/amazonlinux/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/arangodb.md
+++ b/docs/scores/arangodb.md
@@ -63,6 +63,18 @@ ironctl scan my-arangodb
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **arangodb** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/arangodb/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/arangodb/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/archlinux.md
+++ b/docs/scores/archlinux.md
@@ -63,6 +63,18 @@ ironctl scan my-archlinux
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **archlinux** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/archlinux/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/archlinux/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/authelia.md
+++ b/docs/scores/authelia.md
@@ -63,6 +63,18 @@ ironctl scan my-authelia
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **authelia** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/authelia/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/authelia/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/blackbox-exporter.md
+++ b/docs/scores/blackbox-exporter.md
@@ -63,6 +63,18 @@ ironctl scan my-blackbox-exporter
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **blackbox exporter** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/blackbox-exporter/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/blackbox-exporter/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/bun.md
+++ b/docs/scores/bun.md
@@ -63,6 +63,18 @@ ironctl scan my-bun
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **bun** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/bun/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/bun/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/busybox.md
+++ b/docs/scores/busybox.md
@@ -63,6 +63,18 @@ ironctl scan my-busybox
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **busybox** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/busybox/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/busybox/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/caddy.md
+++ b/docs/scores/caddy.md
@@ -63,6 +63,18 @@ ironctl scan my-caddy
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **caddy** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/caddy/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/caddy/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/cassandra.md
+++ b/docs/scores/cassandra.md
@@ -63,6 +63,18 @@ ironctl scan my-cassandra
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **cassandra** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/cassandra/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/cassandra/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/chroma.md
+++ b/docs/scores/chroma.md
@@ -63,6 +63,18 @@ ironctl scan my-chroma
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **chroma** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/chroma/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/chroma/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/chronograf.md
+++ b/docs/scores/chronograf.md
@@ -63,6 +63,18 @@ ironctl scan my-chronograf
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **chronograf** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/chronograf/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/chronograf/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/clickhouse.md
+++ b/docs/scores/clickhouse.md
@@ -63,6 +63,18 @@ ironctl scan my-clickhouse
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **clickhouse** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/clickhouse/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/clickhouse/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/clojure.md
+++ b/docs/scores/clojure.md
@@ -63,6 +63,18 @@ ironctl scan my-clojure
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **clojure** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/clojure/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/clojure/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/cockroach.md
+++ b/docs/scores/cockroach.md
@@ -63,6 +63,18 @@ ironctl scan my-cockroach
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **cockroach** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/cockroach/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/cockroach/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/consul.md
+++ b/docs/scores/consul.md
@@ -63,6 +63,18 @@ ironctl scan my-consul
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **consul** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/consul/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/consul/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/couchdb.md
+++ b/docs/scores/couchdb.md
@@ -63,6 +63,18 @@ ironctl scan my-couchdb
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **couchdb** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/couchdb/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/couchdb/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/cp-kafka.md
+++ b/docs/scores/cp-kafka.md
@@ -61,6 +61,18 @@ ironctl scan my-cp-kafka
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **cp kafka** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/cp-kafka/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/cp-kafka/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/dart.md
+++ b/docs/scores/dart.md
@@ -63,6 +63,18 @@ ironctl scan my-dart
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **dart** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/dart/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/dart/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/debian.md
+++ b/docs/scores/debian.md
@@ -63,6 +63,18 @@ ironctl scan my-debian
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **debian** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/debian/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/debian/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/deno.md
+++ b/docs/scores/deno.md
@@ -63,6 +63,18 @@ ironctl scan my-deno
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **deno** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/deno/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/deno/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/docker.md
+++ b/docs/scores/docker.md
@@ -63,6 +63,18 @@ ironctl scan my-docker
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **docker** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/docker/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/docker/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/dragonfly.md
+++ b/docs/scores/dragonfly.md
@@ -63,6 +63,18 @@ ironctl scan my-dragonfly
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **dragonfly** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/dragonfly/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/dragonfly/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/drone.md
+++ b/docs/scores/drone.md
@@ -63,6 +63,18 @@ ironctl scan my-drone
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **drone** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/drone/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/drone/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/drupal.md
+++ b/docs/scores/drupal.md
@@ -63,6 +63,18 @@ ironctl scan my-drupal
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **drupal** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/drupal/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/drupal/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/eclipse-mosquitto.md
+++ b/docs/scores/eclipse-mosquitto.md
@@ -63,6 +63,18 @@ ironctl scan my-eclipse-mosquitto
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **eclipse mosquitto** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/eclipse-mosquitto/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/eclipse-mosquitto/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/eclipse-temurin.md
+++ b/docs/scores/eclipse-temurin.md
@@ -63,6 +63,18 @@ ironctl scan my-eclipse-temurin
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **eclipse temurin** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/eclipse-temurin/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/eclipse-temurin/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/elixir.md
+++ b/docs/scores/elixir.md
@@ -63,6 +63,18 @@ ironctl scan my-elixir
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **elixir** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/elixir/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/elixir/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/emqx.md
+++ b/docs/scores/emqx.md
@@ -61,6 +61,18 @@ ironctl scan my-emqx
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **emqx** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/emqx/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/emqx/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/envoy.md
+++ b/docs/scores/envoy.md
@@ -63,6 +63,18 @@ ironctl scan my-envoy
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **envoy** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/envoy/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/envoy/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/erlang.md
+++ b/docs/scores/erlang.md
@@ -63,6 +63,18 @@ ironctl scan my-erlang
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **erlang** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/erlang/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/erlang/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/fedora.md
+++ b/docs/scores/fedora.md
@@ -63,6 +63,18 @@ ironctl scan my-fedora
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **fedora** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/fedora/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/fedora/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/flink.md
+++ b/docs/scores/flink.md
@@ -63,6 +63,18 @@ ironctl scan my-flink
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **flink** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/flink/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/flink/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/fluentd.md
+++ b/docs/scores/fluentd.md
@@ -61,6 +61,18 @@ ironctl scan my-fluentd
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **fluentd** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/fluentd/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/fluentd/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/forgejo.md
+++ b/docs/scores/forgejo.md
@@ -63,6 +63,18 @@ ironctl scan my-forgejo
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **forgejo** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/forgejo/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/forgejo/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/gcc.md
+++ b/docs/scores/gcc.md
@@ -63,6 +63,18 @@ ironctl scan my-gcc
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **gcc** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/gcc/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/gcc/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/ghost.md
+++ b/docs/scores/ghost.md
@@ -63,6 +63,18 @@ ironctl scan my-ghost
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **ghost** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/ghost/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/ghost/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/gitea.md
+++ b/docs/scores/gitea.md
@@ -63,6 +63,18 @@ ironctl scan my-gitea
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **gitea** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/gitea/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/gitea/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/gogs.md
+++ b/docs/scores/gogs.md
@@ -63,6 +63,18 @@ ironctl scan my-gogs
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **gogs** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/gogs/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/gogs/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/golang.md
+++ b/docs/scores/golang.md
@@ -63,6 +63,18 @@ ironctl scan my-golang
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **golang** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/golang/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/golang/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/gradle.md
+++ b/docs/scores/gradle.md
@@ -63,6 +63,18 @@ ironctl scan my-gradle
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **gradle** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/gradle/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/gradle/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/grafana.md
+++ b/docs/scores/grafana.md
@@ -61,6 +61,18 @@ ironctl scan my-grafana
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **grafana** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/grafana/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/grafana/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/graylog.md
+++ b/docs/scores/graylog.md
@@ -61,6 +61,18 @@ ironctl scan my-graylog
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **graylog** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/graylog/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/graylog/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/groovy.md
+++ b/docs/scores/groovy.md
@@ -61,6 +61,18 @@ ironctl scan my-groovy
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **groovy** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/groovy/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/groovy/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/haproxy.md
+++ b/docs/scores/haproxy.md
@@ -61,6 +61,18 @@ ironctl scan my-haproxy
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **haproxy** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/haproxy/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/haproxy/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/haskell.md
+++ b/docs/scores/haskell.md
@@ -63,6 +63,18 @@ ironctl scan my-haskell
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **haskell** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/haskell/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/haskell/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/httpd.md
+++ b/docs/scores/httpd.md
@@ -63,6 +63,18 @@ ironctl scan my-httpd
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **httpd** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/httpd/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/httpd/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/hydra.md
+++ b/docs/scores/hydra.md
@@ -61,6 +61,18 @@ ironctl scan my-hydra
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **hydra** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/hydra/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/hydra/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/index.json
+++ b/docs/scores/index.json
@@ -131,7 +131,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none adguard/adguardhome:latest"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none adguard/adguardhome:latest",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/adguardhome/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/adguardhome/)"
     },
     {
       "slug": "alloy",
@@ -213,7 +216,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none grafana/alloy:latest"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none grafana/alloy:latest",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/alloy/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/alloy/)"
     },
     {
       "slug": "almalinux",
@@ -295,7 +301,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none almalinux:9"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none almalinux:9",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/almalinux/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/almalinux/)"
     },
     {
       "slug": "alpine",
@@ -377,7 +386,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none alpine:3.21"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none alpine:3.21",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/alpine/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/alpine/)"
     },
     {
       "slug": "amazoncorretto",
@@ -459,7 +471,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none amazoncorretto:21"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none amazoncorretto:21",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/amazoncorretto/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/amazoncorretto/)"
     },
     {
       "slug": "amazonlinux",
@@ -541,7 +556,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none amazonlinux:2023"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none amazonlinux:2023",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/amazonlinux/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/amazonlinux/)"
     },
     {
       "slug": "arangodb",
@@ -623,7 +641,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none arangodb:3.12"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none arangodb:3.12",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/arangodb/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/arangodb/)"
     },
     {
       "slug": "archlinux",
@@ -705,7 +726,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none archlinux:latest"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none archlinux:latest",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/archlinux/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/archlinux/)"
     },
     {
       "slug": "authelia",
@@ -787,7 +811,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none authelia/authelia:4.38"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none authelia/authelia:4.38",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/authelia/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/authelia/)"
     },
     {
       "slug": "blackbox-exporter",
@@ -869,7 +896,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none prom/blackbox-exporter:v0.25.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none prom/blackbox-exporter:v0.25.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/blackbox-exporter/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/blackbox-exporter/)"
     },
     {
       "slug": "bun",
@@ -951,7 +981,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none oven/bun:1.1"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none oven/bun:1.1",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/bun/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/bun/)"
     },
     {
       "slug": "busybox",
@@ -1033,7 +1066,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none busybox:1.37"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none busybox:1.37",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/busybox/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/busybox/)"
     },
     {
       "slug": "caddy",
@@ -1115,7 +1151,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none caddy:2-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none caddy:2-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/caddy/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/caddy/)"
     },
     {
       "slug": "cassandra",
@@ -1197,7 +1236,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none cassandra:5.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none cassandra:5.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/cassandra/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/cassandra/)"
     },
     {
       "slug": "chroma",
@@ -1279,7 +1321,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none chromadb/chroma:0.5.23"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none chromadb/chroma:0.5.23",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/chroma/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/chroma/)"
     },
     {
       "slug": "chronograf",
@@ -1361,7 +1406,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none chronograf:1.10"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none chronograf:1.10",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/chronograf/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/chronograf/)"
     },
     {
       "slug": "clickhouse",
@@ -1443,7 +1491,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none clickhouse:24.8"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none clickhouse:24.8",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/clickhouse/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/clickhouse/)"
     },
     {
       "slug": "clojure",
@@ -1525,7 +1576,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none clojure:temurin-21-tools-deps"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none clojure:temurin-21-tools-deps",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/clojure/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/clojure/)"
     },
     {
       "slug": "cockroach",
@@ -1607,7 +1661,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none cockroachdb/cockroach:latest"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none cockroachdb/cockroach:latest",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/cockroach/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/cockroach/)"
     },
     {
       "slug": "consul",
@@ -1689,7 +1746,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none hashicorp/consul:1.20"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none hashicorp/consul:1.20",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/consul/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/consul/)"
     },
     {
       "slug": "couchdb",
@@ -1771,7 +1831,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none couchdb:3.4"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none couchdb:3.4",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/couchdb/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/couchdb/)"
     },
     {
       "slug": "dart",
@@ -1853,7 +1916,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none dart:3.6"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none dart:3.6",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/dart/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/dart/)"
     },
     {
       "slug": "debian",
@@ -1935,7 +2001,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none debian:12-slim"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none debian:12-slim",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/debian/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/debian/)"
     },
     {
       "slug": "deno",
@@ -2017,7 +2086,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none denoland/deno:2.1.4"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none denoland/deno:2.1.4",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/deno/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/deno/)"
     },
     {
       "slug": "docker",
@@ -2099,7 +2171,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none docker:27-dind"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none docker:27-dind",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/docker/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/docker/)"
     },
     {
       "slug": "dragonfly",
@@ -2181,7 +2256,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none docker.dragonflydb.io/dragonflydb/dragonfly:latest"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none docker.dragonflydb.io/dragonflydb/dragonfly:latest",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/dragonfly/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/dragonfly/)"
     },
     {
       "slug": "drone",
@@ -2263,7 +2341,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none drone/drone:2"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none drone/drone:2",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/drone/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/drone/)"
     },
     {
       "slug": "drupal",
@@ -2345,7 +2426,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none drupal:11-apache"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none drupal:11-apache",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/drupal/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/drupal/)"
     },
     {
       "slug": "eclipse-mosquitto",
@@ -2427,7 +2511,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none eclipse-mosquitto:2"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none eclipse-mosquitto:2",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/eclipse-mosquitto/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/eclipse-mosquitto/)"
     },
     {
       "slug": "eclipse-temurin",
@@ -2509,7 +2596,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none eclipse-temurin:21-jre-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none eclipse-temurin:21-jre-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/eclipse-temurin/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/eclipse-temurin/)"
     },
     {
       "slug": "elixir",
@@ -2591,7 +2681,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none elixir:1.18-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none elixir:1.18-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/elixir/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/elixir/)"
     },
     {
       "slug": "envoy",
@@ -2673,7 +2766,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none envoyproxy/envoy:v1.32-latest"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none envoyproxy/envoy:v1.32-latest",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/envoy/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/envoy/)"
     },
     {
       "slug": "erlang",
@@ -2755,7 +2851,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none erlang:27-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none erlang:27-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/erlang/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/erlang/)"
     },
     {
       "slug": "fedora",
@@ -2837,7 +2936,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none fedora:41"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none fedora:41",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/fedora/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/fedora/)"
     },
     {
       "slug": "flink",
@@ -2919,7 +3021,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none flink:1.20"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none flink:1.20",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/flink/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/flink/)"
     },
     {
       "slug": "forgejo",
@@ -3001,7 +3106,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none codeberg.org/forgejo/forgejo:9"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none codeberg.org/forgejo/forgejo:9",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/forgejo/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/forgejo/)"
     },
     {
       "slug": "gcc",
@@ -3083,7 +3191,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none gcc:14"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none gcc:14",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/gcc/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/gcc/)"
     },
     {
       "slug": "ghost",
@@ -3165,7 +3276,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none ghost:5-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none ghost:5-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/ghost/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/ghost/)"
     },
     {
       "slug": "gitea",
@@ -3247,7 +3361,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none gitea/gitea:1.22"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none gitea/gitea:1.22",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/gitea/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/gitea/)"
     },
     {
       "slug": "gogs",
@@ -3329,7 +3446,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none gogs/gogs:0.13"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none gogs/gogs:0.13",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/gogs/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/gogs/)"
     },
     {
       "slug": "golang",
@@ -3411,7 +3531,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none golang:1.23-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none golang:1.23-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/golang/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/golang/)"
     },
     {
       "slug": "gradle",
@@ -3493,7 +3616,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none gradle:8-jdk21"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none gradle:8-jdk21",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/gradle/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/gradle/)"
     },
     {
       "slug": "haskell",
@@ -3575,7 +3701,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none haskell:9.8"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none haskell:9.8",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/haskell/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/haskell/)"
     },
     {
       "slug": "httpd",
@@ -3657,7 +3786,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none httpd:2.4-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none httpd:2.4-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/httpd/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/httpd/)"
     },
     {
       "slug": "influxdb",
@@ -3739,7 +3871,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none influxdb:2.7-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none influxdb:2.7-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/influxdb/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/influxdb/)"
     },
     {
       "slug": "jellyfin",
@@ -3821,7 +3956,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none jellyfin/jellyfin:10.10.3"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none jellyfin/jellyfin:10.10.3",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/jellyfin/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/jellyfin/)"
     },
     {
       "slug": "joomla",
@@ -3903,7 +4041,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none joomla:5-apache"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none joomla:5-apache",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/joomla/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/joomla/)"
     },
     {
       "slug": "julia",
@@ -3985,7 +4126,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none julia:1.11"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none julia:1.11",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/julia/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/julia/)"
     },
     {
       "slug": "kapacitor",
@@ -4067,7 +4211,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none kapacitor:1.7"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none kapacitor:1.7",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/kapacitor/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/kapacitor/)"
     },
     {
       "slug": "keydb",
@@ -4149,7 +4296,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none eqalpha/keydb:latest"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none eqalpha/keydb:latest",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/keydb/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/keydb/)"
     },
     {
       "slug": "leap",
@@ -4231,7 +4381,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none opensuse/leap:15.6"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none opensuse/leap:15.6",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/leap/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/leap/)"
     },
     {
       "slug": "localstack",
@@ -4313,7 +4466,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none localstack/localstack:4"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none localstack/localstack:4",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/localstack/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/localstack/)"
     },
     {
       "slug": "mailpit",
@@ -4395,7 +4551,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none axllent/mailpit:latest"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none axllent/mailpit:latest",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/mailpit/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mailpit/)"
     },
     {
       "slug": "mariadb",
@@ -4477,7 +4636,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none mariadb:11"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none mariadb:11",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/mariadb/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mariadb/)"
     },
     {
       "slug": "matomo",
@@ -4559,7 +4721,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none matomo:5"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none matomo:5",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/matomo/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/matomo/)"
     },
     {
       "slug": "maven",
@@ -4641,7 +4806,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none maven:3.9-eclipse-temurin-21"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none maven:3.9-eclipse-temurin-21",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/maven/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/maven/)"
     },
     {
       "slug": "mediawiki",
@@ -4723,7 +4891,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none mediawiki:1.43"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none mediawiki:1.43",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/mediawiki/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mediawiki/)"
     },
     {
       "slug": "meilisearch",
@@ -4805,7 +4976,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none getmeili/meilisearch:v1.11"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none getmeili/meilisearch:v1.11",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/meilisearch/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/meilisearch/)"
     },
     {
       "slug": "metabase",
@@ -4887,7 +5061,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none metabase/metabase:v0.52.4"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none metabase/metabase:v0.52.4",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/metabase/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/metabase/)"
     },
     {
       "slug": "minio",
@@ -4969,7 +5146,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none minio/minio:latest"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none minio/minio:latest",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/minio/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/minio/)"
     },
     {
       "slug": "mongo",
@@ -5051,7 +5231,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none mongo:7"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none mongo:7",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/mongo/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mongo/)"
     },
     {
       "slug": "mongo-express",
@@ -5133,7 +5316,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none mongo-express:1.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none mongo-express:1.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/mongo-express/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mongo-express/)"
     },
     {
       "slug": "mysql",
@@ -5215,7 +5401,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none mysql:8.4"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none mysql:8.4",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/mysql/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mysql/)"
     },
     {
       "slug": "nats",
@@ -5297,7 +5486,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none nats:2.10-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none nats:2.10-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/nats/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/nats/)"
     },
     {
       "slug": "neo4j",
@@ -5379,7 +5571,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none neo4j:5"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none neo4j:5",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/neo4j/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/neo4j/)"
     },
     {
       "slug": "netdata",
@@ -5461,7 +5656,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none netdata/netdata:stable"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none netdata/netdata:stable",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/netdata/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/netdata/)"
     },
     {
       "slug": "nextcloud",
@@ -5543,7 +5741,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none nextcloud:30-apache"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none nextcloud:30-apache",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/nextcloud/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/nextcloud/)"
     },
     {
       "slug": "nginx",
@@ -5625,7 +5826,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none nginx:1.27-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none nginx:1.27-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/nginx/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/nginx/)"
     },
     {
       "slug": "node",
@@ -5707,7 +5911,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none node:22-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none node:22-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/node/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/node/)"
     },
     {
       "slug": "nomad",
@@ -5789,7 +5996,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none hashicorp/nomad:1.9"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none hashicorp/nomad:1.9",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/nomad/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/nomad/)"
     },
     {
       "slug": "openresty",
@@ -5871,7 +6081,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none openresty/openresty:alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none openresty/openresty:alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/openresty/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/openresty/)"
     },
     {
       "slug": "oraclelinux",
@@ -5953,7 +6166,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none oraclelinux:9"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none oraclelinux:9",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/oraclelinux/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/oraclelinux/)"
     },
     {
       "slug": "perl",
@@ -6035,7 +6251,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none perl:5.40-slim"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none perl:5.40-slim",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/perl/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/perl/)"
     },
     {
       "slug": "pgvector",
@@ -6117,7 +6336,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none pgvector/pgvector:pg17"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none pgvector/pgvector:pg17",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/pgvector/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/pgvector/)"
     },
     {
       "slug": "photon",
@@ -6199,7 +6421,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none photon:5.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none photon:5.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/photon/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/photon/)"
     },
     {
       "slug": "php",
@@ -6281,7 +6506,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none php:8.4-apache"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none php:8.4-apache",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/php/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/php/)"
     },
     {
       "slug": "phpmyadmin",
@@ -6363,7 +6591,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none phpmyadmin:5.2"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none phpmyadmin:5.2",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/phpmyadmin/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/phpmyadmin/)"
     },
     {
       "slug": "pihole",
@@ -6445,7 +6676,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none pihole/pihole:2024.07.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none pihole/pihole:2024.07.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/pihole/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/pihole/)"
     },
     {
       "slug": "postgis",
@@ -6527,7 +6761,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none postgis/postgis:17-3.5"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none postgis/postgis:17-3.5",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/postgis/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/postgis/)"
     },
     {
       "slug": "postgres",
@@ -6609,7 +6846,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none postgres:17-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none postgres:17-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/postgres/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/postgres/)"
     },
     {
       "slug": "promtail",
@@ -6691,7 +6931,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none grafana/promtail:3.3.2"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none grafana/promtail:3.3.2",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/promtail/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/promtail/)"
     },
     {
       "slug": "pypy",
@@ -6773,7 +7016,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none pypy:3.10-slim"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none pypy:3.10-slim",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/pypy/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/pypy/)"
     },
     {
       "slug": "python",
@@ -6855,7 +7101,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none python:3.13-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none python:3.13-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/python/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/python/)"
     },
     {
       "slug": "qdrant",
@@ -6937,7 +7186,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none qdrant/qdrant:v1.12.4"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none qdrant/qdrant:v1.12.4",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/qdrant/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/qdrant/)"
     },
     {
       "slug": "questdb",
@@ -7019,7 +7271,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none questdb/questdb:8.2.1"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none questdb/questdb:8.2.1",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/questdb/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/questdb/)"
     },
     {
       "slug": "rabbitmq",
@@ -7101,7 +7356,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none rabbitmq:4-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none rabbitmq:4-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/rabbitmq/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/rabbitmq/)"
     },
     {
       "slug": "redis",
@@ -7183,7 +7441,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none redis:7-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none redis:7-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/redis/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/redis/)"
     },
     {
       "slug": "redis-stack-server",
@@ -7265,7 +7526,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none redis/redis-stack-server:7.4.0-v3"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none redis/redis-stack-server:7.4.0-v3",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/redis-stack-server/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/redis-stack-server/)"
     },
     {
       "slug": "redmine",
@@ -7347,7 +7611,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none redmine:6"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none redmine:6",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/redmine/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/redmine/)"
     },
     {
       "slug": "registry",
@@ -7429,7 +7696,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none registry:2.8.3"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none registry:2.8.3",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/registry/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/registry/)"
     },
     {
       "slug": "rethinkdb",
@@ -7511,7 +7781,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none rethinkdb:2.4"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none rethinkdb:2.4",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/rethinkdb/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/rethinkdb/)"
     },
     {
       "slug": "rockylinux",
@@ -7593,7 +7866,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none rockylinux:9"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none rockylinux:9",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/rockylinux/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/rockylinux/)"
     },
     {
       "slug": "ruby",
@@ -7675,7 +7951,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none ruby:3.4-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none ruby:3.4-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/ruby/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/ruby/)"
     },
     {
       "slug": "rust",
@@ -7757,7 +8036,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none rust:1.83-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none rust:1.83-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/rust/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/rust/)"
     },
     {
       "slug": "scylla",
@@ -7839,7 +8121,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none scylladb/scylla:6.2"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none scylladb/scylla:6.2",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/scylla/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/scylla/)"
     },
     {
       "slug": "server",
@@ -7921,7 +8206,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none vaultwarden/server:1.32.7"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none vaultwarden/server:1.32.7",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/server/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/server/)"
     },
     {
       "slug": "snipe-it",
@@ -8003,7 +8291,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none snipe/snipe-it:v7.0.13"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none snipe/snipe-it:v7.0.13",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/snipe-it/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/snipe-it/)"
     },
     {
       "slug": "swagger-ui",
@@ -8085,7 +8376,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none swaggerapi/swagger-ui:latest"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none swaggerapi/swagger-ui:latest",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/swagger-ui/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/swagger-ui/)"
     },
     {
       "slug": "telegraf",
@@ -8167,7 +8461,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none telegraf:1.33-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none telegraf:1.33-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/telegraf/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/telegraf/)"
     },
     {
       "slug": "terraform",
@@ -8249,7 +8546,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none hashicorp/terraform:1.10"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none hashicorp/terraform:1.10",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/terraform/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/terraform/)"
     },
     {
       "slug": "tomcat",
@@ -8331,7 +8631,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none tomcat:10.1-jre21-temurin"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none tomcat:10.1-jre21-temurin",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/tomcat/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/tomcat/)"
     },
     {
       "slug": "traefik",
@@ -8413,7 +8716,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none traefik:v3.2"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none traefik:v3.2",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/traefik/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/traefik/)"
     },
     {
       "slug": "typesense",
@@ -8495,7 +8801,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none typesense/typesense:27.1"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none typesense/typesense:27.1",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/typesense/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/typesense/)"
     },
     {
       "slug": "ubuntu",
@@ -8577,7 +8886,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none ubuntu:24.04"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none ubuntu:24.04",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/ubuntu/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/ubuntu/)"
     },
     {
       "slug": "unit",
@@ -8659,7 +8971,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none unit:1.34.1-minimal"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none unit:1.34.1-minimal",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/unit/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/unit/)"
     },
     {
       "slug": "uptime-kuma",
@@ -8741,7 +9056,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none louislam/uptime-kuma:1"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none louislam/uptime-kuma:1",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/uptime-kuma/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/uptime-kuma/)"
     },
     {
       "slug": "valkey",
@@ -8823,7 +9141,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none valkey/valkey:8"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none valkey/valkey:8",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/valkey/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/valkey/)"
     },
     {
       "slug": "vault",
@@ -8905,7 +9226,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none hashicorp/vault:1.18"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none hashicorp/vault:1.18",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/vault/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/vault/)"
     },
     {
       "slug": "vector",
@@ -8987,7 +9311,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none timberio/vector:0.43.0-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none timberio/vector:0.43.0-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/vector/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/vector/)"
     },
     {
       "slug": "victoria-metrics",
@@ -9069,7 +9396,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none victoriametrics/victoria-metrics:v1.107.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none victoriametrics/victoria-metrics:v1.107.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/victoria-metrics/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/victoria-metrics/)"
     },
     {
       "slug": "weaviate",
@@ -9151,7 +9481,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none semitechnologies/weaviate:1.28.1"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none semitechnologies/weaviate:1.28.1",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/weaviate/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/weaviate/)"
     },
     {
       "slug": "wordpress",
@@ -9233,7 +9566,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none wordpress:6-php8.3-apache"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none wordpress:6-php8.3-apache",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/wordpress/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/wordpress/)"
     },
     {
       "slug": "zookeeper",
@@ -9315,7 +9651,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none zookeeper:3.9"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none zookeeper:3.9",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/zookeeper/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a",
+      "badgeMarkdown": "[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/zookeeper/)"
     },
     {
       "slug": "adminer",
@@ -9397,7 +9736,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none adminer:4.8.1"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none adminer:4.8.1",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/adminer/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/adminer/)"
     },
     {
       "slug": "alertmanager",
@@ -9479,7 +9821,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none prom/alertmanager:v0.28.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none prom/alertmanager:v0.28.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/alertmanager/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/alertmanager/)"
     },
     {
       "slug": "cp-kafka",
@@ -9561,7 +9906,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none confluentinc/cp-kafka:7.8.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none confluentinc/cp-kafka:7.8.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/cp-kafka/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/cp-kafka/)"
     },
     {
       "slug": "emqx",
@@ -9643,7 +9991,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none emqx:5"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none emqx:5",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/emqx/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/emqx/)"
     },
     {
       "slug": "fluentd",
@@ -9725,7 +10076,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none fluent/fluentd:v1.17"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none fluent/fluentd:v1.17",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/fluentd/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/fluentd/)"
     },
     {
       "slug": "grafana",
@@ -9807,7 +10161,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none grafana/grafana:11.4.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none grafana/grafana:11.4.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/grafana/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/grafana/)"
     },
     {
       "slug": "graylog",
@@ -9889,7 +10246,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none graylog/graylog:6.1"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none graylog/graylog:6.1",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/graylog/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/graylog/)"
     },
     {
       "slug": "groovy",
@@ -9971,7 +10331,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none groovy:4"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none groovy:4",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/groovy/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/groovy/)"
     },
     {
       "slug": "haproxy",
@@ -10053,7 +10416,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none haproxy:3.1-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none haproxy:3.1-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/haproxy/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/haproxy/)"
     },
     {
       "slug": "hydra",
@@ -10135,7 +10501,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none oryd/hydra:v2.2.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none oryd/hydra:v2.2.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/hydra/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/hydra/)"
     },
     {
       "slug": "jaeger",
@@ -10217,7 +10586,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none jaegertracing/jaeger:2.1.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none jaegertracing/jaeger:2.1.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/jaeger/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/jaeger/)"
     },
     {
       "slug": "jenkins",
@@ -10299,7 +10671,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none jenkins/jenkins:lts"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none jenkins/jenkins:lts",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/jenkins/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/jenkins/)"
     },
     {
       "slug": "jetty",
@@ -10381,7 +10756,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none jetty:12-jre21"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none jetty:12-jre21",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/jetty/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/jetty/)"
     },
     {
       "slug": "kafka",
@@ -10463,7 +10841,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none apache/kafka:3.9.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none apache/kafka:3.9.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/kafka/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/kafka/)"
     },
     {
       "slug": "kong",
@@ -10545,7 +10926,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none kong:3.8"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none kong:3.8",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/kong/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/kong/)"
     },
     {
       "slug": "loki",
@@ -10627,7 +11011,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none grafana/loki:3.3.2"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none grafana/loki:3.3.2",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/loki/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/loki/)"
     },
     {
       "slug": "mailhog",
@@ -10709,7 +11096,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none mailhog/mailhog:v1.0.1"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none mailhog/mailhog:v1.0.1",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/mailhog/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/mailhog/)"
     },
     {
       "slug": "mattermost-team-edition",
@@ -10791,7 +11181,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none mattermost/mattermost-team-edition:10.2"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none mattermost/mattermost-team-edition:10.2",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/mattermost-team-edition/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/mattermost-team-edition/)"
     },
     {
       "slug": "memcached",
@@ -10873,7 +11266,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none memcached:1.6-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none memcached:1.6-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/memcached/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/memcached/)"
     },
     {
       "slug": "n8n",
@@ -10955,7 +11351,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none n8nio/n8n:1.71.3"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none n8nio/n8n:1.71.3",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/n8n/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/n8n/)"
     },
     {
       "slug": "nexus3",
@@ -11037,7 +11436,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none sonatype/nexus3:3.75.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none sonatype/nexus3:3.75.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/nexus3/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/nexus3/)"
     },
     {
       "slug": "nginx-unprivileged",
@@ -11119,7 +11521,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none nginxinc/nginx-unprivileged:1.27-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none nginxinc/nginx-unprivileged:1.27-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/nginx-unprivileged/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/nginx-unprivileged/)"
     },
     {
       "slug": "node-exporter",
@@ -11201,7 +11606,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none prom/node-exporter:v1.8.2"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none prom/node-exporter:v1.8.2",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/node-exporter/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/node-exporter/)"
     },
     {
       "slug": "opensearch",
@@ -11283,7 +11691,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none opensearchproject/opensearch:2"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none opensearchproject/opensearch:2",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/opensearch/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/opensearch/)"
     },
     {
       "slug": "percona",
@@ -11365,7 +11776,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none percona:8.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none percona:8.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/percona/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/percona/)"
     },
     {
       "slug": "pgadmin4",
@@ -11447,7 +11861,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none dpage/pgadmin4:8"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none dpage/pgadmin4:8",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/pgadmin4/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/pgadmin4/)"
     },
     {
       "slug": "prometheus",
@@ -11529,7 +11946,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none prom/prometheus:v3.1.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none prom/prometheus:v3.1.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/prometheus/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/prometheus/)"
     },
     {
       "slug": "pulsar",
@@ -11611,7 +12031,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none apachepulsar/pulsar:3.3.2"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none apachepulsar/pulsar:3.3.2",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/pulsar/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/pulsar/)"
     },
     {
       "slug": "pushgateway",
@@ -11693,7 +12116,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none prom/pushgateway:v1.10.0"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none prom/pushgateway:v1.10.0",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/pushgateway/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/pushgateway/)"
     },
     {
       "slug": "redisinsight",
@@ -11775,7 +12201,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none redis/redisinsight:latest"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none redis/redisinsight:latest",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/redisinsight/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/redisinsight/)"
     },
     {
       "slug": "redpanda",
@@ -11857,7 +12286,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none redpandadata/redpanda:v24.2.11"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none redpandadata/redpanda:v24.2.11",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/redpanda/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/redpanda/)"
     },
     {
       "slug": "solr",
@@ -11939,7 +12371,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none solr:9"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none solr:9",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/solr/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/solr/)"
     },
     {
       "slug": "sonarqube",
@@ -12021,7 +12456,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none sonarqube:community"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none sonarqube:community",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/sonarqube/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/sonarqube/)"
     },
     {
       "slug": "tempo",
@@ -12103,7 +12541,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none grafana/tempo:2.6.1"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none grafana/tempo:2.6.1",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/tempo/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/tempo/)"
     },
     {
       "slug": "tika",
@@ -12185,7 +12626,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none apache/tika:latest"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none apache/tika:latest",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/tika/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/tika/)"
     },
     {
       "slug": "varnish",
@@ -12267,7 +12711,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none varnish:7.6-alpine"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none varnish:7.6-alpine",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/varnish/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/varnish/)"
     },
     {
       "slug": "verdaccio",
@@ -12349,7 +12796,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none verdaccio/verdaccio:6"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none verdaccio/verdaccio:6",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/verdaccio/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/verdaccio/)"
     },
     {
       "slug": "wiki",
@@ -12431,7 +12881,10 @@
         "--read-only --tmpfs /tmp",
         "--network=none"
       ],
-      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none requarks/wiki:2"
+      "hardenedCommand": "docker run -d --user 65532:65532 --cap-drop=ALL --security-opt=no-new-privileges --read-only --tmpfs /tmp --network=none requarks/wiki:2",
+      "pageUrl": "https://ironsecco.github.io/ironclaw/scores/wiki/",
+      "badgeUrl": "https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c",
+      "badgeMarkdown": "[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/wiki/)"
     }
   ]
 }

--- a/docs/scores/index.md
+++ b/docs/scores/index.md
@@ -11,6 +11,8 @@ How isolated is the container you just `docker run`? This directory grades **151
 
 > **Scan your own container:** `brew install ironsecco/ironclaw/ironclaw && ironctl scan my-container`. See [Scan any container](../scan.md).
 
+> **New:** the [Container Isolation Leaderboard](leaderboard.md) ranks every image best-to-worst, with a Hall of Fame and a Worst-offenders cut. Each scorecard now carries a copy-paste [shields.io badge](leaderboard.md) you can embed in your repo.
+
 ## Every image, worst-isolated first
 
 | Image | Score | Grade | Top gaps (default config) |

--- a/docs/scores/influxdb.md
+++ b/docs/scores/influxdb.md
@@ -63,6 +63,18 @@ ironctl scan my-influxdb
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **influxdb** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/influxdb/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/influxdb/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/jaeger.md
+++ b/docs/scores/jaeger.md
@@ -61,6 +61,18 @@ ironctl scan my-jaeger
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **jaeger** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/jaeger/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/jaeger/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/jellyfin.md
+++ b/docs/scores/jellyfin.md
@@ -63,6 +63,18 @@ ironctl scan my-jellyfin
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **jellyfin** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/jellyfin/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/jellyfin/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/jenkins.md
+++ b/docs/scores/jenkins.md
@@ -61,6 +61,18 @@ ironctl scan my-jenkins
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **jenkins** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/jenkins/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/jenkins/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/jetty.md
+++ b/docs/scores/jetty.md
@@ -61,6 +61,18 @@ ironctl scan my-jetty
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **jetty** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/jetty/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/jetty/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/joomla.md
+++ b/docs/scores/joomla.md
@@ -63,6 +63,18 @@ ironctl scan my-joomla
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **joomla** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/joomla/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/joomla/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/julia.md
+++ b/docs/scores/julia.md
@@ -63,6 +63,18 @@ ironctl scan my-julia
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **julia** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/julia/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/julia/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/kafka.md
+++ b/docs/scores/kafka.md
@@ -61,6 +61,18 @@ ironctl scan my-kafka
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **kafka** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/kafka/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/kafka/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/kapacitor.md
+++ b/docs/scores/kapacitor.md
@@ -63,6 +63,18 @@ ironctl scan my-kapacitor
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **kapacitor** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/kapacitor/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/kapacitor/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/keydb.md
+++ b/docs/scores/keydb.md
@@ -63,6 +63,18 @@ ironctl scan my-keydb
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **keydb** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/keydb/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/keydb/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/kong.md
+++ b/docs/scores/kong.md
@@ -61,6 +61,18 @@ ironctl scan my-kong
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **kong** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/kong/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/kong/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/leaderboard.md
+++ b/docs/scores/leaderboard.md
@@ -1,0 +1,242 @@
+---
+title: "Container Isolation Leaderboard: the most (and least) isolated Docker images"
+description: A ranked leaderboard of the default container isolation score for 151 of the most-pulled public Docker images, graded 0-100 by ironctl scan. Hall of Fame and worst offenders included.
+---
+
+# Container Isolation Leaderboard
+
+Every one of **151 of the most-pulled public Docker images**, ranked by how isolated it is when you `docker run` it with plain defaults, no hardening flags. Scores run **48/100 to 63/100** (average **52/100**), graded across IronClaw's seven containment dimensions by `ironctl scan`. Higher is safer. Regenerated with the [weekly survey refresh](index.md), so this ranking never goes stale.
+
+> The uncomfortable headline: **no popular image ships isolated.** Even the leaders leave capabilities, egress, and a writable root filesystem wide open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## 🏆 Hall of Fame
+
+No image ships at grade A, so this is the next best thing: the **15 best-isolated images by default**, the ones that start you closest to a hardened posture.
+
+| Rank | Image | Score | Grade | Remaining gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------------|
+| 🥇 1 | [`adminer:4.8.1`](adminer.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥈 2 | [`prom/alertmanager:v0.28.0`](alertmanager.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥉 3 | [`confluentinc/cp-kafka:7.8.0`](cp-kafka.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 4 | [`emqx:5`](emqx.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 5 | [`fluent/fluentd:v1.17`](fluentd.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 6 | [`grafana/grafana:11.4.0`](grafana.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 7 | [`graylog/graylog:6.1`](graylog.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 8 | [`groovy:4`](groovy.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 9 | [`haproxy:3.1-alpine`](haproxy.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 10 | [`oryd/hydra:v2.2.0`](hydra.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 11 | [`jaegertracing/jaeger:2.1.0`](jaeger.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 12 | [`jenkins/jenkins:lts`](jenkins.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 13 | [`jetty:12-jre21`](jetty.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 14 | [`apache/kafka:3.9.0`](kafka.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 15 | [`kong:3.8`](kong.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+
+## 🚨 Worst offenders
+
+The **15 least-isolated images** in the survey. Pulling one of these unhardened puts a container escape one step from host uid 0. Each links to the exact flags that fix it.
+
+| # | Image | Score | Grade | Top gaps (default config) |
+|--:|-------|------:|:-----:|---------------------------|
+| 1 | [`zookeeper:3.9`](zookeeper.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 2 | [`wordpress:6-php8.3-apache`](wordpress.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 3 | [`semitechnologies/weaviate:1.28.1`](weaviate.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 4 | [`victoriametrics/victoria-metrics:v1.107.0`](victoria-metrics.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 5 | [`timberio/vector:0.43.0-alpine`](vector.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 6 | [`hashicorp/vault:1.18`](vault.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 7 | [`valkey/valkey:8`](valkey.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 8 | [`louislam/uptime-kuma:1`](uptime-kuma.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 9 | [`unit:1.34.1-minimal`](unit.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 10 | [`ubuntu:24.04`](ubuntu.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 11 | [`typesense/typesense:27.1`](typesense.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 12 | [`traefik:v3.2`](traefik.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 13 | [`tomcat:10.1-jre21-temurin`](tomcat.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 14 | [`hashicorp/terraform:1.10`](terraform.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 15 | [`telegraf:1.33-alpine`](telegraf.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Best in each category
+
+The most-isolated default image in every family. Comparing like with like, a database against a database, a base OS against a base OS:
+
+| Category | Best-isolated image | Score | Grade |
+|----------|---------------------|------:|:-----:|
+| Base OS images | [`alpine:3.21`](alpine.md) | 48/100 | 🟠 **D** |
+| Language runtimes | [`eclipse-temurin:21-jre-alpine`](eclipse-temurin.md) | 48/100 | 🟠 **D** |
+| Databases, caches, and stores | [`memcached:1.6-alpine`](memcached.md) | 63/100 | 🟡 **C** |
+| Web servers, proxies, and apps | [`adminer:4.8.1`](adminer.md) | 63/100 | 🟡 **C** |
+| Platform and infra services | [`prom/alertmanager:v0.28.0`](alertmanager.md) | 63/100 | 🟡 **C** |
+
+## Full ranking, best to worst
+
+Every graded image, most-isolated first. Click any image for its per-dimension breakdown, the exact hardening flags, and a copy-paste score badge you can embed in your repo.
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`adminer:4.8.1`](adminer.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥈 2 | [`prom/alertmanager:v0.28.0`](alertmanager.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥉 3 | [`confluentinc/cp-kafka:7.8.0`](cp-kafka.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 4 | [`emqx:5`](emqx.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 5 | [`fluent/fluentd:v1.17`](fluentd.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 6 | [`grafana/grafana:11.4.0`](grafana.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 7 | [`graylog/graylog:6.1`](graylog.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 8 | [`groovy:4`](groovy.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 9 | [`haproxy:3.1-alpine`](haproxy.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 10 | [`oryd/hydra:v2.2.0`](hydra.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 11 | [`jaegertracing/jaeger:2.1.0`](jaeger.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 12 | [`jenkins/jenkins:lts`](jenkins.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 13 | [`jetty:12-jre21`](jetty.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 14 | [`apache/kafka:3.9.0`](kafka.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 15 | [`kong:3.8`](kong.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 16 | [`grafana/loki:3.3.2`](loki.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 17 | [`mailhog/mailhog:v1.0.1`](mailhog.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 18 | [`mattermost/mattermost-team-edition:10.2`](mattermost-team-edition.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 19 | [`memcached:1.6-alpine`](memcached.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 20 | [`n8nio/n8n:1.71.3`](n8n.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 21 | [`sonatype/nexus3:3.75.0`](nexus3.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 22 | [`nginxinc/nginx-unprivileged:1.27-alpine`](nginx-unprivileged.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 23 | [`prom/node-exporter:v1.8.2`](node-exporter.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 24 | [`opensearchproject/opensearch:2`](opensearch.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 25 | [`percona:8.0`](percona.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 26 | [`dpage/pgadmin4:8`](pgadmin4.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 27 | [`prom/prometheus:v3.1.0`](prometheus.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 28 | [`apachepulsar/pulsar:3.3.2`](pulsar.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 29 | [`prom/pushgateway:v1.10.0`](pushgateway.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 30 | [`redis/redisinsight:latest`](redisinsight.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 31 | [`redpandadata/redpanda:v24.2.11`](redpanda.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 32 | [`solr:9`](solr.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 33 | [`sonarqube:community`](sonarqube.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 34 | [`grafana/tempo:2.6.1`](tempo.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 35 | [`apache/tika:latest`](tika.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 36 | [`varnish:7.6-alpine`](varnish.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 37 | [`verdaccio/verdaccio:6`](verdaccio.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 38 | [`requarks/wiki:2`](wiki.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 39 | [`adguard/adguardhome:latest`](adguardhome.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 40 | [`grafana/alloy:latest`](alloy.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 41 | [`almalinux:9`](almalinux.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 42 | [`alpine:3.21`](alpine.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 43 | [`amazoncorretto:21`](amazoncorretto.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 44 | [`amazonlinux:2023`](amazonlinux.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 45 | [`arangodb:3.12`](arangodb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 46 | [`archlinux:latest`](archlinux.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 47 | [`authelia/authelia:4.38`](authelia.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 48 | [`prom/blackbox-exporter:v0.25.0`](blackbox-exporter.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 49 | [`oven/bun:1.1`](bun.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 50 | [`busybox:1.37`](busybox.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 51 | [`caddy:2-alpine`](caddy.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 52 | [`cassandra:5.0`](cassandra.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 53 | [`chromadb/chroma:0.5.23`](chroma.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 54 | [`chronograf:1.10`](chronograf.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 55 | [`clickhouse:24.8`](clickhouse.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 56 | [`clojure:temurin-21-tools-deps`](clojure.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 57 | [`cockroachdb/cockroach:latest`](cockroach.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 58 | [`hashicorp/consul:1.20`](consul.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 59 | [`couchdb:3.4`](couchdb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 60 | [`dart:3.6`](dart.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 61 | [`debian:12-slim`](debian.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 62 | [`denoland/deno:2.1.4`](deno.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 63 | [`docker:27-dind`](docker.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 64 | [`docker.dragonflydb.io/dragonflydb/dragonfly:latest`](dragonfly.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 65 | [`drone/drone:2`](drone.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 66 | [`drupal:11-apache`](drupal.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 67 | [`eclipse-mosquitto:2`](eclipse-mosquitto.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 68 | [`eclipse-temurin:21-jre-alpine`](eclipse-temurin.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 69 | [`elixir:1.18-alpine`](elixir.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 70 | [`envoyproxy/envoy:v1.32-latest`](envoy.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 71 | [`erlang:27-alpine`](erlang.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 72 | [`fedora:41`](fedora.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 73 | [`flink:1.20`](flink.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 74 | [`codeberg.org/forgejo/forgejo:9`](forgejo.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 75 | [`gcc:14`](gcc.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 76 | [`ghost:5-alpine`](ghost.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 77 | [`gitea/gitea:1.22`](gitea.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 78 | [`gogs/gogs:0.13`](gogs.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 79 | [`golang:1.23-alpine`](golang.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 80 | [`gradle:8-jdk21`](gradle.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 81 | [`haskell:9.8`](haskell.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 82 | [`httpd:2.4-alpine`](httpd.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 83 | [`influxdb:2.7-alpine`](influxdb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 84 | [`jellyfin/jellyfin:10.10.3`](jellyfin.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 85 | [`joomla:5-apache`](joomla.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 86 | [`julia:1.11`](julia.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 87 | [`kapacitor:1.7`](kapacitor.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 88 | [`eqalpha/keydb:latest`](keydb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 89 | [`opensuse/leap:15.6`](leap.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 90 | [`localstack/localstack:4`](localstack.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 91 | [`axllent/mailpit:latest`](mailpit.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 92 | [`mariadb:11`](mariadb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 93 | [`matomo:5`](matomo.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 94 | [`maven:3.9-eclipse-temurin-21`](maven.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 95 | [`mediawiki:1.43`](mediawiki.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 96 | [`getmeili/meilisearch:v1.11`](meilisearch.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 97 | [`metabase/metabase:v0.52.4`](metabase.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 98 | [`minio/minio:latest`](minio.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 99 | [`mongo:7`](mongo.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 100 | [`mongo-express:1.0`](mongo-express.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 101 | [`mysql:8.4`](mysql.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 102 | [`nats:2.10-alpine`](nats.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 103 | [`neo4j:5`](neo4j.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 104 | [`netdata/netdata:stable`](netdata.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 105 | [`nextcloud:30-apache`](nextcloud.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 106 | [`nginx:1.27-alpine`](nginx.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 107 | [`node:22-alpine`](node.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 108 | [`hashicorp/nomad:1.9`](nomad.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 109 | [`openresty/openresty:alpine`](openresty.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 110 | [`oraclelinux:9`](oraclelinux.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 111 | [`perl:5.40-slim`](perl.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 112 | [`pgvector/pgvector:pg17`](pgvector.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 113 | [`photon:5.0`](photon.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 114 | [`php:8.4-apache`](php.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 115 | [`phpmyadmin:5.2`](phpmyadmin.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 116 | [`pihole/pihole:2024.07.0`](pihole.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 117 | [`postgis/postgis:17-3.5`](postgis.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 118 | [`postgres:17-alpine`](postgres.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 119 | [`grafana/promtail:3.3.2`](promtail.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 120 | [`pypy:3.10-slim`](pypy.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 121 | [`python:3.13-alpine`](python.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 122 | [`qdrant/qdrant:v1.12.4`](qdrant.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 123 | [`questdb/questdb:8.2.1`](questdb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 124 | [`rabbitmq:4-alpine`](rabbitmq.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 125 | [`redis:7-alpine`](redis.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 126 | [`redis/redis-stack-server:7.4.0-v3`](redis-stack-server.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 127 | [`redmine:6`](redmine.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 128 | [`registry:2.8.3`](registry.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 129 | [`rethinkdb:2.4`](rethinkdb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 130 | [`rockylinux:9`](rockylinux.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 131 | [`ruby:3.4-alpine`](ruby.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 132 | [`rust:1.83-alpine`](rust.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 133 | [`scylladb/scylla:6.2`](scylla.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 134 | [`vaultwarden/server:1.32.7`](server.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 135 | [`snipe/snipe-it:v7.0.13`](snipe-it.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 136 | [`swaggerapi/swagger-ui:latest`](swagger-ui.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 137 | [`telegraf:1.33-alpine`](telegraf.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 138 | [`hashicorp/terraform:1.10`](terraform.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 139 | [`tomcat:10.1-jre21-temurin`](tomcat.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 140 | [`traefik:v3.2`](traefik.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 141 | [`typesense/typesense:27.1`](typesense.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 142 | [`ubuntu:24.04`](ubuntu.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 143 | [`unit:1.34.1-minimal`](unit.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 144 | [`louislam/uptime-kuma:1`](uptime-kuma.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 145 | [`valkey/valkey:8`](valkey.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 146 | [`hashicorp/vault:1.18`](vault.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 147 | [`timberio/vector:0.43.0-alpine`](vector.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 148 | [`victoriametrics/victoria-metrics:v1.107.0`](victoria-metrics.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 149 | [`semitechnologies/weaviate:1.28.1`](weaviate.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 150 | [`wordpress:6-php8.3-apache`](wordpress.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 151 | [`zookeeper:3.9`](zookeeper.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Move up the leaderboard
+
+Every gap on this page closes with `docker run` flags. Audit your own container, or one you maintain, with the same credential-free command that produced these grades:
+
+```bash
+brew install ironsecco/ironclaw/ironclaw
+ironctl scan my-container
+```
+
+- [Container Isolation Scores directory](index.md), every scorecard, worst-isolated first.
+- [Scan any container &rarr;](../scan.md), the full command reference.
+- [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
+- [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey.
+
+---
+
+*Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py`. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/leap.md
+++ b/docs/scores/leap.md
@@ -63,6 +63,18 @@ ironctl scan my-leap
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **leap** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/leap/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/leap/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/localstack.md
+++ b/docs/scores/localstack.md
@@ -63,6 +63,18 @@ ironctl scan my-localstack
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **localstack** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/localstack/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/localstack/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/loki.md
+++ b/docs/scores/loki.md
@@ -61,6 +61,18 @@ ironctl scan my-loki
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **loki** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/loki/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/loki/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/mailhog.md
+++ b/docs/scores/mailhog.md
@@ -61,6 +61,18 @@ ironctl scan my-mailhog
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **mailhog** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/mailhog/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/mailhog/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/mailpit.md
+++ b/docs/scores/mailpit.md
@@ -63,6 +63,18 @@ ironctl scan my-mailpit
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **mailpit** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mailpit/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mailpit/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/mariadb.md
+++ b/docs/scores/mariadb.md
@@ -63,6 +63,18 @@ ironctl scan my-mariadb
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **mariadb** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mariadb/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mariadb/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/matomo.md
+++ b/docs/scores/matomo.md
@@ -63,6 +63,18 @@ ironctl scan my-matomo
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **matomo** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/matomo/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/matomo/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/mattermost-team-edition.md
+++ b/docs/scores/mattermost-team-edition.md
@@ -61,6 +61,18 @@ ironctl scan my-mattermost-team-edition
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **mattermost team edition** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/mattermost-team-edition/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/mattermost-team-edition/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/maven.md
+++ b/docs/scores/maven.md
@@ -63,6 +63,18 @@ ironctl scan my-maven
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **maven** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/maven/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/maven/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/mediawiki.md
+++ b/docs/scores/mediawiki.md
@@ -63,6 +63,18 @@ ironctl scan my-mediawiki
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **mediawiki** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mediawiki/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mediawiki/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/meilisearch.md
+++ b/docs/scores/meilisearch.md
@@ -63,6 +63,18 @@ ironctl scan my-meilisearch
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **meilisearch** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/meilisearch/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/meilisearch/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/memcached.md
+++ b/docs/scores/memcached.md
@@ -61,6 +61,18 @@ ironctl scan my-memcached
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **memcached** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/memcached/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/memcached/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/metabase.md
+++ b/docs/scores/metabase.md
@@ -63,6 +63,18 @@ ironctl scan my-metabase
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **metabase** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/metabase/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/metabase/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/minio.md
+++ b/docs/scores/minio.md
@@ -63,6 +63,18 @@ ironctl scan my-minio
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **minio** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/minio/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/minio/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/mongo-express.md
+++ b/docs/scores/mongo-express.md
@@ -63,6 +63,18 @@ ironctl scan my-mongo-express
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **mongo express** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mongo-express/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mongo-express/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/mongo.md
+++ b/docs/scores/mongo.md
@@ -63,6 +63,18 @@ ironctl scan my-mongo
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **mongo** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mongo/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mongo/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/mysql.md
+++ b/docs/scores/mysql.md
@@ -63,6 +63,18 @@ ironctl scan my-mysql
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **mysql** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mysql/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/mysql/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/n8n.md
+++ b/docs/scores/n8n.md
@@ -61,6 +61,18 @@ ironctl scan my-n8n
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **n8n** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/n8n/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/n8n/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/nats.md
+++ b/docs/scores/nats.md
@@ -63,6 +63,18 @@ ironctl scan my-nats
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **nats** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/nats/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/nats/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/neo4j.md
+++ b/docs/scores/neo4j.md
@@ -63,6 +63,18 @@ ironctl scan my-neo4j
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **neo4j** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/neo4j/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/neo4j/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/netdata.md
+++ b/docs/scores/netdata.md
@@ -63,6 +63,18 @@ ironctl scan my-netdata
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **netdata** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/netdata/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/netdata/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/nextcloud.md
+++ b/docs/scores/nextcloud.md
@@ -63,6 +63,18 @@ ironctl scan my-nextcloud
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **nextcloud** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/nextcloud/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/nextcloud/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/nexus3.md
+++ b/docs/scores/nexus3.md
@@ -61,6 +61,18 @@ ironctl scan my-nexus3
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **nexus3** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/nexus3/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/nexus3/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/nginx-unprivileged.md
+++ b/docs/scores/nginx-unprivileged.md
@@ -61,6 +61,18 @@ ironctl scan my-nginx-unprivileged
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **nginx unprivileged** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/nginx-unprivileged/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/nginx-unprivileged/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/nginx.md
+++ b/docs/scores/nginx.md
@@ -63,6 +63,18 @@ ironctl scan my-nginx
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **nginx** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/nginx/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/nginx/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/node-exporter.md
+++ b/docs/scores/node-exporter.md
@@ -61,6 +61,18 @@ ironctl scan my-node-exporter
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **node exporter** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/node-exporter/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/node-exporter/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/node.md
+++ b/docs/scores/node.md
@@ -63,6 +63,18 @@ ironctl scan my-node
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **node** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/node/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/node/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/nomad.md
+++ b/docs/scores/nomad.md
@@ -63,6 +63,18 @@ ironctl scan my-nomad
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **nomad** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/nomad/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/nomad/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/openresty.md
+++ b/docs/scores/openresty.md
@@ -63,6 +63,18 @@ ironctl scan my-openresty
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **openresty** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/openresty/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/openresty/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/opensearch.md
+++ b/docs/scores/opensearch.md
@@ -61,6 +61,18 @@ ironctl scan my-opensearch
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **opensearch** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/opensearch/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/opensearch/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/oraclelinux.md
+++ b/docs/scores/oraclelinux.md
@@ -63,6 +63,18 @@ ironctl scan my-oraclelinux
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **oraclelinux** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/oraclelinux/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/oraclelinux/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/percona.md
+++ b/docs/scores/percona.md
@@ -61,6 +61,18 @@ ironctl scan my-percona
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **percona** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/percona/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/percona/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/perl.md
+++ b/docs/scores/perl.md
@@ -63,6 +63,18 @@ ironctl scan my-perl
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **perl** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/perl/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/perl/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/pgadmin4.md
+++ b/docs/scores/pgadmin4.md
@@ -61,6 +61,18 @@ ironctl scan my-pgadmin4
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **pgadmin4** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/pgadmin4/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/pgadmin4/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/pgvector.md
+++ b/docs/scores/pgvector.md
@@ -63,6 +63,18 @@ ironctl scan my-pgvector
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **pgvector** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/pgvector/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/pgvector/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/photon.md
+++ b/docs/scores/photon.md
@@ -63,6 +63,18 @@ ironctl scan my-photon
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **photon** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/photon/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/photon/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/php.md
+++ b/docs/scores/php.md
@@ -63,6 +63,18 @@ ironctl scan my-php
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **php** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/php/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/php/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/phpmyadmin.md
+++ b/docs/scores/phpmyadmin.md
@@ -63,6 +63,18 @@ ironctl scan my-phpmyadmin
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **phpmyadmin** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/phpmyadmin/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/phpmyadmin/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/pihole.md
+++ b/docs/scores/pihole.md
@@ -63,6 +63,18 @@ ironctl scan my-pihole
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **pihole** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/pihole/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/pihole/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/postgis.md
+++ b/docs/scores/postgis.md
@@ -63,6 +63,18 @@ ironctl scan my-postgis
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **postgis** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/postgis/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/postgis/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/postgres.md
+++ b/docs/scores/postgres.md
@@ -63,6 +63,18 @@ ironctl scan my-postgres
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **postgres** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/postgres/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/postgres/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/prometheus.md
+++ b/docs/scores/prometheus.md
@@ -61,6 +61,18 @@ ironctl scan my-prometheus
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **prometheus** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/prometheus/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/prometheus/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/promtail.md
+++ b/docs/scores/promtail.md
@@ -63,6 +63,18 @@ ironctl scan my-promtail
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **promtail** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/promtail/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/promtail/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/pulsar.md
+++ b/docs/scores/pulsar.md
@@ -61,6 +61,18 @@ ironctl scan my-pulsar
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **pulsar** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/pulsar/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/pulsar/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/pushgateway.md
+++ b/docs/scores/pushgateway.md
@@ -61,6 +61,18 @@ ironctl scan my-pushgateway
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **pushgateway** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/pushgateway/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/pushgateway/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/pypy.md
+++ b/docs/scores/pypy.md
@@ -63,6 +63,18 @@ ironctl scan my-pypy
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **pypy** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/pypy/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/pypy/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/python.md
+++ b/docs/scores/python.md
@@ -63,6 +63,18 @@ ironctl scan my-python
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **python** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/python/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/python/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/qdrant.md
+++ b/docs/scores/qdrant.md
@@ -63,6 +63,18 @@ ironctl scan my-qdrant
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **qdrant** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/qdrant/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/qdrant/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/questdb.md
+++ b/docs/scores/questdb.md
@@ -63,6 +63,18 @@ ironctl scan my-questdb
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **questdb** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/questdb/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/questdb/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/rabbitmq.md
+++ b/docs/scores/rabbitmq.md
@@ -63,6 +63,18 @@ ironctl scan my-rabbitmq
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **rabbitmq** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/rabbitmq/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/rabbitmq/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/redis-stack-server.md
+++ b/docs/scores/redis-stack-server.md
@@ -63,6 +63,18 @@ ironctl scan my-redis-stack-server
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **redis stack server** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/redis-stack-server/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/redis-stack-server/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/redis.md
+++ b/docs/scores/redis.md
@@ -63,6 +63,18 @@ ironctl scan my-redis
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **redis** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/redis/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/redis/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/redisinsight.md
+++ b/docs/scores/redisinsight.md
@@ -61,6 +61,18 @@ ironctl scan my-redisinsight
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **redisinsight** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/redisinsight/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/redisinsight/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/redmine.md
+++ b/docs/scores/redmine.md
@@ -63,6 +63,18 @@ ironctl scan my-redmine
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **redmine** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/redmine/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/redmine/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/redpanda.md
+++ b/docs/scores/redpanda.md
@@ -61,6 +61,18 @@ ironctl scan my-redpanda
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **redpanda** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/redpanda/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/redpanda/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/registry.md
+++ b/docs/scores/registry.md
@@ -63,6 +63,18 @@ ironctl scan my-registry
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **registry** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/registry/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/registry/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/rethinkdb.md
+++ b/docs/scores/rethinkdb.md
@@ -63,6 +63,18 @@ ironctl scan my-rethinkdb
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **rethinkdb** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/rethinkdb/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/rethinkdb/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/rockylinux.md
+++ b/docs/scores/rockylinux.md
@@ -63,6 +63,18 @@ ironctl scan my-rockylinux
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **rockylinux** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/rockylinux/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/rockylinux/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/ruby.md
+++ b/docs/scores/ruby.md
@@ -63,6 +63,18 @@ ironctl scan my-ruby
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **ruby** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/ruby/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/ruby/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/rust.md
+++ b/docs/scores/rust.md
@@ -63,6 +63,18 @@ ironctl scan my-rust
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **rust** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/rust/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/rust/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/scylla.md
+++ b/docs/scores/scylla.md
@@ -63,6 +63,18 @@ ironctl scan my-scylla
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **scylla** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/scylla/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/scylla/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/server.md
+++ b/docs/scores/server.md
@@ -63,6 +63,18 @@ ironctl scan my-server
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **server** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/server/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/server/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/snipe-it.md
+++ b/docs/scores/snipe-it.md
@@ -63,6 +63,18 @@ ironctl scan my-snipe-it
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **snipe it** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/snipe-it/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/snipe-it/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/solr.md
+++ b/docs/scores/solr.md
@@ -61,6 +61,18 @@ ironctl scan my-solr
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **solr** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/solr/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/solr/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/sonarqube.md
+++ b/docs/scores/sonarqube.md
@@ -61,6 +61,18 @@ ironctl scan my-sonarqube
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **sonarqube** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/sonarqube/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/sonarqube/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/swagger-ui.md
+++ b/docs/scores/swagger-ui.md
@@ -63,6 +63,18 @@ ironctl scan my-swagger-ui
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **swagger ui** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/swagger-ui/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/swagger-ui/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/telegraf.md
+++ b/docs/scores/telegraf.md
@@ -63,6 +63,18 @@ ironctl scan my-telegraf
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **telegraf** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/telegraf/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/telegraf/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/tempo.md
+++ b/docs/scores/tempo.md
@@ -61,6 +61,18 @@ ironctl scan my-tempo
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **tempo** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/tempo/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/tempo/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/terraform.md
+++ b/docs/scores/terraform.md
@@ -63,6 +63,18 @@ ironctl scan my-terraform
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **terraform** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/terraform/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/terraform/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/tika.md
+++ b/docs/scores/tika.md
@@ -61,6 +61,18 @@ ironctl scan my-tika
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **tika** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/tika/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/tika/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/tomcat.md
+++ b/docs/scores/tomcat.md
@@ -63,6 +63,18 @@ ironctl scan my-tomcat
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **tomcat** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/tomcat/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/tomcat/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/traefik.md
+++ b/docs/scores/traefik.md
@@ -63,6 +63,18 @@ ironctl scan my-traefik
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **traefik** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/traefik/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/traefik/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/typesense.md
+++ b/docs/scores/typesense.md
@@ -63,6 +63,18 @@ ironctl scan my-typesense
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **typesense** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/typesense/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/typesense/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/ubuntu.md
+++ b/docs/scores/ubuntu.md
@@ -63,6 +63,18 @@ ironctl scan my-ubuntu
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **ubuntu** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/ubuntu/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/ubuntu/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/unit.md
+++ b/docs/scores/unit.md
@@ -63,6 +63,18 @@ ironctl scan my-unit
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **unit** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/unit/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/unit/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/uptime-kuma.md
+++ b/docs/scores/uptime-kuma.md
@@ -63,6 +63,18 @@ ironctl scan my-uptime-kuma
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **uptime kuma** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/uptime-kuma/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/uptime-kuma/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/valkey.md
+++ b/docs/scores/valkey.md
@@ -63,6 +63,18 @@ ironctl scan my-valkey
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **valkey** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/valkey/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/valkey/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/varnish.md
+++ b/docs/scores/varnish.md
@@ -61,6 +61,18 @@ ironctl scan my-varnish
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **varnish** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/varnish/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/varnish/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/vault.md
+++ b/docs/scores/vault.md
@@ -63,6 +63,18 @@ ironctl scan my-vault
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **vault** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/vault/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/vault/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/vector.md
+++ b/docs/scores/vector.md
@@ -63,6 +63,18 @@ ironctl scan my-vector
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **vector** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/vector/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/vector/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/verdaccio.md
+++ b/docs/scores/verdaccio.md
@@ -61,6 +61,18 @@ ironctl scan my-verdaccio
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **verdaccio** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/verdaccio/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/verdaccio/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/victoria-metrics.md
+++ b/docs/scores/victoria-metrics.md
@@ -63,6 +63,18 @@ ironctl scan my-victoria-metrics
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **victoria metrics** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/victoria-metrics/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/victoria-metrics/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/weaviate.md
+++ b/docs/scores/weaviate.md
@@ -63,6 +63,18 @@ ironctl scan my-weaviate
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **weaviate** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/weaviate/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/weaviate/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/wiki.md
+++ b/docs/scores/wiki.md
@@ -61,6 +61,18 @@ ironctl scan my-wiki
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **wiki** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/wiki/)
+
+```markdown
+[![Container Isolation Score: 63/100 C](https://img.shields.io/badge/container%20isolation-63%2F100%20C-d4a72c)](https://ironsecco.github.io/ironclaw/scores/wiki/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/wordpress.md
+++ b/docs/scores/wordpress.md
@@ -63,6 +63,18 @@ ironctl scan my-wordpress
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **wordpress** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/wordpress/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/wordpress/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/docs/scores/zookeeper.md
+++ b/docs/scores/zookeeper.md
@@ -63,6 +63,18 @@ ironctl scan my-zookeeper
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey this directory is built from.
 - [Run untrusted code in a real sandbox &rarr;](../index.md), IronClaw wraps every AI-agent session in a gVisor/Kata isolation boundary with `network=none` by default.
 
+## Badge this image
+
+Maintain **zookeeper** (or run it)? Show its default-config isolation score with a badge that links back to this scorecard:
+
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/zookeeper/)
+
+```markdown
+[![Container Isolation Score: 48/100 D](https://img.shields.io/badge/container%20isolation-48%2F100%20D-e8873a)](https://ironsecco.github.io/ironclaw/scores/zookeeper/)
+```
+
+The badge is a plain [shields.io](https://shields.io) URL: no server, no build step, nothing to host. It reflects this page's default-configuration grade. Hardened your own deployment? Generate a live badge of *your* config with [`ironctl scan --badge-json`](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every image on the [leaderboard](leaderboard.md).
+
 ---
 
 *Part of the [Container Isolation Scores](index.md) directory, default-configuration containment grades for the most-pulled public images.*

--- a/examples/isolation-survey/gen_scorecards.py
+++ b/examples/isolation-survey/gen_scorecards.py
@@ -75,6 +75,40 @@ GRADE_WORD = {
 GRADE_EMOJI = {"A": "🟢", "B": "🟢", "C": "🟡", "D": "🟠", "F": "🔴"}
 VERDICT_MARK = {"PASS": "✅", "WARN": "⚠️", "FAIL": "❌", "UNKNOWN": "❌"}
 
+# Grade -> shields.io color (6-hex, no leading '#'). Mirrors gradeColor() in
+# internal/host/scan/render.go so the committed per-image badges match the
+# `ironctl scan --badge-json` palette exactly.
+GRADE_COLOR = {"A": "3fb950", "B": "9acd32", "C": "d4a72c", "D": "e8873a", "F": "d1242f"}
+
+# Published site root (mkdocs site_url). Per-image scorecard pages live at
+# `${SITE_URL}/scores/<slug>/`; the embeddable badge links back here so a
+# maintainer who badges their repo hands us an inbound backlink (IRO-459).
+SITE_URL = "https://ironsecco.github.io/ironclaw"
+
+
+def scorecard_url(slug: str) -> str:
+    """Canonical published URL for an image's scorecard page."""
+    return f"{SITE_URL}/scores/{slug}/"
+
+
+def badge_url(score: int, grade: str) -> str:
+    """A committed-file-free shields.io STATIC badge for an image's default score.
+
+    No server and no per-image JSON file: shields renders the score straight from
+    the URL, colored to match `ironctl scan --badge-json`. `/` and space are
+    percent-escaped; the message carries no literal dash/underscore so shields'
+    `--`/`__` escaping is not needed.
+    """
+    color = GRADE_COLOR.get(grade, GRADE_COLOR["F"])
+    return (f"https://img.shields.io/badge/"
+            f"container%20isolation-{score}%2F100%20{grade}-{color}")
+
+
+def badge_markdown(slug: str, score: int, grade: str) -> str:
+    """Copy-paste markdown: the shields badge wrapped in a link to the scorecard."""
+    alt = f"Container Isolation Score: {score}/100 {grade}"
+    return f"[![{alt}]({badge_url(score, grade)})]({scorecard_url(slug)})"
+
 # Category facet for the /scores explorer chips (IRO-450 SPEC §5 `family`).
 # Values: web|database|runtime|base|infra. Keyed by image slug; explicit so the
 # machine JSON stays deterministic and reviewable. Unmapped slugs fall back to
@@ -307,6 +341,29 @@ def render_page(scn: dict) -> str:
              "IronClaw wraps every AI-agent session in a gVisor/Kata isolation "
              "boundary with `network=none` by default.")
     L.append("")
+
+    # Embeddable badge. A committed-file-free shields.io static badge maintainers
+    # can paste into their README; clicking it lands here, an inbound backlink
+    # (IRO-459). Rendered live + as a copy-paste markdown snippet.
+    L.append("## Badge this image")
+    L.append("")
+    L.append(f"Maintain **{name}** (or run it)? Show its default-config isolation "
+             f"score with a badge that links back to this scorecard:")
+    L.append("")
+    L.append(badge_markdown(slug, score, grade))
+    L.append("")
+    L.append("```markdown")
+    L.append(badge_markdown(slug, score, grade))
+    L.append("```")
+    L.append("")
+    L.append("The badge is a plain [shields.io](https://shields.io) URL: no server, "
+             "no build step, nothing to host. It reflects this page's "
+             "default-configuration grade. Hardened your own deployment? Generate a "
+             "live badge of *your* config with "
+             "[`ironctl scan --badge-json`](../blog/"
+             "add-a-sandbox-isolation-score-badge-to-your-repo.md), or compare every "
+             "image on the [leaderboard](leaderboard.md).")
+    L.append("")
     L.append("---")
     L.append("")
     L.append("*Part of the [Container Isolation Scores](index.md) directory — "
@@ -353,6 +410,11 @@ def render_index(defaults: list) -> str:
              "`brew install ironsecco/ironclaw/ironclaw && ironctl scan my-container`. "
              "See [Scan any container](../scan.md).")
     L.append("")
+    L.append("> **New:** the [Container Isolation Leaderboard](leaderboard.md) ranks "
+             "every image best-to-worst, with a Hall of Fame and a Worst-offenders "
+             "cut. Each scorecard now carries a copy-paste "
+             "[shields.io badge](leaderboard.md) you can embed in your repo.")
+    L.append("")
     L.append("## Every image, worst-isolated first")
     L.append("")
     L.append("| Image | Score | Grade | Top gaps (default config) |")
@@ -397,6 +459,172 @@ def render_index(defaults: list) -> str:
     return "\n".join(L)
 
 
+# Family slug -> human label for the leaderboard's grouped cut.
+FAMILY_LABEL = {
+    "base": "Base OS images",
+    "runtime": "Language runtimes",
+    "database": "Databases, caches, and stores",
+    "web": "Web servers, proxies, and apps",
+    "infra": "Platform and infra services",
+}
+MEDAL = {1: "🥇", 2: "🥈", 3: "🥉"}
+
+
+def _leaderboard_row(rank, scn, medals=True):
+    """One `| rank | image | score | grade | gaps |` row for a leaderboard table.
+    Medals decorate the top three only when `medals` is set (best-first tables);
+    the worst-offenders table passes medals=False so a gold medal never lands on
+    the least-isolated image."""
+    rep = scn["report"]
+    slug = slug_for(scn["image"])
+    grade = rep.get("grade", "?")
+    emoji = GRADE_EMOJI.get(grade, "")
+    medal = MEDAL.get(rank, "") if medals else ""
+    gaps = ", ".join(t for t, _, _ in top_fixes(rep, 3)) or "none, fully hardened"
+    img = scn["image"].split("@")[0]
+    rank_cell = f"{medal} {rank}".strip()
+    return (f"| {rank_cell} | [`{img}`]({slug}.md) | {rep.get('score',0)}/100 | "
+            f"{emoji} **{grade}** | {gaps} |")
+
+
+def render_leaderboard(defaults: list) -> str:
+    """The ranked, shareable leaderboard: best-to-worst, plus a Hall of Fame,
+    a Worst-offenders cut, and a best-in-category group. Generated from the same
+    scenarios as the scorecards, so the weekly refresh keeps it in sync.
+    """
+    # Best-first, ties broken by slug for determinism.
+    rows = sorted(defaults, key=lambda s: (-s["report"].get("score", 0), slug_for(s["image"])))
+    total = len(rows)
+    avg = round(sum(s["report"].get("score", 0) for s in rows) / total) if total else 0
+    best = rows[0]["report"].get("score", 0) if rows else 0
+    worst = rows[-1]["report"].get("score", 0) if rows else 0
+
+    # Hall of Fame: any grade-A defaults if they exist, else the top decile
+    # (min 5, capped at 15). Worst offenders: the mirror-image bottom cut.
+    cut = max(5, min(15, total // 10))
+    grade_a = [s for s in rows if s["report"].get("grade") == "A"]
+    hall = grade_a if grade_a else rows[:cut]
+    worst_off = list(reversed(rows[-cut:]))  # worst first
+
+    L = []
+    L.append("---")
+    L.append('title: "Container Isolation Leaderboard: the most (and least) isolated Docker images"')
+    L.append("description: A ranked leaderboard of the default container isolation "
+             f"score for {total} of the most-pulled public Docker images, graded "
+             "0-100 by ironctl scan. Hall of Fame and worst offenders included.")
+    L.append("---")
+    L.append("")
+    L.append("# Container Isolation Leaderboard")
+    L.append("")
+    L.append(f"Every one of **{total} of the most-pulled public Docker images**, "
+             f"ranked by how isolated it is when you `docker run` it with plain "
+             f"defaults, no hardening flags. Scores run **{worst}/100 to {best}/100** "
+             f"(average **{avg}/100**), graded across IronClaw's seven containment "
+             f"dimensions by `ironctl scan`. Higher is safer. Regenerated with the "
+             f"[weekly survey refresh](index.md), so this ranking never goes stale.")
+    L.append("")
+    L.append("> The uncomfortable headline: **no popular image ships isolated.** "
+             "Even the leaders leave capabilities, egress, and a writable root "
+             "filesystem wide open. The gap between any image here and a clean "
+             "**100/100 grade A** is a handful of `docker run` flags, shown on every "
+             "scorecard.")
+    L.append("")
+
+    # Hall of Fame.
+    L.append("## 🏆 Hall of Fame")
+    L.append("")
+    if grade_a:
+        L.append("Images that reach **grade A (100/100)** in their default "
+                 "configuration, out of the box:")
+    else:
+        L.append(f"No image ships at grade A, so this is the next best thing: the "
+                 f"**{len(hall)} best-isolated images by default**, the ones that "
+                 f"start you closest to a hardened posture.")
+    L.append("")
+    L.append("| Rank | Image | Score | Grade | Remaining gaps (default config) |")
+    L.append("|-----:|-------|------:|:-----:|---------------------------------|")
+    for i, s in enumerate(hall, 1):
+        L.append(_leaderboard_row(i, s))
+    L.append("")
+
+    # Worst offenders.
+    L.append("## 🚨 Worst offenders")
+    L.append("")
+    L.append(f"The **{len(worst_off)} least-isolated images** in the survey. Pulling "
+             f"one of these unhardened puts a container escape one step from host "
+             f"uid 0. Each links to the exact flags that fix it.")
+    L.append("")
+    L.append("| # | Image | Score | Grade | Top gaps (default config) |")
+    L.append("|--:|-------|------:|:-----:|---------------------------|")
+    for i, s in enumerate(worst_off, 1):
+        L.append(_leaderboard_row(i, s, medals=False))
+    L.append("")
+
+    # Best-in-category grouped cut.
+    L.append("## Best in each category")
+    L.append("")
+    L.append("The most-isolated default image in every family. Comparing like with "
+             "like, a database against a database, a base OS against a base OS:")
+    L.append("")
+    L.append("| Category | Best-isolated image | Score | Grade |")
+    L.append("|----------|---------------------|------:|:-----:|")
+    for fam in ("base", "runtime", "database", "web", "infra"):
+        fam_rows = [s for s in rows if family_for(slug_for(s["image"])) == fam]
+        if not fam_rows:
+            continue
+        top = fam_rows[0]  # rows already best-first
+        rep = top["report"]
+        slug = slug_for(top["image"])
+        grade = rep.get("grade", "?")
+        emoji = GRADE_EMOJI.get(grade, "")
+        img = top["image"].split("@")[0]
+        L.append(f"| {FAMILY_LABEL[fam]} | [`{img}`]({slug}.md) | "
+                 f"{rep.get('score',0)}/100 | {emoji} **{grade}** |")
+    L.append("")
+
+    # Full ranking.
+    L.append("## Full ranking, best to worst")
+    L.append("")
+    L.append("Every graded image, most-isolated first. Click any image for its "
+             "per-dimension breakdown, the exact hardening flags, and a copy-paste "
+             "score badge you can embed in your repo.")
+    L.append("")
+    L.append("| Rank | Image | Score | Grade | Top gaps (default config) |")
+    L.append("|-----:|-------|------:|:-----:|---------------------------|")
+    for i, s in enumerate(rows, 1):
+        L.append(_leaderboard_row(i, s))
+    L.append("")
+
+    # CTA / cross-links.
+    L.append("## Move up the leaderboard")
+    L.append("")
+    L.append("Every gap on this page closes with `docker run` flags. Audit your own "
+             "container, or one you maintain, with the same credential-free command "
+             "that produced these grades:")
+    L.append("")
+    L.append("```bash")
+    L.append("brew install ironsecco/ironclaw/ironclaw")
+    L.append("ironctl scan my-container")
+    L.append("```")
+    L.append("")
+    L.append("- [Container Isolation Scores directory](index.md) — every scorecard, "
+             "worst-isolated first.")
+    L.append("- [Scan any container &rarr;](../scan.md) — the full command reference.")
+    L.append("- [Add an isolation-score badge to your repo &rarr;]"
+             "(../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)")
+    L.append("- [The State of Container Isolation, 2026 &rarr;]"
+             "(../blog/state-of-container-isolation-2026.md) — the full survey.")
+    L.append("")
+    L.append("---")
+    L.append("")
+    L.append("*Generated from a reproducible survey by "
+             "`examples/isolation-survey/gen_scorecards.py`. Grades reflect each "
+             "image's default configuration, not a limit of the image itself: every "
+             "one reaches grade A with the right `docker run` flags.*")
+    L.append("")
+    return "\n".join(L)
+
+
 def image_row(scn: dict) -> dict:
     """One machine-readable image record for index.json (SPEC §5 images[])."""
     rep = scn["report"]
@@ -431,6 +659,12 @@ def image_row(scn: dict) -> dict:
         "hardenedGrade": "A",
         "hardenedFlags": list(HARDENED_FLAGS),
         "hardenedCommand": hardened_command,
+        # Embeddable shields.io badge for this image (IRO-459). Server-free static
+        # URL + copy-paste markdown that links back to the scorecard page, so the
+        # explorer can render the same copy affordance as the .md scorecard.
+        "pageUrl": scorecard_url(slug),
+        "badgeUrl": badge_url(score, grade),
+        "badgeMarkdown": badge_markdown(slug, score, grade),
     }
 
 
@@ -494,6 +728,8 @@ def main():
             f.write(no_dashes(render_page(scn)))
     with open(os.path.join(out_dir, "index.md"), "w") as f:
         f.write(no_dashes(render_index(list(pages.values()))))
+    with open(os.path.join(out_dir, "leaderboard.md"), "w") as f:
+        f.write(no_dashes(render_leaderboard(list(pages.values()))))
 
     # Machine-readable index for the /scores explorer (IRO-450/451, SPEC §5).
     # Emitted next to the .md files so it publishes with the docs site and is
@@ -504,8 +740,8 @@ def main():
         json.dump(index, f, indent=2, ensure_ascii=False)
         f.write("\n")
 
-    print(f"wrote {len(pages)} scorecard pages + index.md + index.json "
-          f"({index['meta']['imageCount']} images) to {out_dir}")
+    print(f"wrote {len(pages)} scorecard pages + index.md + leaderboard.md + "
+          f"index.json ({index['meta']['imageCount']} images) to {out_dir}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Deepen the scores wedge by turning the auto-refreshing 151-image container isolation dataset into a non-gated discovery loop (IRO-459). All generated from `gen_scorecards.py`, so the weekly `scores-refresh` action keeps everything in sync.

### 1. Ranked leaderboard — `docs/scores/leaderboard.md`
- Full ranking, best-to-worst, medals on the top three.
- **🏆 Hall of Fame**: grade-A defaults if any exist, else the top decile (the images closest to hardened out of the box).
- **🚨 Worst offenders**: the least-isolated images (no medals, so a gold never lands on the worst).
- **Best in each category**: the top image per family (base / runtime / database / web / infra) for a like-with-like cut.
- SEO/shareable framing; regenerated with the weekly refresh.

### 2. Per-image embeddable badge
- Every scorecard gains a **Badge this image** section: a live shields.io badge + copy-paste markdown snippet.
- Committed-file-free **static** shields URL (no server, no per-image JSON), palette mirrors `ironctl scan --badge-json`.
- Badge links back to the scorecard page → base-image maintainers who badge their repo hand us an inbound backlink.
- `index.json` now carries `pageUrl` / `badgeUrl` / `badgeMarkdown` per image so the `/scores` explorer (IRO-451) can render the same affordance.

### 3. Committed-file-hosted, guardrail-safe
- No server. No em/en-dashes (IRO-254). `mkdocs build --strict` passes (exit 0).

### 4. Cross-links
- Leaderboard linked from the scores intro (`index.md`), `scan.md` (both callouts), and pinned in `docs/scores/.nav.yml`.

## Verification
- `python3 examples/isolation-survey/gen_scorecards.py results.json docs/scores` → 151 scorecards + index.md + **leaderboard.md** + index.json.
- `mkdocs build --strict` → exit 0, leaderboard + badges render.
- No em/en-dashes in any published doc.