### PR TITLE
feat(scan): `ironctl scan --compare A B` side-by-side isolation diff (IRO-468)

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -35,6 +35,7 @@ func cmdScan(args []string) error {
 	md := fs.Bool("md", false, "print a shareable markdown block (README/blog section)")
 	fix := fs.Bool("fix", false, "emit concrete remediation config for each failed dimension")
 	remediate := fs.Bool("remediate", false, "alias for --fix")
+	compareFlag := fs.Bool("compare", false, "compare two containers side-by-side (takes two positional targets)")
 	compose := fs.String("compose", "", "grade a service in this docker-compose file")
 	service := fs.String("service", "", "compose service name (required if the file has >1 service)")
 	k8s := fs.String("k8s", "", "grade the first container in this Kubernetes pod/workload manifest")
@@ -59,6 +60,19 @@ func cmdScan(args []string) error {
 		}
 		positional = append(positional, rest[0])
 		rest = rest[1:]
+	}
+
+	// --compare A B: grade two live containers and print a side-by-side diff.
+	// Reuses the same adapters and scorer as a single scan; only the presentation
+	// differs, so it returns early with its own renderers.
+	if *compareFlag {
+		return runCompare(compareArgs{
+			targets: positional,
+			runtime: *runtime,
+			bins:    runtimeBins{docker: *dockerBin, podman: *podmanBin, nerdctl: *nerdctlBin},
+			asJSON:  *asJSON,
+			md:      *md,
+		})
 	}
 
 	// Resolve the source and build a normalized Spec. configFile/configRaw carry
@@ -161,6 +175,57 @@ func cmdScan(args []string) error {
 	// CI gate: fail-closed below the requested threshold.
 	if *minScore > 0 && report.Score < *minScore {
 		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, *minScore)
+	}
+	return nil
+}
+
+// compareArgs carries the resolved inputs for a `scan --compare` run.
+type compareArgs struct {
+	targets []string
+	runtime string
+	bins    runtimeBins
+	asJSON  bool
+	md      bool
+}
+
+// runCompare grades exactly two live containers and prints a side-by-side diff.
+// It reuses containerSpec (the same docker/podman/nerdctl adapters as a single
+// scan) and scan.Score, then defers to the comparison renderers. It fails closed:
+// if either target cannot be inspected, the whole compare errors rather than
+// printing a half diff.
+func runCompare(a compareArgs) error {
+	if len(a.targets) != 2 {
+		scanUsage(os.Stderr)
+		return fmt.Errorf("scan --compare needs exactly two targets; got %d", len(a.targets))
+	}
+	if a.targets[0] == a.targets[1] {
+		return fmt.Errorf("scan --compare needs two distinct targets; both are %q", a.targets[0])
+	}
+
+	reports := make([]scan.Report, 2)
+	for i, target := range a.targets {
+		spec, err := containerSpec(a.runtime, a.bins, target)
+		if err != nil {
+			return fmt.Errorf("scan target %q: %w", target, err)
+		}
+		r := scan.Score(spec)
+		r.Version = version.String()
+		r.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+		reports[i] = r
+	}
+
+	cmp := scan.Compare(reports[0], reports[1])
+	switch {
+	case a.asJSON:
+		if err := scan.RenderComparisonJSON(os.Stdout, cmp); err != nil {
+			return err
+		}
+	default:
+		scan.RenderComparisonTable(os.Stdout, cmp)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderComparisonMarkdown(cmp))
 	}
 	return nil
 }
@@ -281,9 +346,11 @@ USAGE:
   ironctl scan <container>                    grade a running container (docker|podman|nerdctl)
   ironctl scan --compose FILE [--service N]   grade a docker-compose service
   ironctl scan --k8s FILE                     grade a Kubernetes pod/workload manifest
+  ironctl scan --compare A B                   diff two containers' isolation posture
 
 FLAGS:
   --runtime NAME      container runtime: auto|docker|podman|nerdctl (default: auto)
+  --compare           compare two positional targets side-by-side (score/verdict diff)
   --json              emit the scorecard as JSON
   --fix               emit concrete remediation config for each failed dimension
   --remediate         alias for --fix

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -105,7 +105,46 @@ the runtime name. The dimension scorers remain the authority on the score.
 | `--badge-json badge.json` | a [shields.io endpoint](https://shields.io/badges/endpoint-badge) JSON file for a live, self-updating README badge |
 | `--sarif scan.sarif` | a SARIF 2.1.0 log you can upload to GitHub code scanning (findings land in the repo Security tab) |
 | `--md` | a shareable markdown block for a README or blog post |
+| `--compare A B` | grade two containers and print a side-by-side isolation-posture diff |
 | `--min-score N` | exit non-zero when the score is below N (a CI gate) |
+
+## Compare two containers
+
+`--compare` grades two running containers and prints a side-by-side diff: each of
+the seven dimensions with both scores, a per-dimension winner marker, the overall
+grade and point delta, and a one-line verdict naming the more hardened target and
+why. It reuses the same adapters and scorer as a single scan, so the numbers match
+what `ironctl scan <container>` reports for each side.
+
+Use it to pick a base image (alpine vs distroless), to prove a hardening change
+moved the needle, or to generate the data behind an "X vs Y container isolation"
+comparison page.
+
+```bash
+ironctl scan --compare my-hardened-ctr my-default-ctr
+```
+
+```
+IronClaw containment scan: comparison
+
+  A: my-hardened-ctr (docker)  90/100 grade A
+  B: my-default-ctr (docker)  40/100 grade F
+
+DIMENSION                   A          B         WINNER
+Non-root user (uid != 0)    [+] 15/15  [x] 0/15  < A
+Dropped capabilities        [+] 20/20  [x] 4/20  < A
+...
+OVERALL                     90/100 A   40/100 F  A (+50)
+
+  Verdict: A (`my-hardened-ctr`) is more hardened: 90/100 (grade A) vs 40/100
+  (grade F), a 50-point lead; it leads on Dropped capabilities, ...
+```
+
+Add `--json` for the machine-readable diff (each side is a full scan report under
+`a`/`b`, plus a `dimensions` delta array, `scoreDelta`, `winner`, and `verdict`),
+or `--md` for a markdown table you can drop straight into a blog post or README.
+The two targets must be distinct; either target failing to inspect fails the whole
+compare (fail-closed) rather than printing a half diff.
 
 ## Sandbox Isolation Score badge
 

--- a/internal/host/scan/compare.go
+++ b/internal/host/scan/compare.go
@@ -1,0 +1,325 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/tabwriter"
+)
+
+// Side identifies which of the two compared targets won a dimension (or the
+// overall grade). "tie" is a real outcome: two equally-hardened targets.
+type Side string
+
+const (
+	SideA   Side = "A"
+	SideB   Side = "B"
+	SideTie Side = "tie"
+)
+
+// DimensionDelta is the per-dimension diff between the two compared reports. Both
+// sides share the same scorer set, so Key/Title/Max are common; only the earned
+// score and verdict differ.
+type DimensionDelta struct {
+	Key      string  `json:"key"`
+	Title    string  `json:"title"`
+	Max      int     `json:"max"`
+	AScore   int     `json:"aScore"`
+	BScore   int     `json:"bScore"`
+	AVerdict Verdict `json:"aVerdict"`
+	BVerdict Verdict `json:"bVerdict"`
+	// Winner is the side that scored higher on THIS dimension (SideTie if equal).
+	Winner Side `json:"winner"`
+}
+
+// Comparison is the full side-by-side diff of two scorecards. It is derived
+// purely from two Reports: no I/O, deterministic for a given pair.
+type Comparison struct {
+	A          Report           `json:"a"`
+	B          Report           `json:"b"`
+	Dimensions []DimensionDelta `json:"dimensions"`
+	// ScoreDelta is A.Score - B.Score (positive means A is more hardened).
+	ScoreDelta int `json:"scoreDelta"`
+	// Winner is the more-hardened side overall (higher total score; SideTie if
+	// the totals match).
+	Winner Side `json:"winner"`
+	// Verdict is a one-line human summary naming the winner and why.
+	Verdict string `json:"verdict"`
+}
+
+// Compare diffs two scorecards dimension-by-dimension and picks an overall
+// winner. It aligns dimensions by Key (both reports come from the same scorer
+// set, so the order already matches, but aligning by key is robust to either
+// report being built differently). Ordering follows the canonical scorer order
+// for deterministic output.
+func Compare(a, b Report) Comparison {
+	bByKey := make(map[string]Dimension, len(b.Dimensions))
+	for _, d := range b.Dimensions {
+		bByKey[d.Key] = d
+	}
+
+	c := Comparison{A: a, B: b, ScoreDelta: a.Score - b.Score}
+	for _, da := range a.Dimensions {
+		db := bByKey[da.Key]
+		c.Dimensions = append(c.Dimensions, DimensionDelta{
+			Key:      da.Key,
+			Title:    da.Title,
+			Max:      da.Max,
+			AScore:   da.Score,
+			BScore:   db.Score,
+			AVerdict: da.Verdict,
+			BVerdict: db.Verdict,
+			Winner:   sideOf(da.Score, db.Score),
+		})
+	}
+
+	c.Winner = sideOf(a.Score, b.Score)
+	c.Verdict = compareVerdict(c)
+	return c
+}
+
+// sideOf returns which side scored higher (SideTie on equality).
+func sideOf(aScore, bScore int) Side {
+	switch {
+	case aScore > bScore:
+		return SideA
+	case bScore > aScore:
+		return SideB
+	default:
+		return SideTie
+	}
+}
+
+// compareVerdict builds the one-line summary: who is more hardened, by how much,
+// and the dimensions the winner leads on. The lead list is ordered by point gap
+// (largest first), tie-broken by canonical dimension order, and capped so the
+// line stays short.
+func compareVerdict(c Comparison) string {
+	winLabel := func(s Side) string {
+		switch s {
+		case SideA:
+			return fmt.Sprintf("A (`%s`)", nz(c.A.Target, "A"))
+		case SideB:
+			return fmt.Sprintf("B (`%s`)", nz(c.B.Target, "B"))
+		default:
+			return "neither"
+		}
+	}
+
+	if c.Winner == SideTie {
+		return fmt.Sprintf("Even match: both score %d/100 (grade %s). No isolation-posture difference at this granularity.",
+			c.A.Score, c.A.Grade)
+	}
+
+	delta := c.ScoreDelta
+	if delta < 0 {
+		delta = -delta
+	}
+	win, lose := c.A, c.B
+	if c.Winner == SideB {
+		win, lose = c.B, c.A
+	}
+
+	leads := winnerLeads(c)
+	why := ""
+	if len(leads) > 0 {
+		why = "; it leads on " + humanJoin(leads) + "."
+	} else {
+		why = "."
+	}
+	return fmt.Sprintf("%s is more hardened: %d/100 (grade %s) vs %d/100 (grade %s), %s %d-point lead%s",
+		winLabel(c.Winner), win.Score, win.Grade, lose.Score, lose.Grade, article(delta), delta, why)
+}
+
+// winnerLeads returns the titles of the dimensions the overall winner strictly
+// leads on, ordered by point gap (desc) then canonical order, capped to keep the
+// verdict readable.
+func winnerLeads(c Comparison) []string {
+	const maxLeads = 3
+	type lead struct {
+		title string
+		gap   int
+		order int
+	}
+	var leads []lead
+	for i, d := range c.Dimensions {
+		gap := d.AScore - d.BScore
+		if c.Winner == SideB {
+			gap = -gap
+		}
+		if gap > 0 {
+			leads = append(leads, lead{title: d.Title, gap: gap, order: i})
+		}
+	}
+	sort.SliceStable(leads, func(i, j int) bool {
+		if leads[i].gap != leads[j].gap {
+			return leads[i].gap > leads[j].gap
+		}
+		return leads[i].order < leads[j].order
+	})
+
+	titles := make([]string, 0, len(leads))
+	for _, l := range leads {
+		titles = append(titles, l.title)
+	}
+	if len(titles) > maxLeads {
+		extra := len(titles) - maxLeads
+		titles = titles[:maxLeads]
+		titles = append(titles, fmt.Sprintf("and %d more", extra))
+	}
+	return titles
+}
+
+// article returns the indefinite article ("a"/"an") that reads correctly before
+// the spoken form of n. Only the leading digit governs the vowel sound: 8, 11,
+// and 18 read with a leading vowel ("an eight", "an eleven", "an eighteen").
+func article(n int) string {
+	if n < 0 {
+		n = -n
+	}
+	s := fmt.Sprintf("%d", n)
+	switch {
+	case s == "11" || s == "18" || strings.HasPrefix(s, "8"):
+		return "an"
+	default:
+		return "a"
+	}
+}
+
+// humanJoin joins items with commas and a trailing "and". "and N more" (already
+// carrying its own conjunction) is appended verbatim.
+func humanJoin(items []string) string {
+	switch len(items) {
+	case 0:
+		return ""
+	case 1:
+		return items[0]
+	case 2:
+		return items[0] + " and " + items[1]
+	default:
+		return strings.Join(items[:len(items)-1], ", ") + ", " + items[len(items)-1]
+	}
+}
+
+// --------------------------------------------------------------------------- //
+// Renderers. Table (default), JSON (--json), Markdown (--md). All three reuse
+// the single-scan glyph/color helpers so the surfaces stay consistent.
+// --------------------------------------------------------------------------- //
+
+// RenderComparisonTable writes the human-readable side-by-side scorecard to w.
+func RenderComparisonTable(w io.Writer, c Comparison) {
+	fmt.Fprintf(w, "IronClaw containment scan: comparison\n\n")
+	fmt.Fprintf(w, "  A: %s (%s)  %d/%d grade %s\n", nz(c.A.Target, "?"), nz(c.A.Source, "?"), c.A.Score, c.A.Max, c.A.Grade)
+	fmt.Fprintf(w, "  B: %s (%s)  %d/%d grade %s\n\n", nz(c.B.Target, "?"), nz(c.B.Source, "?"), c.B.Score, c.B.Max, c.B.Grade)
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "DIMENSION\tA\tB\tWINNER")
+	for _, d := range c.Dimensions {
+		fmt.Fprintf(tw, "%s\t%s %d/%d\t%s %d/%d\t%s\n",
+			d.Title,
+			verdictGlyph(d.AVerdict), d.AScore, d.Max,
+			verdictGlyph(d.BVerdict), d.BScore, d.Max,
+			winnerMark(d.Winner))
+	}
+	fmt.Fprintf(tw, "OVERALL\t%d/%d %s\t%d/%d %s\t%s\n",
+		c.A.Score, c.A.Max, c.A.Grade, c.B.Score, c.B.Max, c.B.Grade, overallMark(c))
+	tw.Flush()
+
+	fmt.Fprintf(w, "\n  Verdict: %s\n", c.Verdict)
+	fmt.Fprintf(w, "\n  Harden your sandbox: https://ironsecco.github.io/ironclaw/scan/\n")
+}
+
+// winnerMark renders the per-dimension winner column.
+func winnerMark(s Side) string {
+	switch s {
+	case SideA:
+		return "< A"
+	case SideB:
+		return "B >"
+	default:
+		return "= tie"
+	}
+}
+
+// overallMark renders the OVERALL winner cell with the signed point delta.
+func overallMark(c Comparison) string {
+	if c.Winner == SideTie {
+		return "= tie"
+	}
+	delta := c.ScoreDelta
+	if delta < 0 {
+		delta = -delta
+	}
+	return fmt.Sprintf("%s (+%d)", c.Winner, delta)
+}
+
+// RenderComparisonJSON writes the machine-readable comparison (schemaVersion
+// 1.0). It reuses the single-scan Report marshaling for each side, so consumers
+// that already parse a scan report get the same shape under "a" and "b".
+func RenderComparisonJSON(w io.Writer, c Comparison) error {
+	m := map[string]any{
+		"schemaVersion": "1.0",
+		"report":        "ironclaw-containment-comparison",
+		"a":             c.A,
+		"b":             c.B,
+		"dimensions":    c.Dimensions,
+		"scoreDelta":    c.ScoreDelta,
+		"winner":        c.Winner,
+		"verdict":       c.Verdict,
+	}
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(append(out, '\n'))
+	return err
+}
+
+// RenderComparisonMarkdown returns a shareable markdown block directly
+// embeddable in a blog post or README (the data engine behind "X vs Y container
+// isolation" comparison pages). Public-copy house style: no em/en-dashes.
+func RenderComparisonMarkdown(c Comparison) string {
+	var b strings.Builder
+	aName := nz(c.A.Target, "A")
+	bName := nz(c.B.Target, "B")
+	fmt.Fprintf(&b, "### IronClaw containment scan: `%s` vs `%s`\n\n", aName, bName)
+	fmt.Fprintf(&b, "| Dimension | `%s` | `%s` | Winner |\n|---|---|---|---|\n", aName, bName)
+	for _, d := range c.Dimensions {
+		fmt.Fprintf(&b, "| %s | %s %d/%d | %s %d/%d | %s |\n",
+			d.Title,
+			mdGlyph(d.AVerdict), d.AScore, d.Max,
+			mdGlyph(d.BVerdict), d.BScore, d.Max,
+			mdWinner(d.Winner))
+	}
+	fmt.Fprintf(&b, "| **Overall** | **%d/100 (%s)** | **%d/100 (%s)** | **%s** |\n",
+		c.A.Score, c.A.Grade, c.B.Score, c.B.Grade, mdOverall(c))
+	fmt.Fprintf(&b, "\n**Verdict:** %s\n", c.Verdict)
+	fmt.Fprintf(&b, "\nAudit your own sandbox: `ironctl scan <container>` (https://github.com/IronSecCo/ironclaw)\n")
+	return b.String()
+}
+
+// mdWinner renders the per-dimension winner cell in markdown.
+func mdWinner(s Side) string {
+	switch s {
+	case SideA:
+		return "A"
+	case SideB:
+		return "B"
+	default:
+		return "tie"
+	}
+}
+
+// mdOverall renders the OVERALL winner cell in markdown with the point delta.
+func mdOverall(c Comparison) string {
+	if c.Winner == SideTie {
+		return "tie"
+	}
+	delta := c.ScoreDelta
+	if delta < 0 {
+		delta = -delta
+	}
+	return fmt.Sprintf("%s (+%d)", c.Winner, delta)
+}

--- a/internal/host/scan/compare_test.go
+++ b/internal/host/scan/compare_test.go
@@ -1,0 +1,204 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+// hardenedSpec grades to 100/A; laxSpec grades near the floor. They give Compare
+// a maximally-separated pair to diff.
+func hardenedSpec(target string) Spec {
+	return Spec{
+		Source: "docker", Target: target,
+		RunAsNonRoot: Yes, User: "65532",
+		CapDropAll:   Yes,
+		Seccomp:      "default",
+		NetworkMode:  "none",
+		ReadonlyRoot: Yes,
+		DockerSock:   No,
+		HostPID:      No, HostIPC: No, HostNetwork: No,
+	}
+}
+
+func laxSpec(target string) Spec {
+	return Spec{
+		Source: "docker", Target: target,
+		RunAsNonRoot: No, User: "0",
+		CapDropAll:   No,
+		Seccomp:      "unconfined",
+		NetworkMode:  "host", HostNetwork: Yes,
+		ReadonlyRoot: No,
+		DockerSock:   Yes,
+		HostPID:      Yes,
+	}
+}
+
+func TestCompareWinnerAndDelta(t *testing.T) {
+	a := Score(hardenedSpec("distroless"))
+	b := Score(laxSpec("alpine"))
+
+	c := Compare(a, b)
+
+	if a.Score != 100 {
+		t.Fatalf("precondition: hardened should be 100, got %d", a.Score)
+	}
+	if c.Winner != SideA {
+		t.Fatalf("winner: got %s want A", c.Winner)
+	}
+	if c.ScoreDelta != a.Score-b.Score {
+		t.Fatalf("scoreDelta: got %d want %d", c.ScoreDelta, a.Score-b.Score)
+	}
+	if c.ScoreDelta <= 0 {
+		t.Fatalf("hardened should lead: delta %d", c.ScoreDelta)
+	}
+}
+
+func TestCompareDimensionAlignmentAndWinners(t *testing.T) {
+	a := Score(hardenedSpec("distroless"))
+	b := Score(laxSpec("alpine"))
+	c := Compare(a, b)
+
+	if len(c.Dimensions) != len(scorers) {
+		t.Fatalf("dimensions: got %d want %d", len(c.Dimensions), len(scorers))
+	}
+	// Deterministic ordering: comparison dimensions follow the canonical scorer
+	// order exactly.
+	for i, d := range c.Dimensions {
+		if d.Key != scorers[i].key {
+			t.Fatalf("order[%d]: got %s want %s", i, d.Key, scorers[i].key)
+		}
+	}
+	// Every dimension: hardened >= lax, and hardened wins the ones it leads.
+	for _, d := range c.Dimensions {
+		if d.AScore < d.BScore {
+			t.Fatalf("%s: hardened %d < lax %d", d.Key, d.AScore, d.BScore)
+		}
+		if d.AScore > d.BScore && d.Winner != SideA {
+			t.Fatalf("%s: A leads but winner=%s", d.Key, d.Winner)
+		}
+	}
+}
+
+func TestCompareTie(t *testing.T) {
+	a := Score(hardenedSpec("img-a"))
+	b := Score(hardenedSpec("img-b"))
+	c := Compare(a, b)
+
+	if c.Winner != SideTie {
+		t.Fatalf("winner: got %s want tie", c.Winner)
+	}
+	if c.ScoreDelta != 0 {
+		t.Fatalf("scoreDelta: got %d want 0", c.ScoreDelta)
+	}
+	if !strings.Contains(c.Verdict, "Even match") {
+		t.Fatalf("tie verdict should say even match: %q", c.Verdict)
+	}
+	// Per-dimension winners are all ties.
+	for _, d := range c.Dimensions {
+		if d.Winner != SideTie {
+			t.Fatalf("%s: winner=%s want tie", d.Key, d.Winner)
+		}
+	}
+}
+
+func TestCompareBWins(t *testing.T) {
+	a := Score(laxSpec("alpine"))
+	b := Score(hardenedSpec("distroless"))
+	c := Compare(a, b)
+
+	if c.Winner != SideB {
+		t.Fatalf("winner: got %s want B", c.Winner)
+	}
+	if c.ScoreDelta >= 0 {
+		t.Fatalf("A is lax so delta should be negative, got %d", c.ScoreDelta)
+	}
+	if !strings.Contains(c.Verdict, "`distroless`") {
+		t.Fatalf("verdict should name the winner target: %q", c.Verdict)
+	}
+}
+
+func TestCompareVerdictNamesLeads(t *testing.T) {
+	a := Score(hardenedSpec("distroless"))
+	b := Score(laxSpec("alpine"))
+	c := Compare(a, b)
+	// Highest-weight dimension the winner leads on (caps, 20 pts) should surface
+	// in the one-line verdict.
+	if !strings.Contains(c.Verdict, "Dropped capabilities") {
+		t.Fatalf("verdict should cite the largest-gap lead: %q", c.Verdict)
+	}
+	if !strings.Contains(c.Verdict, "more hardened") {
+		t.Fatalf("verdict phrasing: %q", c.Verdict)
+	}
+}
+
+func TestArticle(t *testing.T) {
+	cases := map[int]string{1: "a", 5: "a", 8: "an", 11: "an", 18: "an", 80: "an", 84: "an", 90: "a", 96: "a", 100: "a"}
+	for n, want := range cases {
+		if got := article(n); got != want {
+			t.Fatalf("article(%d): got %q want %q", n, got, want)
+		}
+	}
+}
+
+func TestRenderComparisonMarkdownDeterministic(t *testing.T) {
+	a := Score(hardenedSpec("distroless"))
+	b := Score(laxSpec("alpine"))
+	c := Compare(a, b)
+
+	md1 := RenderComparisonMarkdown(c)
+	md2 := RenderComparisonMarkdown(c)
+	if md1 != md2 {
+		t.Fatal("markdown render not deterministic")
+	}
+	for _, want := range []string{
+		"`distroless` vs `alpine`",
+		"| Dimension |",
+		"| **Overall** |",
+		"**Verdict:**",
+	} {
+		if !strings.Contains(md1, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, md1)
+		}
+	}
+	// No em/en-dashes in public copy.
+	if strings.ContainsAny(md1, "—–") {
+		t.Fatalf("markdown contains an em/en-dash: %q", md1)
+	}
+}
+
+func TestRenderComparisonJSONRoundTrip(t *testing.T) {
+	a := Score(hardenedSpec("distroless"))
+	b := Score(laxSpec("alpine"))
+	c := Compare(a, b)
+
+	var sb strings.Builder
+	if err := RenderComparisonJSON(&sb, c); err != nil {
+		t.Fatalf("render json: %v", err)
+	}
+	out := sb.String()
+	for _, want := range []string{
+		`"report": "ironclaw-containment-comparison"`,
+		`"scoreDelta"`,
+		`"winner": "A"`,
+		`"dimensions"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("json missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderComparisonTableHasWinnerColumn(t *testing.T) {
+	a := Score(hardenedSpec("distroless"))
+	b := Score(laxSpec("alpine"))
+	c := Compare(a, b)
+
+	var sb strings.Builder
+	RenderComparisonTable(&sb, c)
+	out := sb.String()
+	for _, want := range []string{"DIMENSION", "WINNER", "OVERALL", "Verdict:"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("table missing %q:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds `ironctl scan --compare <A> <B>`: grades two live containers and prints a side-by-side containment diff.

- Two-column table: each of the 7 dimensions, both scores, a per-dimension winner marker
- Overall grade + signed point delta, and a one-line verdict naming the more hardened target and why
- `--json` emits the machine diff (each side is a full scan report under `a`/`b`, plus a `dimensions` delta array, `scoreDelta`, `winner`, `verdict`)
- `--md` emits a markdown table directly embeddable in an "X vs Y container isolation" blog post

## How it fits the lenses

- **No new scoring logic.** Reuses the existing docker/podman/nerdctl adapters (`containerSpec`) and `scan.Score`; the diff is a pure `scan.Compare(a, b Report) Comparison`.
- **Fail-closed.** Requires two distinct targets; if either target fails to inspect, the whole compare errors rather than printing a half diff.
- **Deterministic.** Dimensions follow the canonical scorer order; lead list ordered by point gap then order. Renderers are pure.

## Tests

- `internal/host/scan/compare_test.go` — winner/delta, dimension alignment + ordering, tie, B-wins, verdict lead-naming, markdown/JSON/table renderers, article helper. `go test ./internal/host/scan/ ./cmd/ironctl/` = 204 pass.
- e2e smoke: hardened (`--user 65532 --cap-drop ALL --network none --read-only`) vs `--privileged --network host -v docker.sock` → 84/B vs 0/F, +84, verdict cites top leads. Docs mkdocs `--strict` build green.

## Docs

`docs/scan.md`: new "Compare two containers" section + `--compare` row in the output-formats table.

Delegated by CEO from IRO-467 (non-gated growth wave). QA: verify escape-diff on a hardened vs unhardened pair.