### PR TITLE
docs(blog): "X vs Y container isolation" comparison posts (IRO-470)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,14 @@ containers you already run stack up. Rankings live on the
 (Hall of Fame vs worst offenders), and the interactive
 [scores explorer](https://nivardsec.com/scores) lets you filter and grab a badge for your repo.
 
+Head-to-head reads backed by the same scan data:
+[Alpine vs Debian vs Ubuntu](https://ironsecco.github.io/ironclaw/blog/alpine-vs-debian-vs-ubuntu-container-isolation/)
+(does the base image change isolation?),
+[Docker default vs hardened](https://ironsecco.github.io/ironclaw/blog/docker-default-vs-hardened-container-isolation/)
+(the 48-point gap, flag by flag), and
+[gVisor vs runc](https://ironsecco.github.io/ironclaw/blog/gvisor-vs-runc-container-isolation-compared/)
+(when a shared host kernel is the weak link).
+
 ### Show your score
 
 Put your containment grade in your README, the same way a coverage or build badge does.

--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -11,4 +11,7 @@ nav:
   - We graded 151 popular Docker images for isolation: container-isolation-leaderboard-what-151-images-scored.md
   - Escape suite vs Docker, gVisor, E2B, Daytona: containment-benchmark-docker-gvisor-e2b-daytona.md
   - Add a Sandbox Isolation Score badge to your repo: add-a-sandbox-isolation-score-badge-to-your-repo.md
+  - "Alpine vs Debian vs Ubuntu: base image and isolation": alpine-vs-debian-vs-ubuntu-container-isolation.md
+  - "Docker default vs hardened: the isolation score gap": docker-default-vs-hardened-container-isolation.md
+  - "gVisor vs runc: containment compared": gvisor-vs-runc-container-isolation-compared.md
   - "*.md"

--- a/docs/blog/alpine-vs-debian-vs-ubuntu-container-isolation.md
+++ b/docs/blog/alpine-vs-debian-vs-ubuntu-container-isolation.md
@@ -1,0 +1,105 @@
+---
+title: "Alpine vs Debian vs Ubuntu: does your base image change container isolation?"
+description: "We scored the seven most-pulled base OS images (alpine, debian, ubuntu, busybox, amazonlinux, rockylinux, fedora) for container isolation with ironctl scan. Every one landed on the same 48 out of 100, grade D. Base image choice barely moves the isolation needle. Here is why, with the per-dimension data, and the docker run flags that actually take any of them to 100."
+---
+
+# Alpine vs Debian vs Ubuntu: does your base image change container isolation?
+
+Search "alpine vs debian" or "is alpine more secure" and you get a hundred posts
+arguing about package counts and CVE surface. Those are real questions. But they
+answer a different question than the one most people are actually asking, which
+is: **if I run untrusted code in this container, how much isolation stands between
+that code and my host?**
+
+That is a containment question, not a base-image question. So we measured it.
+We ran [`ironctl scan`](audit-your-sandbox-in-10-seconds.md) over the seven
+most-pulled base OS images in their default `docker run` configuration and
+graded each 0 to 100 on how contained it is.
+
+The result is the same number, seven times.
+
+## The scores
+
+| Base image | Isolation score | Grade |
+| --- | ---: | :---: |
+| `alpine:3.21` | 48 | D |
+| `debian:12-slim` | 48 | D |
+| `ubuntu:24.04` | 48 | D |
+| `busybox:1.37` | 48 | D |
+| `amazonlinux` | 48 | D |
+| `rockylinux` | 48 | D |
+| `fedora` | 48 | D |
+
+Not close-together. Identical. And it is not just the total: the per-dimension
+breakdown is byte-for-byte the same across all seven.
+
+| Dimension | alpine | debian | ubuntu | Max |
+| --- | :---: | :---: | :---: | ---: |
+| Non-root user | 0 | 0 | 0 | 15 |
+| Dropped capabilities | 4 | 4 | 4 | 20 |
+| Seccomp profile | 15 | 15 | 15 | 15 |
+| Network isolation / egress | 4 | 4 | 4 | 15 |
+| Read-only root filesystem | 0 | 0 | 0 | 10 |
+| No docker.sock exposure | 15 | 15 | 15 | 15 |
+| No shared host namespaces | 10 | 10 | 10 | 10 |
+| **Total** | **48** | **48** | **48** | **100** |
+
+## Why they tie
+
+Isolation is a property of *how you run the container*, not of *what is inside the
+image*. `ironctl scan` grades the runtime posture the container gets from the host:
+which capabilities it keeps, whether it runs as root, whether the root filesystem
+is writable, whether egress is open. None of those are decided by whether the
+userland was assembled from Alpine's apk or Debian's apt.
+
+Every one of these images ships the same way by default: root user (uid 0), full
+default capability set, writable root filesystem, open egress on the default
+bridge. That is why they all land on 48. The base image you pick changes your CVE
+surface and your image size. It does not, on its own, change your blast radius when
+code inside the container turns hostile.
+
+This does not mean Alpine and Debian are interchangeable. A smaller userland with
+fewer packages means fewer things to patch, and that is a legitimate reason to
+prefer a minimal base. But "fewer packages" is a supply-chain argument, not a
+containment one. If you switch base images expecting a stronger boundary and change
+nothing else, the boundary is exactly as strong as it was.
+
+## What actually moves the number
+
+The same handful of `docker run` flags takes every one of these images from 48 to
+a clean 100 out of 100, grade A, without changing the base image at all:
+
+```bash
+docker run -d \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  alpine:3.21
+```
+
+Swap `alpine:3.21` for `debian:12-slim` or `ubuntu:24.04` and the score is still
+100. The flags are what carry the grade, not the image. `ironctl scan --fix` writes
+this stanza for you from any failing scan.
+
+## The honest takeaway
+
+If your question is "which base image is more isolated," the data says: none of
+them, by default, and they are tied. Pick your base image for size, package
+freshness, and CVE surface. Then earn your isolation separately, with runtime
+flags, and verify it with a number instead of a vibe.
+
+## See where your images land
+
+Every image above has a per-dimension scorecard with the exact flags that close
+each gap. Browse the full interactive ranking across 151 images, filter by
+category, and grab a copy-paste score badge for your own repo at the
+**[Container Isolation Scores explorer](https://nivardsec.com/scores)**. The
+[leaderboard](../scores/leaderboard.md) refreshes weekly.
+
+Scan the image you actually run in about ten seconds:
+
+```bash
+ironctl scan your-image:tag
+```

--- a/docs/blog/docker-default-vs-hardened-container-isolation.md
+++ b/docs/blog/docker-default-vs-hardened-container-isolation.md
@@ -1,0 +1,104 @@
+---
+title: "Docker default vs hardened: the container isolation score gap, measured"
+description: "How much isolation do you gain by hardening a docker run command? We scored 151 popular images on defaults (average 52 out of 100, grade D) and re-scored them hardened (100 out of 100, grade A, every single one). Here is the exact 48-point jump, dimension by dimension, and the six flags that produce it."
+---
+
+# Docker default vs hardened: the container isolation score gap, measured
+
+"Harden your containers" is advice everyone repeats and almost nobody quantifies.
+How much isolation does hardening actually buy you? We put a number on it.
+
+We ran [`ironctl scan`](audit-your-sandbox-in-10-seconds.md) over 151 of the
+most-pulled public Docker images twice: once on the exact `docker run` defaults
+their own READMEs tell you to use, and once with a standard hardening stanza
+applied. The scan grades seven containment dimensions 0 to 100.
+
+The gap is not subtle.
+
+| Configuration | Average score | Grade range |
+| --- | ---: | :---: |
+| Default `docker run` | 52 | D to C (48 to 63) |
+| Hardened `docker run` | 100 | A (every image) |
+
+On defaults, not one of the 151 images reaches an A. Scores run from 48 to 63.
+Hardened, **all 151 land on a clean 100**. The full leaderboard on defaults is
+[here](../scores/leaderboard.md); the delta below is what hardening adds on top.
+
+## The six flags that carry the grade
+
+Here is the hardened command the scan grades. It is base-image agnostic; it scores
+100 whether the last argument is `alpine`, `debian`, `node`, or `postgres`:
+
+```bash
+docker run -d \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  your-image:tag
+```
+
+## Dimension by dimension: where the 48 points come from
+
+Take a typical default-configured image at 48 out of 100 and watch each flag close
+a specific hole:
+
+| Dimension | Default | Hardened | Flag that closes it | Max |
+| --- | :---: | :---: | --- | ---: |
+| Non-root user | 0 | 15 | `--user 65532:65532` | 15 |
+| Dropped capabilities | 4 | 20 | `--cap-drop=ALL` | 20 |
+| Read-only root filesystem | 0 | 10 | `--read-only --tmpfs /tmp` | 10 |
+| Network isolation / egress | 4 | 15 | `--network=none` | 15 |
+| Seccomp profile | 15 | 15 | already on by default | 15 |
+| No docker.sock exposure | 15 | 15 | do not mount the socket | 15 |
+| No shared host namespaces | 10 | 10 | do not share host namespaces | 10 |
+| **Total** | **48** | **100** | | **100** |
+
+Four dimensions do the work. Docker's default seccomp profile already earns full
+marks, and most images do not mount the docker socket or share host namespaces, so
+those three are usually green before you touch anything. The points you are leaving
+on the table are the first four: **root user, full capabilities, writable
+filesystem, and open egress.**
+
+## What separates a C from a D on defaults
+
+The only reason any default image scores above 48 is that it already dropped one of
+those habits. The images at the top of the leaderboard, at 63 out of 100, are the
+ones whose image sets a non-root user in the Dockerfile. That single choice is worth
+15 points:
+
+| Dimension | `alpine` (48, D) | `adminer` (63, C) |
+| --- | :---: | :---: |
+| Non-root user | 0 | 15 |
+| every other dimension | same | same |
+
+That is the whole difference between the best and worst default scores in a
+151-image survey: one dimension. Which is the point. Isolation on defaults is a
+narrow band because almost every image makes the same four omissions.
+
+## The catch hardening does not fix
+
+Every flag above is real, worthwhile hardening, and it takes you from a D to an A on
+the config scan. But the scan grades *configuration posture*, and there is one thing
+configuration cannot change: a hardened container still shares the host kernel. When
+we ran a live escape suite, hardening a container blocked 4 of 5 escape attempts, up
+from 2 of 5 on raw defaults. The one it never blocks is the kernel-sharing attempt.
+Closing that last gap needs a different runtime, not a different flag. That is a
+separate decision, covered in
+[gVisor vs runc](gvisor-vs-runc-container-isolation-compared.md).
+
+For the config layer, though, the math is clean: six flags, +48 points, D to A, on
+every image we tested.
+
+## Scan and fix your own images
+
+Every scorecard names the exact flags for that image, and `ironctl scan --fix`
+writes the hardened stanza for you. Browse the full interactive ranking and grab a
+score badge for your repo at the
+**[Container Isolation Scores explorer](https://nivardsec.com/scores)**.
+
+```bash
+ironctl scan your-image:tag        # see your default score
+ironctl scan your-image:tag --fix  # get the hardened command
+```

--- a/docs/blog/gvisor-vs-runc-container-isolation-compared.md
+++ b/docs/blog/gvisor-vs-runc-container-isolation-compared.md
@@ -1,0 +1,97 @@
+---
+title: "gVisor vs runc: container isolation compared, with escape-suite numbers"
+description: "gVisor and runc score identically on a config scan, yet block a different number of real escape attempts. runc (default) blocked 2 of 5, hardened runc blocked 4 of 5, gVisor blocked 5 of 5. The gap is one attempt: the shared host kernel. Here is when hardened runc is enough and when you need a user-space kernel, backed by a re-runnable benchmark."
+---
+
+# gVisor vs runc: container isolation compared
+
+If you are choosing a container runtime for untrusted or AI-generated code, the
+question is narrow and important: **does gVisor actually contain more than runc, and
+by how much?** Two things surprised us when we measured it, and both matter for the
+decision.
+
+The first: on a configuration scan, gVisor and runc score the *same*. The second:
+against a live escape suite, they do not. Understanding why is the whole answer.
+
+## Same config, same score
+
+[`ironctl scan`](audit-your-sandbox-in-10-seconds.md) grades a container's
+configuration posture: capabilities, user, filesystem, egress, seccomp. It is
+deliberately runtime-agnostic. Run the same hardened container under runc and under
+gVisor and you get the identical 100 out of 100, because the *configuration* is
+identical. The scan cannot see the runtime underneath.
+
+That is not a gap in the scan. It is the point. A config scanner tells you whether
+you closed the holes you control with flags. It cannot tell you whether the kernel
+serving your syscalls is the host's. For that you have to actually attack the box.
+
+## Different runtime, different containment
+
+So we did. We built one fixed escape-attempt suite, ran it from *inside* each
+runtime posture, and counted what got through. Full method and per-attempt
+breakdown are in the
+[containment benchmark](containment-benchmark-docker-gvisor-e2b-daytona.md); the
+head-to-head is this:
+
+| Runtime posture | Escape attempts | Blocked | Block rate |
+| --- | ---: | ---: | ---: |
+| runc, default | 5 | 2 | 40% |
+| runc, hardened | 5 | 4 | 80% |
+| gVisor / runsc | 5 | 5 | 100% |
+
+Hardening runc with dropped capabilities, `--network=none`, and a read-only rootfs
+takes you from 40% to 80%. That is real and worth doing. But there is one attempt it
+never blocks, no matter how many flags you add:
+
+| Escape attempt | runc hardened | gVisor |
+| --- | :---: | :---: |
+| No network interface | BLOCKED | BLOCKED |
+| No outbound egress | BLOCKED | BLOCKED |
+| Host root not mounted | BLOCKED | BLOCKED |
+| Privileged syscalls dropped | BLOCKED | BLOCKED |
+| **Host kernel not reached** | **OPEN** | **BLOCKED** |
+
+## The one line that separates them
+
+Under runc, every syscall a compromised process makes is served by the **host
+kernel**. Hardening removes privileges, but the process is still talking directly to
+your kernel, so its full syscall and CVE surface is one bug away. That is the
+`kernel.shared-host` attempt, and it stays OPEN under runc at any hardening level.
+
+Under gVisor, a user-space kernel called the Sentry sits in the path and serves those
+syscalls itself. The host kernel is never the thing the workload talks to. That is
+the row where the last attempt finally flips to BLOCKED, and it is the entire reason
+gVisor exists.
+
+## Which one do you need?
+
+Runtime choice is a threat-model choice, not a "more is better" choice.
+
+- **Hardened runc (80%) is enough when** you trust the code you run and want strong
+  defense in depth against a container that gets popped. Dropped caps, no egress, and
+  a read-only rootfs are a genuine boundary. Most production workloads live here, and
+  they should be hardened, not run on defaults.
+- **gVisor (100%) is what you want when** the code is untrusted by design: AI agents
+  executing generated code, multi-tenant sandboxes, anything where you must assume the
+  workload is already hostile. There, the shared host kernel is not an acceptable
+  single point of failure, and a user-space kernel is the thing that closes it.
+
+The cost of gVisor is a syscall-performance overhead and some compatibility edges.
+The benefit is that the last escape attempt has nowhere to go. For an autonomous
+agent running arbitrary code, that trade is the whole reason
+[IronClaw](https://github.com/IronSecCo/ironclaw) defaults its runtime to gVisor.
+
+## Verify it yourself
+
+The benchmark is a committed script that runs in CI, so the numbers cannot quietly
+drift. Re-run the
+[containment-matrix harness](https://github.com/IronSecCo/ironclaw/blob/main/scripts/bench/containment-matrix.sh)
+and check the block rates against this post. And whatever runtime you land on, scan
+your container's configuration so the flags you *do* control are not the weak link:
+
+```bash
+ironctl scan your-image:tag
+```
+
+Browse the full 151-image isolation ranking and grab a score badge for your repo at
+the **[Container Isolation Scores explorer](https://nivardsec.com/scores)**.

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -28,3 +28,19 @@ adjectives standing in for numbers.
   generate a shields.io endpoint JSON with `ironctl scan --badge-json`, commit it as a
   static file, and render a live 0 to 100 A-to-F containment grade in your README. No
   server, no scan on every badge hit.
+
+## Comparisons
+
+Head-to-head reads, each backed by the same scan data, for the questions people
+actually search.
+
+- [Alpine vs Debian vs Ubuntu: does your base image change container isolation?](alpine-vs-debian-vs-ubuntu-container-isolation.md) -
+  we scored the seven most-pulled base OS images. Every one landed on the same 48
+  of 100. Base image choice barely moves the isolation needle; runtime flags do.
+- [Docker default vs hardened: the container isolation score gap, measured](docker-default-vs-hardened-container-isolation.md) -
+  151 images averaged 52 of 100 on defaults and 100 of 100 hardened. The exact
+  48-point jump, dimension by dimension, and the six flags that produce it.
+- [gVisor vs runc: container isolation compared](gvisor-vs-runc-container-isolation-compared.md) -
+  they score identically on a config scan yet block a different number of real
+  escape attempts. When hardened runc is enough and when you need a user-space
+  kernel.

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -294,3 +294,15 @@ shared host namespaces, on a gVisor (runsc) runtime. See
 [Security and isolation](security-isolation.md) and the
 [containment benchmark](compare/sandbox-containment-benchmark.md) for how that
 posture is built and proven.
+
+## Compare with real scan data
+
+Head-to-head reads that answer common questions using the same seven-dimension
+grade this page describes:
+
+- [Alpine vs Debian vs Ubuntu](blog/alpine-vs-debian-vs-ubuntu-container-isolation.md):
+  does the base image change isolation? (Spoiler: all seven base images tie at 48.)
+- [Docker default vs hardened](blog/docker-default-vs-hardened-container-isolation.md):
+  the 48-point jump from a D to an A, flag by flag, across 151 images.
+- [gVisor vs runc](blog/gvisor-vs-runc-container-isolation-compared.md): why they
+  score the same on a config scan yet block a different number of live escape attempts.


### PR DESCRIPTION
Three high-intent comparison blog posts under `docs/blog/`, each backed by the existing 151-image scorecard dataset (`docs/scores/index.json`) + leaderboard. Non-gated SEO lever from the IRO-467 growth wave.

## Posts
| Post | Angle | Real data |
|---|---|---|
| **Alpine vs Debian vs Ubuntu** | Does the base image change isolation? | All 7 base OS images tie at **48/100 D**; identical per-dimension breakdown. Isolation is a runtime property, not an image property. |
| **Docker default vs hardened** | The isolation score gap, measured | 151 images: **avg 52 -> 100** hardened. The 48-point D-to-A jump, dimension by dimension, six flags. |
| **gVisor vs runc** | Config scan vs live containment | Identical config-scan score, yet escape suite blocks **40% / 80% / 100%**. When hardened runc is enough vs when a user-space kernel is needed. |

## Acceptance criteria
- [x] 3 posts in `docs/blog/*.md` (not `posts/`), each: unique title+meta, real numbers from `docs/scores` + leaderboard, comparison table, CTA to /scores explorer + `ironctl scan` quickstart
- [x] No em/en-dash in public copy (standing rule)
- [x] Cross-linked from README, `docs/scan.md`, blog index, and `.nav.yml` (funnel loop closed)
- [x] `mkdocs build --strict` passes
- [x] Cited scorecard values directly (IRO-468 `--compare` `--md` not required; the two-way tables are cited from `index.json`)

Posting to external channels (HN/Reddit) remains board-gated and is out of scope.