### PR TITLE
test(scan): cover Tristate helpers

### DIFF
--- a/internal/host/scan/spec_test.go
+++ b/internal/host/scan/spec_test.go
@@ -1,0 +1,42 @@
+package scan
+
+import "testing"
+
+func TestTristateString(t *testing.T) {
+	tests := []struct {
+		name  string
+		value Tristate
+		want  string
+	}{
+		{name: "unknown", value: Unknown, want: "unknown"},
+		{name: "yes", value: Yes, want: "yes"},
+		{name: "no", value: No, want: "no"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.value.String(); got != tt.want {
+				t.Fatalf("Tristate(%d).String() = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBoolTri(t *testing.T) {
+	tests := []struct {
+		name  string
+		value bool
+		want  Tristate
+	}{
+		{name: "true", value: true, want: Yes},
+		{name: "false", value: false, want: No},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := boolTri(tt.value); got != tt.want {
+				t.Fatalf("boolTri(%t) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add table-driven coverage for every defined `Tristate.String()` value
- verify `boolTri` maps both boolean inputs to the expected tristate

Closes #449.

## Validation

- `go test ./internal/host/scan/...`
- `gofmt -l internal/host/scan/spec_test.go` (clean)
- `git diff --check`

I also ran `go test ./...`; the scan package passed, while unrelated platform-dependent suites fail on Windows because this checkout has CGO disabled and lacks Unix filesystem/runtime behavior required by those tests.

## CLA

I understand that this contribution is subject to the project's CLA and dual-license terms.
