### PR TITLE
docs(roadmap): correct stale repro + channel-adapter count (IRO-479)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ signed releases with an SBOM and build provenance. The remaining work to 1.0 is
 **product surface and ecosystem**, not the core.
 
 - ✅ Isolation (gVisor + Kata), encrypted queues, approval gateway, egress broker
-- ✅ 11 channel adapters + an in-product web chat playground (12 delivery surfaces)
+- ✅ 12 channel adapters + an in-product web chat playground (13 delivery surfaces)
 - ✅ Multi-provider models (Anthropic · OpenAI · OpenRouter · Codex · Gemini · Vertex · local OpenAI-compatible)
 - ✅ Embedded mesh-only web console (approvals inbox, sessions, logs, chat playground)
 - ✅ Signed releases + SBOM + provenance; threat model; OpenAPI spec; docs site
@@ -49,8 +49,10 @@ areas where outside contributions land best:
   packages; fuzz targets for parsers.
 - **Developer experience** — onboarding friction, `ironctl` ergonomics, build and
   tooling polish.
-- **Reproducible builds** — help close the control-plane reproducibility gap (the
-  `ironctl` and `sandbox` binaries already reproduce).
+- **Reproducible builds** — all three binaries (control-plane, `ironctl`, and
+  `sandbox`) already reproduce bit-for-bit on Linux, same-runner and cross-machine.
+  Help extend verified reproducibility to more platforms and independently
+  rebuild-and-verify a published release against its `SHA256SUMS`.
 
 The fastest way in is a
 [**good first issue**](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -79,6 +79,7 @@ widening the network posture — ships embedded in the control-plane binary:
 | Channel adapter: Email / Gmail | ✅ |
 | Channel adapter: Matrix | ✅ |
 | Channel adapter: Google Chat | ✅ |
+| Channel adapter: Mattermost | ✅ |
 | Channel adapters: Microsoft Teams, Signal, iMessage | ✅ |
 | First-class persona / identity surface | ✅ |
 | Observability CLI (`ironctl status` / `doctor` / usage) | ✅ |
@@ -86,8 +87,8 @@ widening the network posture — ships embedded in the control-plane binary:
 | Multi-provider model support | ✅ |
 
 IronClaw now speaks Slack, Discord, Telegram, Microsoft Teams, Signal, iMessage,
-Webhook, WhatsApp, Email/SMTP, Matrix, and Google Chat — plus the in-product web
-chat playground, for twelve delivery surfaces in all.
+Webhook, WhatsApp, Email/SMTP, Matrix, Google Chat, and Mattermost — plus the
+in-product web chat playground, for thirteen delivery surfaces in all.
 
 ## Wave 8 — Trust, supply-chain & ecosystem
 
@@ -101,7 +102,7 @@ Press the security advantage — several of these are wins neither peer has clai
 | Signed releases + SBOM + provenance | ✅ |
 | Supply-chain hygiene (Dependabot / CodeQL / secret scanning / pinned actions) | ✅ |
 | OpenSSF Scorecard + Best-Practices badges | 🚧 (Scorecard workflow live) |
-| Reproducible builds | 🚧 (`ironctl` / `sandbox` reproducible; control-plane tracked) |
+| Reproducible builds | ✅ (all three binaries reproduce bit-for-bit, same-runner + cross-machine) |
 | Examples gallery + templates | ✅ |
 | Public roadmap + comparison (this page) | ✅ |
 | Third-party security audit | 👤 |
@@ -130,7 +131,7 @@ will evolve — corrections welcome via an issue.
 | Container isolation | Docker / opt-in host access | gVisor + `network=none` + Kata backend | ✅ **stronger** |
 | Approval / permissions | role checks / host access | mandatory **deterministic gateway** with a human-approval floor | ✅ **stronger** |
 | Encrypted per-session queues | single-writer SQLite | SQLCipher-encrypted, read-only inbound | ✅ **stronger** |
-| Channels | broad | Slack · Discord · Telegram · Teams · Signal · iMessage · Webhook · WhatsApp · Email · Matrix · Google Chat · web chat | ✅ **at parity** (was a gap; closed) |
+| Channels | broad | Slack · Discord · Telegram · Teams · Signal · iMessage · Webhook · WhatsApp · Email · Matrix · Google Chat · Mattermost · web chat | ✅ **at parity** (was a gap; closed) |
 | Outbound + interactive tools | yes | send / file / ask / schedule / tasks / a2a `create_agent` | ✅ at parity |
 | Scheduling & multi-agent (a2a) | yes | yes (RFC-0004, gateway-gated `create_agent`) | ✅ at parity |
 | Published threat model | partial / none | full STRIDE + data-flow + privilege matrix | ✅ **ahead** |
@@ -142,15 +143,15 @@ will evolve — corrections welcome via an issue.
 | Credential vault (arbitrary APIs) | yes | logical-name `vault://` injection via a separate host-side injector behind the gateway-approved egress broker (per-group deny-by-default, agent never holds a key) | ✅ **shipped** (1.0) |
 | Multiple LLM providers | drop-in modules | Anthropic / OpenAI / OpenRouter / Codex via host proxy | ✅ at parity |
 | In-product diagnostics | `/status` `/usage` | Prometheus metrics + audit + `ironctl status`/`doctor` | ✅ at parity |
-| **Signed releases + SBOM + provenance** | neither peer | cosign-signed releases + SBOM + build provenance, reproducible `ironctl`/`sandbox` | ✅ **shipped** (a win neither peer has claimed) |
+| **Signed releases + SBOM + provenance** | neither peer | cosign-signed releases + SBOM + build provenance, bit-for-bit reproducible builds | ✅ **shipped** (a win neither peer has claimed) |
 
 **The short version:** IronClaw is *ahead on the security spine* — provable
 isolation, a mandatory approval gateway, encrypted queues, and a published threat
 model — and has *closed most of the product-surface gap* (channels, an embedded web
 console, skills, and multi-provider support are all shipped). The supply-chain trust
 items — cosign-signed releases, an SBOM, and build provenance — have now shipped too;
-they're differentiators neither peer has claimed, and reproducible builds are landing
-component by component.
+they're differentiators neither peer has claimed, and all three binaries now build
+bit-for-bit reproducibly.
 
 ---
 


### PR DESCRIPTION
## What

Audit of `ROADMAP.md` + the docs-site [roadmap page](https://ironsecco.github.io/ironclaw/roadmap/) against actually-shipped state (git log, workflows, wired code). Docs-only, no code.

## Stale entries corrected

**1. Control-plane reproducibility — was framed as an open gap, is DONE.**
`.github/workflows/reproducibility.yml` hard-asserts all three binaries (`controlplane`, `ironctl`, `sandbox`) reproduce bit-for-bit, same-runner **and** cross-machine; the control-plane exception (IRO-44) was removed. Fixed in both surfaces:
- ROADMAP.md help-wanted bullet reworded (no longer claims a `control-plane reproducibility gap` with only `ironctl`/`sandbox` reproducing) — kept as a contributor-facing theme per the intentional funnel, just made accurate.
- docs Wave 8 row `🚧 → ✅`; comparison table + summary prose updated.

**2. Mattermost adapter shipped but unlisted — undercount.**
`internal/host/channels/mattermost.go` is a full adapter with tests, registered in `cmd/controlplane/main.go` (`IRONCLAW_MATTERMOST_WEBHOOK_URL`), yet absent from every channel enumeration. Corrected the count **11 → 12 adapters / 12 → 13 delivery surfaces** and added Mattermost to the Wave 7 table, the prose list, and the comparison-table channels row.

## Lockstep + scope

- Both roadmap surfaces updated together; ROADMAP.md still defers to the docs page as source of truth.
- Good-first-issue help-wanted framing left intact (only the stale repro bullet touched).
- Verified: `mkdocs build --strict` passes (exit 0); no links added/removed, so all resolve.

## Follow-up (out of scope, flagging)
README.md line ~1072 channel-breadth checklist also omits Mattermost — separate one-liner if we want full lockstep across all three surfaces.

Routing to CEO (81d192d4) as issue owner.