### PR TITLE
docs(scores): programmatic SEO collection/ranking pages (IRO-476)

### DIFF
--- a/docs/scores/.nav.yml
+++ b/docs/scores/.nav.yml
@@ -9,4 +9,5 @@
 nav:
   - All container isolation scores: index.md
   - Leaderboard: leaderboard.md
+  - Scores by category: collections
   - "*.md"

--- a/docs/scores/collections/.nav.yml
+++ b/docs/scores/collections/.nav.yml
@@ -1,0 +1,10 @@
+# Navigation for the "Scores by category" collection pages (IRO-476).
+#
+# High-intent, ranked collection pages generated from the isolation-survey
+# dataset by `examples/isolation-survey/gen_scorecards.py` (write_collections).
+# The hub index is pinned first; the `*.md` glob auto-includes every generated
+# `<category>.md` (titled from its H1) with ZERO edit here, so a new collection
+# appears in nav automatically on the weekly refresh.
+nav:
+  - Scores by category: index.md
+  - "*.md"

--- a/docs/scores/collections/base-os.md
+++ b/docs/scores/collections/base-os.md
@@ -1,0 +1,49 @@
+---
+title: "Most secure base OS container images, ranked by isolation score"
+description: "Ranked isolation scores for 12 base OS container images, graded 0-100 by ironctl scan. Best 48/100, average 48/100. See which ship hardened."
+---
+
+# Most secure base OS container images, ranked by isolation score
+
+How isolated are the most-pulled **base OS** container images when you `docker run` them with plain defaults, no hardening flags? This page ranks **12 base operating system images (Alpine, Debian, Ubuntu, Fedora, Rocky Linux)** on IronClaw's seven-dimension container containment scale (0-100), best-isolated first. Scores run **48/100 to 48/100** (average **48/100**). Higher is safer. Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+> No base OS image ships fully isolated by default: the leaders still leave capabilities, egress, or a writable root filesystem open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## Ranked best to worst
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`almalinux:9`](../almalinux.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 🥈 2 | [`alpine:3.21`](../alpine.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 🥉 3 | [`amazonlinux:2023`](../amazonlinux.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 4 | [`archlinux:latest`](../archlinux.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 5 | [`busybox:1.37`](../busybox.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 6 | [`debian:12-slim`](../debian.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 7 | [`fedora:41`](../fedora.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 8 | [`opensuse/leap:15.6`](../leap.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 9 | [`oraclelinux:9`](../oraclelinux.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 10 | [`photon:5.0`](../photon.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 11 | [`rockylinux:9`](../rockylinux.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 12 | [`ubuntu:24.04`](../ubuntu.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Scan your own base OS container
+
+These grades come from `ironctl scan`, one credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just the base OS images ranked above:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own container the same way this page was generated
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Browse every category &rarr;](index.md), the full set of ranked collection pages.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked, with a Hall of Fame and worst offenders.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+- [The State of Container Isolation, 2026 &rarr;](../../blog/state-of-container-isolation-2026.md), the survey these grades are built from.
+
+---
+
+*Part of the [Container Isolation Scores](../index.md) directory. Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so this ranking never goes stale. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/collections/ci-cd-git.md
+++ b/docs/scores/collections/ci-cd-git.md
@@ -1,0 +1,56 @@
+---
+title: "Most secure CI/CD and Git container images, ranked by isolation score"
+description: "Ranked isolation scores for 19 CI/CD and Git container images, graded 0-100 by ironctl scan. Best 63/100, average 54/100. See which ship hardened."
+---
+
+# Most secure CI/CD and Git container images, ranked by isolation score
+
+How isolated are the most-pulled **CI/CD and Git** container images when you `docker run` them with plain defaults, no hardening flags? This page ranks **19 build runners, CI servers, and Git forges (Jenkins, GitLab, Gitea, Drone, Concourse)** on IronClaw's seven-dimension container containment scale (0-100), best-isolated first. Scores run **48/100 to 63/100** (average **54/100**). Higher is safer. Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+> No CI/CD and Git image ships fully isolated by default: the leaders still leave capabilities, egress, or a writable root filesystem open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## Ranked best to worst
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`ghcr.io/actions/actions-runner:2.321.0`](../actions-runner.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥈 2 | [`quay.io/argoproj/argocd:v2.13.2`](../argocd.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥉 3 | [`goharbor/harbor-core:v2.12.0`](../harbor-core.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 4 | [`jenkins/jenkins:lts`](../jenkins.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 5 | [`sonatype/nexus3:3.75.0`](../nexus3.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 6 | [`sonarqube:community`](../sonarqube.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 7 | [`jetbrains/teamcity-server:2024.12`](../teamcity-server.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 8 | [`gitea/act_runner:0.2.11`](../act_runner.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 9 | [`concourse/concourse:7.12.0`](../concourse.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 10 | [`drone/drone:2`](../drone.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 11 | [`codeberg.org/forgejo/forgejo:9`](../forgejo.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 12 | [`gitea/gitea:1.22`](../gitea.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 13 | [`gitlab/gitlab-ce:17.7.0-ce.0`](../gitlab-ce.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 14 | [`gitlab/gitlab-runner:v17.7.0`](../gitlab-runner.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 15 | [`gogs/gogs:0.13`](../gogs.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 16 | [`hashicorp/packer:1.11.2`](../packer.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 17 | [`pulumi/pulumi:3.144.1`](../pulumi.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 18 | [`rancher/rancher:v2.10.1`](../rancher.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 19 | [`hashicorp/terraform:1.10`](../terraform.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Scan your own CI/CD and Git container
+
+These grades come from `ironctl scan`, one credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just the CI/CD and Git images ranked above:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own container the same way this page was generated
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Browse every category &rarr;](index.md), the full set of ranked collection pages.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked, with a Hall of Fame and worst offenders.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+- [The State of Container Isolation, 2026 &rarr;](../../blog/state-of-container-isolation-2026.md), the survey these grades are built from.
+
+---
+
+*Part of the [Container Isolation Scores](../index.md) directory. Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so this ranking never goes stale. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/collections/data-ml.md
+++ b/docs/scores/collections/data-ml.md
@@ -1,0 +1,51 @@
+---
+title: "Most secure data engineering and ML container images, ranked by isolation score"
+description: "Ranked isolation scores for 14 data engineering and ML container images, graded 0-100 by ironctl scan. Best 63/100, average 54/100. See which ship hardened."
+---
+
+# Most secure data engineering and ML container images, ranked by isolation score
+
+How isolated are the most-pulled **data engineering and ML** container images when you `docker run` them with plain defaults, no hardening flags? This page ranks **14 data pipelines, analytics, and ML platforms (Airflow, Spark, Flink, MLflow, Jupyter)** on IronClaw's seven-dimension container containment scale (0-100), best-isolated first. Scores run **48/100 to 63/100** (average **54/100**). Higher is safer. Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+> No data engineering and ML image ships fully isolated by default: the leaders still leave capabilities, egress, or a writable root filesystem open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## Ranked best to worst
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`apache/airflow:2.10.4`](../airflow.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥈 2 | [`quay.io/jupyter/base-notebook:latest`](../base-notebook.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥉 3 | [`apache/nifi:2.0.0`](../nifi.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 4 | [`apache/spark:3.5.3`](../spark.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 5 | [`apache/superset:4.1.1`](../superset.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 6 | [`apache/zeppelin:0.11.2`](../zeppelin.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 7 | [`flink:1.20`](../flink.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 8 | [`jupyterhub/jupyterhub:5.2.1`](../jupyterhub.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 9 | [`metabase/metabase:v0.52.4`](../metabase.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 10 | [`ghcr.io/mlflow/mlflow:v2.19.0`](../mlflow.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 11 | [`ollama/ollama:0.5.4`](../ollama.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 12 | [`rocker/rstudio:4.4.2`](../rstudio.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 13 | [`storm:2.7.1`](../storm.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 14 | [`tensorflow/tensorflow:2.18.0`](../tensorflow.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Scan your own data engineering and ML container
+
+These grades come from `ironctl scan`, one credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just the data engineering and ML images ranked above:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own container the same way this page was generated
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Browse every category &rarr;](index.md), the full set of ranked collection pages.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked, with a Hall of Fame and worst offenders.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+- [The State of Container Isolation, 2026 &rarr;](../../blog/state-of-container-isolation-2026.md), the survey these grades are built from.
+
+---
+
+*Part of the [Container Isolation Scores](../index.md) directory. Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so this ranking never goes stale. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/collections/databases.md
+++ b/docs/scores/collections/databases.md
@@ -1,0 +1,75 @@
+---
+title: "Most secure database container images, ranked by isolation score"
+description: "Ranked isolation scores for 38 database container images, graded 0-100 by ironctl scan. Best 63/100, average 51/100. See which ship hardened."
+---
+
+# Most secure database container images, ranked by isolation score
+
+How isolated are the most-pulled **database** container images when you `docker run` them with plain defaults, no hardening flags? This page ranks **38 relational, document, key-value, and time-series databases (Postgres, MySQL, MongoDB, Redis)** on IronClaw's seven-dimension container containment scale (0-100), best-isolated first. Scores run **48/100 to 63/100** (average **51/100**). Higher is safer. Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+> No database image ships fully isolated by default: the leaders still leave capabilities, egress, or a writable root filesystem open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## Ranked best to worst
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`adminer:4.8.1`](../adminer.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥈 2 | [`apache/druid:31.0.0`](../druid.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥉 3 | [`hazelcast/hazelcast:5.5.0`](../hazelcast.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 4 | [`memcached:1.6-alpine`](../memcached.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 5 | [`percona:8.0`](../percona.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 6 | [`dpage/pgadmin4:8`](../pgadmin4.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 7 | [`redis/redisinsight:latest`](../redisinsight.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 8 | [`aerospike/aerospike-server:7.2.0.1`](../aerospike-server.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 9 | [`arangodb:3.12`](../arangodb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 10 | [`cassandra:5.0`](../cassandra.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 11 | [`clickhouse:24.8`](../clickhouse.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 12 | [`cockroachdb/cockroach:latest`](../cockroach.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 13 | [`couchdb:3.4`](../couchdb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 14 | [`dgraph/dgraph:v24.0.5`](../dgraph.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 15 | [`docker.dragonflydb.io/dragonflydb/dragonfly:latest`](../dragonfly.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 16 | [`firebirdsql/firebird:5.0.1`](../firebird.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 17 | [`apacheignite/ignite:2.16.0`](../ignite.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 18 | [`influxdb:2.7-alpine`](../influxdb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 19 | [`eqalpha/keydb:latest`](../keydb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 20 | [`mariadb:11`](../mariadb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 21 | [`mongo:7`](../mongo.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 22 | [`mongo-express:1.0`](../mongo-express.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 23 | [`mysql:8.4`](../mysql.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 24 | [`neo4j:5`](../neo4j.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 25 | [`orientdb:3.2.35`](../orientdb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 26 | [`phpmyadmin:5.2`](../phpmyadmin.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 27 | [`postgis/postgis:17-3.5`](../postgis.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 28 | [`postgres:17-alpine`](../postgres.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 29 | [`questdb/questdb:8.2.1`](../questdb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 30 | [`redis:7-alpine`](../redis.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 31 | [`redis/redis-stack-server:7.4.0-v3`](../redis-stack-server.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 32 | [`rethinkdb:2.4`](../rethinkdb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 33 | [`scylladb/scylla:6.2`](../scylla.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 34 | [`tarantool/tarantool:3.3.0`](../tarantool.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 35 | [`pingcap/tidb:v8.5.0`](../tidb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 36 | [`timescale/timescaledb:2.17.2-pg17`](../timescaledb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 37 | [`valkey/valkey:8`](../valkey.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 38 | [`yugabytedb/yugabyte:2.23.0.0-b710`](../yugabyte.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Scan your own database container
+
+These grades come from `ironctl scan`, one credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just the database images ranked above:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own container the same way this page was generated
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Browse every category &rarr;](index.md), the full set of ranked collection pages.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked, with a Hall of Fame and worst offenders.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+- [The State of Container Isolation, 2026 &rarr;](../../blog/state-of-container-isolation-2026.md), the survey these grades are built from.
+
+---
+
+*Part of the [Container Isolation Scores](../index.md) directory. Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so this ranking never goes stale. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/collections/identity-sso.md
+++ b/docs/scores/collections/identity-sso.md
@@ -1,0 +1,41 @@
+---
+title: "Most secure identity and SSO container images, ranked by isolation score"
+description: "Ranked isolation scores for 4 identity and SSO container images, graded 0-100 by ironctl scan. Best 63/100, average 59/100. See which ship hardened."
+---
+
+# Most secure identity and SSO container images, ranked by isolation score
+
+How isolated are the most-pulled **identity and SSO** container images when you `docker run` them with plain defaults, no hardening flags? This page ranks **4 identity providers and single-sign-on servers (Keycloak, Authelia, Dex, Hydra)** on IronClaw's seven-dimension container containment scale (0-100), best-isolated first. Scores run **48/100 to 63/100** (average **59/100**). Higher is safer. Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+> No identity and SSO image ships fully isolated by default: the leaders still leave capabilities, egress, or a writable root filesystem open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## Ranked best to worst
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`dexidp/dex:v2.41.1`](../dex.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥈 2 | [`oryd/hydra:v2.2.0`](../hydra.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥉 3 | [`quay.io/keycloak/keycloak:26.0.7`](../keycloak.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 4 | [`authelia/authelia:4.38`](../authelia.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Scan your own identity and SSO container
+
+These grades come from `ironctl scan`, one credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just the identity and SSO images ranked above:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own container the same way this page was generated
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Browse every category &rarr;](index.md), the full set of ranked collection pages.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked, with a Hall of Fame and worst offenders.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+- [The State of Container Isolation, 2026 &rarr;](../../blog/state-of-container-isolation-2026.md), the survey these grades are built from.
+
+---
+
+*Part of the [Container Isolation Scores](../index.md) directory. Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so this ranking never goes stale. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/collections/index.md
+++ b/docs/scores/collections/index.md
@@ -1,0 +1,40 @@
+---
+title: Container isolation scores by category
+description: Ranked container isolation scores by category: databases, language runtimes, web servers, CI/CD, observability, and more. Graded 0-100 by ironctl scan.
+---
+
+# Container isolation scores by category
+
+The [container isolation scores directory](../index.md) grades hundreds of the most-pulled public Docker images as they ship. These **14 category pages** rank them by topic, so you can compare like with like: a database against a database, a language runtime against a runtime. Every page is regenerated on the weekly survey refresh, so the rankings never go stale.
+
+| Category | Images | Avg score | Best-isolated (default config) |
+|----------|-------:|----------:|--------------------------------|
+| [Vector databases](vector-databases.md) | 5 | 48/100 | [`chromadb/chroma:0.5.23`](../chroma.md) 48/100 🟠 D |
+| [Search engines](search-engines.md) | 9 | 58/100 | [`elasticsearch:8.16.1`](../elasticsearch.md) 63/100 🟡 C |
+| [Monitoring and observability](observability.md) | 27 | 56/100 | [`prom/alertmanager:v0.28.0`](../alertmanager.md) 63/100 🟡 C |
+| [Message queues and streaming](message-queues.md) | 13 | 56/100 | [`apache/activemq-artemis:2.38.0`](../activemq-artemis.md) 63/100 🟡 C |
+| [Databases](databases.md) | 38 | 51/100 | [`adminer:4.8.1`](../adminer.md) 63/100 🟡 C |
+| [CI/CD and Git](ci-cd-git.md) | 19 | 54/100 | [`ghcr.io/actions/actions-runner:2.321.0`](../actions-runner.md) 63/100 🟡 C |
+| [Language runtimes (Node.js, Python, Go, ...)](language-runtimes.md) | 33 | 48/100 | [`groovy:4`](../groovy.md) 63/100 🟡 C |
+| [Web servers and proxies](web-servers.md) | 16 | 53/100 | [`haproxy:3.1-alpine`](../haproxy.md) 63/100 🟡 C |
+| [Base OS images](base-os.md) | 12 | 48/100 | [`almalinux:9`](../almalinux.md) 48/100 🟠 D |
+| [Identity and SSO](identity-sso.md) | 4 | 59/100 | [`dexidp/dex:v2.41.1`](../dex.md) 63/100 🟡 C |
+| [Object storage](object-storage.md) | 4 | 48/100 | [`quay.io/ceph/ceph:v18.2.4`](../ceph.md) 48/100 🟠 D |
+| [Data engineering and ML](data-ml.md) | 14 | 54/100 | [`apache/airflow:2.10.4`](../airflow.md) 63/100 🟡 C |
+| [Infrastructure and networking](infra-networking.md) | 8 | 48/100 | [`hashicorp/consul:1.20`](../consul.md) 48/100 🟠 D |
+| [Self-hosted apps](self-hosted-apps.md) | 38 | 51/100 | [`directus/directus:11.3.5`](../directus.md) 63/100 🟡 C |
+
+Across these categories, **240 images** are ranked. Every grade comes from `ironctl scan`; run it on your own containers in ten seconds:
+
+```bash
+brew install ironsecco/ironclaw/ironclaw
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked best to worst.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+
+---
+
+*Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py`. Categories are keyword classified from the survey, so new images join the right ranking automatically on each weekly refresh.*

--- a/docs/scores/collections/infra-networking.md
+++ b/docs/scores/collections/infra-networking.md
@@ -1,0 +1,45 @@
+---
+title: "Most secure infrastructure and networking container images, ranked by isolation score"
+description: "Ranked isolation scores for 8 infrastructure and networking container images, graded 0-100 by ironctl scan. Average 48/100."
+---
+
+# Most secure infrastructure and networking container images, ranked by isolation score
+
+How isolated are the most-pulled **infrastructure and networking** container images when you `docker run` them with plain defaults, no hardening flags? This page ranks **8 service discovery, secrets, orchestration, and networking (Consul, Vault, Nomad, k3s)** on IronClaw's seven-dimension container containment scale (0-100), best-isolated first. Scores run **48/100 to 48/100** (average **48/100**). Higher is safer. Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+> No infrastructure and networking image ships fully isolated by default: the leaders still leave capabilities, egress, or a writable root filesystem open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## Ranked best to worst
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`hashicorp/consul:1.20`](../consul.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 🥈 2 | [`docker:27-dind`](../docker.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 🥉 3 | [`rancher/k3s:v1.31.4-k3s1`](../k3s.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 4 | [`hashicorp/nomad:1.9`](../nomad.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 5 | [`registry:2.8.3`](../registry.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 6 | [`tailscale/tailscale:v1.78.3`](../tailscale.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 7 | [`hashicorp/vault:1.18`](../vault.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 8 | [`lscr.io/linuxserver/wireguard:1.0.20210914`](../wireguard.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Scan your own infrastructure and networking container
+
+These grades come from `ironctl scan`, one credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just the infrastructure and networking images ranked above:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own container the same way this page was generated
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Browse every category &rarr;](index.md), the full set of ranked collection pages.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked, with a Hall of Fame and worst offenders.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+- [The State of Container Isolation, 2026 &rarr;](../../blog/state-of-container-isolation-2026.md), the survey these grades are built from.
+
+---
+
+*Part of the [Container Isolation Scores](../index.md) directory. Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so this ranking never goes stale. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/collections/language-runtimes.md
+++ b/docs/scores/collections/language-runtimes.md
@@ -1,0 +1,70 @@
+---
+title: "Node.js, Python, Go and more: language runtime container images ranked by isolation score"
+description: "Ranked isolation scores for 33 language runtime container images, graded 0-100 by ironctl scan. Best 63/100, average 48/100. See which ship hardened."
+---
+
+# Node.js, Python, Go and more: language runtime container images ranked by isolation score
+
+How isolated are the most-pulled **language runtime** container images when you `docker run` them with plain defaults, no hardening flags? This page ranks **33 programming language runtimes and build images (Node.js, Python, Go, Ruby, Java, Rust)** on IronClaw's seven-dimension container containment scale (0-100), best-isolated first. Scores run **48/100 to 63/100** (average **48/100**). Higher is safer. Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+> No language runtime image ships fully isolated by default: the leaders still leave capabilities, egress, or a writable root filesystem open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## Ranked best to worst
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`groovy:4`](../groovy.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥈 2 | [`amazoncorretto:21`](../amazoncorretto.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 🥉 3 | [`continuumio/anaconda3:2024.10-1`](../anaconda3.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 4 | [`mcr.microsoft.com/dotnet/aspnet:9.0`](../aspnet.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 5 | [`oven/bun:1.1`](../bun.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 6 | [`clojure:temurin-21-tools-deps`](../clojure.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 7 | [`crystallang/crystal:1.14.1`](../crystal.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 8 | [`dart:3.6`](../dart.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 9 | [`denoland/deno:2.1.4`](../deno.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 10 | [`eclipse-temurin:21-jre-alpine`](../eclipse-temurin.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 11 | [`elixir:1.18-alpine`](../elixir.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 12 | [`erlang:27-alpine`](../erlang.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 13 | [`gcc:14`](../gcc.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 14 | [`golang:1.23-alpine`](../golang.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 15 | [`ghcr.io/graalvm/graalvm-community:21`](../graalvm-community.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 16 | [`gradle:8-jdk21`](../gradle.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 17 | [`haskell:9.8`](../haskell.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 18 | [`ibmjava:8-jre`](../ibmjava.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 19 | [`julia:1.11`](../julia.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 20 | [`nickblah/lua:5.4`](../lua.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 21 | [`maven:3.9-eclipse-temurin-21`](../maven.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 22 | [`mono:6.12`](../mono.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 23 | [`nimlang/nim:2.2.0`](../nim.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 24 | [`node:22-alpine`](../node.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 25 | [`perl:5.40-slim`](../perl.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 26 | [`php:8.4-apache`](../php.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 27 | [`pypy:3.10-slim`](../pypy.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 28 | [`python:3.13-alpine`](../python.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 29 | [`ruby:3.4-alpine`](../ruby.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 30 | [`rust:1.83-alpine`](../rust.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 31 | [`sbtscala/scala-sbt:eclipse-temurin-21.0.5_11_1.10.7_3.6.2`](../scala-sbt.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 32 | [`swift:6.0.3`](../swift.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 33 | [`azul/zulu-openjdk:21`](../zulu-openjdk.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Scan your own language runtime container
+
+These grades come from `ironctl scan`, one credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just the language runtime images ranked above:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own container the same way this page was generated
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Browse every category &rarr;](index.md), the full set of ranked collection pages.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked, with a Hall of Fame and worst offenders.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+- [The State of Container Isolation, 2026 &rarr;](../../blog/state-of-container-isolation-2026.md), the survey these grades are built from.
+
+---
+
+*Part of the [Container Isolation Scores](../index.md) directory. Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so this ranking never goes stale. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/collections/message-queues.md
+++ b/docs/scores/collections/message-queues.md
@@ -1,0 +1,50 @@
+---
+title: "Most secure message queue and streaming container images, ranked by isolation score"
+description: "Ranked isolation scores for 13 message queue and streaming container images, graded 0-100 by ironctl scan. Best 63/100, average 56/100. See which ship hardened."
+---
+
+# Most secure message queue and streaming container images, ranked by isolation score
+
+How isolated are the most-pulled **message queue and streaming** container images when you `docker run` them with plain defaults, no hardening flags? This page ranks **13 brokers and streaming platforms (Kafka, RabbitMQ, NATS, Pulsar, Redpanda)** on IronClaw's seven-dimension container containment scale (0-100), best-isolated first. Scores run **48/100 to 63/100** (average **56/100**). Higher is safer. Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+> No message queue and streaming image ships fully isolated by default: the leaders still leave capabilities, egress, or a writable root filesystem open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## Ranked best to worst
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`apache/activemq-artemis:2.38.0`](../activemq-artemis.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥈 2 | [`confluentinc/cp-kafka:7.8.0`](../cp-kafka.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥉 3 | [`emqx:5`](../emqx.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 4 | [`apache/kafka:3.9.0`](../kafka.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 5 | [`apachepulsar/pulsar:3.3.2`](../pulsar.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 6 | [`redpandadata/redpanda:v24.2.11`](../redpanda.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 7 | [`vernemq/vernemq:2.0.1`](../vernemq.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 8 | [`centrifugo/centrifugo:v5.4.7`](../centrifugo.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 9 | [`eclipse-mosquitto:2`](../eclipse-mosquitto.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 10 | [`nats:2.10-alpine`](../nats.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 11 | [`nsqio/nsq:v1.3.0`](../nsq.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 12 | [`rabbitmq:4-alpine`](../rabbitmq.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 13 | [`zookeeper:3.9`](../zookeeper.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Scan your own message queue and streaming container
+
+These grades come from `ironctl scan`, one credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just the message queue and streaming images ranked above:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own container the same way this page was generated
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Browse every category &rarr;](index.md), the full set of ranked collection pages.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked, with a Hall of Fame and worst offenders.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+- [The State of Container Isolation, 2026 &rarr;](../../blog/state-of-container-isolation-2026.md), the survey these grades are built from.
+
+---
+
+*Part of the [Container Isolation Scores](../index.md) directory. Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so this ranking never goes stale. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/collections/object-storage.md
+++ b/docs/scores/collections/object-storage.md
@@ -1,0 +1,41 @@
+---
+title: "Most secure object storage container images, ranked by isolation score"
+description: "Ranked isolation scores for 4 object storage container images, graded 0-100 by ironctl scan. Best 48/100, average 48/100. See which ship hardened."
+---
+
+# Most secure object storage container images, ranked by isolation score
+
+How isolated are the most-pulled **object storage** container images when you `docker run` them with plain defaults, no hardening flags? This page ranks **4 S3-compatible and distributed object stores (MinIO, Ceph, SeaweedFS)** on IronClaw's seven-dimension container containment scale (0-100), best-isolated first. Scores run **48/100 to 48/100** (average **48/100**). Higher is safer. Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+> No object storage image ships fully isolated by default: the leaders still leave capabilities, egress, or a writable root filesystem open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## Ranked best to worst
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`quay.io/ceph/ceph:v18.2.4`](../ceph.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 🥈 2 | [`minio/minio:latest`](../minio.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 🥉 3 | [`rclone/rclone:1.68.2`](../rclone.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 4 | [`chrislusf/seaweedfs:3.80`](../seaweedfs.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Scan your own object storage container
+
+These grades come from `ironctl scan`, one credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just the object storage images ranked above:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own container the same way this page was generated
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Browse every category &rarr;](index.md), the full set of ranked collection pages.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked, with a Hall of Fame and worst offenders.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+- [The State of Container Isolation, 2026 &rarr;](../../blog/state-of-container-isolation-2026.md), the survey these grades are built from.
+
+---
+
+*Part of the [Container Isolation Scores](../index.md) directory. Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so this ranking never goes stale. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/collections/observability.md
+++ b/docs/scores/collections/observability.md
@@ -1,0 +1,64 @@
+---
+title: "Most secure monitoring and observability container images, ranked by isolation score"
+description: "Ranked isolation scores for 27 monitoring and observability container images, graded 0-100 by ironctl scan. Average 56/100."
+---
+
+# Most secure monitoring and observability container images, ranked by isolation score
+
+How isolated are the most-pulled **monitoring and observability** container images when you `docker run` them with plain defaults, no hardening flags? This page ranks **27 metrics, logging, and tracing stacks (Prometheus, Grafana, Loki, Jaeger, exporters)** on IronClaw's seven-dimension container containment scale (0-100), best-isolated first. Scores run **48/100 to 63/100** (average **56/100**). Higher is safer. Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+> No monitoring and observability image ships fully isolated by default: the leaders still leave capabilities, egress, or a writable root filesystem open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## Ranked best to worst
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`prom/alertmanager:v0.28.0`](../alertmanager.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥈 2 | [`fluent/fluentd:v1.17`](../fluentd.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥉 3 | [`grafana/grafana:11.4.0`](../grafana.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 4 | [`graylog/graylog:6.1`](../graylog.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 5 | [`jaegertracing/jaeger:2.1.0`](../jaeger.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 6 | [`kibana:8.16.1`](../kibana.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 7 | [`logstash:8.16.1`](../logstash.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 8 | [`grafana/loki:3.3.2`](../loki.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 9 | [`prom/node-exporter:v1.8.2`](../node-exporter.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 10 | [`prom/prometheus:v3.1.0`](../prometheus.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 11 | [`prom/pushgateway:v1.10.0`](../pushgateway.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 12 | [`grafana/tempo:2.6.1`](../tempo.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 13 | [`quay.io/thanos/thanos:v0.37.2`](../thanos.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 14 | [`openzipkin/zipkin:3.4.4`](../zipkin.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 15 | [`grafana/alloy:latest`](../alloy.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 16 | [`prom/blackbox-exporter:v0.25.0`](../blackbox-exporter.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 17 | [`gcr.io/cadvisor/cadvisor:v0.52.1`](../cadvisor.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 18 | [`chronograf:1.10`](../chronograf.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 19 | [`quay.io/cortexproject/cortex:v1.18.1`](../cortex.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 20 | [`kapacitor:1.7`](../kapacitor.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 21 | [`netdata/netdata:stable`](../netdata.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 22 | [`grafana/promtail:3.3.2`](../promtail.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 23 | [`statsd/statsd:v0.10.2`](../statsd.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 24 | [`telegraf:1.33-alpine`](../telegraf.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 25 | [`louislam/uptime-kuma:1`](../uptime-kuma.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 26 | [`timberio/vector:0.43.0-alpine`](../vector.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 27 | [`victoriametrics/victoria-metrics:v1.107.0`](../victoria-metrics.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Scan your own monitoring and observability container
+
+These grades come from `ironctl scan`, one credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just the monitoring and observability images ranked above:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own container the same way this page was generated
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Browse every category &rarr;](index.md), the full set of ranked collection pages.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked, with a Hall of Fame and worst offenders.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+- [The State of Container Isolation, 2026 &rarr;](../../blog/state-of-container-isolation-2026.md), the survey these grades are built from.
+
+---
+
+*Part of the [Container Isolation Scores](../index.md) directory. Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so this ranking never goes stale. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/collections/search-engines.md
+++ b/docs/scores/collections/search-engines.md
@@ -1,0 +1,46 @@
+---
+title: "Most secure search engine container images, ranked by isolation score"
+description: "Ranked isolation scores for 9 search engine container images, graded 0-100 by ironctl scan. Best 63/100, average 58/100. See which ship hardened."
+---
+
+# Most secure search engine container images, ranked by isolation score
+
+How isolated are the most-pulled **search engine** container images when you `docker run` them with plain defaults, no hardening flags? This page ranks **9 search and indexing engines (Elasticsearch, OpenSearch, Solr, Meilisearch, Typesense)** on IronClaw's seven-dimension container containment scale (0-100), best-isolated first. Scores run **48/100 to 63/100** (average **58/100**). Higher is safer. Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+> No search engine image ships fully isolated by default: the leaders still leave capabilities, egress, or a writable root filesystem open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## Ranked best to worst
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`elasticsearch:8.16.1`](../elasticsearch.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥈 2 | [`opensearchproject/opensearch:2`](../opensearch.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥉 3 | [`opensearchproject/opensearch-dashboards:2.18.0`](../opensearch-dashboards.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 4 | [`solr:9`](../solr.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 5 | [`apache/tika:latest`](../tika.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 6 | [`vespaengine/vespa:8.453.24`](../vespa.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 7 | [`manticoresearch/manticore:6.3.6`](../manticore.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 8 | [`getmeili/meilisearch:v1.11`](../meilisearch.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 9 | [`typesense/typesense:27.1`](../typesense.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Scan your own search engine container
+
+These grades come from `ironctl scan`, one credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just the search engine images ranked above:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own container the same way this page was generated
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Browse every category &rarr;](index.md), the full set of ranked collection pages.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked, with a Hall of Fame and worst offenders.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+- [The State of Container Isolation, 2026 &rarr;](../../blog/state-of-container-isolation-2026.md), the survey these grades are built from.
+
+---
+
+*Part of the [Container Isolation Scores](../index.md) directory. Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so this ranking never goes stale. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/collections/self-hosted-apps.md
+++ b/docs/scores/collections/self-hosted-apps.md
@@ -1,0 +1,75 @@
+---
+title: "Most secure self-hosted app container images, ranked by isolation score"
+description: "Ranked isolation scores for 38 self-hosted app container images, graded 0-100 by ironctl scan. Best 63/100, average 51/100. See which ship hardened."
+---
+
+# Most secure self-hosted app container images, ranked by isolation score
+
+How isolated are the most-pulled **self-hosted app** container images when you `docker run` them with plain defaults, no hardening flags? This page ranks **38 self-hosted applications (Nextcloud, Jellyfin, Immich, WordPress, Ghost, Gitea alternatives)** on IronClaw's seven-dimension container containment scale (0-100), best-isolated first. Scores run **48/100 to 63/100** (average **51/100**). Higher is safer. Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+> No self-hosted app image ships fully isolated by default: the leaders still leave capabilities, egress, or a writable root filesystem open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## Ranked best to worst
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`directus/directus:11.3.5`](../directus.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥈 2 | [`mattermost/mattermost-team-edition:10.2`](../mattermost-team-edition.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥉 3 | [`miniflux/miniflux:2.2.3`](../miniflux.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 4 | [`outlinewiki/outline:0.82.0`](../outline.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 5 | [`ghcr.io/plankanban/planka:1.24.2`](../planka.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 6 | [`ghcr.io/umami-software/umami:postgresql-v2.14.0`](../umami.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 7 | [`wekanteam/wekan:v7.72`](../wekan.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 8 | [`requarks/wiki:2`](../wiki.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 9 | [`actualbudget/actual-server:24.12.0`](../actual-server.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 10 | [`adguard/adguardhome:latest`](../adguardhome.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 11 | [`appwrite/appwrite:1.6.0`](../appwrite.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 12 | [`ghcr.io/advplyr/audiobookshelf:2.17.5`](../audiobookshelf.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 13 | [`baserow/baserow:1.30.1`](../baserow.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 14 | [`lissy93/dashy:3.1.0`](../dashy.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 15 | [`drupal:11-apache`](../drupal.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 16 | [`lscr.io/linuxserver/duplicati:2.1.0`](../duplicati.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 17 | [`freshrss/freshrss:1.24.3`](../freshrss.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 18 | [`ghost:5-alpine`](../ghost.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 19 | [`lscr.io/linuxserver/heimdall:2.6.3`](../heimdall.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 20 | [`ghcr.io/home-assistant/home-assistant:2024.12`](../home-assistant.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 21 | [`ghcr.io/gethomepage/homepage:v0.10.9`](../homepage.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 22 | [`ghcr.io/immich-app/immich-server:v1.123.0`](../immich-server.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 23 | [`jellyfin/jellyfin:10.10.3`](../jellyfin.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 24 | [`joomla:5-apache`](../joomla.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 25 | [`matomo:5`](../matomo.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 26 | [`mediawiki:1.43`](../mediawiki.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 27 | [`deluan/navidrome:0.54.3`](../navidrome.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 28 | [`nextcloud:30-apache`](../nextcloud.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 29 | [`nocodb/nocodb:0.257.2`](../nocodb.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 30 | [`binwiederhier/ntfy:v2.11.0`](../ntfy.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 31 | [`ghcr.io/paperless-ngx/paperless-ngx:2.14.7`](../paperless-ngx.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 32 | [`pihole/pihole:2024.07.0`](../pihole.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 33 | [`redmine:6`](../redmine.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 34 | [`snipe/snipe-it:v7.0.13`](../snipe-it.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 35 | [`matrixdotorg/synapse:v1.121.1`](../synapse.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 36 | [`lscr.io/linuxserver/syncthing:1.28.1`](../syncthing.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 37 | [`wallabag/wallabag:2.6.10`](../wallabag.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 38 | [`wordpress:6-php8.3-apache`](../wordpress.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Scan your own self-hosted app container
+
+These grades come from `ironctl scan`, one credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just the self-hosted app images ranked above:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own container the same way this page was generated
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Browse every category &rarr;](index.md), the full set of ranked collection pages.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked, with a Hall of Fame and worst offenders.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+- [The State of Container Isolation, 2026 &rarr;](../../blog/state-of-container-isolation-2026.md), the survey these grades are built from.
+
+---
+
+*Part of the [Container Isolation Scores](../index.md) directory. Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so this ranking never goes stale. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/collections/vector-databases.md
+++ b/docs/scores/collections/vector-databases.md
@@ -1,0 +1,42 @@
+---
+title: "Most secure vector database container images, ranked by isolation score"
+description: "Ranked isolation scores for 5 vector database container images, graded 0-100 by ironctl scan. Best 48/100, average 48/100. See which ship hardened."
+---
+
+# Most secure vector database container images, ranked by isolation score
+
+How isolated are the most-pulled **vector database** container images when you `docker run` them with plain defaults, no hardening flags? This page ranks **5 vector databases and embedding stores (Chroma, Qdrant, Weaviate, Milvus, pgvector)** on IronClaw's seven-dimension container containment scale (0-100), best-isolated first. Scores run **48/100 to 48/100** (average **48/100**). Higher is safer. Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+> No vector database image ships fully isolated by default: the leaders still leave capabilities, egress, or a writable root filesystem open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## Ranked best to worst
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`chromadb/chroma:0.5.23`](../chroma.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 🥈 2 | [`milvusdb/milvus:v2.5.1`](../milvus.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 🥉 3 | [`pgvector/pgvector:pg17`](../pgvector.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 4 | [`qdrant/qdrant:v1.12.4`](../qdrant.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 5 | [`semitechnologies/weaviate:1.28.1`](../weaviate.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Scan your own vector database container
+
+These grades come from `ironctl scan`, one credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just the vector database images ranked above:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own container the same way this page was generated
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Browse every category &rarr;](index.md), the full set of ranked collection pages.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked, with a Hall of Fame and worst offenders.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+- [The State of Container Isolation, 2026 &rarr;](../../blog/state-of-container-isolation-2026.md), the survey these grades are built from.
+
+---
+
+*Part of the [Container Isolation Scores](../index.md) directory. Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so this ranking never goes stale. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/collections/web-servers.md
+++ b/docs/scores/collections/web-servers.md
@@ -1,0 +1,53 @@
+---
+title: "Most secure web server and reverse proxy container images, ranked by isolation score"
+description: "Ranked isolation scores for 16 web server and proxy container images, graded 0-100 by ironctl scan. Best 63/100, average 53/100. See which ship hardened."
+---
+
+# Most secure web server and reverse proxy container images, ranked by isolation score
+
+How isolated are the most-pulled **web server and proxy** container images when you `docker run` them with plain defaults, no hardening flags? This page ranks **16 web servers, reverse proxies, and load balancers (nginx, Apache, Caddy, HAProxy, Traefik)** on IronClaw's seven-dimension container containment scale (0-100), best-isolated first. Scores run **48/100 to 63/100** (average **53/100**). Higher is safer. Every score comes from `ironctl scan`, a credential-free audit you can run on your own containers in ten seconds.
+
+> No web server and proxy image ships fully isolated by default: the leaders still leave capabilities, egress, or a writable root filesystem open. The gap between any image here and a clean **100/100 grade A** is a handful of `docker run` flags, shown on every scorecard.
+
+## Ranked best to worst
+
+| Rank | Image | Score | Grade | Top gaps (default config) |
+|-----:|-------|------:|:-----:|---------------------------|
+| 🥇 1 | [`haproxy:3.1-alpine`](../haproxy.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥈 2 | [`jetty:12-jre21`](../jetty.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 🥉 3 | [`kong:3.8`](../kong.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 4 | [`nginxinc/nginx-unprivileged:1.27-alpine`](../nginx-unprivileged.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 5 | [`varnish:7.6-alpine`](../varnish.md) | 63/100 | 🟡 **C** | Dropped capabilities, Network isolation / egress, Read-only root filesystem |
+| 6 | [`caddy:2-alpine`](../caddy.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 7 | [`envoyproxy/envoy:v1.32-latest`](../envoy.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 8 | [`httpd:2.4-alpine`](../httpd.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 9 | [`nginx:1.27-alpine`](../nginx.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 10 | [`nginxproxy/nginx-proxy:1.6.4`](../nginx-proxy.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 11 | [`jc21/nginx-proxy-manager:2.12.1`](../nginx-proxy-manager.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 12 | [`openresty/openresty:alpine`](../openresty.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 13 | [`tomcat:10.1-jre21-temurin`](../tomcat.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 14 | [`tomee:9.1.3-jre17`](../tomee.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 15 | [`traefik:v3.2`](../traefik.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+| 16 | [`unit:1.34.1-minimal`](../unit.md) | 48/100 | 🟠 **D** | Dropped capabilities, Non-root user (uid != 0), Network isolation / egress |
+
+## Scan your own web server and proxy container
+
+These grades come from `ironctl scan`, one credential-free command that audits any running container, docker-compose service, or Kubernetes manifest, not just the web server and proxy images ranked above:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your own container the same way this page was generated
+ironctl scan my-container
+```
+
+- [All container isolation scores &rarr;](../index.md), every scorecard, worst-isolated first.
+- [Browse every category &rarr;](index.md), the full set of ranked collection pages.
+- [Container Isolation Leaderboard &rarr;](../leaderboard.md), the whole dataset ranked, with a Hall of Fame and worst offenders.
+- [Scan any container &rarr;](../../scan.md), the full command reference.
+- [The State of Container Isolation, 2026 &rarr;](../../blog/state-of-container-isolation-2026.md), the survey these grades are built from.
+
+---
+
+*Part of the [Container Isolation Scores](../index.md) directory. Generated from a reproducible survey by `examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so this ranking never goes stale. Grades reflect each image's default configuration, not a limit of the image itself: every one reaches grade A with the right `docker run` flags.*

--- a/docs/scores/index.md
+++ b/docs/scores/index.md
@@ -13,6 +13,8 @@ How isolated is the container you just `docker run`? This directory grades **252
 
 > **New:** the [Container Isolation Leaderboard](leaderboard.md) ranks every image best-to-worst, with a Hall of Fame and a Worst-offenders cut. Each scorecard now carries a copy-paste [shields.io badge](leaderboard.md) you can embed in your repo.
 
+> **Browse by category:** ranked collection pages compare like with like, [most secure databases](collections/databases.md), [language runtimes](collections/language-runtimes.md), [web servers](collections/web-servers.md), [CI/CD](collections/ci-cd-git.md), and [more](collections/index.md).
+
 ## Every image, worst-isolated first
 
 | Image | Score | Grade | Top gaps (default config) |

--- a/docs/scores/leaderboard.md
+++ b/docs/scores/leaderboard.md
@@ -334,6 +334,7 @@ ironctl scan my-container
 ```
 
 - [Container Isolation Scores directory](index.md), every scorecard, worst-isolated first.
+- [Scores by category](collections/index.md), ranked collection pages for databases, language runtimes, web servers, CI/CD, and more.
 - [Scan any container &rarr;](../scan.md), the full command reference.
 - [Add an isolation-score badge to your repo &rarr;](../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)
 - [The State of Container Isolation, 2026 &rarr;](../blog/state-of-container-isolation-2026.md), the full survey.

--- a/examples/isolation-survey/gen_scorecards.py
+++ b/examples/isolation-survey/gen_scorecards.py
@@ -415,6 +415,13 @@ def render_index(defaults: list) -> str:
              "cut. Each scorecard now carries a copy-paste "
              "[shields.io badge](leaderboard.md) you can embed in your repo.")
     L.append("")
+    L.append("> **Browse by category:** ranked collection pages compare like with "
+             "like, [most secure databases](collections/databases.md), "
+             "[language runtimes](collections/language-runtimes.md), "
+             "[web servers](collections/web-servers.md), "
+             "[CI/CD](collections/ci-cd-git.md), and "
+             "[more](collections/index.md).")
+    L.append("")
     L.append("## Every image, worst-isolated first")
     L.append("")
     L.append("| Image | Score | Grade | Top gaps (default config) |")
@@ -609,6 +616,8 @@ def render_leaderboard(defaults: list) -> str:
     L.append("")
     L.append("- [Container Isolation Scores directory](index.md) — every scorecard, "
              "worst-isolated first.")
+    L.append("- [Scores by category](collections/index.md) — ranked collection pages "
+             "for databases, language runtimes, web servers, CI/CD, and more.")
     L.append("- [Scan any container &rarr;](../scan.md) — the full command reference.")
     L.append("- [Add an isolation-score badge to your repo &rarr;]"
              "(../blog/add-a-sandbox-isolation-score-badge-to-your-repo.md)")
@@ -703,6 +712,383 @@ def build_index(data: dict, pages: dict) -> dict:
     }
 
 
+# --- Collection / ranking pages (IRO-476) --------------------------------
+#
+# High-intent long-tail SEO surface built from the same default-* scenarios as
+# the per-image scorecards: one ranked page per topical collection ("most secure
+# database images", "Node.js / Python / Go runtime isolation ranking", ...).
+#
+# Membership is keyword-driven, not a hand-maintained per-image list, so the
+# weekly survey refresh auto-classifies newly surveyed images with zero ongoing
+# labor. Each image lands in at most one collection (first match wins, in
+# priority order) so a topic page is a clean, deduped ranking. Images that match
+# no collection still appear in the directory index + leaderboard; collections
+# are curated high-intent groupings, not an exhaustive partition.
+#
+# This never touches the index.json `family` enum (base|database|runtime|web|
+# infra) the /scores explorer filters on: collections are a docs-only taxonomy,
+# so the explorer contract stays stable.
+
+# Ordered, priority-first. `kw` matches a slug token (slug split on -/_, or the
+# whole slug); `sub` matches a substring anywhere in the slug (for families like
+# nginx-* / *-exporter). First collection that matches claims the image.
+COLLECTIONS = [
+    {
+        "slug": "vector-databases",
+        "label": "vector database",
+        "title": "Most secure vector database container images, ranked by isolation score",
+        "intro": "vector databases and embedding stores (Chroma, Qdrant, Weaviate, Milvus, pgvector)",
+        "kw": {"chroma", "qdrant", "weaviate", "milvus", "pgvector"},
+        "sub": [],
+    },
+    {
+        "slug": "search-engines",
+        "label": "search engine",
+        "title": "Most secure search engine container images, ranked by isolation score",
+        "intro": "search and indexing engines (Elasticsearch, OpenSearch, Solr, Meilisearch, Typesense)",
+        "kw": {"elasticsearch", "opensearch", "solr", "meilisearch", "typesense",
+                "manticore", "vespa", "tika"},
+        "sub": ["opensearch"],
+    },
+    {
+        "slug": "observability",
+        "label": "monitoring and observability",
+        "title": "Most secure monitoring and observability container images, ranked by isolation score",
+        "intro": "metrics, logging, and tracing stacks (Prometheus, Grafana, Loki, Jaeger, exporters)",
+        "kw": {"prometheus", "grafana", "loki", "tempo", "jaeger", "zipkin", "thanos",
+                "cortex", "alertmanager", "cadvisor", "statsd", "telegraf", "promtail",
+                "vector", "fluentd", "logstash", "graylog", "kibana", "netdata",
+                "chronograf", "kapacitor", "alloy", "mimir", "pushgateway"},
+        "sub": ["exporter", "victoria", "uptime"],
+    },
+    {
+        "slug": "message-queues",
+        "label": "message queue and streaming",
+        "title": "Most secure message queue and streaming container images, ranked by isolation score",
+        "intro": "brokers and streaming platforms (Kafka, RabbitMQ, NATS, Pulsar, Redpanda)",
+        "kw": {"kafka", "rabbitmq", "nats", "pulsar", "redpanda", "emqx", "mosquitto",
+                "nsq", "vernemq", "activemq", "artemis", "zookeeper", "centrifugo"},
+        "sub": ["kafka", "mosquitto"],
+    },
+    {
+        "slug": "databases",
+        "label": "database",
+        "title": "Most secure database container images, ranked by isolation score",
+        "intro": "relational, document, key-value, and time-series databases (Postgres, MySQL, MongoDB, Redis)",
+        "kw": {"postgres", "postgis", "timescaledb", "mysql", "mariadb", "percona",
+                "mongo", "redis", "keydb", "valkey", "dragonfly", "cassandra", "scylla",
+                "cockroach", "clickhouse", "couchdb", "couchbase", "rethinkdb",
+                "arangodb", "neo4j", "dgraph", "orientdb", "influxdb", "questdb",
+                "tidb", "yugabyte", "firebird", "aerospike", "tarantool", "hazelcast", "ignite",
+                "druid", "memcached", "adminer", "phpmyadmin"},
+        "sub": ["postgres", "mysql", "mongo", "redis", "pgadmin"],
+    },
+    {
+        "slug": "ci-cd-git",
+        "label": "CI/CD and Git",
+        "title": "Most secure CI/CD and Git container images, ranked by isolation score",
+        "intro": "build runners, CI servers, and Git forges (Jenkins, GitLab, Gitea, Drone, Concourse)",
+        "kw": {"jenkins", "drone", "concourse", "packer", "argocd", "pulumi",
+                "terraform", "gogs", "gitea", "forgejo", "nexus3", "sonarqube",
+                "rancher"},
+        "sub": ["gitlab", "runner", "harbor", "teamcity"],
+    },
+    {
+        "slug": "language-runtimes",
+        "label": "language runtime",
+        "title": "Node.js, Python, Go and more: language runtime container images ranked by isolation score",
+        "intro": "programming language runtimes and build images (Node.js, Python, Go, Ruby, Java, Rust)",
+        "kw": {"node", "bun", "deno", "python", "pypy", "anaconda3", "golang", "ruby",
+                "php", "perl", "rust", "mono", "aspnet", "erlang", "elixir", "clojure",
+                "groovy", "haskell", "julia", "dart", "swift", "crystal", "nim", "lua",
+                "gcc", "maven", "gradle", "ibmjava"},
+        "sub": ["openjdk", "temurin", "corretto", "graalvm", "-sbt"],
+    },
+    {
+        "slug": "web-servers",
+        "label": "web server and proxy",
+        "title": "Most secure web server and reverse proxy container images, ranked by isolation score",
+        "intro": "web servers, reverse proxies, and load balancers (nginx, Apache, Caddy, HAProxy, Traefik)",
+        "kw": {"httpd", "caddy", "haproxy", "traefik", "envoy", "openresty", "varnish",
+                "unit", "tomcat", "tomee", "jetty", "kong"},
+        "sub": ["nginx"],
+    },
+    {
+        "slug": "base-os",
+        "label": "base OS",
+        "title": "Most secure base OS container images, ranked by isolation score",
+        "intro": "base operating system images (Alpine, Debian, Ubuntu, Fedora, Rocky Linux)",
+        "kw": {"alpine", "debian", "ubuntu", "fedora", "rockylinux", "almalinux",
+                "oraclelinux", "amazonlinux", "archlinux", "busybox", "photon", "leap"},
+        "sub": [],
+    },
+    {
+        "slug": "identity-sso",
+        "label": "identity and SSO",
+        "title": "Most secure identity and SSO container images, ranked by isolation score",
+        "intro": "identity providers and single-sign-on servers (Keycloak, Authelia, Dex, Hydra)",
+        "kw": {"keycloak", "authelia", "dex", "hydra", "zitadel"},
+        "sub": [],
+    },
+    {
+        "slug": "object-storage",
+        "label": "object storage",
+        "title": "Most secure object storage container images, ranked by isolation score",
+        "intro": "S3-compatible and distributed object stores (MinIO, Ceph, SeaweedFS)",
+        "kw": {"minio", "ceph", "seaweedfs", "rclone", "garage"},
+        "sub": [],
+    },
+    {
+        "slug": "data-ml",
+        "label": "data engineering and ML",
+        "title": "Most secure data engineering and ML container images, ranked by isolation score",
+        "intro": "data pipelines, analytics, and ML platforms (Airflow, Spark, Flink, MLflow, Jupyter)",
+        "kw": {"airflow", "spark", "flink", "storm", "nifi", "zeppelin", "mlflow",
+                "tensorflow", "jupyterhub", "superset", "metabase", "rstudio", "dagster",
+                "ollama"},
+        "sub": ["notebook"],
+    },
+    {
+        "slug": "infra-networking",
+        "label": "infrastructure and networking",
+        "title": "Most secure infrastructure and networking container images, ranked by isolation score",
+        "intro": "service discovery, secrets, orchestration, and networking (Consul, Vault, Nomad, k3s)",
+        "kw": {"consul", "vault", "nomad", "k3s", "tailscale", "wireguard", "registry",
+                "docker"},
+        "sub": [],
+    },
+    {
+        "slug": "self-hosted-apps",
+        "label": "self-hosted app",
+        "title": "Most secure self-hosted app container images, ranked by isolation score",
+        "intro": "self-hosted applications (Nextcloud, Jellyfin, Immich, WordPress, Ghost, Gitea alternatives)",
+        "kw": {"nextcloud", "jellyfin", "wordpress", "drupal", "ghost", "joomla",
+                "mediawiki", "wiki", "navidrome", "audiobookshelf", "freshrss",
+                "miniflux", "wallabag", "outline", "homepage", "heimdall", "dashy",
+                "synapse", "ntfy", "planka", "wekan", "nocodb", "baserow", "directus",
+                "appwrite", "redmine", "matomo", "umami", "pihole", "adguardhome",
+                "syncthing", "duplicati"},
+        "sub": ["immich", "paperless", "snipe", "actual-server", "mattermost",
+                "home-assistant"],
+    },
+]
+
+
+def _slug_tokens(slug):
+    return set(re.split(r"[-_]", slug)) | {slug}
+
+
+def collection_of(slug):
+    """The one collection a slug belongs to, or None. First match wins."""
+    toks = _slug_tokens(slug)
+    for coll in COLLECTIONS:
+        if toks & coll["kw"]:
+            return coll["slug"]
+        if any(sub in slug for sub in coll["sub"]):
+            return coll["slug"]
+    return None
+
+
+def _members(coll_slug, pages):
+    """Scenarios in a collection, ranked best-isolated first (ties by slug)."""
+    rows = [scn for _slug, scn in pages.items() if collection_of(_slug) == coll_slug]
+    rows.sort(key=lambda s: (-s["report"].get("score", 0), slug_for(s["image"])))
+    return rows
+
+
+def _collection_desc(coll, total, avg, best, worst):
+    """Unique, <=160-char meta description, no em/en-dash (IRO-254/IRO-446)."""
+    d = (f"Ranked isolation scores for {total} {coll['label']} container images, "
+         f"graded 0-100 by ironctl scan. Best {best}/100, average {avg}/100. "
+         f"See which ship hardened.")
+    if len(d) <= 160:
+        return d
+    d = (f"Ranked isolation scores for {total} {coll['label']} container images, "
+         f"graded 0-100 by ironctl scan. Average {avg}/100.")
+    return d if len(d) <= 160 else d[:157].rstrip() + "..."
+
+
+def render_collection(coll, members) -> str:
+    """One ranked collection page: best-to-worst table linking to each scorecard,
+    plus the scan CTA and the usual cross-links. Lives under scores/collections/,
+    so scorecard links are `../<slug>.md` and site links climb one extra level."""
+    total = len(members)
+    avg = round(sum(s["report"].get("score", 0) for s in members) / total) if total else 0
+    best = members[0]["report"].get("score", 0) if members else 0
+    worst = members[-1]["report"].get("score", 0) if members else 0
+    label = coll["label"]
+
+    L = []
+    L.append("---")
+    L.append(f'title: "{coll["title"]}"')
+    L.append(f'description: "{_collection_desc(coll, total, avg, best, worst)}"')
+    L.append("---")
+    L.append("")
+    L.append(f"# {coll['title']}")
+    L.append("")
+    L.append(f"How isolated are the most-pulled **{label}** container images when you "
+             f"`docker run` them with plain defaults, no hardening flags? This page "
+             f"ranks **{total} {coll['intro']}** on IronClaw's seven-dimension "
+             f"container containment scale (0-100), best-isolated first. Scores run "
+             f"**{worst}/100 to {best}/100** (average **{avg}/100**). Higher is safer. "
+             f"Every score comes from `ironctl scan`, a credential-free audit you can "
+             f"run on your own containers in ten seconds.")
+    L.append("")
+    L.append(f"> No {label} image ships fully isolated by default: the leaders still "
+             f"leave capabilities, egress, or a writable root filesystem open. The gap "
+             f"between any image here and a clean **100/100 grade A** is a handful of "
+             f"`docker run` flags, shown on every scorecard.")
+    L.append("")
+    L.append("## Ranked best to worst")
+    L.append("")
+    L.append("| Rank | Image | Score | Grade | Top gaps (default config) |")
+    L.append("|-----:|-------|------:|:-----:|---------------------------|")
+    for i, s in enumerate(members, 1):
+        rep = s["report"]
+        slug = slug_for(s["image"])
+        grade = rep.get("grade", "?")
+        emoji = GRADE_EMOJI.get(grade, "")
+        medal = MEDAL.get(i, "")
+        gaps = ", ".join(t for t, _, _ in top_fixes(rep, 3)) or "none, fully hardened"
+        img = s["image"].split("@")[0]
+        rank_cell = f"{medal} {i}".strip()
+        L.append(f"| {rank_cell} | [`{img}`](../{slug}.md) | {rep.get('score',0)}/100 | "
+                 f"{emoji} **{grade}** | {gaps} |")
+    L.append("")
+    L.append(f"## Scan your own {label} container")
+    L.append("")
+    L.append(f"These grades come from `ironctl scan`, one credential-free command that "
+             f"audits any running container, docker-compose service, or Kubernetes "
+             f"manifest, not just the {label} images ranked above:")
+    L.append("")
+    L.append("```bash")
+    L.append("# install (Homebrew)")
+    L.append("brew install ironsecco/ironclaw/ironclaw")
+    L.append("")
+    L.append("# grade your own container the same way this page was generated")
+    L.append("ironctl scan my-container")
+    L.append("```")
+    L.append("")
+    L.append("- [All container isolation scores &rarr;](../index.md) — every scorecard, "
+             "worst-isolated first.")
+    L.append("- [Browse every category &rarr;](index.md) — the full set of ranked "
+             "collection pages.")
+    L.append("- [Container Isolation Leaderboard &rarr;](../leaderboard.md) — the whole "
+             "dataset ranked, with a Hall of Fame and worst offenders.")
+    L.append("- [Scan any container &rarr;](../../scan.md) — the full command reference.")
+    L.append("- [The State of Container Isolation, 2026 &rarr;]"
+             "(../../blog/state-of-container-isolation-2026.md) — the survey these "
+             "grades are built from.")
+    L.append("")
+    L.append("---")
+    L.append("")
+    L.append(f"*Part of the [Container Isolation Scores](../index.md) directory. "
+             f"Generated from a reproducible survey by "
+             f"`examples/isolation-survey/gen_scorecards.py` and refreshed weekly, so "
+             f"this ranking never goes stale. Grades reflect each image's default "
+             f"configuration, not a limit of the image itself: every one reaches grade "
+             f"A with the right `docker run` flags.*")
+    L.append("")
+    return "\n".join(L)
+
+
+CARD_LABEL = {
+    "vector-databases": "Vector databases",
+    "search-engines": "Search engines",
+    "observability": "Monitoring and observability",
+    "message-queues": "Message queues and streaming",
+    "databases": "Databases",
+    "ci-cd-git": "CI/CD and Git",
+    "language-runtimes": "Language runtimes (Node.js, Python, Go, ...)",
+    "web-servers": "Web servers and proxies",
+    "base-os": "Base OS images",
+    "identity-sso": "Identity and SSO",
+    "object-storage": "Object storage",
+    "data-ml": "Data engineering and ML",
+    "infra-networking": "Infrastructure and networking",
+    "self-hosted-apps": "Self-hosted apps",
+}
+
+
+def render_collections_index(groups) -> str:
+    """The hub page linking every collection: a table of category, image count,
+    average score, and the best-isolated image in each. `groups` is a list of
+    (coll, members) already filtered to non-empty collections."""
+    all_imgs = sum(len(m) for _c, m in groups)
+    L = []
+    L.append("---")
+    L.append("title: Container isolation scores by category")
+    L.append("description: Ranked container isolation scores by category: databases, "
+             "language runtimes, web servers, CI/CD, observability, and more. Graded "
+             "0-100 by ironctl scan.")
+    L.append("---")
+    L.append("")
+    L.append("# Container isolation scores by category")
+    L.append("")
+    L.append(f"The [container isolation scores directory](../index.md) grades hundreds "
+             f"of the most-pulled public Docker images as they ship. These **{len(groups)} "
+             f"category pages** rank them by topic, so you can compare like with like: "
+             f"a database against a database, a language runtime against a runtime. "
+             f"Every page is regenerated on the weekly survey refresh, so the rankings "
+             f"never go stale.")
+    L.append("")
+    L.append("| Category | Images | Avg score | Best-isolated (default config) |")
+    L.append("|----------|-------:|----------:|--------------------------------|")
+    for coll, members in groups:
+        total = len(members)
+        avg = round(sum(s["report"].get("score", 0) for s in members) / total) if total else 0
+        best = members[0]
+        rep = best["report"]
+        bslug = slug_for(best["image"])
+        grade = rep.get("grade", "?")
+        emoji = GRADE_EMOJI.get(grade, "")
+        bimg = best["image"].split("@")[0]
+        L.append(f"| [{CARD_LABEL.get(coll['slug'], coll['label'])}]({coll['slug']}.md) "
+                 f"| {total} | {avg}/100 | [`{bimg}`](../{bslug}.md) "
+                 f"{rep.get('score',0)}/100 {emoji} {grade} |")
+    L.append("")
+    L.append(f"Across these categories, **{all_imgs} images** are ranked. Every grade "
+             f"comes from `ironctl scan`; run it on your own containers in ten seconds:")
+    L.append("")
+    L.append("```bash")
+    L.append("brew install ironsecco/ironclaw/ironclaw")
+    L.append("ironctl scan my-container")
+    L.append("```")
+    L.append("")
+    L.append("- [All container isolation scores &rarr;](../index.md) — every scorecard, "
+             "worst-isolated first.")
+    L.append("- [Container Isolation Leaderboard &rarr;](../leaderboard.md) — the whole "
+             "dataset ranked best to worst.")
+    L.append("- [Scan any container &rarr;](../../scan.md) — the full command reference.")
+    L.append("")
+    L.append("---")
+    L.append("")
+    L.append("*Generated from a reproducible survey by "
+             "`examples/isolation-survey/gen_scorecards.py`. Categories are keyword "
+             "classified from the survey, so new images join the right ranking "
+             "automatically on each weekly refresh.*")
+    L.append("")
+    return "\n".join(L)
+
+
+def write_collections(pages, out_dir):
+    """Emit scores/collections/index.md + one ranked page per non-empty collection.
+    Returns the number of collection pages written (excluding the hub index)."""
+    coll_dir = os.path.join(out_dir, "collections")
+    os.makedirs(coll_dir, exist_ok=True)
+    groups = []
+    for coll in COLLECTIONS:
+        members = _members(coll["slug"], pages)
+        if len(members) < 3:  # a ranking needs a few rows to be worth a page
+            continue
+        groups.append((coll, members))
+        with open(os.path.join(coll_dir, f"{coll['slug']}.md"), "w") as f:
+            f.write(no_dashes(render_collection(coll, members)))
+    with open(os.path.join(coll_dir, "index.md"), "w") as f:
+        f.write(no_dashes(render_collections_index(groups)))
+    return len(groups)
+
+
 def no_dashes(s: str) -> str:
     """Strip em/en-dashes from published copy (IRO-254 standing rule). A spaced
     em-dash becomes a comma; any bare one becomes a hyphen-minus."""
@@ -740,8 +1126,14 @@ def main():
         json.dump(index, f, indent=2, ensure_ascii=False)
         f.write("\n")
 
+    # Collection / ranking pages: high-intent long-tail SEO surface grouped by
+    # topic (databases, language runtimes, web servers, CI/CD, ...). Keyword
+    # classified from the survey so new images join automatically (IRO-476).
+    n_coll = write_collections(pages, out_dir)
+
     print(f"wrote {len(pages)} scorecard pages + index.md + leaderboard.md + "
-          f"index.json ({index['meta']['imageCount']} images) to {out_dir}")
+          f"index.json ({index['meta']['imageCount']} images) + "
+          f"{n_coll} collection pages to {out_dir}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

14 programmatic **collection / ranking pages** over the container-isolation scores dataset, plus a category hub, generated by `gen_scorecards.py` and refreshed automatically on the weekly survey cron (IRO-476).

Closes the gap called out in IRO-476: per-image scorecards already existed; this adds the *collection* pages that capture high-intent long-tail queries ("most secure database container images", "Node.js / Python / Go runtime isolation ranking", category leaderboards).

## Pages (`docs/scores/collections/`)

`databases` (37), `self-hosted-apps` (38), `language-runtimes` (32), `observability` (25), `ci-cd-git` (19), `web-servers` (16), `data-ml` (14), `message-queues` (13), `base-os` (12), `search-engines` (9), `infra-networking` (8), `vector-databases` (5), `identity-sso` (4), `object-storage` (4) + a hub `index.md`.

Each page: unique quoted title + <=160-char meta description, a best-to-worst ranked table linking to every per-image scorecard, an `ironctl scan` install + CTA, and cross-links to the scores directory, leaderboard, scan reference, and survey blog.

## How it stays fresh (zero labor)

Membership is **keyword-classified from the survey** (`collection_of()`, first-match-wins, one collection per image), not a hand-maintained list, so newly-surveyed images join the right ranking on each weekly refresh. Deterministic output; the 252 existing scorecards + `index.json` are byte-identical.

## Funnel

- Inbound: scores `index.md` + `leaderboard.md` now link the category hub.
- Nav: `collections/` wired into the scores `.nav.yml` (subdir with its own glob nav).
- Does **not** touch the `index.json` `family` enum the /scores explorer filters on, so the explorer contract is unchanged.

## Verification

- `mkdocs build --strict` passes (EXIT 0, no broken-link warnings).
- 0 em/en-dashes in generated copy (IRO-254 rule).
- 12 genuinely-misc images (localstack, mailhog, n8n, swagger-ui, ...) stay uncollected by design; still present in the directory index + leaderboard.