### PR TITLE
test: cover OpenRouter partial overrides

### DIFF
--- a/internal/sandbox/provider/openrouter_test.go
+++ b/internal/sandbox/provider/openrouter_test.go
@@ -50,3 +50,57 @@ func TestOpenRouterFactoryOverrides(t *testing.T) {
 		t.Fatalf("openrouter override url = %q, want the overridden host standard /v1 path", op.url)
 	}
 }
+
+func TestOpenRouterFactoryHostOnlyOverride(t *testing.T) {
+	const host = "gateway.example.test"
+
+	pv, err := New(Config{Kind: KindOpenRouter, UpstreamHost: host})
+	if err != nil {
+		t.Fatalf("openrouter host-only override: %v", err)
+	}
+	op, ok := pv.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("openrouter kind = %T, want *OpenAIProvider", pv)
+	}
+	if op.cfg.UpstreamHost != host {
+		t.Fatalf("openrouter upstream host = %q, want overridden %q", op.cfg.UpstreamHost, host)
+	}
+	if op.cfg.Model != defaultOpenRouterModel {
+		t.Fatalf("openrouter model = %q, want default %q", op.cfg.Model, defaultOpenRouterModel)
+	}
+	if !strings.Contains(op.url, host+"/v1/chat/completions") {
+		t.Fatalf("openrouter host-only override url = %q, want the overridden host standard /v1 path", op.url)
+	}
+}
+
+func TestOpenRouterFactoryModelOnlyOverride(t *testing.T) {
+	const model = "meta-llama/llama-3.1-8b-instruct"
+
+	pv, err := New(Config{Kind: KindOpenRouter, Model: model})
+	if err != nil {
+		t.Fatalf("openrouter model-only override: %v", err)
+	}
+	op, ok := pv.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("openrouter kind = %T, want *OpenAIProvider", pv)
+	}
+	if op.cfg.UpstreamHost != openRouterUpstreamHost {
+		t.Fatalf("openrouter upstream host = %q, want default %q", op.cfg.UpstreamHost, openRouterUpstreamHost)
+	}
+	if op.cfg.Model != model {
+		t.Fatalf("openrouter model = %q, want overridden %q", op.cfg.Model, model)
+	}
+	if !strings.Contains(op.url, openRouterUpstreamHost+"/api/v1/chat/completions") {
+		t.Fatalf("openrouter model-only override url = %q, want the %s /api/v1 path", op.url, openRouterUpstreamHost)
+	}
+}
+
+func TestOpenRouterFactoryRegistered(t *testing.T) {
+	pv, err := New(Config{Kind: KindOpenRouter})
+	if err != nil {
+		t.Fatalf("openrouter registry discovery: %v", err)
+	}
+	if pv == nil {
+		t.Fatal("openrouter registry discovery = nil, want non-nil provider")
+	}
+}


### PR DESCRIPTION
## What & why

Cover OpenRouter's per-field defaults so partial host or model overrides keep the correct counterpart and request path.

Closes #443

## Changes

- test host-only overrides with the default OpenRouter model
- test model-only overrides with the default OpenRouter host
- verify OpenRouter registry discovery through `New`

## Checklist

- [x] **Tests pass:** `CGO_ENABLED=1 go test ./...` is green.
- [ ] **Formatted & vetted:** `go vet ./...` passes and the changed file is gofmt-clean; repository-wide `gofmt -l .` still reports the pre-existing `internal/host/scan/compare_test.go` formatting issue that is also present on current `origin/main`.
- [x] **Frozen contract:** `internal/contract/**` is untouched.
- [x] **Threat model:** no sandbox or approval-gateway behavior changes.
- [x] **Docs updated:** not required for this test-only change.
- [x] **No secrets:** no tokens, keys, or credentials are included.

## Validation

- [x] `CGO_ENABLED=1 go test ./internal/sandbox/provider`
- [x] `CGO_ENABLED=1 go test ./...`
- [x] `CGO_ENABLED=1 go vet ./...`
- [x] `CGO_ENABLED=1 go build ./...`
- [x] `gofmt -l internal/sandbox/provider/openrouter_test.go` is empty
- [x] `git diff --check origin/main...HEAD`
- [ ] `gofmt -l .` is empty — blocked only by the unrelated pre-existing file noted above
