### PR TITLE
fix(release): reset brew/track to live main tip, not release build-sha (IRO-482)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -749,12 +749,19 @@ jobs:
           # current main tip every release is always cleanly rebased onto main, so the
           # tracking PR can never conflict, and there is never more than one open.
           branch="brew/track"
-          base_sha="$(git rev-parse HEAD)"
-          # Blob OID of the formula already on main == the Contents API `sha` we must
-          # pass to replace it. Git's blob hash and GitHub's content sha are the same.
-          # After the reset below the rolling branch == main, so this is the blob to
-          # replace on the branch too.
-          file_sha="$(git rev-parse "HEAD:Formula/ironclaw.rb")"
+          # Resolve the LIVE default-branch tip at PR-open time, not the release
+          # build commit this job checked out. Using git rev-parse HEAD would pin
+          # the rolling branch to the release tag's ancestor, so if another commit
+          # (e.g. a prior release's formula bump) lands on main before this PR
+          # merges, brew/track and main both rewrite the same formula lines from a
+          # common ancestor → CONFLICT that update-branch cannot auto-resolve
+          # (IRO-482). Fetching via the API gives us the true current tip.
+          base_sha="$(gh api "repos/${REPO}/git/ref/heads/main" --jq .object.sha)"
+          # Blob OID of the formula on the LIVE main, not the release checkout.
+          # The Contents API `sha` must match the file being replaced on the branch;
+          # after the reset below brew/track == live main, so we need live main's
+          # blob sha, not the release tag's blob sha.
+          file_sha="$(gh api "repos/${REPO}/contents/Formula/ironclaw.rb?ref=main" --jq .sha)"
           content_b64="$(base64 -w0 < Formula/ironclaw.rb)"
 
           # Create the rolling branch at the current main tip, or force-reset it there
@@ -866,6 +873,26 @@ jobs:
             else
               emit_manual_fallback "gh pr create failed for ${branch}: ${out}"
             fi
+          fi
+
+          # Guardrail (IRO-482): assert the rolling PR is actually MERGEABLE after
+          # the branch reset + formula commit. If a race still causes a conflict the
+          # job fails LOUD here with the manual runbook instead of silently leaving a
+          # CONFLICTING PR for the next operator to discover.
+          # Poll up to ~30 s — GitHub computes mergeability asynchronously.
+          pr_num="$(gh pr list --repo "${REPO}" --head "${branch}" --state open \
+            --json number -q '.[0].number' 2>/dev/null || true)"
+          if [ -n "${pr_num:-}" ]; then
+            mergeable="UNKNOWN"
+            for _i in 1 2 3 4 5 6; do
+              mergeable="$(gh api "repos/${REPO}/pulls/${pr_num}" --jq .mergeable 2>/dev/null || echo "UNKNOWN")"
+              [ "${mergeable}" != "null" ] && [ "${mergeable}" != "UNKNOWN" ] && break
+              sleep 5
+            done
+            if [ "${mergeable}" != "true" ]; then
+              emit_manual_fallback "brew/track PR #${pr_num} is not MERGEABLE after reset (mergeable=${mergeable}). Force-reset brew/track to live main and re-run, or merge manually."
+            fi
+            echo "brew/track PR #${pr_num} is MERGEABLE — conflict-free."
           fi
 
           # Housekeeping: close any legacy per-tag bump PRs the pre-IRO-270 flow left


### PR DESCRIPTION
## Problem

`brew/track` was force-reset to `git rev-parse HEAD` — the release tag's checkout commit — not the current `main` tip at PR-open time.

When a prior release's formula bump merged to `main` *after* this job started (releases outrunning brew merges), both that merged commit and `brew/track` had independently rewritten the same `version`/`url`/`sha256` lines from a common ancestor. Result: unresolvable MERGE CONFLICT. `gh pr update-branch` fails; PR sits `DIRTY`/`CONFLICTING`; requires manual CEO intervention (observed 2026-07-13, PR #468).

## Fix

**`base_sha`** — replaced `git rev-parse HEAD` with a live API call:
```bash
base_sha="$(gh api "repos/${REPO}/git/ref/heads/main" --jq .object.sha)"
```
The rolling branch is now force-reset to the true current `main` tip at job-run time, making `brew/track` a clean fast-forward off live `main` regardless of release/merge interleaving.

**`file_sha`** — replaced `git rev-parse HEAD:Formula/ironclaw.rb` with:
```bash
file_sha="$(gh api "repos/${REPO}/contents/Formula/ironclaw.rb?ref=main" --jq .sha)"
```
The Contents API `sha` must match the blob being replaced on the branch. After the reset, `brew/track` == live `main`, so we need live `main`'s blob sha, not the release tag's blob sha (they differ when a prior formula bump is already on `main`).

**Guardrail** — after the PR is open/refreshed, polls `mergeable` (up to 30 s, GitHub computes it async) and calls `emit_manual_fallback` if not `true`. Future races fail LOUD in the job summary instead of silently stranding a conflicting PR.

## Load-bearing invariants preserved

- Singular `git/ref/heads/<branch>` existence probe (not plural, IRO-318) — unchanged.
- CLA-author pinning (IRO-353, IRO-363) — unchanged.
- `emit_manual_fallback` contract — unchanged (guardrail adds a new call site).
- Squash-merge-only note (unsigned commit OK because squash is GitHub-signed) — unchanged.

## Verification

Walk the two-releases-one-unmerged scenario:
1. Release N fires → `base_sha` = live `main` tip M0 → `brew/track` reset to M0 → formula bumped for vN → PR #X opens.
2. PR #X merges → `main` moves to M1 (formula now vN).
3. Release N+1 fires *before or after* #X merges → `base_sha` = current live `main` (M1 or later) → `brew/track` reset to that tip → formula bumped for vN+1 on top of it → clean fast-forward, no conflict.

Shellcheck passes (no new constructs; loop var `_i` is intentionally unused).