### PR TITLE
feat(action): publish scan Action to Marketplace via root action.yml (IRO-485)

### DIFF
--- a/.github/actions/scan/README.md
+++ b/.github/actions/scan/README.md
@@ -10,6 +10,10 @@ file) and **never talks to any control-plane or needs credentials**. The only
 network access is downloading the released `ironctl` binary. Fail-closed: any
 dimension it cannot determine is graded as insecure.
 
+> **Marketplace shortcut:** the same action is published at the repo root, so you
+> can also write the shorter `uses: IronSecCo/ironclaw@v1`. Both refs run one
+> `scan.sh` and never diverge; this subdir path stays supported as a fallback.
+
 ## Quick start
 
 ```yaml

--- a/.github/workflows/scan-scorecard.yml
+++ b/.github/workflows/scan-scorecard.yml
@@ -1,9 +1,13 @@
 name: Sandbox scan scorecard (dogfood)
 
-# Green-run proof + live example for the reusable `IronClaw sandbox scan` action
-# (.github/actions/scan). It runs the exact thing an external adopter runs —
-# `uses: <the action>` against real containers — so a broken action surfaces here
-# before an adopter hits it, and this PR itself renders the scorecard comments.
+# Green-run proof + live example for the reusable `IronClaw sandbox scan` action.
+# It runs the exact thing an external adopter runs — `uses: <the action>` against
+# real containers — so a broken action surfaces here before an adopter hits it,
+# and this PR itself renders the scorecard comments.
+#
+# It exercises BOTH entry points so neither can rot:
+#   * the subdir ref  `./.github/actions/scan`  (existing users' path)
+#   * the root ref     `./`                      (the Marketplace action.yml)
 #
 # Two contrasting targets prove the grader both ways:
 #   * a HARDENED container  -> ~100/A, gated at min-score 90 (must pass)
@@ -17,10 +21,12 @@ on:
   push:
     branches: [main]
     paths:
+      - "action.yml"
       - ".github/actions/scan/**"
       - ".github/workflows/scan-scorecard.yml"
   pull_request:
     paths:
+      - "action.yml"
       - ".github/actions/scan/**"
       - ".github/workflows/scan-scorecard.yml"
   workflow_dispatch:
@@ -70,11 +76,28 @@ jobs:
           mode: container
           min-score: 0
 
-      - name: Assert the hardened container graded A
+      # Prove the Marketplace root action.yml runs end-to-end via the root ref
+      # `uses: ./`. Same hardened target; comment off so it does not fight the
+      # subdir run over the sticky scorecard (same mode+target marker).
+      - name: Scan the hardened sandbox via the ROOT action (uses ./)
+        id: root
+        uses: ./
+        with:
+          target: hardened-sandbox
+          mode: container
+          min-score: 90
+          comment: false
+
+      - name: Assert both entry points graded the hardened container A
         env:
           SCORE: ${{ steps.hardened.outputs.score }}
           GRADE: ${{ steps.hardened.outputs.grade }}
+          ROOT_SCORE: ${{ steps.root.outputs.score }}
+          ROOT_GRADE: ${{ steps.root.outputs.grade }}
         run: |
-          echo "hardened score=${SCORE} grade=${GRADE}"
+          echo "subdir score=${SCORE} grade=${GRADE}"
+          echo "root   score=${ROOT_SCORE} grade=${ROOT_GRADE}"
           test "${GRADE}" = "A" \
-            || { echo "::error::expected the hardened container to grade A"; exit 1; }
+            || { echo "::error::expected the subdir action to grade the hardened container A"; exit 1; }
+          test "${ROOT_GRADE}" = "A" \
+            || { echo "::error::expected the root action.yml to grade the hardened container A"; exit 1; }

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,133 @@
+# IronClaw sandbox scan — Marketplace entry point (root action).
+#
+# This is a THIN wrapper around .github/actions/scan so the action is
+# discoverable on the GitHub Marketplace, which requires a root-level
+# action.yml. It does not duplicate any scan logic: it runs the exact same
+# scan.sh that ships under .github/actions/scan, and re-uses the same
+# SARIF/badge upload steps. The subdir action stays valid for existing users.
+#
+# Grades the isolation posture of a running container, a docker-compose service,
+# or a Kubernetes manifest 0-100 with `ironctl scan`, posts the scorecard as a
+# sticky pull-request comment (create-or-update, never spam), and optionally
+# fails the check when the score drops below a threshold.
+#
+# It is LOCAL and read-only: it inspects configuration (docker inspect / a
+# compose or k8s file), never talks to any control-plane, and needs no
+# credentials. The only network access is downloading the released `ironctl`
+# binary from GitHub Releases. Fail-closed: any dimension it cannot determine is
+# graded as insecure.
+#
+# Usage (in a consumer repo):
+#
+#   - uses: IronSecCo/ironclaw@v1
+#     with:
+#       target: my-container          # container name/id, or file path for compose/k8s
+#       mode: container               # container | compose | k8s
+#       min-score: 0                  # 0 = report-only; >0 fails the check below it
+#
+# The subdir ref `IronSecCo/ironclaw/.github/actions/scan@v1` keeps working as a
+# fallback. See docs/scan-action.md for the full guide.
+name: 'IronClaw sandbox scan'
+description: 'Grade a container / compose / k8s sandbox isolation posture 0-100 and post a sticky PR scorecard.'
+author: 'IronSec Co.'
+branding:
+  icon: 'shield'
+  color: 'blue'
+
+inputs:
+  target:
+    description: 'What to scan: a running container name/id (mode=container), or a path to a compose/k8s file (mode=compose|k8s).'
+    required: true
+  mode:
+    description: 'Scan mode: container | compose | k8s.'
+    required: false
+    default: 'container'
+  service:
+    description: 'Compose service name (required only when mode=compose and the file has more than one service).'
+    required: false
+    default: ''
+  min-score:
+    description: 'Fail the check when the containment score is below this (0-100). 0 = report-only (default).'
+    required: false
+    default: '0'
+  comment:
+    description: 'Post the scorecard as a sticky comment on the pull request (true/false).'
+    required: false
+    default: 'true'
+  badge:
+    description: 'Write and upload the shareable SVG badge as a build artifact (true/false).'
+    required: false
+    default: 'false'
+  upload-sarif:
+    description: 'Emit SARIF and upload it to GitHub code scanning so failed dimensions appear in the Security tab (true/false). Requires `permissions: security-events: write` in the calling workflow. Default false so the action needs no extra permission unless you opt in.'
+    required: false
+    default: 'false'
+  version:
+    description: 'ironctl release to use: a tag like v0.1.252, or "latest" (default).'
+    required: false
+    default: 'latest'
+  github-token:
+    description: 'Token used to post the PR comment and resolve the latest release. Defaults to the workflow token.'
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  score:
+    description: 'The overall containment score (0-100).'
+    value: ${{ steps.scan.outputs.score }}
+  grade:
+    description: 'The letter grade (A-F).'
+    value: ${{ steps.scan.outputs.grade }}
+  scorecard:
+    description: 'Path to the rendered markdown scorecard.'
+    value: ${{ steps.scan.outputs.scorecard }}
+  badge-path:
+    description: 'Path to the SVG badge (only when badge=true).'
+    value: ${{ steps.scan.outputs.badge-path }}
+  sarif-path:
+    description: 'Path to the SARIF log (only when upload-sarif=true).'
+    value: ${{ steps.scan.outputs.sarif-path }}
+  passed:
+    description: 'true when the score met min-score (or min-score was 0).'
+    value: ${{ steps.scan.outputs.passed }}
+
+runs:
+  using: 'composite'
+  steps:
+    # Single source of truth: run the same scan.sh that ships under
+    # .github/actions/scan. GITHUB_ACTION_PATH is this repo's root when consumed
+    # as `IronSecCo/ironclaw@v1`, so the subdir script resolves without copying.
+    - id: scan
+      shell: bash
+      env:
+        IC_TARGET: ${{ inputs.target }}
+        IC_MODE: ${{ inputs.mode }}
+        IC_SERVICE: ${{ inputs.service }}
+        IC_MIN_SCORE: ${{ inputs.min-score }}
+        IC_COMMENT: ${{ inputs.comment }}
+        IC_BADGE: ${{ inputs.badge }}
+        IC_UPLOAD_SARIF: ${{ inputs.upload-sarif }}
+        IC_VERSION: ${{ inputs.version }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: bash "${GITHUB_ACTION_PATH}/.github/actions/scan/scan.sh"
+
+    # Opt-in SARIF upload: surfaces failed isolation dimensions in the repo's
+    # Security > Code scanning tab. Gated on upload-sarif so the action needs no
+    # security-events permission unless the consumer opts in. always() so a SARIF
+    # written before a min-score gate failure still uploads. codeql-action pinned
+    # by commit SHA (supply-chain).
+    - if: ${{ always() && inputs.upload-sarif == 'true' && steps.scan.outputs.sarif-path != '' }}
+      uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
+      with:
+        sarif_file: ${{ steps.scan.outputs.sarif-path }}
+        category: ironclaw-scan
+
+    # Uploaded as a separate composite step, with always(), so the artifact
+    # survives even when the scan step fails the min-score gate after the badge
+    # file is already written.
+    - if: ${{ always() && inputs.badge == 'true' && steps.scan.outputs.badge-path != '' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ironclaw-scan-badge
+        path: ${{ steps.scan.outputs.badge-path }}
+        if-no-files-found: warn

--- a/docs/scan-action.md
+++ b/docs/scan-action.md
@@ -23,11 +23,16 @@ jobs:
       - name: Start the container you want to grade
         run: docker run -d --name my-sandbox my-image:latest sleep 3600
 
-      - uses: IronSecCo/ironclaw/.github/actions/scan@v1
+      - uses: IronSecCo/ironclaw@v1
         with:
           target: my-sandbox
           min-score: 90        # omit / 0 = report-only, never blocks the check
 ```
+
+`IronSecCo/ironclaw@v1` is the [Marketplace](https://github.com/marketplace/actions/ironclaw-sandbox-scan)
+listing (root `action.yml`). The subdir ref
+`IronSecCo/ironclaw/.github/actions/scan@v1` runs the exact same grader and stays
+supported as a fallback — both point at one `scan.sh`, so they never diverge.
 
 On the pull request you get a scorecard comment that updates in place on every
 push:
@@ -50,14 +55,14 @@ The file modes need no Docker daemon — the action reads the file directly:
 
 ```yaml
 # a docker-compose service
-- uses: IronSecCo/ironclaw/.github/actions/scan@v1
+- uses: IronSecCo/ironclaw@v1
   with:
     mode: compose
     target: docker-compose.yml
     service: app            # required only if the file has >1 service
 
 # a Kubernetes pod / workload manifest
-- uses: IronSecCo/ironclaw/.github/actions/scan@v1
+- uses: IronSecCo/ironclaw@v1
   with:
     mode: k8s
     target: deploy/pod.yaml
@@ -97,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: IronSecCo/ironclaw/.github/actions/scan@v1
+      - uses: IronSecCo/ironclaw@v1
         with:
           mode: compose
           target: docker-compose.yml


### PR DESCRIPTION
## What

Makes the **IronClaw sandbox scan** GitHub Action discoverable on the [GitHub Marketplace](https://docs.github.com/en/actions/sharing-automations/creating-actions/publishing-actions-in-github-marketplace) by adding a root-level `action.yml`. Marketplace requires a root `action.yml` and spends the repo's single Marketplace slot — CEO product decision (IRO-485): spend it on scan, our strongest CI on-ramp.

## How

- **Root `action.yml`** — thin composite wrapper. It runs the *same* `.github/actions/scan/scan.sh` via `${GITHUB_ACTION_PATH}/.github/actions/scan/scan.sh` and re-uses the identical SARIF/badge upload steps. **No scan logic is duplicated** — one `scan.sh` is the single source of truth. Full Marketplace metadata: name, description, author, branding (`shield`/`blue`), and the complete inputs/outputs contract.
- **Subdir action untouched** — `IronSecCo/ironclaw/.github/actions/scan@v1` keeps working for existing users.
- **Dogfood smoke** — `scan-scorecard.yml` now exercises **both** entry points against the hardened container (`./.github/actions/scan` and `uses: ./`) and asserts both grade **A**, so neither ref can rot. Added `action.yml` to the workflow's path filters.
- **Docs** — `docs/scan-action.md` and the subdir README lead with `uses: IronSecCo/ironclaw@v1` and document the subdir path as a supported fallback.

## Verification

- `python3 yaml.safe_load` ✓ on root `action.yml`, subdir `action.yml`, and the workflow.
- `mkdocs build --strict` ✓ (docs touched).
- Live end-to-end proof runs in CI via the updated dogfood workflow (both refs → grade A on the hardened container).

## Security lenses

Egress/isolation posture unchanged — the root action is a pure wrapper over the existing read-only, credential-free `scan.sh` (only egress = the `ironctl` release download). No trust boundary, gateway, encryption, or key-custody surface touched. `upload-sarif` stays opt-in (no `security-events` permission unless requested); pinned external actions kept SHA-pinned.

## Follow-up (post-merge, non-gated)

After admin-merge to `main`, cut/point a `v1` tag at the merge commit and publish the release to Marketplace (publish checkbox on the release; org admin = repo owner, `gh` authenticated — no board account needed). Tracked in IRO-485.

Ungated → reviewer-approve + admin-merge.

Closes IRO-485.