### PR TITLE
docs(blog): 'how to harden <X>' hardening guides from scorecard data (IRO-486)

### DIFF
--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -14,4 +14,8 @@ nav:
   - "Alpine vs Debian vs Ubuntu: base image and isolation": alpine-vs-debian-vs-ubuntu-container-isolation.md
   - "Docker default vs hardened: the isolation score gap": docker-default-vs-hardened-container-isolation.md
   - "gVisor vs runc: containment compared": gvisor-vs-runc-container-isolation-compared.md
+  - "How to harden a Postgres container": harden-postgres-container-isolation.md
+  - "How to harden a Redis container": harden-redis-container-isolation.md
+  - "How to run untrusted Node.js code safely": run-untrusted-nodejs-code-safely.md
+  - "How to harden an nginx container": harden-nginx-container-isolation.md
   - "*.md"

--- a/docs/blog/harden-nginx-container-isolation.md
+++ b/docs/blog/harden-nginx-container-isolation.md
@@ -1,0 +1,101 @@
+---
+title: "How to harden an nginx container: nginx:1.27-alpine scores 48/100 by default"
+description: "nginx:1.27-alpine defaults score 48/100 (grade D): root, full caps, open egress. The ironctl scan --fix flags that harden a proxy to its honest 89/100 grade B."
+---
+
+# How to harden an nginx container (nginx:1.27-alpine scores 48/100 by default)
+
+nginx sits at the edge, which is exactly why its container should be the tightest one you run.
+A stock `docker run nginx:1.27-alpine` is not that. Graded on IronClaw's seven-dimension
+containment scale, the default configuration scores **48 of 100, grade D (porous)**. Higher is
+safer. A few runtime flags take the same image to **89 of 100, grade B**, one point off an A,
+and the one dimension it cannot reach is the one a reverse proxy needs by definition (egress).
+Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `nginx:1.27-alpine`, the same
+> data behind its [isolation scorecard](../scores/nginx.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run nginx:1.27-alpine`, four fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | master process runs as root (uid 0); an escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For an internet-facing proxy, the **root master process** and **retained capabilities** are the
+sharp edges: a request-smuggling or module CVE that lands code execution lands it as root with
+`CAP_NET_RAW` and friends. And while a reverse proxy must reach its upstreams, it almost never
+needs arbitrary internet **egress**, so the open `bridge` default is attack surface: a
+compromised nginx should not be able to call out anywhere it likes.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-nginx --fix` prints one remediation per failed dimension, then one hardened
+run. For `nginx:1.27-alpine`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every capability. If you keep the
+  stock image and bind port 80 inside the container you must add `--cap-add=NET_BIND_SERVICE`
+  back, which costs 4 of the 20 points. Better: use the `nginx-unprivileged` image and publish a
+  high port, so you drop all capabilities and add none back for the full +16.
+- **`--user 65532:65532`** (Non-root user, +15): run the workers and the master as non-root.
+  The `nginxinc/nginx-unprivileged` image is built for exactly this; a fixed non-root uid is the
+  auditable choice.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  proxy, it needs to reach upstreams. Any named or bridge network scores 4 of 15 (a WARN, not a
+  fail): egress is possible. This is the one dimension a reverse proxy cannot max out. Contain it
+  anyway: attach a user-defined network scoped to just the upstreams, with no default route out.
+- **`--read-only --tmpfs /tmp --tmpfs /var/cache/nginx --tmpfs /var/run`** (Read-only rootfs,
+  +10): nginx only needs to write its cache and pid; mount those as `tmpfs` and make the rest of
+  the root filesystem read-only. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name nginx -p 8080:80 nginx:1.27-alpine
+
+# After: 89/100, grade B (using the unprivileged image, high port inside)
+docker run -d --name nginx-hardened -p 8080:8080 \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only \
+  --tmpfs /tmp --tmpfs /var/cache/nginx --tmpfs /var/run \
+  nginxinc/nginx-unprivileged:1.27-alpine
+```
+
+Rescan: `ironctl scan nginx-hardened` reports `89/100 grade B`. A **41-point swing** with no
+custom image build, just the right flags and the unprivileged variant. The only dimension still
+short of full marks is egress (4 of 15), because a reverse proxy has to reach its upstreams;
+`network=none` would score the last points but break the proxy. That is the honest ceiling for
+an internet-facing nginx, and it is a long way from the default D.
+
+## Verify it on your own edge
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-nginx
+ironctl scan my-nginx --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can
+grade the nginx in your real deployment, not just a bare `docker run`.
+
+## Keep going
+
+- [nginx:1.27-alpine isolation scorecard &rarr;](../scores/nginx.md): the full dimension breakdown.
+- [Web servers, ranked by isolation &rarr;](../scores/collections/web-servers.md): how nginx compares to httpd, Caddy, Traefik, and the rest.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-postgres-container-isolation.md
+++ b/docs/blog/harden-postgres-container-isolation.md
@@ -1,0 +1,94 @@
+---
+title: "How to harden a Postgres container: postgres:17-alpine scores 48/100 by default"
+description: "postgres:17-alpine defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden a Postgres container (and is postgres:17-alpine safe for untrusted workloads?)
+
+Short answer: a stock `docker run postgres:17-alpine` is **not** a boundary you should trust
+around untrusted code or an untrusted network. Graded on IronClaw's seven-dimension
+containment scale, the default configuration scores **48 of 100, grade D (porous)**. Higher
+is safer. Six runtime flags take the same image to **100 of 100, grade A**. This guide shows
+the exact gaps and the exact fixes, straight from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `postgres:17-alpine`, the same
+> data behind its [isolation scorecard](../scores/postgres.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run postgres:17-alpine`, four of them fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a database, the two that should worry you most are **egress** and **root**. A Postgres
+process that can reach the network is a Postgres process that can exfiltrate your tables the
+moment it is compromised (a poisoned extension, a `COPY ... TO PROGRAM`, a driver CVE). And a
+root process that escapes the container escapes as root on the host.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-postgres --fix` prints one remediation per failed dimension, then assembles a
+single copy-pasteable hardened run. For `postgres:17-alpine` the prescription is:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only
+  what the workload provably needs. Postgres itself needs none of the defaults.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin
+  as host uid 0. Point `PGDATA` at a volume this uid owns.
+- **`--network=none`** (Network isolation, +11): if the database is only reached by services on
+  a private user-defined network, cut host egress entirely; otherwise attach a
+  single internal network with no default route, not `bridge`.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only
+  and mount the data directory as an explicit writable volume. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name postgres postgres:17-alpine
+
+# After: 100/100, grade A
+docker run -d --name postgres-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v postgres-data:/var/lib/postgresql/data \
+  --network=none \
+  postgres:17-alpine
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan postgres-hardened` reports
+`100/100 grade A`. That is a **48-point swing from four one-line flags**, no image rebuild.
+
+## Verify it on your own database
+
+The grade above is the default image. Your deployment is what matters. Scan it in ten seconds:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-postgres
+ironctl scan my-postgres --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can
+grade the Postgres in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [postgres:17-alpine isolation scorecard &rarr;](../scores/postgres.md): the full dimension breakdown.
+- [Databases, ranked by isolation &rarr;](../scores/collections/databases.md): how Postgres compares to MySQL, Redis, Mongo, and the rest.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-redis-container-isolation.md
+++ b/docs/blog/harden-redis-container-isolation.md
@@ -1,0 +1,97 @@
+---
+title: "How to harden a Redis container: redis:7-alpine scores 48/100 by default"
+description: "redis:7-alpine defaults score 48/100 (grade D): root, full caps, open egress. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden a Redis container (and is redis:7-alpine safe to expose?)
+
+Short answer: the stock `docker run redis:7-alpine` is a weak boundary, and Redis has a long
+history of turning a reachable instance into remote code execution (`CONFIG SET dir` plus a
+malicious module or cron write). Graded on IronClaw's seven-dimension containment scale, the
+default configuration scores **48 of 100, grade D (porous)**. Higher is safer. Six runtime
+flags take the same image to **100 of 100, grade A**. Here are the exact gaps and fixes, from
+the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `redis:7-alpine`, the same data
+> behind its [isolation scorecard](../scores/redis.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run redis:7-alpine`, four fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+Redis makes the **writable rootfs** and **retained capabilities** especially sharp. The classic
+unauthenticated-Redis exploit uses `CONFIG SET dir /` plus `dbfilename` to write an arbitrary
+file (an SSH key, a cron job, a loadable module) to the host-visible filesystem. A read-only
+rootfs and a dropped capability set take that primitive off the table before you even reach
+authentication.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-redis --fix` prints one remediation per failed dimension, then assembles a
+single hardened run. For `redis:7-alpine`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability. Redis needs
+  none of the defaults for a normal keystore workload.
+- **`--user 65532:65532`** (Non-root user, +15): run as a non-root uid so an escape does not
+  land as host root. The official image already ships a `redis` user; a fixed non-root uid is
+  the auditable choice.
+- **`--network=none`** (Network isolation, +11): if only in-stack services talk to Redis, put
+  it on an internal user-defined network with no egress instead of `bridge`. Also set a
+  password (`--requirepass`) and rename the `CONFIG` command, but the isolation flags are the
+  boundary that holds when auth does not.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): read-only root plus an explicit
+  writable volume for persistence. This is the single highest-leverage flag against the
+  file-write RCE.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name redis redis:7-alpine
+
+# After: 100/100, grade A
+docker run -d --name redis-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v redis-data:/data \
+  --network=none \
+  redis:7-alpine
+```
+
+Rescan: `ironctl scan redis-hardened` reports `100/100 grade A`. A **48-point swing from four
+one-line flags**, no image rebuild.
+
+## Verify it on your own instance
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-redis
+ironctl scan my-redis --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can
+grade the Redis in your real stack.
+
+## Keep going
+
+- [redis:7-alpine isolation scorecard &rarr;](../scores/redis.md): the full dimension breakdown.
+- [Databases, ranked by isolation &rarr;](../scores/collections/databases.md): how Redis compares to Postgres, MySQL, Mongo, and the rest.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -29,6 +29,24 @@ adjectives standing in for numbers.
   static file, and render a live 0 to 100 A-to-F containment grade in your README. No
   server, no scan on every badge hit.
 
+## Hardening guides
+
+Per-image, data-driven walkthroughs: the default isolation grade, the exact dimensions that
+fail, and the precise `ironctl scan --fix` flags that close the gap, with before and after scores.
+
+- [How to harden a Postgres container](harden-postgres-container-isolation.md) -
+  `postgres:17-alpine` scores 48 of 100 (D) on defaults: root, full capabilities, writable
+  rootfs. Four flags take it to 100 of 100 (A). Is it safe for untrusted workloads?
+- [How to harden a Redis container](harden-redis-container-isolation.md) -
+  `redis:7-alpine` scores 48 of 100 (D). A read-only rootfs and dropped capabilities take the
+  classic `CONFIG SET dir` file-write RCE off the table before auth. To 100 of 100 (A).
+- [How to run untrusted Node.js code safely](run-untrusted-nodejs-code-safely.md) -
+  the container is the sandbox, not the `vm` module. `node:22-alpine` is 48 of 100 (D) by
+  default; `network=none` plus five flags make it a 100 of 100 (A) boundary for untrusted JS.
+- [How to harden an nginx container](harden-nginx-container-isolation.md) -
+  `nginx:1.27-alpine` scores 48 of 100 (D). The honest hardened ceiling for an internet-facing
+  proxy is 89 of 100 (B), because it must reach its upstreams. Here is exactly why.
+
 ## Comparisons
 
 Head-to-head reads, each backed by the same scan data, for the questions people

--- a/docs/blog/run-untrusted-nodejs-code-safely.md
+++ b/docs/blog/run-untrusted-nodejs-code-safely.md
@@ -1,0 +1,103 @@
+---
+title: "How to run untrusted Node.js code safely: node:22-alpine scores 48/100 by default"
+description: "node:22-alpine defaults score 48/100 (grade D): root, full caps, open egress. The exact flags that make it a 100/100 grade A sandbox for untrusted JavaScript."
+---
+
+# How to run untrusted Node.js code safely in a container
+
+If you execute code you did not write, user-submitted snippets, an AI agent's tool calls, a
+plugin, a build step from an untrusted repo, the container is your security boundary, not the
+Node.js runtime. And a plain `docker run node:22-alpine` is a weak boundary. Graded on
+IronClaw's seven-dimension containment scale it scores **48 of 100, grade D (porous)**. Higher
+is safer. Six runtime flags take it to **100 of 100, grade A**. This guide shows the exact gaps
+and fixes from the scan data, tuned for the untrusted-code case.
+
+> Every number here comes from a read-only `docker inspect` of `node:22-alpine`, the same data
+> behind its [isolation scorecard](../scores/node.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Why the default is not a sandbox
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run node:22-alpine`, four fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+Untrusted JavaScript makes every one of these gaps live. Open **egress** means a malicious
+`npm install` or a prompt-injected agent can phone home and exfiltrate. **Root plus full
+capabilities** means an escape (a native-addon exploit, a `vm`-escape, a kernel CVE) lands as
+host root. A **writable rootfs** lets the payload drop persistence. The Node.js `vm` module is
+explicitly documented as **not** a security mechanism; the container has to be.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-sandbox --fix` prints one remediation per failed dimension and one hardened
+run. For untrusted `node:22-alpine`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability. Untrusted code
+  should hold none.
+- **`--user 65532:65532`** (Non-root user, +15): the official image ships a `node` user; pin a
+  fixed non-root uid so an escape is not host root.
+- **`--network=none`** (Network isolation, +11): this is the big one for untrusted code. No NIC
+  but loopback means no exfiltration and no callback, full stop. If the code genuinely needs a
+  specific endpoint, use an egress proxy with an allowlist instead of open `bridge`.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): read-only root with a small writable
+  `tmpfs` for scratch. The payload cannot persist.
+- **`--pids-limit` and `--memory`**: not scored dimensions, but add them so untrusted code
+  cannot fork-bomb or OOM the host.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run --rm node:22-alpine node untrusted.js
+
+# After: 100/100, grade A
+docker run --rm \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  --pids-limit=128 --memory=256m \
+  -v "$PWD/untrusted.js:/untrusted.js:ro" \
+  node:22-alpine node /untrusted.js
+```
+
+Rescan a persistent variant: `ironctl scan node-hardened` reports `100/100 grade A`. A
+**48-point swing from a handful of one-line flags**, no image rebuild.
+
+## When flags are not enough
+
+Config flags harden the container, but they still run untrusted code on the **host kernel**. If
+the threat model includes kernel exploits, put a user-space kernel under it. In our
+[escape-suite benchmark](containment-benchmark-docker-gvisor-e2b-daytona.md), hardened runc
+blocked 4 of 5 real escape attempts and gVisor (runsc) blocked 5 of 5. IronClaw runs every
+agent session on gVisor with exactly the posture above by default, which is the point of the
+project: a real sandbox for code you do not trust.
+
+## Verify it yourself
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your sandbox, then print the fixes
+ironctl scan my-sandbox
+ironctl scan my-sandbox --fix
+```
+
+## Keep going
+
+- [node:22-alpine isolation scorecard &rarr;](../scores/node.md): the full dimension breakdown.
+- [Language runtimes, ranked by isolation &rarr;](../scores/collections/language-runtimes.md): how Node compares to Python, Go, Ruby, and the rest.
+- [Escape suite vs Docker, gVisor, E2B, Daytona &rarr;](containment-benchmark-docker-gvisor-e2b-daytona.md): what config flags cannot stop.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -345,3 +345,10 @@ grade this page describes:
   the 48-point jump from a D to an A, flag by flag, across 151 images.
 - [gVisor vs runc](blog/gvisor-vs-runc-container-isolation-compared.md): why they
   score the same on a config scan yet block a different number of live escape attempts.
+
+Per-image hardening walkthroughs, default grade to hardened, with the exact `--fix` flags:
+
+- [Harden a Postgres container](blog/harden-postgres-container-isolation.md): `postgres:17-alpine`, 48 to 100.
+- [Harden a Redis container](blog/harden-redis-container-isolation.md): `redis:7-alpine`, 48 to 100.
+- [Run untrusted Node.js code safely](blog/run-untrusted-nodejs-code-safely.md): `node:22-alpine`, 48 to 100.
+- [Harden an nginx container](blog/harden-nginx-container-isolation.md): `nginx:1.27-alpine`, 48 to 89 (the honest proxy ceiling).


### PR DESCRIPTION
## What

Four long-tail SEO hardening guides under `docs/blog/`, extending the non-gated organic-discovery flywheel (board directive IRO-475). Each is data-driven from the same read-only `docker inspect` scan behind the isolation scorecards, targeting high-intent queries like *how to harden postgres container* and *run untrusted node.js code safely*.

| Guide | Image | Default | Hardened |
|---|---|---|---|
| Harden Postgres | postgres:17-alpine | 48/D | 100/A |
| Harden Redis | redis:7-alpine | 48/D | 100/A |
| Run untrusted Node.js safely | node:22-alpine | 48/D | 100/A |
| Harden nginx | nginx:1.27-alpine | 48/D | **89/B** |

Each page: the failing dimensions, the exact `ironctl scan --fix` flags, before/after scores.

## Accuracy note (credibility over hype)

nginx claims **89/B**, not 100/A. A functional reverse proxy cannot use `--network=none`, so egress stays a WARN (4/15) by definition. Grade bands are A>=90, so 89 is the honest hardened ceiling for an internet-facing nginx. Stated plainly rather than overclaiming.

## SEO / funnel

- Unique `title` + <=160-char `description` per page (IRO-277/446); no em/en-dashes (IRO-254).
- Each guide cross-links its scorecard, its collection page, `scan.md`, and the sandbox index.
- Inbound funnel: added to blog index, blog `.nav.yml`, and the `scan.md` funnel list.
- Collection/scorecard pages are cron-generated; guides link *out* to them (stable targets). No generated file hand-edited.

## Verify

- `mkdocs build --strict` passes (only pre-existing INFO notes, none from these files).

Closes IRO-486.