### PR TITLE
feat(action): base-branch score delta in the sticky PR scorecard (IRO-499)

### DIFF
--- a/.github/actions/scan/scan.sh
+++ b/.github/actions/scan/scan.sh
@@ -60,6 +60,23 @@ IRONCTL="$(find "${WORK}" -maxdepth 2 -type f -name ironctl | head -1)"
 chmod +x "$IRONCTL"
 "$IRONCTL" version || true
 
+# grade_file MODE FILE SERVICE -> echoes the 0-100 score for a compose/k8s file,
+# or nothing on any failure. Used to grade the base-branch version of a scanned
+# file so the PR comment can show a delta. Fail-open by design.
+grade_file() {
+  local m="$1" f="$2" svc="$3"
+  local a=()
+  case "$m" in
+    compose) a+=(--compose "$f"); [ -n "$svc" ] && a+=(--service "$svc") ;;
+    k8s)     a+=(--k8s "$f") ;;
+    *)       return 1 ;;
+  esac
+  a+=(--md)
+  local o
+  o="$("$IRONCTL" scan "${a[@]}" 2>/dev/null)" || return 1
+  printf '%s' "$o" | sed -nE 's/.*scored \*\*([0-9]+)\/100.*/\1/p' | head -1
+}
+
 # ---------------------------------------------------------------------------
 # 2. Build the scan arguments for the requested mode.
 # ---------------------------------------------------------------------------
@@ -133,7 +150,38 @@ fi
 if [ "$COMMENT" = "true" ] && [ -n "$pr" ] && [ -n "${GH_TOKEN:-}" ]; then
   marker="<!-- ironclaw-scan-scorecard:${MODE}:${TARGET} -->"
   body="${WORK}/comment.md"
-  { echo "$marker"; cat "$scorecard"; } >"$body"
+
+  # Base-branch delta (compose/k8s file modes only). Fetch the base version of
+  # the scanned file via the contents API — no extra checkout depth needed — and
+  # grade it, so the comment shows how this PR moved the posture. Container mode
+  # has no git base to compare against, so it is skipped. Entirely fail-open: any
+  # hiccup just omits the delta line and never touches the scorecard or gate.
+  delta_line=""
+  if [ "$MODE" = "compose" ] || [ "$MODE" = "k8s" ]; then
+    base_ref="$(jq -r '.pull_request.base.ref // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"
+    base_sha="$(jq -r '.pull_request.base.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"
+    if [ -n "$base_sha" ]; then
+      base_file="${WORK}/base-target"
+      if gh api "repos/${GITHUB_REPOSITORY}/contents/${TARGET}?ref=${base_sha}" \
+           --jq '.content' 2>/dev/null | base64 -d >"$base_file" 2>/dev/null && [ -s "$base_file" ]; then
+        base_score="$(grade_file "$MODE" "$base_file" "$SERVICE" || true)"
+        if [ -n "$base_score" ]; then
+          d=$(( score - base_score ))
+          if [ "$d" -gt 0 ]; then
+            delta_line="> **Δ vs base (\`${base_ref:-base}\`): +${d}** — base scored ${base_score}/100. Posture improved. :arrow_up:"
+          elif [ "$d" -lt 0 ]; then
+            delta_line="> **Δ vs base (\`${base_ref:-base}\`): ${d}** — base scored ${base_score}/100. Posture regressed. :warning:"
+          else
+            delta_line="> **Δ vs base (\`${base_ref:-base}\`): 0** — unchanged from ${base_score}/100."
+          fi
+        fi
+      else
+        delta_line="> _New file on this PR — no base version to compare against._"
+      fi
+    fi
+  fi
+
+  { echo "$marker"; cat "$scorecard"; [ -n "$delta_line" ] && { echo; echo "$delta_line"; }; } >"$body"
 
   # Find an existing comment carrying our marker and update it; else create one.
   existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" --paginate \

--- a/.github/workflows/scan-scorecard.yml
+++ b/.github/workflows/scan-scorecard.yml
@@ -76,6 +76,18 @@ jobs:
           mode: container
           min-score: 0
 
+      # Dogfood the base-branch DELTA path: compose mode reads a checked-in file,
+      # so the action fetches the base version of docker-compose.yml and renders a
+      # "Δ vs base" line in the sticky comment. On PRs that do not change the file
+      # the delta is 0; a PR that hardens/regresses it shows the movement.
+      - name: Scan a compose file (delta vs base)
+        uses: ./.github/actions/scan
+        with:
+          mode: compose
+          target: docker-compose.yml
+          service: controlplane
+          min-score: 0
+
       # Prove the Marketplace root action.yml runs end-to-end via the root ref
       # `uses: ./`. Same hardened target; comment off so it does not fight the
       # subdir run over the sticky scorecard (same mode+target marker).

--- a/docs/scan-action.md
+++ b/docs/scan-action.md
@@ -132,6 +132,16 @@ is keyed by mode + target, so re-runs update in place instead of spamming, and
 multiple targets in one PR each keep their own comment. On non-PR events the
 scorecard goes to the job summary instead.
 
+For the file modes (`compose` / `k8s`) the comment also shows a **delta versus
+the base branch**: the action fetches the base version of the scanned file via
+the contents API, grades it, and adds a line such as
+`Δ vs base (main): +12 — base scored 88/100. Posture improved.` so a reviewer
+sees at a glance whether the change hardened or regressed the posture. A file
+that is new on the PR is noted as such, and the whole delta step is fail-open —
+if the base cannot be fetched or graded, the scorecard is still posted without a
+delta line. `container` mode has no git base to compare against, so it shows no
+delta.
+
 Everything the [scan](scan.md) command guarantees still holds: it is local and
 read-only, it never talks to a control-plane, it needs no credentials, and it is
 fail-closed. See [`.github/actions/scan`](https://github.com/IronSecCo/ironclaw/tree/main/.github/actions/scan)


### PR DESCRIPTION
## What

IRO-499 asked for the scan Action to post a **sticky scorecard comment on PRs**. That core — the opt-in \`comment\` input, the hidden-marker create-or-update comment, fail-open commenting, SHA-pinned actions, a dogfood workflow, and docs — already shipped with the Marketplace root \`action.yml\` (IRO-485, PR #473) and is live on main.

This PR delivers the one remaining requirement, the **stretch goal**, which is what makes the Action "materially more useful": a **base-branch score delta** in the sticky comment for the file modes.

On a \`pull_request\` event, for \`compose\`/\`k8s\` modes, the action:
1. Fetches the base-branch version of the scanned file via the GitHub contents API (\`?ref=<base sha>\`) — no extra checkout depth needed.
2. Grades it with the same \`ironctl scan\`.
3. Renders a delta line in the comment, e.g. \`Δ vs base (main): +12 — base scored 88/100. Posture improved.\`

## Security lenses

- **Egress least-privilege / trust boundary**: no new network path — the base file comes through the same GitHub API with the \`GITHUB_TOKEN\` already in scope for commenting; no new permission, no external action, no control-plane. Still local, read-only, credential-free.
- **Fail-open**: any failure to fetch or grade the base omits the delta line and never touches the scorecard, outputs, or the \`min-score\` gate. \`container\` mode has no git base and is skipped.
- **No injection**: \`TARGET\`/\`base_ref\` come from trusted action config / the PR base branch and flow into a URL path and a markdown body, not a shell eval.

## Changes

- \`scan.sh\`: \`grade_file\` helper + fail-open delta block inside the existing comment path.
- \`scan-scorecard.yml\`: dogfood step scans \`docker-compose.yml\` in compose mode so the delta path renders on this repo's own PRs.
- \`docs/scan-action.md\`: documented the delta.

## Verification

- \`bash -n\` clean.
- Built \`ironctl\` (\`CGO_ENABLED=1\`) and exercised the exact \`grade_file\` + delta arithmetic against a hardened base compose (100/A) vs a weak head compose (19/F): correctly reported \`regressed -81\`.
- Dogfood workflow \`scan-scorecard.yml\` runs on this PR (it touches \`.github/actions/scan/**\`) — the compose step will render the delta comment.

Ungated: repo files + built-in \`GITHUB_TOKEN\`, no account.