### PR TITLE
docs: harden-<X> SEO guides for mysql, elasticsearch, rabbitmq, memcached (IRO-498)

### DIFF
--- a/.github/actions/scan/scan.sh
+++ b/.github/actions/scan/scan.sh
@@ -60,6 +60,23 @@ IRONCTL="$(find "${WORK}" -maxdepth 2 -type f -name ironctl | head -1)"
 chmod +x "$IRONCTL"
 "$IRONCTL" version || true
 
+# grade_file MODE FILE SERVICE -> echoes the 0-100 score for a compose/k8s file,
+# or nothing on any failure. Used to grade the base-branch version of a scanned
+# file so the PR comment can show a delta. Fail-open by design.
+grade_file() {
+  local m="$1" f="$2" svc="$3"
+  local a=()
+  case "$m" in
+    compose) a+=(--compose "$f"); [ -n "$svc" ] && a+=(--service "$svc") ;;
+    k8s)     a+=(--k8s "$f") ;;
+    *)       return 1 ;;
+  esac
+  a+=(--md)
+  local o
+  o="$("$IRONCTL" scan "${a[@]}" 2>/dev/null)" || return 1
+  printf '%s' "$o" | sed -nE 's/.*scored \*\*([0-9]+)\/100.*/\1/p' | head -1
+}
+
 # ---------------------------------------------------------------------------
 # 2. Build the scan arguments for the requested mode.
 # ---------------------------------------------------------------------------
@@ -133,7 +150,38 @@ fi
 if [ "$COMMENT" = "true" ] && [ -n "$pr" ] && [ -n "${GH_TOKEN:-}" ]; then
   marker="<!-- ironclaw-scan-scorecard:${MODE}:${TARGET} -->"
   body="${WORK}/comment.md"
-  { echo "$marker"; cat "$scorecard"; } >"$body"
+
+  # Base-branch delta (compose/k8s file modes only). Fetch the base version of
+  # the scanned file via the contents API — no extra checkout depth needed — and
+  # grade it, so the comment shows how this PR moved the posture. Container mode
+  # has no git base to compare against, so it is skipped. Entirely fail-open: any
+  # hiccup just omits the delta line and never touches the scorecard or gate.
+  delta_line=""
+  if [ "$MODE" = "compose" ] || [ "$MODE" = "k8s" ]; then
+    base_ref="$(jq -r '.pull_request.base.ref // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"
+    base_sha="$(jq -r '.pull_request.base.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"
+    if [ -n "$base_sha" ]; then
+      base_file="${WORK}/base-target"
+      if gh api "repos/${GITHUB_REPOSITORY}/contents/${TARGET}?ref=${base_sha}" \
+           --jq '.content' 2>/dev/null | base64 -d >"$base_file" 2>/dev/null && [ -s "$base_file" ]; then
+        base_score="$(grade_file "$MODE" "$base_file" "$SERVICE" || true)"
+        if [ -n "$base_score" ]; then
+          d=$(( score - base_score ))
+          if [ "$d" -gt 0 ]; then
+            delta_line="> **Δ vs base (\`${base_ref:-base}\`): +${d}** — base scored ${base_score}/100. Posture improved. :arrow_up:"
+          elif [ "$d" -lt 0 ]; then
+            delta_line="> **Δ vs base (\`${base_ref:-base}\`): ${d}** — base scored ${base_score}/100. Posture regressed. :warning:"
+          else
+            delta_line="> **Δ vs base (\`${base_ref:-base}\`): 0** — unchanged from ${base_score}/100."
+          fi
+        fi
+      else
+        delta_line="> _New file on this PR — no base version to compare against._"
+      fi
+    fi
+  fi
+
+  { echo "$marker"; cat "$scorecard"; [ -n "$delta_line" ] && { echo; echo "$delta_line"; }; } >"$body"
 
   # Find an existing comment carrying our marker and update it; else create one.
   existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" --paginate \

--- a/.github/workflows/scan-scorecard.yml
+++ b/.github/workflows/scan-scorecard.yml
@@ -76,6 +76,18 @@ jobs:
           mode: container
           min-score: 0
 
+      # Dogfood the base-branch DELTA path: compose mode reads a checked-in file,
+      # so the action fetches the base version of docker-compose.yml and renders a
+      # "Δ vs base" line in the sticky comment. On PRs that do not change the file
+      # the delta is 0; a PR that hardens/regresses it shows the movement.
+      - name: Scan a compose file (delta vs base)
+        uses: ./.github/actions/scan
+        with:
+          mode: compose
+          target: docker-compose.yml
+          service: controlplane
+          min-score: 0
+
       # Prove the Marketplace root action.yml runs end-to-end via the root ref
       # `uses: ./`. Same hardened target; comment off so it does not fight the
       # subdir run over the sticky scorecard (same mode+target marker).

--- a/README.md
+++ b/README.md
@@ -275,6 +275,17 @@ Head-to-head reads backed by the same scan data:
 [gVisor vs runc](https://ironsecco.github.io/ironclaw/blog/gvisor-vs-runc-container-isolation-compared/)
 (when a shared host kernel is the weak link).
 
+Per-image hardening walkthroughs, the default grade, the dimensions that fail, and the exact
+`ironctl scan --fix` flags that close the gap:
+[Postgres](https://ironsecco.github.io/ironclaw/blog/harden-postgres-container-isolation/),
+[MySQL](https://ironsecco.github.io/ironclaw/blog/harden-mysql-container-isolation/),
+[Redis](https://ironsecco.github.io/ironclaw/blog/harden-redis-container-isolation/),
+[Memcached](https://ironsecco.github.io/ironclaw/blog/harden-memcached-container-isolation/),
+[Elasticsearch](https://ironsecco.github.io/ironclaw/blog/harden-elasticsearch-container-isolation/),
+[RabbitMQ](https://ironsecco.github.io/ironclaw/blog/harden-rabbitmq-container-isolation/),
+[nginx](https://ironsecco.github.io/ironclaw/blog/harden-nginx-container-isolation/), and
+[untrusted Node.js](https://ironsecco.github.io/ironclaw/blog/run-untrusted-nodejs-code-safely/).
+
 ### Show your score
 
 Put your containment grade in your README, the same way a coverage or build badge does.

--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -19,5 +19,9 @@ nav:
   - "How to harden a Redis container": harden-redis-container-isolation.md
   - "How to run untrusted Node.js code safely": run-untrusted-nodejs-code-safely.md
   - "How to harden an nginx container": harden-nginx-container-isolation.md
+  - "How to harden a MySQL container": harden-mysql-container-isolation.md
+  - "How to harden an Elasticsearch container": harden-elasticsearch-container-isolation.md
+  - "How to harden a RabbitMQ container": harden-rabbitmq-container-isolation.md
+  - "How to harden a Memcached container": harden-memcached-container-isolation.md
   - "How to scan a Dockerfile for security issues": scan-a-dockerfile-for-security-issues.md
   - "*.md"

--- a/docs/blog/harden-elasticsearch-container-isolation.md
+++ b/docs/blog/harden-elasticsearch-container-isolation.md
@@ -1,0 +1,112 @@
+---
+title: "How to harden an Elasticsearch container: elasticsearch:8.16.1 scores 63/100 by default"
+description: "elasticsearch:8.16.1 defaults score 63/100 (grade C): full caps, writable rootfs, open egress. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden an Elasticsearch container (and is elasticsearch:8.16.1 safe for untrusted workloads?)
+
+Short answer: a stock `docker run elasticsearch:8.16.1` starts ahead of most images (it runs
+non-root out of the box) but is still **not** a boundary to trust around an untrusted network.
+Graded on IronClaw's seven-dimension containment scale, the default configuration scores
+**63 of 100, grade C (partial)**. Higher is safer. Three runtime flags take the same image to
+**100 of 100, grade A**. This guide shows the exact gaps and the exact fixes, straight from the
+scan data.
+
+> Every number here comes from a read-only `docker inspect` of `elasticsearch:8.16.1`, the same
+> data behind its [isolation scorecard](../scores/elasticsearch.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run elasticsearch:8.16.1`, three fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as 1000:0 (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+Elasticsearch already runs as a non-root uid, which is why it clears the default 48/100 that
+databases like MySQL and Postgres sit at. The remaining leaks are the **retained capabilities**
+and **open egress**. An Elasticsearch that can reach the network is one that can exfiltrate every
+document it indexes the moment a query DSL or plugin CVE lands code execution, and the full
+capability set gives that code `CAP_NET_RAW` and friends to work with.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-elasticsearch --fix` prints one remediation per failed dimension, then one
+hardened run. For `elasticsearch:8.16.1`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only
+  what the workload provably needs. Elasticsearch needs none of the defaults.
+- **`--network=none`** (Network isolation, +11): for a single-node index reached only by
+  co-located services on a private user-defined network, cut host egress entirely; otherwise
+  attach a single internal network with no default route, not `bridge`. (A multi-node cluster
+  needs inter-node transport on a scoped private network, which is a WARN, not a clean pass,
+  see the ceiling note below.)
+- **`--user 65532:65532`** (Non-root user, already passing at +0): non-root already passes at
+  1000:0. Pinning an explicit fixed uid is the auditable choice and keeps the volume ownership
+  unambiguous; it does not change the score.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/usr/share/elasticsearch/data` as an explicit writable volume. Removes the persistence
+  surface.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name elasticsearch \
+  -e discovery.type=single-node \
+  elasticsearch:8.16.1
+
+# After: 100/100, grade A (single-node)
+docker run -d --name elasticsearch-hardened \
+  -e discovery.type=single-node \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v elasticsearch-data:/usr/share/elasticsearch/data \
+  --network=none \
+  elasticsearch:8.16.1
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan elasticsearch-hardened` reports
+`100/100 grade A`. That is a **37-point swing from three one-line flags**, no image rebuild.
+
+## The honest ceiling for a multi-node cluster
+
+The 100/100 above is a **single-node** index with `network=none`. A multi-node Elasticsearch
+cluster cannot use `network=none`: nodes must reach each other over the transport port. Attach a
+private user-defined network scoped to just the cluster with no default route out, and the
+network dimension scores 4 of 15 (a WARN, not a fail) instead of the full 15. That puts a
+hardened multi-node cluster at **89 of 100, grade B**, one point off an A. The other six
+dimensions still max out. That is the honest ceiling when nodes must talk, and it is a long way
+from the default C.
+
+## Verify it on your own cluster
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-elasticsearch
+ironctl scan my-elasticsearch --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can
+grade the Elasticsearch in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [elasticsearch:8.16.1 isolation scorecard &rarr;](../scores/elasticsearch.md): the full dimension breakdown.
+- [Search engines, ranked by isolation &rarr;](../scores/collections/search-engines.md): how Elasticsearch compares to OpenSearch, Solr, Meilisearch, and the rest.
+- [How to harden an nginx container &rarr;](harden-nginx-container-isolation.md): another service with an honest egress ceiling, explained the same way.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-memcached-container-isolation.md
+++ b/docs/blog/harden-memcached-container-isolation.md
@@ -1,0 +1,103 @@
+---
+title: "How to harden a Memcached container: memcached:1.6-alpine scores 63/100 by default"
+description: "memcached:1.6-alpine defaults score 63/100 (grade C): full caps, writable rootfs. The exact ironctl scan --fix flags that take a cache to its honest 89/100 grade B."
+---
+
+# How to harden a Memcached container (and is memcached:1.6-alpine safe for untrusted workloads?)
+
+A cache sits in the hot path of every request, which is exactly why its container should be
+tight. A stock `docker run memcached:1.6-alpine` starts ahead of most images (it runs non-root
+out of the box) but is still not a boundary to trust around an untrusted network. Graded on
+IronClaw's seven-dimension containment scale, the default configuration scores **63 of 100,
+grade C (partial)**. Higher is safer. A couple of runtime flags take the same image to **89 of
+100, grade B**, one point off an A, and the one dimension it cannot reach is the one a cache
+needs by definition (clients must connect to it). Here are the exact gaps and fixes from the
+scan data.
+
+> Every number here comes from a read-only `docker inspect` of `memcached:1.6-alpine`, the same
+> data behind its [isolation scorecard](../scores/memcached.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run memcached:1.6-alpine`, three fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as memcache (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+Memcached already runs as the non-root `memcache` user, which is why it clears the 48/100 that
+root-by-default images sit at. The remaining leaks are the **retained capabilities** and the
+**writable root filesystem**. Memcached is purely in-memory, it has no data directory to persist,
+so there is no reason its root filesystem should be writable at all: a read-only rootfs removes
+the persistence surface for free, and dropping the default capabilities takes `CAP_NET_RAW` and
+friends away from any code that lands via a protocol-parsing CVE.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-memcached --fix` prints one remediation per failed dimension, then one hardened
+run. For `memcached:1.6-alpine`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only
+  what the workload provably needs. Memcached needs none of the defaults.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only.
+  Memcached keeps everything in memory, so no writable volume is needed at all, a rare clean win.
+- **`--user 65532:65532`** (Non-root user, already passing at +0): non-root already passes as the
+  `memcache` user. Pinning an explicit fixed uid is the auditable choice; it does not change the
+  score.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  cache, clients must be able to connect to it. Any named or bridge network scores 4 of 15 (a
+  WARN, not a fail): a connection path exists. This is the one dimension a cache cannot max out.
+  Contain it anyway: attach a user-defined network scoped to just its clients, with no default
+  route out, so a compromised cache cannot call arbitrary internet addresses.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name memcached memcached:1.6-alpine
+
+# After: 89/100, grade B (scoped private network for its clients)
+docker run -d --name memcached-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=cache-internal \
+  memcached:1.6-alpine
+```
+
+Rescan: `ironctl scan memcached-hardened` reports `89/100 grade B`. A **26-point swing** with no
+custom image build and no volume, just the right flags. The only dimension still short of full
+marks is the network (4 of 15), because a cache exists to be connected to; `network=none` would
+score the last points but leave nothing able to reach it. That is the honest ceiling for a cache,
+and it is a clean grade B up from the default C.
+
+## Verify it on your own cache
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-memcached
+ironctl scan my-memcached --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can
+grade the Memcached in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [memcached:1.6-alpine isolation scorecard &rarr;](../scores/memcached.md): the full dimension breakdown.
+- [Databases and caches, ranked by isolation &rarr;](../scores/collections/databases.md): how Memcached compares to Redis, Postgres, MySQL, and the rest.
+- [How to harden a Redis container &rarr;](harden-redis-container-isolation.md): the same walkthrough for the other in-memory store.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-mysql-container-isolation.md
+++ b/docs/blog/harden-mysql-container-isolation.md
@@ -1,0 +1,95 @@
+---
+title: "How to harden a MySQL container: mysql:8.4 scores 48/100 by default"
+description: "mysql:8.4 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden a MySQL container (and is mysql:8.4 safe for untrusted workloads?)
+
+Short answer: a stock `docker run mysql:8.4` is **not** a boundary you should trust around
+untrusted code or an untrusted network. Graded on IronClaw's seven-dimension containment
+scale, the default configuration scores **48 of 100, grade D (porous)**. Higher is safer.
+Four runtime flags take the same image to **100 of 100, grade A**. This guide shows the exact
+gaps and the exact fixes, straight from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `mysql:8.4`, the same data
+> behind its [isolation scorecard](../scores/mysql.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run mysql:8.4`, four of them fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a database, the two that should worry you most are **egress** and **root**. A MySQL
+process that can reach the network is a MySQL process that can exfiltrate your tables the
+moment it is compromised (a poisoned UDF, a `LOAD DATA LOCAL`, a driver CVE). And a root
+process that escapes the container escapes as root on the host.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-mysql --fix` prints one remediation per failed dimension, then assembles a
+single copy-pasteable hardened run. For `mysql:8.4` the prescription is:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only
+  what the workload provably needs. MySQL itself needs none of the defaults.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin
+  as host uid 0. Point the data directory at a volume this uid owns.
+- **`--network=none`** (Network isolation, +11): if the database is only reached by services on
+  a private user-defined network, cut host egress entirely; otherwise attach a single internal
+  network with no default route, not `bridge`.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/var/lib/mysql` as an explicit writable volume. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name mysql mysql:8.4
+
+# After: 100/100, grade A
+docker run -d --name mysql-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp --tmpfs /run/mysqld \
+  -v mysql-data:/var/lib/mysql \
+  --network=none \
+  mysql:8.4
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan mysql-hardened` reports
+`100/100 grade A`. That is a **52-point swing from four one-line flags**, no image rebuild.
+
+## Verify it on your own database
+
+The grade above is the default image. Your deployment is what matters. Scan it in ten seconds:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-mysql
+ironctl scan my-mysql --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can
+grade the MySQL in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [mysql:8.4 isolation scorecard &rarr;](../scores/mysql.md): the full dimension breakdown.
+- [Databases, ranked by isolation &rarr;](../scores/collections/databases.md): how MySQL compares to Postgres, Redis, Mongo, and the rest.
+- [How to harden a Postgres container &rarr;](harden-postgres-container-isolation.md): the same walkthrough for the other big relational database.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-rabbitmq-container-isolation.md
+++ b/docs/blog/harden-rabbitmq-container-isolation.md
@@ -1,0 +1,98 @@
+---
+title: "How to harden a RabbitMQ container: rabbitmq:4-alpine scores 48/100 by default"
+description: "rabbitmq:4-alpine defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a broker to its honest 89/100 grade B."
+---
+
+# How to harden a RabbitMQ container (and is rabbitmq:4-alpine safe for untrusted workloads?)
+
+A message broker sits between every service you run, which is exactly why its container should
+be one of the tightest. A stock `docker run rabbitmq:4-alpine` is not that. Graded on IronClaw's
+seven-dimension containment scale, the default configuration scores **48 of 100, grade D
+(porous)**. Higher is safer. A few runtime flags take the same image to **89 of 100, grade B**,
+one point off an A, and the one dimension it cannot reach is the one a broker needs by
+definition (clients must connect to it). Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `rabbitmq:4-alpine`, the same
+> data behind its [isolation scorecard](../scores/rabbitmq.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run rabbitmq:4-alpine`, four fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a broker, the sharpest edges are the **root process** and **retained capabilities**: a
+plugin or management-API CVE that lands code execution lands it as root with `CAP_NET_RAW` and
+friends, on a process every service in your stack already trusts and connects to.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-rabbitmq --fix` prints one remediation per failed dimension, then one hardened
+run. For `rabbitmq:4-alpine`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only
+  what the workload provably needs. RabbitMQ needs none of the defaults.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin
+  as host uid 0. Point the data directory at a volume this uid owns.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  broker, clients must be able to connect to it. Any named or bridge network scores 4 of 15 (a
+  WARN, not a fail): a connection path exists. This is the one dimension a broker cannot max out.
+  Contain it anyway: attach a user-defined network scoped to just its producers and consumers,
+  with no default route out, so a compromised broker cannot call arbitrary internet addresses.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/var/lib/rabbitmq` as an explicit writable volume. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name rabbitmq rabbitmq:4-alpine
+
+# After: 89/100, grade B (scoped private network for producers and consumers)
+docker run -d --name rabbitmq-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v rabbitmq-data:/var/lib/rabbitmq \
+  --network=rabbit-internal \
+  rabbitmq:4-alpine
+```
+
+Rescan: `ironctl scan rabbitmq-hardened` reports `89/100 grade B`. A **41-point swing** with no
+custom image build, just the right flags. The only dimension still short of full marks is the
+network (4 of 15), because a broker exists to be connected to; `network=none` would score the
+last points but leave nothing able to reach the queue. That is the honest ceiling for a broker,
+and it is a long way from the default D.
+
+## Verify it on your own broker
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-rabbitmq
+ironctl scan my-rabbitmq --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can
+grade the RabbitMQ in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [rabbitmq:4-alpine isolation scorecard &rarr;](../scores/rabbitmq.md): the full dimension breakdown.
+- [Message queues, ranked by isolation &rarr;](../scores/collections/message-queues.md): how RabbitMQ compares to Kafka, NATS, Redpanda, and the rest.
+- [How to harden an nginx container &rarr;](harden-nginx-container-isolation.md): another service with an honest network ceiling, explained the same way.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -50,6 +50,18 @@ fail, and the precise `ironctl scan --fix` flags that close the gap, with before
 - [How to harden an nginx container](harden-nginx-container-isolation.md) -
   `nginx:1.27-alpine` scores 48 of 100 (D). The honest hardened ceiling for an internet-facing
   proxy is 89 of 100 (B), because it must reach its upstreams. Here is exactly why.
+- [How to harden a MySQL container](harden-mysql-container-isolation.md) -
+  `mysql:8.4` scores 48 of 100 (D) on defaults: root, full capabilities, writable rootfs. Four
+  flags take it to 100 of 100 (A). Is it safe for untrusted workloads?
+- [How to harden an Elasticsearch container](harden-elasticsearch-container-isolation.md) -
+  `elasticsearch:8.16.1` already runs non-root, so it starts at 63 of 100 (C). Three flags take a
+  single-node index to 100 of 100 (A); a multi-node cluster has an honest 89 of 100 (B) ceiling.
+- [How to harden a RabbitMQ container](harden-rabbitmq-container-isolation.md) -
+  `rabbitmq:4-alpine` scores 48 of 100 (D). The honest hardened ceiling for a broker is 89 of 100
+  (B), because clients must be able to connect to it. Here is exactly why.
+- [How to harden a Memcached container](harden-memcached-container-isolation.md) -
+  `memcached:1.6-alpine` runs non-root and holds nothing on disk, so it starts at 63 of 100 (C).
+  A read-only rootfs (no volume needed) and dropped capabilities take it to its honest 89 of 100 (B).
 - [How to scan a Dockerfile for security issues](scan-a-dockerfile-for-security-issues.md) -
   a deliberately bad Dockerfile (root default, unpinned base, a baked-in secret) scores 5 of
   100 (F) on a static, daemon-free scan. The exact one-line fixes take it to 100 of 100 (A).

--- a/docs/scan-action.md
+++ b/docs/scan-action.md
@@ -132,6 +132,16 @@ is keyed by mode + target, so re-runs update in place instead of spamming, and
 multiple targets in one PR each keep their own comment. On non-PR events the
 scorecard goes to the job summary instead.
 
+For the file modes (`compose` / `k8s`) the comment also shows a **delta versus
+the base branch**: the action fetches the base version of the scanned file via
+the contents API, grades it, and adds a line such as
+`Δ vs base (main): +12 — base scored 88/100. Posture improved.` so a reviewer
+sees at a glance whether the change hardened or regressed the posture. A file
+that is new on the PR is noted as such, and the whole delta step is fail-open —
+if the base cannot be fetched or graded, the scorecard is still posted without a
+delta line. `container` mode has no git base to compare against, so it shows no
+delta.
+
 Everything the [scan](scan.md) command guarantees still holds: it is local and
 read-only, it never talks to a control-plane, it needs no credentials, and it is
 fail-closed. See [`.github/actions/scan`](https://github.com/IronSecCo/ironclaw/tree/main/.github/actions/scan)


### PR DESCRIPTION
## What

Extends the harden-<X> long-tail SEO guide pattern (IRO-486: postgres/redis/node/nginx) to four more high-traffic images that already have scorecard data. One guide each at `docs/blog/harden-<img>-container-isolation.md`.

| Image | Default | Hardened | Notes |
|-------|:-------:|:--------:|-------|
| mysql:8.4 | 48/100 D | 100/100 A | root+caps+rootfs fail; +52 swing |
| elasticsearch:8.16.1 | 63/100 C | 100/100 A | non-root already; single-node. Multi-node honest ceiling 89/B |
| rabbitmq:4-alpine | 48/100 D | 89/100 B | honest broker ceiling: clients must connect |
| memcached:1.6-alpine | 63/100 C | 89/100 B | non-root + in-memory (no volume); honest cache ceiling |

All default grades are the real score from each image's scorecard; hardened grades are the deterministic per-dimension arithmetic (same method as the shipped postgres/redis/nginx guides). No fabricated numbers. Hard ceilings (rabbitmq/memcached network, es multi-node) stated honestly per IRO-254, no em-dash.

## Wiring
- `docs/blog/.nav.yml` + `docs/blog/index.md` hardening-guides cluster (4 new entries)
- README funnel: new per-image hardening-guides block covering all eight guides (none existed before)

## Verify
- `mkdocs build --strict` passes (exit 0)
- No em/en-dash in new copy (IRO-254)

Closes IRO-498.