### PR TITLE
docs: harden-<X> SEO guides wave 3 + hardening-guides hub (IRO-502)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,13 +276,18 @@ Head-to-head reads backed by the same scan data:
 (when a shared host kernel is the weak link).
 
 Per-image hardening walkthroughs, the default grade, the dimensions that fail, and the exact
-`ironctl scan --fix` flags that close the gap:
+`ironctl scan --fix` flags that close the gap. Start at the
+[**hardening guides hub**](https://ironsecco.github.io/ironclaw/blog/hardening-guides/), or jump to one:
 [Postgres](https://ironsecco.github.io/ironclaw/blog/harden-postgres-container-isolation/),
 [MySQL](https://ironsecco.github.io/ironclaw/blog/harden-mysql-container-isolation/),
+[MariaDB](https://ironsecco.github.io/ironclaw/blog/harden-mariadb-container-isolation/),
+[MongoDB](https://ironsecco.github.io/ironclaw/blog/harden-mongodb-container-isolation/),
 [Redis](https://ironsecco.github.io/ironclaw/blog/harden-redis-container-isolation/),
 [Memcached](https://ironsecco.github.io/ironclaw/blog/harden-memcached-container-isolation/),
 [Elasticsearch](https://ironsecco.github.io/ironclaw/blog/harden-elasticsearch-container-isolation/),
+[Kafka](https://ironsecco.github.io/ironclaw/blog/harden-kafka-container-isolation/),
 [RabbitMQ](https://ironsecco.github.io/ironclaw/blog/harden-rabbitmq-container-isolation/),
+[Vault](https://ironsecco.github.io/ironclaw/blog/harden-vault-container-isolation/),
 [nginx](https://ironsecco.github.io/ironclaw/blog/harden-nginx-container-isolation/), and
 [untrusted Node.js](https://ironsecco.github.io/ironclaw/blog/run-untrusted-nodejs-code-safely/).
 

--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -15,13 +15,18 @@ nav:
   - "Alpine vs Debian vs Ubuntu: base image and isolation": alpine-vs-debian-vs-ubuntu-container-isolation.md
   - "Docker default vs hardened: the isolation score gap": docker-default-vs-hardened-container-isolation.md
   - "gVisor vs runc: containment compared": gvisor-vs-runc-container-isolation-compared.md
+  - "Container hardening guides (hub)": hardening-guides.md
   - "How to harden a Postgres container": harden-postgres-container-isolation.md
   - "How to harden a Redis container": harden-redis-container-isolation.md
   - "How to run untrusted Node.js code safely": run-untrusted-nodejs-code-safely.md
   - "How to harden an nginx container": harden-nginx-container-isolation.md
   - "How to harden a MySQL container": harden-mysql-container-isolation.md
+  - "How to harden a MariaDB container": harden-mariadb-container-isolation.md
+  - "How to harden a MongoDB container": harden-mongodb-container-isolation.md
   - "How to harden an Elasticsearch container": harden-elasticsearch-container-isolation.md
+  - "How to harden a Kafka container": harden-kafka-container-isolation.md
   - "How to harden a RabbitMQ container": harden-rabbitmq-container-isolation.md
   - "How to harden a Memcached container": harden-memcached-container-isolation.md
+  - "How to harden a Vault container": harden-vault-container-isolation.md
   - "How to scan a Dockerfile for security issues": scan-a-dockerfile-for-security-issues.md
   - "*.md"

--- a/docs/blog/harden-kafka-container-isolation.md
+++ b/docs/blog/harden-kafka-container-isolation.md
@@ -1,0 +1,100 @@
+---
+title: "How to harden a Kafka container: apache/kafka:3.9.0 scores 63/100 by default"
+description: "apache/kafka:3.9.0 defaults score 63/100 (grade C): full caps, writable rootfs. The exact ironctl scan --fix flags that take a broker to its honest 89/100 grade B."
+---
+
+# How to harden a Kafka container (and is apache/kafka:3.9.0 safe for untrusted workloads?)
+
+A broker sits between every service you run, which is exactly why its container should be one of
+the tightest. A stock `docker run apache/kafka:3.9.0` is closer than most, it already runs as a
+non-root user, but graded on IronClaw's seven-dimension containment scale it still scores only
+**63 of 100, grade C (partial)**. Higher is safer. A couple of runtime flags take the same image to
+**89 of 100, grade B**, one point off an A, and the one dimension it cannot reach is the one a
+broker needs by definition (clients must connect to it). Here are the exact gaps and fixes from the
+scan data.
+
+> Every number here comes from a read-only `docker inspect` of `apache/kafka:3.9.0`, the same data
+> behind its [isolation scorecard](../scores/kafka.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+apache/kafka:3.9.0`, three fail or warn (and, notably, non-root already passes):
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as appuser (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+Apache's image already did the hardest part, it drops root. The sharpest edges that remain are the
+**retained capabilities** and the **writable rootfs**: a plugin or connector CVE that lands code
+execution lands it with `CAP_NET_RAW` and friends, on a process every service in your stack already
+connects to, and with a filesystem it can rewrite to persist.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-kafka --fix` prints one remediation per failed dimension, then one hardened run.
+For `apache/kafka:3.9.0`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. Kafka needs none of the defaults.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/var/lib/kafka` as an explicit writable volume. Removes the persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  broker, clients must be able to connect to it. Any named or bridge network scores 4 of 15 (a
+  WARN, not a fail): a connection path exists. This is the one dimension a broker cannot max out.
+  Contain it anyway: attach a user-defined network scoped to just its producers and consumers, with
+  no default route out, so a compromised broker cannot call arbitrary internet addresses.
+
+No `--user` flag is needed: the image already runs as `appuser`.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name kafka apache/kafka:3.9.0
+
+# After: 89/100, grade B (scoped private network for producers and consumers)
+docker run -d --name kafka-hardened \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v kafka-data:/var/lib/kafka \
+  --network=kafka-internal \
+  apache/kafka:3.9.0
+```
+
+Rescan: `ironctl scan kafka-hardened` reports `89/100 grade B`. A **26-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a broker exists to be connected to; `network=none` would score the last points but
+leave nothing able to reach the topics. That is the honest ceiling for a broker, and it is a clear
+step up from the default C.
+
+## Verify it on your own broker
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-kafka
+ironctl scan my-kafka --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Kafka in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [kafka:3.9.0 isolation scorecard &rarr;](../scores/kafka.md): the full dimension breakdown.
+- [Message queues, ranked by isolation &rarr;](../scores/collections/message-queues.md): how Kafka compares to RabbitMQ, NATS, Redpanda, and the rest.
+- [How to harden a RabbitMQ container &rarr;](harden-rabbitmq-container-isolation.md): another broker with the same honest network ceiling, explained the same way.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-mariadb-container-isolation.md
+++ b/docs/blog/harden-mariadb-container-isolation.md
@@ -1,0 +1,96 @@
+---
+title: "How to harden a MariaDB container: mariadb:11 scores 48/100 by default"
+description: "mariadb:11 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden a MariaDB container (and is mariadb:11 safe for untrusted workloads?)
+
+Short answer: a stock `docker run mariadb:11` is **not** a boundary you should trust around
+untrusted code or an untrusted network. Graded on IronClaw's seven-dimension containment scale,
+the default configuration scores **48 of 100, grade D (porous)**. Higher is safer. Four runtime
+flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and the
+exact fixes, straight from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `mariadb:11`, the same data behind
+> its [isolation scorecard](../scores/mariadb.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+mariadb:11`, four of them fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a relational database, the two that should worry you most are **egress** and **root**. A
+MariaDB process that can reach the network is a MariaDB process that can exfiltrate your tables the
+moment it is compromised (a poisoned UDF, a `LOAD DATA LOCAL`, a driver CVE). And a root process
+that escapes the container escapes as root on the host.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-mariadb --fix` prints one remediation per failed dimension, then assembles a
+single copy-pasteable hardened run. For `mariadb:11` the prescription is:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. MariaDB itself needs none of the defaults.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the data directory at a volume this uid owns.
+- **`--network=none`** (Network isolation, +11): if the database is only reached by services on a
+  private user-defined network, cut host egress entirely; otherwise attach a single internal
+  network with no default route, not `bridge`.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/var/lib/mysql` as an explicit writable volume. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name mariadb mariadb:11
+
+# After: 100/100, grade A
+docker run -d --name mariadb-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp --tmpfs /run/mysqld \
+  -v mariadb-data:/var/lib/mysql \
+  --network=none \
+  mariadb:11
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan mariadb-hardened` reports
+`100/100 grade A`. That is a **52-point swing from four one-line flags**, no image rebuild.
+
+## Verify it on your own database
+
+The grade above is the default image. Your deployment is what matters. Scan it in ten seconds:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-mariadb
+ironctl scan my-mariadb --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the MariaDB in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [mariadb:11 isolation scorecard &rarr;](../scores/mariadb.md): the full dimension breakdown.
+- [Databases, ranked by isolation &rarr;](../scores/collections/databases.md): how MariaDB compares to MySQL, Postgres, Mongo, and the rest.
+- [How to harden a MySQL container &rarr;](harden-mysql-container-isolation.md): the same walkthrough for the other big relational database.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-mongodb-container-isolation.md
+++ b/docs/blog/harden-mongodb-container-isolation.md
@@ -1,0 +1,96 @@
+---
+title: "How to harden a MongoDB container: mongo:7 scores 48/100 by default"
+description: "mongo:7 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden a MongoDB container (and is mongo:7 safe for untrusted workloads?)
+
+Short answer: a stock `docker run mongo:7` is **not** a boundary you should trust around
+untrusted code or an untrusted network. Graded on IronClaw's seven-dimension containment scale,
+the default configuration scores **48 of 100, grade D (porous)**. Higher is safer. Four runtime
+flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and the
+exact fixes, straight from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `mongo:7`, the same data behind
+> its [isolation scorecard](../scores/mongo.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run mongo:7`,
+four of them fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a document database, the two that should worry you most are **egress** and **root**. A Mongo
+process that can reach the network is a Mongo process that can exfiltrate your collections the
+moment it is compromised (a server-side JavaScript CVE, a poisoned `$where`, a driver bug). And a
+root process that escapes the container escapes as root on the host.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-mongo --fix` prints one remediation per failed dimension, then assembles a single
+copy-pasteable hardened run. For `mongo:7` the prescription is:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. MongoDB itself needs none of the defaults.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the data directory at a volume this uid owns.
+- **`--network=none`** (Network isolation, +11): if the database is only reached by services on a
+  private user-defined network, cut host egress entirely; otherwise attach a single internal
+  network with no default route, not `bridge`.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/data/db` as an explicit writable volume. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name mongo mongo:7
+
+# After: 100/100, grade A
+docker run -d --name mongo-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v mongo-data:/data/db \
+  --network=none \
+  mongo:7
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan mongo-hardened` reports
+`100/100 grade A`. That is a **52-point swing from four one-line flags**, no image rebuild.
+
+## Verify it on your own database
+
+The grade above is the default image. Your deployment is what matters. Scan it in ten seconds:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-mongo
+ironctl scan my-mongo --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the MongoDB in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [mongo:7 isolation scorecard &rarr;](../scores/mongo.md): the full dimension breakdown.
+- [Databases, ranked by isolation &rarr;](../scores/collections/databases.md): how Mongo compares to Postgres, MySQL, Redis, and the rest.
+- [How to harden a MariaDB container &rarr;](harden-mariadb-container-isolation.md): the same walkthrough for the relational side.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-vault-container-isolation.md
+++ b/docs/blog/harden-vault-container-isolation.md
@@ -1,0 +1,113 @@
+---
+title: "How to harden a Vault container: hashicorp/vault:1.18 scores 48/100 by default"
+description: "hashicorp/vault:1.18 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a secrets server to its honest 89/100 grade B."
+---
+
+# How to harden a Vault container (and is hashicorp/vault:1.18 safe for untrusted workloads?)
+
+A secrets manager is the one process in your stack that must never be the weak link, because
+everything it holds is, by definition, worth stealing. A stock `docker run hashicorp/vault:1.18` is
+not the boundary that job deserves. Graded on IronClaw's seven-dimension containment scale, the
+default configuration scores **48 of 100, grade D (porous)**. Higher is safer. A few runtime flags
+take the same image to **89 of 100, grade B**, one point off an A, and the one dimension it cannot
+reach is the one a secrets server needs by definition (its clients must connect to it). Here are the
+exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `hashicorp/vault:1.18`, the same data
+> behind its [isolation scorecard](../scores/vault.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+hashicorp/vault:1.18`, four fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a secrets server, the two that should worry you most are **root** and **egress**. A Vault
+process that escapes as root escapes as root on the host, next to every secret it just unsealed. And
+a Vault process that can reach arbitrary network destinations is a Vault process that can quietly
+ship its store to one the moment a plugin or auth-method CVE lands code execution.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-vault --fix` prints one remediation per failed dimension, then one hardened run.
+For `hashicorp/vault:1.18`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. See the mlock note below, the one capability Vault may want back.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the storage directory at a volume this uid owns.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/vault/file` as an explicit writable volume. Removes the persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  secrets server, its clients must be able to reach the API. Any named or bridge network scores 4 of
+  15 (a WARN, not a fail): a connection path exists. This is the one dimension a secrets server
+  cannot max out. Contain it anyway: attach a user-defined network scoped to just the apps that read
+  from Vault, with no default route out, so a compromised Vault cannot call arbitrary internet
+  addresses.
+
+### The mlock note
+
+Vault likes to `mlock` its memory so secrets are never swapped to disk, and `mlock` needs the
+`IPC_LOCK` capability. With `--cap-drop=ALL` you have two honest choices:
+
+- Add just that one capability back: `--cap-add=IPC_LOCK`. Still a world tighter than the default
+  full set.
+- Or disable mlock (`disable_mlock = true` in the Vault config) and make sure swap is off on the
+  host so nothing hits disk anyway, the standard posture on a dedicated Vault node.
+
+Either is fine; pick per your deployment. The score above reflects dropping the default set.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name vault hashicorp/vault:1.18
+
+# After: 89/100, grade B (scoped private network for its client apps)
+docker run -d --name vault-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL --cap-add=IPC_LOCK \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v vault-data:/vault/file \
+  --network=vault-internal \
+  hashicorp/vault:1.18
+```
+
+Rescan: `ironctl scan vault-hardened` reports `89/100 grade B`. A **41-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a secrets server exists to be connected to; `network=none` would score the last points
+but leave nothing able to read a secret. That is the honest ceiling for a secrets server, and it is
+a long way from the default D.
+
+## Verify it on your own Vault
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-vault
+ironctl scan my-vault --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Vault in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [vault:1.18 isolation scorecard &rarr;](../scores/vault.md): the full dimension breakdown.
+- [How to harden a RabbitMQ container &rarr;](harden-rabbitmq-container-isolation.md): another network service with the same honest ceiling, explained the same way.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -1,0 +1,72 @@
+---
+title: "Container hardening guides: harden Postgres, MySQL, Redis, Kafka, Vault and more"
+description: "Every IronClaw harden-a-container walkthrough in one place. Real ironctl scan before/after grades and the exact flags that close the gap, per image."
+---
+
+# Container hardening guides
+
+Every guide below takes one popular Docker image, grades its **default** `docker run` on IronClaw's
+seven-dimension containment scale, and shows the exact `ironctl scan --fix` flags that close the gap.
+The numbers are not hand-waved: each comes from a read-only `docker inspect` of the real image, the
+same data behind that image's [isolation scorecard](../scores/index.md). No workload is executed to
+produce them.
+
+Two patterns show up across the set:
+
+- **Datastores and sandboxes reach grade A.** A database or a code sandbox that only its co-located
+  services talk to can take `--network=none` and hit **100/100**. Root, capabilities, and a
+  read-only rootfs are the whole game.
+- **Network services hit an honest ceiling at grade B.** A broker, cache, proxy, or secrets server
+  *exists to be connected to*, so `--network=none` would score the last points but break the service.
+  The honest ceiling is **89/100, grade B**, with the network dimension held at a WARN and contained
+  with a scoped private network instead. We say so on every page rather than inflate the number.
+
+## Reach grade A (100/100)
+
+| Service | Default | Hardened | The gap that closes |
+|---------|:-------:|:--------:|---------------------|
+| [Postgres](harden-postgres-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
+| [MySQL](harden-mysql-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
+| [MariaDB](harden-mariadb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
+| [MongoDB](harden-mongodb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
+| [Redis](harden-redis-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
+| [Elasticsearch](harden-elasticsearch-container-isolation.md) | 63/100 C | **100/100 A** | full caps, writable rootfs (89/B multi-node) |
+| [Untrusted Node.js](run-untrusted-nodejs-code-safely.md) | 48/100 D | **100/100 A** | run untrusted code in a real sandbox |
+
+## Honest ceiling: grade B (89/100)
+
+These services must accept client connections, so the network dimension holds at a WARN by design.
+
+| Service | Default | Hardened | Why 89 is the ceiling |
+|---------|:-------:|:--------:|-----------------------|
+| [Kafka](harden-kafka-container-isolation.md) | 63/100 C | **89/100 B** | broker: producers and consumers must connect |
+| [RabbitMQ](harden-rabbitmq-container-isolation.md) | 48/100 D | **89/100 B** | broker: every service connects to the queue |
+| [Memcached](harden-memcached-container-isolation.md) | 63/100 C | **89/100 B** | cache: clients read and write over the network |
+| [nginx](harden-nginx-container-isolation.md) | 48/100 D | **89/100 B** | proxy: it exists to forward traffic |
+| [Vault](harden-vault-container-isolation.md) | 48/100 D | **89/100 B** | secrets server: apps must reach the API |
+
+## The pattern, one command
+
+Every grade on this page comes from the same tool. Point it at any running container, a
+`docker-compose.yml` service, or a Kubernetes manifest, and it grades the real thing, then prints the
+fixes:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade it, then print the exact hardening flags
+ironctl scan my-container
+ironctl scan my-container --fix
+```
+
+Want it in CI? The same engine ships as a [GitHub Action on the
+Marketplace](ironclaw-scan-github-action-marketplace.md) that scores every pull request and posts the
+grade as a sticky comment.
+
+## Keep going
+
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Container Isolation Scores &rarr;](../scores/index.md): default-config grades for the most-pulled public images.
+- [The State of Container Isolation, 2026 &rarr;](state-of-container-isolation-2026.md): the survey the whole directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.


### PR DESCRIPTION
## What
Wave 3 of the harden-<X> long-tail SEO guides, generated from real `ironctl scan` scorecard data, plus a **Hardening Guides hub** that turns the growing set into an internally-linked topical cluster.

### Four new guides (honest before/after grades)
| Guide | Default | Hardened | Note |
|---|:--:|:--:|---|
| mongodb (mongo:7) | 48/D | **100/A** | database, co-located network=none |
| mariadb (mariadb:11) | 48/D | **100/A** | database |
| kafka (apache/kafka:3.9.0) | 63/C | **89/B** | broker honest ceiling; already non-root |
| vault (hashicorp/vault:1.18) | 48/D | **89/B** | secrets-server honest ceiling; IPC_LOCK/mlock note |

Kafka + Vault get the honest grade-B ceiling framing (network dimension held at WARN, contained with a scoped private network) same as the rabbitmq/nginx/memcached cases. Vault guide adds the credible `IPC_LOCK`/`disable_mlock` operational nuance.

### Hub page
`docs/blog/hardening-guides.md` lists all 12 harden-<X> guides with one-line grade deltas, split by grade-A datastores/sandboxes vs honest grade-B network services. Each new guide cross-links back to the hub + the scan CLI/Action funnel.

### Wiring
- Blog `.nav.yml`: hub + 4 guides added.
- README funnel: hub link + 4 new guide links.

## Verification
- All grades traced to committed `docs/scores/*.md` scorecards (mongo/mariadb/kafka/vault), read-only `docker inspect` derived. No fabricated numbers.
- `mkdocs build --strict` clean (only pre-existing INFO on unrelated pages).
- No em/en-dashes in public copy.

## Acceptance (IRO-502)
- [x] 4 guides live with real before/after grade tables + scan CTA
- [x] Hub page live, linked from nav + README, links all existing harden guides
- [x] mkdocs builds clean (--strict)
- [x] PR opened; CEO admin-merge after review path

Owner: Growth. Closes IRO-502.