### PR TITLE
feat(scan): ironctl scan --helm — render Helm chart, grade workload isolation (IRO-501)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,13 +276,18 @@ Head-to-head reads backed by the same scan data:
 (when a shared host kernel is the weak link).
 
 Per-image hardening walkthroughs, the default grade, the dimensions that fail, and the exact
-`ironctl scan --fix` flags that close the gap:
+`ironctl scan --fix` flags that close the gap. Start at the
+[**hardening guides hub**](https://ironsecco.github.io/ironclaw/blog/hardening-guides/), or jump to one:
 [Postgres](https://ironsecco.github.io/ironclaw/blog/harden-postgres-container-isolation/),
 [MySQL](https://ironsecco.github.io/ironclaw/blog/harden-mysql-container-isolation/),
+[MariaDB](https://ironsecco.github.io/ironclaw/blog/harden-mariadb-container-isolation/),
+[MongoDB](https://ironsecco.github.io/ironclaw/blog/harden-mongodb-container-isolation/),
 [Redis](https://ironsecco.github.io/ironclaw/blog/harden-redis-container-isolation/),
 [Memcached](https://ironsecco.github.io/ironclaw/blog/harden-memcached-container-isolation/),
 [Elasticsearch](https://ironsecco.github.io/ironclaw/blog/harden-elasticsearch-container-isolation/),
+[Kafka](https://ironsecco.github.io/ironclaw/blog/harden-kafka-container-isolation/),
 [RabbitMQ](https://ironsecco.github.io/ironclaw/blog/harden-rabbitmq-container-isolation/),
+[Vault](https://ironsecco.github.io/ironclaw/blog/harden-vault-container-isolation/),
 [nginx](https://ironsecco.github.io/ironclaw/blog/harden-nginx-container-isolation/), and
 [untrusted Node.js](https://ironsecco.github.io/ironclaw/blog/run-untrusted-nodejs-code-safely/).
 

--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -39,6 +41,8 @@ func cmdScan(args []string) error {
 	compose := fs.String("compose", "", "grade a service in this docker-compose file")
 	service := fs.String("service", "", "compose service name (required if the file has >1 service)")
 	k8s := fs.String("k8s", "", "grade the first container in this Kubernetes pod/workload manifest")
+	helm := fs.String("helm", "", "render a Helm chart (dir or .tgz) with `helm template` and grade the isolation posture of its workloads")
+	helmBin := fs.String("helm-bin", envOrDefault("HELM", "helm"), "helm binary used to render the chart")
 	dockerfile := fs.Bool("dockerfile", false, "statically grade the positional Dockerfile(s) authoring-time posture (daemon-free)")
 	runtime := fs.String("runtime", envOrDefault("IRONCTL_SCAN_RUNTIME", "auto"), "container runtime: auto|docker|podman|nerdctl")
 	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker inspect`")
@@ -89,6 +93,25 @@ func cmdScan(args []string) error {
 		}
 		return runDockerfileScan(dockerfileArgs{
 			paths:     positional,
+			asJSON:    *asJSON,
+			md:        *md,
+			badge:     *badge,
+			badgeJSON: *badgeJSON,
+			sarif:     *sarif,
+			minScore:  *minScore,
+		})
+	}
+
+	// --helm: render a chart locally (`helm template`, no cluster, daemon-free)
+	// and grade the isolation posture of the rendered workloads, reusing the k8s
+	// dimension set. It renders (I/O) here, then defers to the pure
+	// SpecsFromK8sStream + AggregateHelm scorer. Fail-OPEN on a render failure
+	// (helm absent / template error) so an opt-in CI step never crashes the build;
+	// the --min-score gate still applies once the chart renders.
+	if *helm != "" {
+		return runHelmScan(helmArgs{
+			chart:     *helm,
+			helmBin:   *helmBin,
 			asJSON:    *asJSON,
 			md:        *md,
 			badge:     *badge,
@@ -337,6 +360,115 @@ func runDockerfileScan(a dockerfileArgs) error {
 	return nil
 }
 
+// helmArgs carries the resolved inputs for a `scan --helm` run.
+type helmArgs struct {
+	chart     string
+	helmBin   string
+	asJSON    bool
+	md        bool
+	badge     string
+	badgeJSON string
+	sarif     string
+	minScore  int
+}
+
+// runHelmScan renders a Helm chart with `helm template` (no cluster, daemon-free)
+// and grades the isolation posture of its rendered workloads, reusing the k8s
+// scorer. It fails OPEN on a render failure (helm binary absent, or `helm
+// template` errors): it prints a clear diagnostic to stderr and returns nil so
+// an opt-in CI/Action step never crashes the build over tooling or chart-render
+// issues. Once the chart renders, scoring and the --min-score CI gate apply
+// exactly like --k8s (a genuinely low posture still fails the gate).
+func runHelmScan(a helmArgs) error {
+	rendered, err := renderHelmChart(a.helmBin, a.chart)
+	if err != nil {
+		// Fail-open: surface the reason, do not error out.
+		fmt.Fprintf(os.Stderr, "  warning: scan --helm could not render %q (scan skipped, exit 0): %v\n", a.chart, err)
+		return nil
+	}
+
+	specs, err := scan.SpecsFromK8sStream(rendered)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --helm could not parse rendered chart %q (scan skipped, exit 0): %v\n", a.chart, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregateHelm(specs, filepath.Base(strings.TrimRight(a.chart, "/")))
+	if err != nil {
+		// A chart that renders no gradeable workload is a fail-open skip, not a
+		// crash: nothing to grade is not the same as a low score.
+		fmt.Fprintf(os.Stderr, "  warning: scan --helm found nothing to grade in %q (scan skipped, exit 0): %v\n", a.chart, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		// Anchor at the chart with a logical location naming the weakest workload
+		// (the rendered stream has no stable source file/line to point at).
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (render succeeded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// renderHelmChart runs `helm template` against a local chart (unpacked dir or
+// .tgz) and returns the rendered multi-document manifest stream. It is offline
+// and daemon-free: no cluster connection, no network beyond helm's own local
+// dependency resolution. A fixed release name keeps output deterministic.
+func renderHelmChart(helmBin, chart string) ([]byte, error) {
+	if _, err := exec.LookPath(helmBin); err != nil {
+		return nil, fmt.Errorf("helm binary %q not found on PATH (install helm or pass --helm-bin): %w", helmBin, err)
+	}
+	cmd := exec.Command(helmBin, "template", "ironclaw-scan", chart)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("helm template failed: %s", msg)
+	}
+	return stdout.Bytes(), nil
+}
+
 // writeDockerfileSARIF renders the Dockerfile SARIF log to path, fail-open on error.
 func writeDockerfileSARIF(path string, r scan.Report, opts scan.SARIFOptions) error {
 	f, err := os.Create(path)
@@ -466,6 +598,7 @@ USAGE:
   ironctl scan <container>                    grade a running container (docker|podman|nerdctl)
   ironctl scan --compose FILE [--service N]   grade a docker-compose service
   ironctl scan --k8s FILE                     grade a Kubernetes pod/workload manifest
+  ironctl scan --helm CHART                    render a Helm chart (dir or .tgz) and grade its workloads
   ironctl scan --dockerfile FILE...           grade Dockerfile(s) statically (no daemon, no pull)
   ironctl scan --compare A B                   diff two containers' isolation posture
 
@@ -481,6 +614,7 @@ FLAGS:
   --md                print a shareable markdown block
   --min-score N       exit non-zero if the score is below N (CI gate)
   --service NAME      compose service to grade (if the file has >1)
+  --helm-bin BIN      helm binary for `+"`helm template`"+` (default: helm)
   --docker-bin BIN    docker binary for `+"`docker inspect`"+` (default: docker)
   --podman-bin BIN    podman binary for `+"`podman inspect`"+` (default: podman)
   --nerdctl-bin BIN   nerdctl binary for `+"`nerdctl inspect`"+` (default: nerdctl)
@@ -494,6 +628,15 @@ IRO-429 scoring stays runtime-agnostic (no points for a runtime name).
 Dimensions graded: non-root user, dropped capabilities, seccomp, network
 isolation, read-only rootfs, docker.sock exposure, shared host namespaces.
 Unknown postures are graded fail-closed (as insecure).
+
+--helm renders a chart locally with `+"`helm template`"+` (no cluster, daemon-free) and
+grades the rendered workloads with the same k8s dimension set. The chart grade is
+the WEAKEST rendered workload (a chart is only as isolated as its most-exposed
+pod); every workload's score is listed in the notes. Network egress depends on a
+NetworkPolicy that a pod spec does not carry, so it is graded conservatively
+(the honest static ceiling). Rendering failures (helm absent / template error)
+fail OPEN: a clear diagnostic and exit 0, so an opt-in CI step never crashes the
+build. A successful render still trips --min-score on a low posture.
 
 --dockerfile grades a DIFFERENT, authoring-time dimension set (non-root USER,
 pinned base image, no secrets in ENV/ARG, COPY over remote/opaque ADD, no

--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -15,13 +15,18 @@ nav:
   - "Alpine vs Debian vs Ubuntu: base image and isolation": alpine-vs-debian-vs-ubuntu-container-isolation.md
   - "Docker default vs hardened: the isolation score gap": docker-default-vs-hardened-container-isolation.md
   - "gVisor vs runc: containment compared": gvisor-vs-runc-container-isolation-compared.md
+  - "Container hardening guides (hub)": hardening-guides.md
   - "How to harden a Postgres container": harden-postgres-container-isolation.md
   - "How to harden a Redis container": harden-redis-container-isolation.md
   - "How to run untrusted Node.js code safely": run-untrusted-nodejs-code-safely.md
   - "How to harden an nginx container": harden-nginx-container-isolation.md
   - "How to harden a MySQL container": harden-mysql-container-isolation.md
+  - "How to harden a MariaDB container": harden-mariadb-container-isolation.md
+  - "How to harden a MongoDB container": harden-mongodb-container-isolation.md
   - "How to harden an Elasticsearch container": harden-elasticsearch-container-isolation.md
+  - "How to harden a Kafka container": harden-kafka-container-isolation.md
   - "How to harden a RabbitMQ container": harden-rabbitmq-container-isolation.md
   - "How to harden a Memcached container": harden-memcached-container-isolation.md
+  - "How to harden a Vault container": harden-vault-container-isolation.md
   - "How to scan a Dockerfile for security issues": scan-a-dockerfile-for-security-issues.md
   - "*.md"

--- a/docs/blog/harden-kafka-container-isolation.md
+++ b/docs/blog/harden-kafka-container-isolation.md
@@ -1,0 +1,100 @@
+---
+title: "How to harden a Kafka container: apache/kafka:3.9.0 scores 63/100 by default"
+description: "apache/kafka:3.9.0 defaults score 63/100 (grade C): full caps, writable rootfs. The exact ironctl scan --fix flags that take a broker to its honest 89/100 grade B."
+---
+
+# How to harden a Kafka container (and is apache/kafka:3.9.0 safe for untrusted workloads?)
+
+A broker sits between every service you run, which is exactly why its container should be one of
+the tightest. A stock `docker run apache/kafka:3.9.0` is closer than most, it already runs as a
+non-root user, but graded on IronClaw's seven-dimension containment scale it still scores only
+**63 of 100, grade C (partial)**. Higher is safer. A couple of runtime flags take the same image to
+**89 of 100, grade B**, one point off an A, and the one dimension it cannot reach is the one a
+broker needs by definition (clients must connect to it). Here are the exact gaps and fixes from the
+scan data.
+
+> Every number here comes from a read-only `docker inspect` of `apache/kafka:3.9.0`, the same data
+> behind its [isolation scorecard](../scores/kafka.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+apache/kafka:3.9.0`, three fail or warn (and, notably, non-root already passes):
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as appuser (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+Apache's image already did the hardest part, it drops root. The sharpest edges that remain are the
+**retained capabilities** and the **writable rootfs**: a plugin or connector CVE that lands code
+execution lands it with `CAP_NET_RAW` and friends, on a process every service in your stack already
+connects to, and with a filesystem it can rewrite to persist.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-kafka --fix` prints one remediation per failed dimension, then one hardened run.
+For `apache/kafka:3.9.0`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. Kafka needs none of the defaults.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/var/lib/kafka` as an explicit writable volume. Removes the persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  broker, clients must be able to connect to it. Any named or bridge network scores 4 of 15 (a
+  WARN, not a fail): a connection path exists. This is the one dimension a broker cannot max out.
+  Contain it anyway: attach a user-defined network scoped to just its producers and consumers, with
+  no default route out, so a compromised broker cannot call arbitrary internet addresses.
+
+No `--user` flag is needed: the image already runs as `appuser`.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name kafka apache/kafka:3.9.0
+
+# After: 89/100, grade B (scoped private network for producers and consumers)
+docker run -d --name kafka-hardened \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v kafka-data:/var/lib/kafka \
+  --network=kafka-internal \
+  apache/kafka:3.9.0
+```
+
+Rescan: `ironctl scan kafka-hardened` reports `89/100 grade B`. A **26-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a broker exists to be connected to; `network=none` would score the last points but
+leave nothing able to reach the topics. That is the honest ceiling for a broker, and it is a clear
+step up from the default C.
+
+## Verify it on your own broker
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-kafka
+ironctl scan my-kafka --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Kafka in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [kafka:3.9.0 isolation scorecard &rarr;](../scores/kafka.md): the full dimension breakdown.
+- [Message queues, ranked by isolation &rarr;](../scores/collections/message-queues.md): how Kafka compares to RabbitMQ, NATS, Redpanda, and the rest.
+- [How to harden a RabbitMQ container &rarr;](harden-rabbitmq-container-isolation.md): another broker with the same honest network ceiling, explained the same way.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-mariadb-container-isolation.md
+++ b/docs/blog/harden-mariadb-container-isolation.md
@@ -1,0 +1,96 @@
+---
+title: "How to harden a MariaDB container: mariadb:11 scores 48/100 by default"
+description: "mariadb:11 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden a MariaDB container (and is mariadb:11 safe for untrusted workloads?)
+
+Short answer: a stock `docker run mariadb:11` is **not** a boundary you should trust around
+untrusted code or an untrusted network. Graded on IronClaw's seven-dimension containment scale,
+the default configuration scores **48 of 100, grade D (porous)**. Higher is safer. Four runtime
+flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and the
+exact fixes, straight from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `mariadb:11`, the same data behind
+> its [isolation scorecard](../scores/mariadb.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+mariadb:11`, four of them fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a relational database, the two that should worry you most are **egress** and **root**. A
+MariaDB process that can reach the network is a MariaDB process that can exfiltrate your tables the
+moment it is compromised (a poisoned UDF, a `LOAD DATA LOCAL`, a driver CVE). And a root process
+that escapes the container escapes as root on the host.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-mariadb --fix` prints one remediation per failed dimension, then assembles a
+single copy-pasteable hardened run. For `mariadb:11` the prescription is:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. MariaDB itself needs none of the defaults.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the data directory at a volume this uid owns.
+- **`--network=none`** (Network isolation, +11): if the database is only reached by services on a
+  private user-defined network, cut host egress entirely; otherwise attach a single internal
+  network with no default route, not `bridge`.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/var/lib/mysql` as an explicit writable volume. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name mariadb mariadb:11
+
+# After: 100/100, grade A
+docker run -d --name mariadb-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp --tmpfs /run/mysqld \
+  -v mariadb-data:/var/lib/mysql \
+  --network=none \
+  mariadb:11
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan mariadb-hardened` reports
+`100/100 grade A`. That is a **52-point swing from four one-line flags**, no image rebuild.
+
+## Verify it on your own database
+
+The grade above is the default image. Your deployment is what matters. Scan it in ten seconds:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-mariadb
+ironctl scan my-mariadb --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the MariaDB in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [mariadb:11 isolation scorecard &rarr;](../scores/mariadb.md): the full dimension breakdown.
+- [Databases, ranked by isolation &rarr;](../scores/collections/databases.md): how MariaDB compares to MySQL, Postgres, Mongo, and the rest.
+- [How to harden a MySQL container &rarr;](harden-mysql-container-isolation.md): the same walkthrough for the other big relational database.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-mongodb-container-isolation.md
+++ b/docs/blog/harden-mongodb-container-isolation.md
@@ -1,0 +1,96 @@
+---
+title: "How to harden a MongoDB container: mongo:7 scores 48/100 by default"
+description: "mongo:7 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden a MongoDB container (and is mongo:7 safe for untrusted workloads?)
+
+Short answer: a stock `docker run mongo:7` is **not** a boundary you should trust around
+untrusted code or an untrusted network. Graded on IronClaw's seven-dimension containment scale,
+the default configuration scores **48 of 100, grade D (porous)**. Higher is safer. Four runtime
+flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and the
+exact fixes, straight from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `mongo:7`, the same data behind
+> its [isolation scorecard](../scores/mongo.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run mongo:7`,
+four of them fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a document database, the two that should worry you most are **egress** and **root**. A Mongo
+process that can reach the network is a Mongo process that can exfiltrate your collections the
+moment it is compromised (a server-side JavaScript CVE, a poisoned `$where`, a driver bug). And a
+root process that escapes the container escapes as root on the host.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-mongo --fix` prints one remediation per failed dimension, then assembles a single
+copy-pasteable hardened run. For `mongo:7` the prescription is:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. MongoDB itself needs none of the defaults.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the data directory at a volume this uid owns.
+- **`--network=none`** (Network isolation, +11): if the database is only reached by services on a
+  private user-defined network, cut host egress entirely; otherwise attach a single internal
+  network with no default route, not `bridge`.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/data/db` as an explicit writable volume. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name mongo mongo:7
+
+# After: 100/100, grade A
+docker run -d --name mongo-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v mongo-data:/data/db \
+  --network=none \
+  mongo:7
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan mongo-hardened` reports
+`100/100 grade A`. That is a **52-point swing from four one-line flags**, no image rebuild.
+
+## Verify it on your own database
+
+The grade above is the default image. Your deployment is what matters. Scan it in ten seconds:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-mongo
+ironctl scan my-mongo --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the MongoDB in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [mongo:7 isolation scorecard &rarr;](../scores/mongo.md): the full dimension breakdown.
+- [Databases, ranked by isolation &rarr;](../scores/collections/databases.md): how Mongo compares to Postgres, MySQL, Redis, and the rest.
+- [How to harden a MariaDB container &rarr;](harden-mariadb-container-isolation.md): the same walkthrough for the relational side.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-vault-container-isolation.md
+++ b/docs/blog/harden-vault-container-isolation.md
@@ -1,0 +1,113 @@
+---
+title: "How to harden a Vault container: hashicorp/vault:1.18 scores 48/100 by default"
+description: "hashicorp/vault:1.18 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a secrets server to its honest 89/100 grade B."
+---
+
+# How to harden a Vault container (and is hashicorp/vault:1.18 safe for untrusted workloads?)
+
+A secrets manager is the one process in your stack that must never be the weak link, because
+everything it holds is, by definition, worth stealing. A stock `docker run hashicorp/vault:1.18` is
+not the boundary that job deserves. Graded on IronClaw's seven-dimension containment scale, the
+default configuration scores **48 of 100, grade D (porous)**. Higher is safer. A few runtime flags
+take the same image to **89 of 100, grade B**, one point off an A, and the one dimension it cannot
+reach is the one a secrets server needs by definition (its clients must connect to it). Here are the
+exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `hashicorp/vault:1.18`, the same data
+> behind its [isolation scorecard](../scores/vault.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+hashicorp/vault:1.18`, four fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a secrets server, the two that should worry you most are **root** and **egress**. A Vault
+process that escapes as root escapes as root on the host, next to every secret it just unsealed. And
+a Vault process that can reach arbitrary network destinations is a Vault process that can quietly
+ship its store to one the moment a plugin or auth-method CVE lands code execution.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-vault --fix` prints one remediation per failed dimension, then one hardened run.
+For `hashicorp/vault:1.18`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. See the mlock note below, the one capability Vault may want back.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the storage directory at a volume this uid owns.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/vault/file` as an explicit writable volume. Removes the persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  secrets server, its clients must be able to reach the API. Any named or bridge network scores 4 of
+  15 (a WARN, not a fail): a connection path exists. This is the one dimension a secrets server
+  cannot max out. Contain it anyway: attach a user-defined network scoped to just the apps that read
+  from Vault, with no default route out, so a compromised Vault cannot call arbitrary internet
+  addresses.
+
+### The mlock note
+
+Vault likes to `mlock` its memory so secrets are never swapped to disk, and `mlock` needs the
+`IPC_LOCK` capability. With `--cap-drop=ALL` you have two honest choices:
+
+- Add just that one capability back: `--cap-add=IPC_LOCK`. Still a world tighter than the default
+  full set.
+- Or disable mlock (`disable_mlock = true` in the Vault config) and make sure swap is off on the
+  host so nothing hits disk anyway, the standard posture on a dedicated Vault node.
+
+Either is fine; pick per your deployment. The score above reflects dropping the default set.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name vault hashicorp/vault:1.18
+
+# After: 89/100, grade B (scoped private network for its client apps)
+docker run -d --name vault-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL --cap-add=IPC_LOCK \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v vault-data:/vault/file \
+  --network=vault-internal \
+  hashicorp/vault:1.18
+```
+
+Rescan: `ironctl scan vault-hardened` reports `89/100 grade B`. A **41-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a secrets server exists to be connected to; `network=none` would score the last points
+but leave nothing able to read a secret. That is the honest ceiling for a secrets server, and it is
+a long way from the default D.
+
+## Verify it on your own Vault
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-vault
+ironctl scan my-vault --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Vault in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [vault:1.18 isolation scorecard &rarr;](../scores/vault.md): the full dimension breakdown.
+- [How to harden a RabbitMQ container &rarr;](harden-rabbitmq-container-isolation.md): another network service with the same honest ceiling, explained the same way.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -1,0 +1,72 @@
+---
+title: "Container hardening guides: harden Postgres, MySQL, Redis, Kafka, Vault and more"
+description: "Every IronClaw harden-a-container walkthrough in one place. Real ironctl scan before/after grades and the exact flags that close the gap, per image."
+---
+
+# Container hardening guides
+
+Every guide below takes one popular Docker image, grades its **default** `docker run` on IronClaw's
+seven-dimension containment scale, and shows the exact `ironctl scan --fix` flags that close the gap.
+The numbers are not hand-waved: each comes from a read-only `docker inspect` of the real image, the
+same data behind that image's [isolation scorecard](../scores/index.md). No workload is executed to
+produce them.
+
+Two patterns show up across the set:
+
+- **Datastores and sandboxes reach grade A.** A database or a code sandbox that only its co-located
+  services talk to can take `--network=none` and hit **100/100**. Root, capabilities, and a
+  read-only rootfs are the whole game.
+- **Network services hit an honest ceiling at grade B.** A broker, cache, proxy, or secrets server
+  *exists to be connected to*, so `--network=none` would score the last points but break the service.
+  The honest ceiling is **89/100, grade B**, with the network dimension held at a WARN and contained
+  with a scoped private network instead. We say so on every page rather than inflate the number.
+
+## Reach grade A (100/100)
+
+| Service | Default | Hardened | The gap that closes |
+|---------|:-------:|:--------:|---------------------|
+| [Postgres](harden-postgres-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
+| [MySQL](harden-mysql-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
+| [MariaDB](harden-mariadb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
+| [MongoDB](harden-mongodb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
+| [Redis](harden-redis-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
+| [Elasticsearch](harden-elasticsearch-container-isolation.md) | 63/100 C | **100/100 A** | full caps, writable rootfs (89/B multi-node) |
+| [Untrusted Node.js](run-untrusted-nodejs-code-safely.md) | 48/100 D | **100/100 A** | run untrusted code in a real sandbox |
+
+## Honest ceiling: grade B (89/100)
+
+These services must accept client connections, so the network dimension holds at a WARN by design.
+
+| Service | Default | Hardened | Why 89 is the ceiling |
+|---------|:-------:|:--------:|-----------------------|
+| [Kafka](harden-kafka-container-isolation.md) | 63/100 C | **89/100 B** | broker: producers and consumers must connect |
+| [RabbitMQ](harden-rabbitmq-container-isolation.md) | 48/100 D | **89/100 B** | broker: every service connects to the queue |
+| [Memcached](harden-memcached-container-isolation.md) | 63/100 C | **89/100 B** | cache: clients read and write over the network |
+| [nginx](harden-nginx-container-isolation.md) | 48/100 D | **89/100 B** | proxy: it exists to forward traffic |
+| [Vault](harden-vault-container-isolation.md) | 48/100 D | **89/100 B** | secrets server: apps must reach the API |
+
+## The pattern, one command
+
+Every grade on this page comes from the same tool. Point it at any running container, a
+`docker-compose.yml` service, or a Kubernetes manifest, and it grades the real thing, then prints the
+fixes:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade it, then print the exact hardening flags
+ironctl scan my-container
+ironctl scan my-container --fix
+```
+
+Want it in CI? The same engine ships as a [GitHub Action on the
+Marketplace](ironclaw-scan-github-action-marketplace.md) that scores every pull request and posts the
+grade as a sticky comment.
+
+## Keep going
+
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Container Isolation Scores &rarr;](../scores/index.md): default-config grades for the most-pulled public images.
+- [The State of Container Isolation, 2026 &rarr;](state-of-container-isolation-2026.md): the survey the whole directory is built from.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/internal/host/scan/helm.go
+++ b/internal/host/scan/helm.go
@@ -1,0 +1,140 @@
+package scan
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// workloadKinds is the set of Kubernetes kinds that carry a pod spec worth
+// grading. `helm template` emits many non-workload docs (Service, ConfigMap,
+// Secret, Ingress, PVC, ServiceAccount, NetworkPolicy, …); those are skipped.
+var workloadKinds = map[string]bool{
+	"Pod":                   true,
+	"Deployment":            true,
+	"StatefulSet":           true,
+	"DaemonSet":             true,
+	"ReplicaSet":            true,
+	"ReplicationController": true,
+	"Job":                   true,
+	"CronJob":               true,
+}
+
+// SpecsFromK8sStream parses a multi-document Kubernetes YAML stream (the output
+// of `helm template`, or any `---`-separated manifest set) and returns one Spec
+// per gradeable workload, in document order. Non-workload docs and docs with no
+// containers are skipped. Empty documents are tolerated. It is pure and
+// unit-testable: the caller runs the renderer (I/O) and passes the stream here.
+func SpecsFromK8sStream(rendered []byte) ([]Spec, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(rendered))
+	var specs []Spec
+	for {
+		var obj k8sObject
+		err := dec.Decode(&obj)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse rendered manifest stream: %w", err)
+		}
+		// Only grade recognized workload kinds. A doc whose kind is blank (an
+		// empty document between `---` separators) or non-workload is skipped.
+		if !workloadKinds[strings.TrimSpace(obj.Kind)] {
+			continue
+		}
+		ps, ok := obj.podSpecOf()
+		if !ok {
+			continue
+		}
+		s := specFromPodSpec("helm", workloadTarget(obj), ps)
+		specs = append(specs, s)
+	}
+	return specs, nil
+}
+
+// workloadTarget builds a stable, human-readable target label for a workload:
+// "<kind>/<name>" so an aggregate report and SARIF can name exactly which
+// rendered workload each finding came from.
+func workloadTarget(obj k8sObject) string {
+	kind := strings.TrimSpace(obj.Kind)
+	name := strings.TrimSpace(obj.Metadata.Name)
+	switch {
+	case kind != "" && name != "":
+		return kind + "/" + name
+	case name != "":
+		return name
+	default:
+		return kind
+	}
+}
+
+// AggregateHelm folds the per-workload specs of a rendered chart into a single
+// Report representing the chart's isolation posture. The aggregate is the
+// WEAKEST workload (minimum score): a chart is only as isolated as its
+// most-exposed pod, so grading the weakest link is the honest, fail-closed
+// summary. It returns the aggregate Report and the Spec that produced it (for
+// SARIF anchoring). chart names the source chart for the report target. It is
+// pure; the caller injects Version/GeneratedAt. Fail-closed: an empty workload
+// set is an error (a chart that renders no gradeable workload is not a pass).
+func AggregateHelm(specs []Spec, chart string) (Report, Spec, error) {
+	if len(specs) == 0 {
+		return Report{}, Spec{}, fmt.Errorf("no gradeable workloads found in rendered chart (no Pod/Deployment/StatefulSet/DaemonSet/Job/CronJob with containers)")
+	}
+
+	// Score every workload, then pick the weakest. Ties resolve to the first in
+	// document order so the choice is deterministic.
+	all := make([]scoredWorkload, len(specs))
+	worst := 0
+	for i, s := range specs {
+		all[i] = scoredWorkload{spec: s, report: Score(s)}
+		if all[i].report.Score < all[worst].report.Score {
+			worst = i
+		}
+	}
+
+	agg := all[worst].report
+	worstSpec := all[worst].spec
+	// Re-target the aggregate at the chart while keeping the weakest workload's
+	// identity visible in the notes below.
+	if strings.TrimSpace(chart) != "" {
+		agg.Target = chart
+	}
+	agg.Source = "helm"
+
+	// Prepend a chart-level summary so the human/JSON output is honest about what
+	// was aggregated: how many workloads, which one set the grade, and the full
+	// per-workload roll-up. This mirrors the --dockerfile honesty pattern.
+	agg.Notes = append(chartSummaryNotes(all[worst], all), agg.Notes...)
+
+	return agg, worstSpec, nil
+}
+
+// scoredWorkload pairs a rendered workload's Spec with its Report.
+type scoredWorkload struct {
+	spec   Spec
+	report Report
+}
+
+// chartSummaryNotes builds the chart-level roll-up notes for an aggregate helm
+// report: a headline naming the weakest workload and a per-workload score list.
+func chartSummaryNotes(worst scoredWorkload, all []scoredWorkload) []string {
+	notes := []string{
+		fmt.Sprintf("graded %d rendered workload(s); the chart grade is the WEAKEST (a chart is only as isolated as its most-exposed pod). Weakest: %s at %d/100 (grade %s).",
+			len(all), nz(worst.spec.Target, "workload"), worst.report.Score, worst.report.Grade),
+	}
+	// Per-workload roll-up, sorted worst-first for a quick scan.
+	sorted := make([]scoredWorkload, len(all))
+	copy(sorted, all)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].report.Score < sorted[j].report.Score })
+	rows := make([]string, len(sorted))
+	for i, w := range sorted {
+		rows[i] = fmt.Sprintf("%s = %d/100 (%s)", nz(w.spec.Target, "workload"), w.report.Score, w.report.Grade)
+	}
+	notes = append(notes, "per-workload: "+strings.Join(rows, "; "))
+	return notes
+}

--- a/internal/host/scan/helm_test.go
+++ b/internal/host/scan/helm_test.go
@@ -1,0 +1,209 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+// helmRenderedHardened mimics `helm template` output for a well-hardened chart:
+// multiple gradeable workloads (Deployment + CronJob) plus non-workload docs
+// (Service, ConfigMap) that must be skipped.
+const helmRenderedHardened = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports: [{port: 80}]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cfg
+data:
+  key: val
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: web
+          image: web:1
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nightly
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          hostPID: false
+          hostIPC: false
+          hostNetwork: false
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: job
+              image: job:1
+              securityContext:
+                runAsNonRoot: true
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: [ALL]
+`
+
+// helmRenderedMixed pairs a hardened Deployment with a privileged, host-namespace
+// Pod: the aggregate must reflect the WEAKEST (the porous pod).
+const helmRenderedMixed = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: safe
+spec:
+  template:
+    spec:
+      hostPID: false
+      hostIPC: false
+      hostNetwork: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: safe
+          image: safe:1
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: porous
+spec:
+  hostPID: true
+  hostNetwork: true
+  containers:
+    - name: app
+      image: nginx
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - name: sock
+          mountPath: /var/run/docker.sock
+  volumes:
+    - name: sock
+      hostPath:
+        path: /var/run/docker.sock
+`
+
+func TestSpecsFromK8sStream_SkipsNonWorkloadsAndParsesAll(t *testing.T) {
+	specs, err := SpecsFromK8sStream([]byte(helmRenderedHardened))
+	if err != nil {
+		t.Fatalf("SpecsFromK8sStream: %v", err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("want 2 workloads (Deployment+CronJob), got %d: %+v", len(specs), specs)
+	}
+	got := map[string]bool{}
+	for _, s := range specs {
+		got[s.Target] = true
+		if s.Source != "helm" {
+			t.Errorf("source: want helm, got %q", s.Source)
+		}
+	}
+	for _, want := range []string{"Deployment/web", "CronJob/nightly"} {
+		if !got[want] {
+			t.Errorf("missing workload %q in %v", want, got)
+		}
+	}
+}
+
+func TestSpecsFromK8sStream_Empty(t *testing.T) {
+	specs, err := SpecsFromK8sStream([]byte("apiVersion: v1\nkind: Service\nmetadata:\n  name: only\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("want 0 workloads, got %d", len(specs))
+	}
+}
+
+func TestAggregateHelm_HardenedChartHighGrade(t *testing.T) {
+	specs, err := SpecsFromK8sStream([]byte(helmRenderedHardened))
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, worst, err := AggregateHelm(specs, "mychart")
+	if err != nil {
+		t.Fatalf("AggregateHelm: %v", err)
+	}
+	if report.Source != "helm" || report.Target != "mychart" {
+		t.Errorf("aggregate identity: source=%q target=%q", report.Source, report.Target)
+	}
+	// Network egress is the honest ceiling (no NetworkPolicy in a pod spec), so a
+	// fully hardened chart lands in B, not A.
+	if report.Grade != "B" {
+		t.Errorf("hardened chart grade: want B (network ceiling), got %s (score %d)", report.Grade, report.Score)
+	}
+	if report.Score < 75 {
+		t.Errorf("hardened chart score too low: %d", report.Score)
+	}
+	if worst.Target == "" {
+		t.Error("worst spec should be identified")
+	}
+	joined := strings.Join(report.Notes, "\n")
+	if !strings.Contains(joined, "graded 2 rendered workload(s)") {
+		t.Errorf("missing workload-count note: %q", joined)
+	}
+	if !strings.Contains(joined, "per-workload:") {
+		t.Errorf("missing per-workload roll-up: %q", joined)
+	}
+}
+
+func TestAggregateHelm_WeakestWorkloadWins(t *testing.T) {
+	specs, err := SpecsFromK8sStream([]byte(helmRenderedMixed))
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, worst, err := AggregateHelm(specs, "mixed")
+	if err != nil {
+		t.Fatalf("AggregateHelm: %v", err)
+	}
+	// The privileged, host-namespace, docker.sock pod must set the chart grade.
+	if worst.Target != "Pod/porous" {
+		t.Errorf("weakest workload: want Pod/porous, got %q", worst.Target)
+	}
+	if report.Grade != "F" {
+		t.Errorf("mixed chart grade: want F (privileged pod), got %s (score %d)", report.Grade, report.Score)
+	}
+	if report.Score >= 25 {
+		t.Errorf("weakest-link score should be very low, got %d", report.Score)
+	}
+}
+
+func TestAggregateHelm_NoWorkloadsIsError(t *testing.T) {
+	if _, _, err := AggregateHelm(nil, "empty"); err == nil {
+		t.Fatal("want error for empty workload set (fail-closed), got nil")
+	}
+}

--- a/internal/host/scan/k8s.go
+++ b/internal/host/scan/k8s.go
@@ -8,7 +8,9 @@ import (
 )
 
 // k8sObject is a minimal Kubernetes object: enough to locate the pod spec inside
-// a bare Pod or inside a workload template (Deployment/StatefulSet/DaemonSet/Job).
+// a bare Pod, inside a workload template (Deployment/StatefulSet/DaemonSet/Job/
+// ReplicaSet/ReplicationController via spec.template.spec), or inside a CronJob
+// (spec.jobTemplate.spec.template.spec).
 type k8sObject struct {
 	Kind     string `yaml:"kind"`
 	Metadata struct {
@@ -20,7 +22,31 @@ type k8sObject struct {
 		Template struct {
 			Spec podSpec `yaml:"spec"`
 		} `yaml:"template"`
+		// CronJob nests one level deeper: spec.jobTemplate.spec.template.spec.
+		JobTemplate struct {
+			Spec struct {
+				Template struct {
+					Spec podSpec `yaml:"spec"`
+				} `yaml:"template"`
+			} `yaml:"spec"`
+		} `yaml:"jobTemplate"`
 	} `yaml:"spec"`
+}
+
+// podSpecOf returns the graded pod spec for a parsed object, resolving the three
+// nesting shapes (bare Pod / workload template / CronJob jobTemplate), and true
+// when a pod spec with at least one container was found.
+func (obj k8sObject) podSpecOf() (podSpec, bool) {
+	if len(obj.Spec.podSpec.Containers) > 0 {
+		return obj.Spec.podSpec, true
+	}
+	if len(obj.Spec.Template.Spec.Containers) > 0 {
+		return obj.Spec.Template.Spec, true
+	}
+	if len(obj.Spec.JobTemplate.Spec.Template.Spec.Containers) > 0 {
+		return obj.Spec.JobTemplate.Spec.Template.Spec, true
+	}
+	return podSpec{}, false
 }
 
 type podSpec struct {
@@ -80,22 +106,25 @@ func SpecFromK8s(raw []byte) (Spec, error) {
 	if err := yaml.Unmarshal(raw, &obj); err != nil {
 		return Spec{}, fmt.Errorf("parse kubernetes manifest: %w", err)
 	}
-
-	ps := obj.Spec.podSpec
-	// A workload kind (Deployment, …) carries the pod under spec.template.spec.
-	if len(ps.Containers) == 0 && len(obj.Spec.Template.Spec.Containers) > 0 {
-		ps = obj.Spec.Template.Spec
-	}
-	if len(ps.Containers) == 0 {
+	ps, ok := obj.podSpecOf()
+	if !ok {
 		return Spec{}, fmt.Errorf("manifest has no containers to grade")
 	}
+	return specFromPodSpec("k8s", obj.Metadata.Name, ps), nil
+}
+
+// specFromPodSpec maps a parsed Kubernetes pod spec to a normalized Spec, grading
+// its FIRST container. source labels the origin ("k8s" or "helm"); name is the
+// workload's metadata.name (falls back to the container name). It is pure and
+// shared by the single-manifest (SpecFromK8s) and multi-document/Helm paths.
+func specFromPodSpec(source, name string, ps podSpec) Spec {
 	c := ps.Containers[0]
 
-	target := obj.Metadata.Name
+	target := name
 	if target == "" {
 		target = c.Name
 	}
-	s := Spec{Source: "k8s", Target: target, Runtime: ps.RuntimeClass}
+	s := Spec{Source: source, Target: target, Runtime: ps.RuntimeClass}
 
 	// --- user (container securityContext overrides pod-level) ---------------
 	var nonRoot *bool
@@ -211,7 +240,7 @@ func SpecFromK8s(raw []byte) (Spec, error) {
 		}
 	}
 
-	return s, nil
+	return s
 }
 
 // normalizeK8sSeccomp maps a k8s seccompProfile.type to the Spec vocabulary.


### PR DESCRIPTION
## What

Adds `ironctl scan --helm <chart-dir|chart.tgz>`: render a Helm chart locally with `helm template` (no cluster, daemon-free) and grade the isolation posture of the rendered workloads, reusing the existing k8s dimension set. This is an **adapter + renderer, not a new grader** (IRO-501).

## Acceptance criteria

- [x] `--helm <path>` renders the chart (unpacked dir **and** `.tgz`) and emits the same 0-100 / A-F grade as `--k8s`, aggregating across all rendered workloads.
- [x] Reuses the k8s dimension set; no new scoring engine (`SpecsFromK8sStream` + `specFromPodSpec` shared with `--k8s`).
- [x] Honest ceiling notes when a dimension is statically undecidable (network egress depends on a NetworkPolicy not in the pod spec; mirrors the `--dockerfile` honesty pattern).
- [x] Offline / vendored-deps friendly; **fail-open** with a clear diagnostic (exit 0) if `helm` is absent or `helm template` fails — never crashes the Action. `--min-score` still gates once the chart renders.
- [x] `--sarif` and `--json` work for `--helm` just like `--k8s`.
- [x] Table + `--json` outputs.
- [x] Tests: hardened chart (B, network ceiling) and unhardened chart (F, privileged host-namespace pod sets the grade); non-workload skip; empty-set fail-closed.

## Aggregation

The chart grade is the **weakest rendered workload** (a chart is only as isolated as its most-exposed pod). Notes carry the workload count and a per-workload roll-up. Workload kinds handled: Pod, Deployment, StatefulSet, DaemonSet, ReplicaSet, ReplicationController, Job, CronJob (jobTemplate nesting).

## Dogfood

```
$ ironctl scan --helm deploy/helm/ironclaw/
  target:  ironclaw (helm)
  score:   79/100  grade B  (solid, minor gaps)
```

79/B: the network-egress ceiling (NetworkPolicy is not in a pod spec) and unset host namespaces are the honest static gaps — same as `--k8s`.

## Security lenses

- **Isolation:** read-only posture check; render is local/offline, no cluster, no daemon.
- **Egress least-privilege:** no new egress path; `helm template` resolves deps locally only.
- **Trust boundary:** no contract change, no trust-model change. Fail-open is scoped strictly to render/tooling failures (like the existing SARIF side-artifact fail-open); a genuinely low posture still trips `--min-score`.

## Verification

`CGO_ENABLED=1 go build ./...`, `go vet`, `go test ./internal/host/scan/ ./cmd/ironctl/` (228 pass). Dogfooded dir + `.tgz` + `--json` + `--sarif` + `--min-score` gate + fail-open (missing helm → exit 0).

## Follow-ups (separate, non-blocking)

- Growth: "harden your Helm chart" SEO guide + scorecard family from the new output.
- QA: funnel smoke once merged.
- Scan GitHub Action: add a `helm` install step if we expose `--helm` there (issue note).