### PR TITLE
docs: harden-<X> SEO guides wave 4 (cassandra, clickhouse, consul, minio) + hub (IRO-505)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,12 +282,16 @@ Per-image hardening walkthroughs, the default grade, the dimensions that fail, a
 [MySQL](https://ironsecco.github.io/ironclaw/blog/harden-mysql-container-isolation/),
 [MariaDB](https://ironsecco.github.io/ironclaw/blog/harden-mariadb-container-isolation/),
 [MongoDB](https://ironsecco.github.io/ironclaw/blog/harden-mongodb-container-isolation/),
+[Cassandra](https://ironsecco.github.io/ironclaw/blog/harden-cassandra-container-isolation/),
+[ClickHouse](https://ironsecco.github.io/ironclaw/blog/harden-clickhouse-container-isolation/),
 [Redis](https://ironsecco.github.io/ironclaw/blog/harden-redis-container-isolation/),
 [Memcached](https://ironsecco.github.io/ironclaw/blog/harden-memcached-container-isolation/),
 [Elasticsearch](https://ironsecco.github.io/ironclaw/blog/harden-elasticsearch-container-isolation/),
 [Kafka](https://ironsecco.github.io/ironclaw/blog/harden-kafka-container-isolation/),
 [RabbitMQ](https://ironsecco.github.io/ironclaw/blog/harden-rabbitmq-container-isolation/),
 [Vault](https://ironsecco.github.io/ironclaw/blog/harden-vault-container-isolation/),
+[Consul](https://ironsecco.github.io/ironclaw/blog/harden-consul-container-isolation/),
+[MinIO](https://ironsecco.github.io/ironclaw/blog/harden-minio-container-isolation/),
 [nginx](https://ironsecco.github.io/ironclaw/blog/harden-nginx-container-isolation/), and
 [untrusted Node.js](https://ironsecco.github.io/ironclaw/blog/run-untrusted-nodejs-code-safely/).
 

--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -23,10 +23,14 @@ nav:
   - "How to harden a MySQL container": harden-mysql-container-isolation.md
   - "How to harden a MariaDB container": harden-mariadb-container-isolation.md
   - "How to harden a MongoDB container": harden-mongodb-container-isolation.md
+  - "How to harden a Cassandra container": harden-cassandra-container-isolation.md
+  - "How to harden a ClickHouse container": harden-clickhouse-container-isolation.md
   - "How to harden an Elasticsearch container": harden-elasticsearch-container-isolation.md
   - "How to harden a Kafka container": harden-kafka-container-isolation.md
   - "How to harden a RabbitMQ container": harden-rabbitmq-container-isolation.md
   - "How to harden a Memcached container": harden-memcached-container-isolation.md
   - "How to harden a Vault container": harden-vault-container-isolation.md
+  - "How to harden a Consul container": harden-consul-container-isolation.md
+  - "How to harden a MinIO container": harden-minio-container-isolation.md
   - "How to scan a Dockerfile for security issues": scan-a-dockerfile-for-security-issues.md
   - "*.md"

--- a/docs/blog/harden-cassandra-container-isolation.md
+++ b/docs/blog/harden-cassandra-container-isolation.md
@@ -1,0 +1,105 @@
+---
+title: "How to harden a Cassandra container: cassandra:5.0 scores 48/100 by default"
+description: "cassandra:5.0 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden a Cassandra container (and is cassandra:5.0 safe for untrusted workloads?)
+
+Short answer: a stock `docker run cassandra:5.0` is **not** a boundary you should trust around
+untrusted code or an untrusted network. Graded on IronClaw's seven-dimension containment scale,
+the default configuration scores **48 of 100, grade D (porous)**. Higher is safer. Four runtime
+flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and the
+exact fixes, straight from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `cassandra:5.0`, the same data behind
+> its [isolation scorecard](../scores/cassandra.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+cassandra:5.0`, four of them fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a wide-column database, the two that should worry you most are **egress** and **root**. A
+Cassandra process that can reach the network is one that can exfiltrate every keyspace it holds the
+moment it is compromised (a deserialization CVE, a poisoned UDF, a driver bug). And a root process
+that escapes the container escapes as root on the host.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-cassandra --fix` prints one remediation per failed dimension, then assembles a
+single copy-pasteable hardened run. For `cassandra:5.0` the prescription is:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. Cassandra itself needs none of the defaults.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the data directory at a volume this uid owns.
+- **`--network=none`** (Network isolation, +11): a single-node Cassandra reached only by co-located
+  services can cut host egress entirely; otherwise attach one internal network with no default route,
+  not `bridge`. See the cluster note below.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/var/lib/cassandra` as an explicit writable volume. Removes the persistence surface.
+
+### The cluster note
+
+A multi-node Cassandra ring uses the gossip protocol between nodes, so those nodes must reach each
+other. `--network=none` fits a single-node instance that only its co-located app talks to. For a
+real cluster, hold the network dimension at a WARN instead: attach a user-defined network scoped to
+just the ring members and their client apps, with no default route out, so a compromised node cannot
+call arbitrary internet addresses. That posture scores the **89/100, grade B** ceiling the network
+services on this set share; the 100/A run below is the single-node case.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name cassandra cassandra:5.0
+
+# After: 100/100, grade A (single-node, private data volume)
+docker run -d --name cassandra-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v cassandra-data:/var/lib/cassandra \
+  --network=none \
+  cassandra:5.0
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan cassandra-hardened` reports
+`100/100 grade A`. That is a **52-point swing from four one-line flags**, no image rebuild.
+
+## Verify it on your own database
+
+The grade above is the default image. Your deployment is what matters. Scan it in ten seconds:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-cassandra
+ironctl scan my-cassandra --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Cassandra in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [cassandra:5.0 isolation scorecard &rarr;](../scores/cassandra.md): the full dimension breakdown.
+- [Databases, ranked by isolation &rarr;](../scores/collections/databases.md): how Cassandra compares to Postgres, MongoDB, Redis, and the rest.
+- [How to harden a ClickHouse container &rarr;](harden-clickhouse-container-isolation.md): the same walkthrough for the analytics side.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-clickhouse-container-isolation.md
+++ b/docs/blog/harden-clickhouse-container-isolation.md
@@ -1,0 +1,97 @@
+---
+title: "How to harden a ClickHouse container: clickhouse:24.8 scores 48/100 by default"
+description: "clickhouse:24.8 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden a ClickHouse container (and is clickhouse:24.8 safe for untrusted workloads?)
+
+Short answer: a stock `docker run clickhouse:24.8` is **not** a boundary you should trust around
+untrusted code or an untrusted network. Graded on IronClaw's seven-dimension containment scale,
+the default configuration scores **48 of 100, grade D (porous)**. Higher is safer. Four runtime
+flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and the
+exact fixes, straight from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `clickhouse:24.8`, the same data
+> behind its [isolation scorecard](../scores/clickhouse.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+clickhouse:24.8`, four of them fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For an analytics database, the two that should worry you most are **egress** and **root**. A
+ClickHouse process holds your whole event history in queryable columns; one that can reach the
+network can ship it out the moment a URL-table function, a dictionary source, or an HTTP handler CVE
+lands code execution. And a root process that escapes the container escapes as root on the host.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-clickhouse --fix` prints one remediation per failed dimension, then assembles a
+single copy-pasteable hardened run. For `clickhouse:24.8` the prescription is:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. ClickHouse itself needs none of the defaults.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the data directory at a volume this uid owns.
+- **`--network=none`** (Network isolation, +11): if the database is only reached by services on a
+  private user-defined network, cut host egress entirely; otherwise attach a single internal
+  network with no default route, not `bridge`. ClickHouse's remote table functions are exactly the
+  reach you want to close.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/var/lib/clickhouse` as an explicit writable volume. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name clickhouse clickhouse:24.8
+
+# After: 100/100, grade A
+docker run -d --name clickhouse-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v clickhouse-data:/var/lib/clickhouse \
+  --network=none \
+  clickhouse:24.8
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan clickhouse-hardened` reports
+`100/100 grade A`. That is a **52-point swing from four one-line flags**, no image rebuild.
+
+## Verify it on your own database
+
+The grade above is the default image. Your deployment is what matters. Scan it in ten seconds:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-clickhouse
+ironctl scan my-clickhouse --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the ClickHouse in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [clickhouse:24.8 isolation scorecard &rarr;](../scores/clickhouse.md): the full dimension breakdown.
+- [Databases, ranked by isolation &rarr;](../scores/collections/databases.md): how ClickHouse compares to Postgres, MongoDB, Cassandra, and the rest.
+- [How to harden a Cassandra container &rarr;](harden-cassandra-container-isolation.md): the same walkthrough for the wide-column side.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-consul-container-isolation.md
+++ b/docs/blog/harden-consul-container-isolation.md
@@ -1,0 +1,109 @@
+---
+title: "How to harden a Consul container: hashicorp/consul:1.20 scores 48/100 by default"
+description: "hashicorp/consul:1.20 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a service-mesh agent to its honest 89/100 grade B."
+---
+
+# How to harden a Consul container (and is hashicorp/consul:1.20 safe for untrusted workloads?)
+
+Consul is the address book for your whole cluster: it knows where every service lives, holds their
+health state, and often gates their access. That makes it a high-value target, and a stock
+`docker run hashicorp/consul:1.20` is not the boundary that role deserves. Graded on IronClaw's
+seven-dimension containment scale, the default configuration scores **48 of 100, grade D (porous)**.
+Higher is safer. A few runtime flags take the same image to **89 of 100, grade B**, one point off an
+A, and the one dimension it cannot reach is the one a service-discovery agent needs by definition
+(its clients and peers must connect to it). Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `hashicorp/consul:1.20`, the same data
+> behind its [isolation scorecard](../scores/consul.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+hashicorp/consul:1.20`, four fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a service-mesh control agent, the two that should worry you most are **root** and **egress**. A
+Consul process that escapes as root escapes as root on the host, next to the ACL tokens and service
+registry it was just holding. And a Consul process that can reach arbitrary destinations is one that
+can quietly ship its catalog and secrets out the moment an RPC or plugin CVE lands code execution.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-consul --fix` prints one remediation per failed dimension, then one hardened run.
+For `hashicorp/consul:1.20`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. See the mlock note below.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the data directory at a volume this uid owns.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/consul/data` as an explicit writable volume. Removes the persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  service-discovery agent, its peers and clients must reach it. Any named or bridge network scores 4
+  of 15 (a WARN, not a fail): a connection path exists. This is the one dimension a mesh agent cannot
+  max out. Contain it anyway: attach a user-defined network scoped to just the cluster members and
+  the apps that register with them, with no default route out, so a compromised Consul cannot call
+  arbitrary internet addresses.
+
+### The mlock note
+
+Consul can be told to `mlock` its memory so its data is never swapped to disk (`disable_mlock =
+false`), and `mlock` needs the `IPC_LOCK` capability. Unlike Vault, Consul leaves mlock **disabled by
+default**, so `--cap-drop=ALL` with nothing added back is the normal posture. If you deliberately
+enable mlock, add just that one capability back with `--cap-add=IPC_LOCK`, or make sure swap is off
+on the host so nothing hits disk anyway. The score above reflects dropping the default set.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name consul hashicorp/consul:1.20
+
+# After: 89/100, grade B (scoped private network for its peers and clients)
+docker run -d --name consul-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v consul-data:/consul/data \
+  --network=consul-internal \
+  hashicorp/consul:1.20
+```
+
+Rescan: `ironctl scan consul-hardened` reports `89/100 grade B`. A **41-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a service-discovery agent exists to be connected to; `network=none` would score the
+last points but leave nothing able to register or resolve. That is the honest ceiling for a mesh
+agent, and it is a long way from the default D.
+
+## Verify it on your own Consul
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-consul
+ironctl scan my-consul --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Consul in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [consul:1.20 isolation scorecard &rarr;](../scores/consul.md): the full dimension breakdown.
+- [How to harden a Vault container &rarr;](harden-vault-container-isolation.md): the other HashiCorp service, with the same honest ceiling and the mlock story it borrows from.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-minio-container-isolation.md
+++ b/docs/blog/harden-minio-container-isolation.md
@@ -1,0 +1,100 @@
+---
+title: "How to harden a MinIO container: minio/minio scores 48/100 by default"
+description: "minio/minio defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take an object store to its honest 89/100 grade B."
+---
+
+# How to harden a MinIO container (and is minio/minio safe for untrusted workloads?)
+
+An object store is where your buckets live: backups, uploads, model weights, whatever your apps
+stash. A stock `docker run minio/minio` is not the boundary that data deserves. Graded on IronClaw's
+seven-dimension containment scale, the default configuration scores **48 of 100, grade D (porous)**.
+Higher is safer. A few runtime flags take the same image to **89 of 100, grade B**, one point off an
+A, and the one dimension it cannot reach is the one an S3 server needs by definition (its clients
+must connect over the network). Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `minio/minio:latest`, the same data
+> behind its [isolation scorecard](../scores/minio.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+minio/minio`, four fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For an object store, the two that should worry you most are **root** and **egress**. A MinIO
+process that escapes as root escapes as root on the host, next to every bucket it just served. And a
+MinIO process that can reach arbitrary destinations is one that can replicate your buckets out the
+moment a bucket-notification target, a signed-URL bug, or an admin-API CVE lands code execution.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-minio --fix` prints one remediation per failed dimension, then one hardened run.
+For `minio/minio`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. MinIO itself needs none of the defaults.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the data directory at a volume this uid owns.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/data` as an explicit writable volume. Removes the persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for an
+  S3 server, its clients must reach the API. Any named or bridge network scores 4 of 15 (a WARN, not
+  a fail): a connection path exists. This is the one dimension an object store cannot max out.
+  Contain it anyway: attach a user-defined network scoped to just the apps that read and write
+  buckets, with no default route out, so a compromised MinIO cannot call arbitrary internet
+  addresses.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name minio minio/minio server /data
+
+# After: 89/100, grade B (scoped private network for its client apps)
+docker run -d --name minio-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v minio-data:/data \
+  --network=minio-internal \
+  minio/minio server /data
+```
+
+Rescan: `ironctl scan minio-hardened` reports `89/100 grade B`. A **41-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because an S3 server exists to be connected to; `network=none` would score the last points but
+leave nothing able to read a bucket. That is the honest ceiling for an object store, and it is a
+long way from the default D.
+
+## Verify it on your own MinIO
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-minio
+ironctl scan my-minio --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the MinIO in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [minio isolation scorecard &rarr;](../scores/minio.md): the full dimension breakdown.
+- [How to harden a Vault container &rarr;](harden-vault-container-isolation.md): another network service with the same honest ceiling, explained the same way.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -30,6 +30,8 @@ Two patterns show up across the set:
 | [MariaDB](harden-mariadb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
 | [MongoDB](harden-mongodb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
 | [Redis](harden-redis-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
+| [Cassandra](harden-cassandra-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B multi-node) |
+| [ClickHouse](harden-clickhouse-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
 | [Elasticsearch](harden-elasticsearch-container-isolation.md) | 63/100 C | **100/100 A** | full caps, writable rootfs (89/B multi-node) |
 | [Untrusted Node.js](run-untrusted-nodejs-code-safely.md) | 48/100 D | **100/100 A** | run untrusted code in a real sandbox |
 
@@ -44,6 +46,8 @@ These services must accept client connections, so the network dimension holds at
 | [Memcached](harden-memcached-container-isolation.md) | 63/100 C | **89/100 B** | cache: clients read and write over the network |
 | [nginx](harden-nginx-container-isolation.md) | 48/100 D | **89/100 B** | proxy: it exists to forward traffic |
 | [Vault](harden-vault-container-isolation.md) | 48/100 D | **89/100 B** | secrets server: apps must reach the API |
+| [Consul](harden-consul-container-isolation.md) | 48/100 D | **89/100 B** | service mesh: peers and clients must connect |
+| [MinIO](harden-minio-container-isolation.md) | 48/100 D | **89/100 B** | object store: S3 clients must reach the API |
 
 ## The pattern, one command
 

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -62,6 +62,18 @@ fail, and the precise `ironctl scan --fix` flags that close the gap, with before
 - [How to harden a Memcached container](harden-memcached-container-isolation.md) -
   `memcached:1.6-alpine` runs non-root and holds nothing on disk, so it starts at 63 of 100 (C).
   A read-only rootfs (no volume needed) and dropped capabilities take it to its honest 89 of 100 (B).
+- [How to harden a Cassandra container](harden-cassandra-container-isolation.md) -
+  `cassandra:5.0` scores 48 of 100 (D) on defaults: root, full capabilities, writable rootfs. Four
+  flags take a single-node ring to 100 of 100 (A); a gossiping cluster has an honest 89 of 100 (B) ceiling.
+- [How to harden a ClickHouse container](harden-clickhouse-container-isolation.md) -
+  `clickhouse:24.8` scores 48 of 100 (D). Cutting egress closes its remote-table reach; four flags
+  take the analytics store to 100 of 100 (A).
+- [How to harden a Consul container](harden-consul-container-isolation.md) -
+  `hashicorp/consul:1.20` scores 48 of 100 (D). The honest hardened ceiling for a service-mesh agent
+  is 89 of 100 (B), because peers and clients must connect. Unlike Vault, it does not mlock by default.
+- [How to harden a MinIO container](harden-minio-container-isolation.md) -
+  `minio/minio` scores 48 of 100 (D). The honest hardened ceiling for an object store is 89 of 100
+  (B), because S3 clients must reach the API. Here is exactly why.
 - [How to scan a Dockerfile for security issues](scan-a-dockerfile-for-security-issues.md) -
   a deliberately bad Dockerfile (root default, unpinned base, a baked-in secret) scores 5 of
   100 (F) on a static, daemon-free scan. The exact one-line fixes take it to 100 of 100 (A).


### PR DESCRIPTION
Wave 4 of the organic-SEO harden-guide lever (waves 1-3 = 12 guides on main). Same format as harden-mongodb/kafka/vault: real `ironctl scan` scorecard grades BEFORE->AFTER, honest ceiling per workload class.

## New guides (4)
| Guide | Default | Hardened | Class / ceiling |
|-------|:-------:|:--------:|-----------------|
| harden-cassandra | 48/D | **100/A** | datastore (single-node); 89/B multi-node gossip |
| harden-clickhouse | 48/D | **100/A** | analytics datastore |
| harden-consul | 48/D | **89/B** | service mesh, needs network; mlock note (off by default, unlike Vault) |
| harden-minio | 48/D | **89/B** | object store, S3 API needs network |

Grades are real, from each image's isolation scorecard (`docs/scores/{cassandra,clickhouse,consul,minio}.md`, the same survey scan data waves 1-3 used). No invented numbers.

## Wiring
- `docs/blog/hardening-guides.md` HUB: cassandra/clickhouse added to grade-A table, consul/minio to grade-B ceiling table (now 16 guides).
- `docs/blog/.nav.yml`: 4 explicit nav entries.
- `docs/blog/index.md`: 4 crosslink entries with per-class ceiling notes.
- `README.md`: funnel crosslink list extended.

## Verification
- `mkdocs build --strict` exits 0 (no broken links from new pages).
- No em/en-dashes in public copy.