### PR TITLE
feat(scan): ironctl scan --terraform grades container workloads in Terraform plan/state JSON (IRO-504)

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -43,6 +43,8 @@ func cmdScan(args []string) error {
 	k8s := fs.String("k8s", "", "grade the first container in this Kubernetes pod/workload manifest")
 	helm := fs.String("helm", "", "render a Helm chart (dir or .tgz) with `helm template` and grade the isolation posture of its workloads")
 	helmBin := fs.String("helm-bin", envOrDefault("HELM", "helm"), "helm binary used to render the chart")
+	terraform := fs.String("terraform", "", "grade container workloads in a `terraform show -json` file (plan.json/state.json) or a Terraform dir")
+	terraformBin := fs.String("terraform-bin", envOrDefault("TERRAFORM", "terraform"), "terraform binary used to run `terraform show -json` on a dir/binary plan")
 	dockerfile := fs.Bool("dockerfile", false, "statically grade the positional Dockerfile(s) authoring-time posture (daemon-free)")
 	runtime := fs.String("runtime", envOrDefault("IRONCTL_SCAN_RUNTIME", "auto"), "container runtime: auto|docker|podman|nerdctl")
 	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker inspect`")
@@ -118,6 +120,25 @@ func cmdScan(args []string) error {
 			badgeJSON: *badgeJSON,
 			sarif:     *sarif,
 			minScore:  *minScore,
+		})
+	}
+
+	// --terraform: consume `terraform show -json` (plan.json/state.json) and grade
+	// the container workloads it declares (kubernetes_* pods/workloads +
+	// aws_ecs_task_definition), reusing the k8s/ECS dimension mapping. It loads
+	// JSON here (reading a file, or running `terraform show -json` on a dir) then
+	// defers to the pure SpecsFromTerraform + AggregateTerraform scorer. Fail-OPEN
+	// on a load/parse failure; --min-score still gates once workloads are graded.
+	if *terraform != "" {
+		return runTerraformScan(terraformArgs{
+			path:         *terraform,
+			terraformBin: *terraformBin,
+			asJSON:       *asJSON,
+			md:           *md,
+			badge:        *badge,
+			badgeJSON:    *badgeJSON,
+			sarif:        *sarif,
+			minScore:     *minScore,
 		})
 	}
 
@@ -469,6 +490,145 @@ func renderHelmChart(helmBin, chart string) ([]byte, error) {
 	return stdout.Bytes(), nil
 }
 
+// terraformArgs carries the resolved inputs for a `scan --terraform` run.
+type terraformArgs struct {
+	path         string
+	terraformBin string
+	asJSON       bool
+	md           bool
+	badge        string
+	badgeJSON    string
+	sarif        string
+	minScore     int
+}
+
+// runTerraformScan grades the container workloads declared in a `terraform show
+// -json` document (kubernetes_* pods/workloads and aws_ecs_task_definition),
+// reusing the same k8s/ECS dimension mapping and weakest-link aggregate as
+// --helm. It fails OPEN on a load/parse failure (terraform absent, unreadable
+// path, malformed JSON): it prints a clear diagnostic to stderr and returns nil
+// so an opt-in CI/Action step never crashes the build over tooling issues. Once
+// workloads are graded, scoring and the --min-score CI gate apply exactly like
+// --k8s/--helm (a genuinely low posture still fails the gate).
+func runTerraformScan(a terraformArgs) error {
+	raw, err := loadTerraformJSON(a.terraformBin, a.path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --terraform could not load %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	specs, err := scan.SpecsFromTerraform(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --terraform could not parse %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregateTerraform(specs, filepath.Base(strings.TrimRight(a.path, "/")))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --terraform found nothing to grade in %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (workloads graded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// loadTerraformJSON resolves a --terraform argument to `terraform show -json`
+// bytes. A directory is rendered with `terraform -chdir=<dir> show -json` (its
+// current state). A file that already IS JSON (a `terraform show -json` redirect)
+// is used verbatim — the daemon-free primary path. A non-JSON file (a binary
+// tfplan) is converted with `terraform show -json <file>` when terraform is on
+// PATH. It is offline: `terraform show` does not contact a backend for a saved
+// plan, and reads local state for a dir.
+func loadTerraformJSON(terraformBin, path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return runTerraformShow(terraformBin, "-chdir="+path, "show", "-json")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if looksLikeJSON(raw) {
+		return raw, nil
+	}
+	// A binary plan file: convert via `terraform show -json <file>` (needs the
+	// terraform binary and to run in the config directory).
+	dir := filepath.Dir(path)
+	return runTerraformShow(terraformBin, "-chdir="+dir, "show", "-json", filepath.Base(path))
+}
+
+// runTerraformShow runs the terraform binary with the given args and returns its
+// stdout, surfacing terraform's own stderr on failure.
+func runTerraformShow(terraformBin string, args ...string) ([]byte, error) {
+	if _, err := exec.LookPath(terraformBin); err != nil {
+		return nil, fmt.Errorf("terraform binary %q not found on PATH (install terraform, pass --terraform-bin, or pass a `terraform show -json` JSON file directly): %w", terraformBin, err)
+	}
+	cmd := exec.Command(terraformBin, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("terraform show -json failed: %s", msg)
+	}
+	return stdout.Bytes(), nil
+}
+
+// looksLikeJSON reports whether raw begins (after leading whitespace) with a JSON
+// object — enough to distinguish a `terraform show -json` redirect from a binary
+// tfplan without a full parse.
+func looksLikeJSON(raw []byte) bool {
+	trimmed := bytes.TrimLeft(raw, " \t\r\n")
+	return len(trimmed) > 0 && trimmed[0] == '{'
+}
+
 // writeDockerfileSARIF renders the Dockerfile SARIF log to path, fail-open on error.
 func writeDockerfileSARIF(path string, r scan.Report, opts scan.SARIFOptions) error {
 	f, err := os.Create(path)
@@ -599,6 +759,7 @@ USAGE:
   ironctl scan --compose FILE [--service N]   grade a docker-compose service
   ironctl scan --k8s FILE                     grade a Kubernetes pod/workload manifest
   ironctl scan --helm CHART                    render a Helm chart (dir or .tgz) and grade its workloads
+  ironctl scan --terraform PATH                grade container workloads in a terraform show -json file/dir
   ironctl scan --dockerfile FILE...           grade Dockerfile(s) statically (no daemon, no pull)
   ironctl scan --compare A B                   diff two containers' isolation posture
 
@@ -615,6 +776,7 @@ FLAGS:
   --min-score N       exit non-zero if the score is below N (CI gate)
   --service NAME      compose service to grade (if the file has >1)
   --helm-bin BIN      helm binary for `+"`helm template`"+` (default: helm)
+  --terraform-bin BIN terraform binary for `+"`terraform show -json`"+` (default: terraform)
   --docker-bin BIN    docker binary for `+"`docker inspect`"+` (default: docker)
   --podman-bin BIN    podman binary for `+"`podman inspect`"+` (default: podman)
   --nerdctl-bin BIN   nerdctl binary for `+"`nerdctl inspect`"+` (default: nerdctl)
@@ -637,6 +799,13 @@ NetworkPolicy that a pod spec does not carry, so it is graded conservatively
 (the honest static ceiling). Rendering failures (helm absent / template error)
 fail OPEN: a clear diagnostic and exit 0, so an opt-in CI step never crashes the
 build. A successful render still trips --min-score on a low posture.
+
+--terraform consumes `+"`terraform show -json`"+` output (a plan.json or state.json, or a
+Terraform dir it runs `+"`terraform show -json`"+` against) and grades the container
+workloads it declares: the kubernetes provider's pod/workload resources (mapped
+through the SAME pod-spec scorer as --k8s/--helm) and aws_ecs_task_definition
+container definitions. The plan grade is the WEAKEST workload; load/parse failures
+fail OPEN (diagnostic + exit 0). A successful parse still trips --min-score.
 
 --dockerfile grades a DIFFERENT, authoring-time dimension set (non-root USER,
 pinned base image, no secrets in ENV/ARG, COPY over remote/opaque ADD, no

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -65,6 +65,8 @@ inspect data, so probe-masking from inside the container cannot change the score
 | `nerdctl` / containerd | `nerdctl inspect` | Docker-compatible schema; containerd runtime handlers (for example `io.containerd.runsc.v1`) are recognized |
 | compose | `--compose FILE` | grades a service from the file, no runtime needed |
 | Kubernetes | `--k8s FILE` | grades a pod or workload manifest, no runtime needed |
+| Helm | `--helm CHART` | renders a chart with `helm template` and grades its workloads, no cluster needed |
+| Terraform | `--terraform PATH` | grades container workloads in a `terraform show -json` plan/state, no apply needed (see below) |
 | Dockerfile | `--dockerfile FILE` | grades authoring-time posture statically, no daemon and no image pull (see below) |
 
 Selection and binaries:
@@ -97,6 +99,39 @@ When a container runs under a recognized strong-isolation runtime (gVisor /
 informational line. Scoring stays runtime-agnostic on purpose: a container can
 name a hardened runtime and still be misconfigured, so no points are awarded for
 the runtime name. The dimension scorers remain the authority on the score.
+
+## Grade a Terraform plan
+
+`--terraform PATH` grades the container workloads a Terraform configuration
+declares, before `terraform apply` reaches a cluster or an AWS account. It
+consumes `terraform show -json` output, so it is structured and daemon-free:
+
+```bash
+terraform show -json plan.tfplan > plan.json
+ironctl scan --terraform plan.json
+ironctl scan --terraform plan.json --min-score 75   # CI gate
+ironctl scan --terraform plan.json --sarif tf.sarif # GitHub code scanning
+
+ironctl scan --terraform ./infra                    # runs `terraform show -json` for you
+```
+
+Pass a `terraform show -json` JSON file (a plan or state export) directly, or a
+Terraform directory, where `ironctl` runs `terraform show -json` against the
+current state for you. It walks the root module and every child module and grades
+two workload classes:
+
+| Source | What is graded |
+|---|---|
+| `kubernetes_*` resources | `kubernetes_pod`, `kubernetes_deployment`, `kubernetes_stateful_set`, `kubernetes_daemon_set`, `kubernetes_job`, `kubernetes_cron_job`, `kubernetes_replication_controller` (and their `_v1` aliases). The provider embeds a pod spec, graded through the same dimension set as `--k8s`. |
+| `aws_ecs_task_definition` | each entry in `container_definitions`, with the task-level `network_mode` / `pid_mode` / `ipc_mode` folded in. |
+
+The plan grade is the **weakest** workload: a plan is only as isolated as its
+most-exposed container, and every workload's score is listed in the notes.
+Network egress depends on a `NetworkPolicy` (Kubernetes) or a security group
+(ECS) that a workload spec does not carry, so it is graded conservatively, the
+honest static ceiling. Missing tooling or a malformed document fails **open** (a
+clear diagnostic and exit 0) so an opt-in CI step never crashes the build; once
+workloads are graded, `--min-score` still trips on a low posture.
 
 ## Grade a Dockerfile statically
 

--- a/internal/host/scan/k8s.go
+++ b/internal/host/scan/k8s.go
@@ -59,34 +59,46 @@ type podSpec struct {
 	RuntimeClass    string         `yaml:"runtimeClassName"`
 }
 
+// seccompProfile mirrors a Kubernetes securityContext.seccompProfile block. Named
+// (rather than inlined) so non-YAML adapters (e.g. Terraform JSON) can construct
+// the same graded pod spec without re-declaring an anonymous struct.
+type seccompProfile struct {
+	Type string `yaml:"type"`
+}
+
+// capabilities mirrors a container securityContext.capabilities block.
+type capabilities struct {
+	Add  []string `yaml:"add"`
+	Drop []string `yaml:"drop"`
+}
+
 type podSecCtx struct {
-	RunAsNonRoot   *bool  `yaml:"runAsNonRoot"`
-	RunAsUser      *int64 `yaml:"runAsUser"`
-	SeccompProfile *struct {
-		Type string `yaml:"type"`
-	} `yaml:"seccompProfile"`
+	RunAsNonRoot   *bool           `yaml:"runAsNonRoot"`
+	RunAsUser      *int64          `yaml:"runAsUser"`
+	SeccompProfile *seccompProfile `yaml:"seccompProfile"`
+}
+
+// containerSecCtx mirrors a container-level securityContext.
+type containerSecCtx struct {
+	RunAsNonRoot             *bool           `yaml:"runAsNonRoot"`
+	RunAsUser                *int64          `yaml:"runAsUser"`
+	Privileged               *bool           `yaml:"privileged"`
+	ReadOnlyRootFilesystem   *bool           `yaml:"readOnlyRootFilesystem"`
+	AllowPrivilegeEscalation *bool           `yaml:"allowPrivilegeEscalation"`
+	Capabilities             *capabilities   `yaml:"capabilities"`
+	SeccompProfile           *seccompProfile `yaml:"seccompProfile"`
+}
+
+// volumeMount mirrors a container volumeMounts entry.
+type volumeMount struct {
+	Name      string `yaml:"name"`
+	MountPath string `yaml:"mountPath"`
 }
 
 type k8sContainer struct {
-	Name            string `yaml:"name"`
-	SecurityContext *struct {
-		RunAsNonRoot             *bool  `yaml:"runAsNonRoot"`
-		RunAsUser                *int64 `yaml:"runAsUser"`
-		Privileged               *bool  `yaml:"privileged"`
-		ReadOnlyRootFilesystem   *bool  `yaml:"readOnlyRootFilesystem"`
-		AllowPrivilegeEscalation *bool  `yaml:"allowPrivilegeEscalation"`
-		Capabilities             *struct {
-			Add  []string `yaml:"add"`
-			Drop []string `yaml:"drop"`
-		} `yaml:"capabilities"`
-		SeccompProfile *struct {
-			Type string `yaml:"type"`
-		} `yaml:"seccompProfile"`
-	} `yaml:"securityContext"`
-	VolumeMounts []struct {
-		Name      string `yaml:"name"`
-		MountPath string `yaml:"mountPath"`
-	} `yaml:"volumeMounts"`
+	Name            string           `yaml:"name"`
+	SecurityContext *containerSecCtx `yaml:"securityContext"`
+	VolumeMounts    []volumeMount    `yaml:"volumeMounts"`
 }
 
 type k8sVolume struct {

--- a/internal/host/scan/terraform.go
+++ b/internal/host/scan/terraform.go
@@ -1,0 +1,577 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// SpecsFromTerraform parses `terraform show -json` output (a plan.json or a
+// state.json) and returns one graded Spec per container workload it recognizes.
+// It walks the root module and every child module, and grades two workload
+// classes that carry a container isolation posture:
+//
+//   - the Kubernetes provider's workload resources (kubernetes_pod,
+//     kubernetes_deployment, kubernetes_stateful_set, kubernetes_daemon_set,
+//     kubernetes_job, kubernetes_cron_job, kubernetes_replication_controller, and
+//     their _v1 aliases) — the provider embeds a pod spec, which is mapped to the
+//     SAME internal podSpec the --k8s / --helm paths grade (specFromPodSpec).
+//   - aws_ecs_task_definition — each container_definitions entry is graded with
+//     the task-level network/pid/ipc modes folded in.
+//
+// It is pure and unit-testable: the caller runs `terraform show -json` (I/O) and
+// passes the JSON here. Non-container resources are ignored. It fails OPEN on a
+// malformed top-level document (returns the parse error); the CLI wrapper turns
+// that into a skip so an opt-in CI step never crashes the build.
+func SpecsFromTerraform(raw []byte) ([]Spec, error) {
+	var show tfShow
+	if err := json.Unmarshal(raw, &show); err != nil {
+		return nil, fmt.Errorf("parse terraform show -json: %w", err)
+	}
+	// A `terraform show -json` of a plan carries planned_values; of a state, values.
+	// Prefer planned_values (what WILL be applied) and fall back to state.
+	vals := show.PlannedValues
+	if vals == nil {
+		vals = show.Values
+	}
+	if vals == nil {
+		return nil, nil
+	}
+
+	var resources []tfResource
+	collectTFResources(&vals.RootModule, &resources)
+
+	var specs []Spec
+	for _, r := range resources {
+		switch {
+		case k8sWorkloadKind(r.Type) != "":
+			if s, ok := specFromTFK8s(r); ok {
+				specs = append(specs, s)
+			}
+		case r.Type == "aws_ecs_task_definition":
+			specs = append(specs, specsFromTFECS(r)...)
+		}
+	}
+	return specs, nil
+}
+
+// AggregateTerraform folds the per-workload specs from a Terraform plan/state into
+// a single Report representing the configuration's isolation posture. Like
+// AggregateHelm, the aggregate is the WEAKEST workload (minimum score): a plan is
+// only as isolated as its most-exposed container, so grading the weakest link is
+// the honest, fail-closed summary. target names the source (plan/state file base
+// or "terraform"). It returns the aggregate Report and the Spec that produced it
+// (for SARIF anchoring). It is pure; the caller injects Version/GeneratedAt.
+// Fail-closed: an empty workload set is an error (a plan that declares no gradeable
+// container workload is not a pass).
+func AggregateTerraform(specs []Spec, target string) (Report, Spec, error) {
+	if len(specs) == 0 {
+		return Report{}, Spec{}, fmt.Errorf("no gradeable container workloads found in terraform output (looked for kubernetes_* pod/workload resources and aws_ecs_task_definition)")
+	}
+
+	all := make([]scoredWorkload, len(specs))
+	worst := 0
+	for i, s := range specs {
+		all[i] = scoredWorkload{spec: s, report: Score(s)}
+		if all[i].report.Score < all[worst].report.Score {
+			worst = i
+		}
+	}
+
+	agg := all[worst].report
+	worstSpec := all[worst].spec
+	if strings.TrimSpace(target) != "" {
+		agg.Target = target
+	}
+	agg.Source = "terraform"
+	agg.Notes = append(tfSummaryNotes(all[worst], all), agg.Notes...)
+
+	return agg, worstSpec, nil
+}
+
+// tfSummaryNotes builds the plan-level roll-up notes for an aggregate Terraform
+// report: a headline naming the weakest workload and a per-workload score list.
+func tfSummaryNotes(worst scoredWorkload, all []scoredWorkload) []string {
+	notes := []string{
+		fmt.Sprintf("graded %d terraform workload(s); the plan grade is the WEAKEST (a plan is only as isolated as its most-exposed container). Weakest: %s at %d/100 (grade %s).",
+			len(all), nz(worst.spec.Target, "workload"), worst.report.Score, worst.report.Grade),
+	}
+	sorted := make([]scoredWorkload, len(all))
+	copy(sorted, all)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].report.Score < sorted[j].report.Score })
+	rows := make([]string, len(sorted))
+	for i, w := range sorted {
+		rows[i] = fmt.Sprintf("%s = %d/100 (%s)", nz(w.spec.Target, "workload"), w.report.Score, w.report.Grade)
+	}
+	notes = append(notes, "per-workload: "+strings.Join(rows, "; "))
+	return notes
+}
+
+// --------------------------------------------------------------------------- //
+// terraform show -json top-level document model
+// --------------------------------------------------------------------------- //
+
+type tfShow struct {
+	FormatVersion string    `json:"format_version"`
+	PlannedValues *tfValues `json:"planned_values"`
+	Values        *tfValues `json:"values"`
+}
+
+type tfValues struct {
+	RootModule tfModule `json:"root_module"`
+}
+
+type tfModule struct {
+	Resources    []tfResource `json:"resources"`
+	ChildModules []tfModule   `json:"child_modules"`
+}
+
+type tfResource struct {
+	Address string          `json:"address"`
+	Type    string          `json:"type"`
+	Name    string          `json:"name"`
+	Values  json.RawMessage `json:"values"`
+}
+
+// collectTFResources flattens a module tree (root + child modules, recursively)
+// into a single resource slice.
+func collectTFResources(m *tfModule, out *[]tfResource) {
+	*out = append(*out, m.Resources...)
+	for i := range m.ChildModules {
+		collectTFResources(&m.ChildModules[i], out)
+	}
+}
+
+// --------------------------------------------------------------------------- //
+// Kubernetes provider mapping (terraform-provider-kubernetes)
+//
+// The provider models Kubernetes blocks as single-element JSON arrays with
+// snake_case field names (e.g. metadata:[{...}], spec:[{...}],
+// security_context:[{...}]). We decode that shape and convert it to the SAME
+// internal podSpec the --k8s / --helm paths grade, so the dimension scoring is
+// byte-for-byte identical across artifact classes.
+// --------------------------------------------------------------------------- //
+
+// k8sWorkloadKind maps a terraform kubernetes resource type to the Kubernetes
+// Kind it represents, or "" if the type is not a gradeable workload. It tolerates
+// the "_v1"/"_v1beta1" provider aliases.
+func k8sWorkloadKind(tfType string) string {
+	base := strings.TrimPrefix(tfType, "kubernetes_")
+	if base == tfType {
+		return "" // not a kubernetes_* resource
+	}
+	base = strings.TrimSuffix(base, "_v1beta1")
+	base = strings.TrimSuffix(base, "_v1")
+	switch base {
+	case "pod":
+		return "Pod"
+	case "deployment":
+		return "Deployment"
+	case "stateful_set":
+		return "StatefulSet"
+	case "daemon_set":
+		return "DaemonSet"
+	case "replication_controller":
+		return "ReplicationController"
+	case "job":
+		return "Job"
+	case "cron_job":
+		return "CronJob"
+	default:
+		return ""
+	}
+}
+
+type tfK8sValues struct {
+	Metadata []tfMetadata `json:"metadata"`
+	Spec     []tfK8sSpec  `json:"spec"`
+}
+
+type tfMetadata struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+// tfK8sSpec is a resource's top-level spec block. For kubernetes_pod it embeds the
+// pod spec directly; for workload kinds the pod spec is nested under template; for
+// kubernetes_cron_job it nests one level deeper under job_template.
+type tfK8sSpec struct {
+	tfK8sPodSpec
+	Template    []tfTemplate    `json:"template"`
+	JobTemplate []tfJobTemplate `json:"job_template"`
+}
+
+type tfTemplate struct {
+	Spec []tfK8sPodSpec `json:"spec"`
+}
+
+type tfJobTemplate struct {
+	Spec []tfJobSpec `json:"spec"`
+}
+
+type tfJobSpec struct {
+	Template []tfTemplate `json:"template"`
+}
+
+type tfK8sPodSpec struct {
+	HostNetwork      *bool         `json:"host_network"`
+	HostPID          *bool         `json:"host_pid"`
+	HostIPC          *bool         `json:"host_ipc"`
+	RuntimeClassName string        `json:"runtime_class_name"`
+	SecurityContext  []tfPodSecCtx `json:"security_context"`
+	Container        []tfContainer `json:"container"`
+	Volume           []tfVolume    `json:"volume"`
+}
+
+type tfPodSecCtx struct {
+	RunAsNonRoot   *bool       `json:"run_as_non_root"`
+	RunAsUser      *tfInt      `json:"run_as_user"`
+	SeccompProfile []tfSeccomp `json:"seccomp_profile"`
+}
+
+type tfSeccomp struct {
+	Type string `json:"type"`
+}
+
+type tfContainer struct {
+	Name            string              `json:"name"`
+	Image           string              `json:"image"`
+	SecurityContext []tfContainerSecCtx `json:"security_context"`
+	VolumeMount     []tfVolumeMount     `json:"volume_mount"`
+}
+
+type tfContainerSecCtx struct {
+	RunAsNonRoot             *bool          `json:"run_as_non_root"`
+	RunAsUser                *tfInt         `json:"run_as_user"`
+	Privileged               *bool          `json:"privileged"`
+	ReadOnlyRootFilesystem   *bool          `json:"read_only_root_filesystem"`
+	AllowPrivilegeEscalation *bool          `json:"allow_privilege_escalation"`
+	Capabilities             []tfCapability `json:"capabilities"`
+	SeccompProfile           []tfSeccomp    `json:"seccomp_profile"`
+}
+
+type tfCapability struct {
+	Add  []string `json:"add"`
+	Drop []string `json:"drop"`
+}
+
+type tfVolumeMount struct {
+	Name      string `json:"name"`
+	MountPath string `json:"mount_path"`
+}
+
+type tfVolume struct {
+	Name     string          `json:"name"`
+	HostPath []tfVolHostPath `json:"host_path"`
+}
+
+type tfVolHostPath struct {
+	Path string `json:"path"`
+}
+
+// specFromTFK8s decodes one kubernetes_* resource, resolves its pod spec (bare
+// pod / workload template / cron_job job_template), converts it to the internal
+// podSpec, and grades it with the shared specFromPodSpec mapper. ok is false when
+// the resource has no container to grade.
+func specFromTFK8s(r tfResource) (Spec, bool) {
+	var v tfK8sValues
+	if err := json.Unmarshal(r.Values, &v); err != nil {
+		return Spec{}, false
+	}
+	tps, ok := v.resolvePodSpec()
+	if !ok {
+		return Spec{}, false
+	}
+	ps := tps.toPodSpec()
+	if len(ps.Containers) == 0 {
+		return Spec{}, false
+	}
+	name := r.Name
+	if len(v.Metadata) > 0 && strings.TrimSpace(v.Metadata[0].Name) != "" {
+		name = v.Metadata[0].Name
+	}
+	target := k8sWorkloadKind(r.Type) + "/" + name
+	return specFromPodSpec("terraform", target, ps), true
+}
+
+// resolvePodSpec resolves the three nesting shapes to the innermost pod spec,
+// mirroring k8sObject.podSpecOf.
+func (v tfK8sValues) resolvePodSpec() (tfK8sPodSpec, bool) {
+	if len(v.Spec) == 0 {
+		return tfK8sPodSpec{}, false
+	}
+	s := v.Spec[0]
+	// Bare pod: the resource spec IS the pod spec.
+	if len(s.tfK8sPodSpec.Container) > 0 {
+		return s.tfK8sPodSpec, true
+	}
+	// Workload kinds: spec.template.spec.
+	if len(s.Template) > 0 && len(s.Template[0].Spec) > 0 && len(s.Template[0].Spec[0].Container) > 0 {
+		return s.Template[0].Spec[0], true
+	}
+	// CronJob: spec.job_template.spec.template.spec.
+	if len(s.JobTemplate) > 0 && len(s.JobTemplate[0].Spec) > 0 {
+		js := s.JobTemplate[0].Spec[0]
+		if len(js.Template) > 0 && len(js.Template[0].Spec) > 0 && len(js.Template[0].Spec[0].Container) > 0 {
+			return js.Template[0].Spec[0], true
+		}
+	}
+	return tfK8sPodSpec{}, false
+}
+
+// toPodSpec converts a Terraform-decoded pod spec to the internal podSpec that the
+// shared scorer understands.
+func (t tfK8sPodSpec) toPodSpec() podSpec {
+	ps := podSpec{
+		HostPID:      t.HostPID,
+		HostIPC:      t.HostIPC,
+		HostNetwork:  t.HostNetwork,
+		RuntimeClass: t.RuntimeClassName,
+	}
+	if len(t.SecurityContext) > 0 {
+		sc := t.SecurityContext[0]
+		ps.SecurityContext = &podSecCtx{
+			RunAsNonRoot: sc.RunAsNonRoot,
+			RunAsUser:    sc.RunAsUser.ptr(),
+		}
+		if len(sc.SeccompProfile) > 0 {
+			ps.SecurityContext.SeccompProfile = &seccompProfile{Type: sc.SeccompProfile[0].Type}
+		}
+	}
+	for _, c := range t.Container {
+		kc := k8sContainer{Name: c.Name}
+		if len(c.SecurityContext) > 0 {
+			csc := c.SecurityContext[0]
+			kc.SecurityContext = &containerSecCtx{
+				RunAsNonRoot:             csc.RunAsNonRoot,
+				RunAsUser:                csc.RunAsUser.ptr(),
+				Privileged:               csc.Privileged,
+				ReadOnlyRootFilesystem:   csc.ReadOnlyRootFilesystem,
+				AllowPrivilegeEscalation: csc.AllowPrivilegeEscalation,
+			}
+			if len(csc.Capabilities) > 0 {
+				kc.SecurityContext.Capabilities = &capabilities{
+					Add:  csc.Capabilities[0].Add,
+					Drop: csc.Capabilities[0].Drop,
+				}
+			}
+			if len(csc.SeccompProfile) > 0 {
+				kc.SecurityContext.SeccompProfile = &seccompProfile{Type: csc.SeccompProfile[0].Type}
+			}
+		}
+		for _, vm := range c.VolumeMount {
+			kc.VolumeMounts = append(kc.VolumeMounts, volumeMount{Name: vm.Name, MountPath: vm.MountPath})
+		}
+		ps.Containers = append(ps.Containers, kc)
+	}
+	for _, v := range t.Volume {
+		kv := k8sVolume{Name: v.Name}
+		if len(v.HostPath) > 0 {
+			kv.HostPath = &struct {
+				Path string `yaml:"path"`
+			}{Path: v.HostPath[0].Path}
+		}
+		ps.Volumes = append(ps.Volumes, kv)
+	}
+	return ps
+}
+
+// tfInt decodes a terraform value that may be a JSON number OR a quoted number
+// string (the kubernetes provider models run_as_user as a string). An empty or
+// unparseable value decodes to a nil pointer (unknown).
+type tfInt struct{ v *int64 }
+
+func (t *tfInt) UnmarshalJSON(b []byte) error {
+	s := strings.TrimSpace(string(b))
+	if s == "null" || s == `""` || s == "" {
+		return nil
+	}
+	s = strings.Trim(s, `"`)
+	if s == "" {
+		return nil
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return nil // tolerate non-numeric (e.g. a username): leave unknown
+	}
+	t.v = &n
+	return nil
+}
+
+func (t *tfInt) ptr() *int64 {
+	if t == nil {
+		return nil
+	}
+	return t.v
+}
+
+// --------------------------------------------------------------------------- //
+// AWS ECS task definition mapping
+//
+// container_definitions is a JSON-ENCODED STRING holding an array of container
+// definitions (camelCase, Docker-flavored). We decode the string, grade each
+// container, and fold in the task-level network_mode / pid_mode / ipc_mode.
+// --------------------------------------------------------------------------- //
+
+type tfEcsValues struct {
+	Family               string     `json:"family"`
+	NetworkMode          string     `json:"network_mode"`
+	PidMode              string     `json:"pid_mode"`
+	IpcMode              string     `json:"ipc_mode"`
+	ContainerDefinitions string     `json:"container_definitions"`
+	Volume               []tfEcsVol `json:"volume"`
+}
+
+type tfEcsVol struct {
+	Name     string `json:"name"`
+	HostPath string `json:"host_path"`
+}
+
+type ecsContainerDef struct {
+	Name                   string `json:"name"`
+	Privileged             *bool  `json:"privileged"`
+	ReadonlyRootFilesystem *bool  `json:"readonlyRootFilesystem"`
+	User                   string `json:"user"`
+	LinuxParameters        *struct {
+		Capabilities *struct {
+			Add  []string `json:"add"`
+			Drop []string `json:"drop"`
+		} `json:"capabilities"`
+	} `json:"linuxParameters"`
+	DockerSecurityOptions []string `json:"dockerSecurityOptions"`
+}
+
+// specsFromTFECS decodes one aws_ecs_task_definition and returns a graded Spec per
+// container definition. The task-level network/pid/ipc modes and any docker.sock
+// host volume apply to every container in the task.
+func specsFromTFECS(r tfResource) []Spec {
+	var v tfEcsValues
+	if err := json.Unmarshal(r.Values, &v); err != nil {
+		return nil
+	}
+	var defs []ecsContainerDef
+	if strings.TrimSpace(v.ContainerDefinitions) != "" {
+		if err := json.Unmarshal([]byte(v.ContainerDefinitions), &defs); err != nil {
+			return nil
+		}
+	}
+	if len(defs) == 0 {
+		return nil
+	}
+
+	family := nz(v.Family, r.Name)
+
+	// docker.sock exposure is a task-level property: an ECS host volume whose
+	// source path is the control socket is mountable into any container.
+	dockerSock := No
+	for _, vol := range v.Volume {
+		if isControlSocket(vol.HostPath) {
+			dockerSock = Yes
+		}
+	}
+
+	specs := make([]Spec, 0, len(defs))
+	for _, d := range defs {
+		specs = append(specs, ecsSpec(family, d, v, dockerSock))
+	}
+	return specs
+}
+
+// ecsSpec maps one ECS container definition (plus task-level modes) to a Spec.
+func ecsSpec(family string, d ecsContainerDef, task tfEcsValues, dockerSock Tristate) Spec {
+	target := "ecs/" + family
+	if strings.TrimSpace(d.Name) != "" {
+		target = "ecs/" + family + "/" + d.Name
+	}
+	s := Spec{Source: "terraform", Target: target, DockerSock: dockerSock}
+
+	// --- user ---------------------------------------------------------------
+	// ECS `user` is a string: "", "0", "root", "1000", "1000:1000", "appuser".
+	switch u := strings.TrimSpace(d.User); {
+	case u == "":
+		s.RunAsNonRoot = Unknown
+		s.Notes = append(s.Notes, "no container user set; the image default may be root")
+	case ecsUserIsRoot(u):
+		s.RunAsNonRoot = No
+		s.User = u
+	default:
+		s.RunAsNonRoot = Yes
+		s.User = u
+	}
+
+	// --- capabilities / privilege ------------------------------------------
+	s.Privileged = triFromPtr(d.Privileged)
+	if d.LinuxParameters != nil && d.LinuxParameters.Capabilities != nil {
+		caps := d.LinuxParameters.Capabilities
+		for _, dr := range caps.Drop {
+			if strings.EqualFold(strings.TrimSpace(dr), "ALL") {
+				s.CapDropAll = Yes
+			}
+		}
+		if s.CapDropAll == Unknown {
+			s.CapDropAll = No
+		}
+		for _, a := range caps.Add {
+			if a = strings.TrimSpace(a); a != "" {
+				s.CapAdd = append(s.CapAdd, strings.ToUpper(a))
+			}
+		}
+	} else {
+		// No linuxParameters.capabilities: ECS keeps Docker's default capability
+		// set (fail-closed, same as the compose/docker default).
+		s.CapDropAll = No
+	}
+
+	// --- read-only rootfs ---------------------------------------------------
+	s.ReadonlyRoot = triFromPtr(d.ReadonlyRootFilesystem)
+
+	// --- seccomp ------------------------------------------------------------
+	// ECS applies Docker's DEFAULT seccomp profile unless a dockerSecurityOption
+	// disables it. Mirror the docker/compose adapters: default profile = confined.
+	s.Seccomp = "confined"
+	for _, opt := range d.DockerSecurityOptions {
+		o := strings.ToLower(strings.TrimSpace(opt))
+		if o == "seccomp=unconfined" || o == "seccomp:unconfined" {
+			s.Seccomp = "unconfined"
+		}
+		if o == "no-new-privileges" || o == "no-new-privileges:true" {
+			s.NoNewPrivs = Yes
+		}
+	}
+
+	// --- network ------------------------------------------------------------
+	switch nm := strings.ToLower(strings.TrimSpace(task.NetworkMode)); nm {
+	case "none":
+		s.NetworkMode = "none"
+	case "host":
+		s.NetworkMode = "host"
+		s.HostNetwork = Yes
+	case "":
+		// ECS default network mode is bridge on EC2; egress-capable.
+		s.NetworkMode = "bridge"
+	default:
+		// awsvpc / bridge / default: an egress-capable NIC (not host).
+		s.NetworkMode = nm
+	}
+	if s.HostNetwork != Yes {
+		s.HostNetwork = No
+	}
+
+	// --- namespaces ---------------------------------------------------------
+	s.HostPID = boolTri(strings.EqualFold(strings.TrimSpace(task.PidMode), "host"))
+	s.HostIPC = boolTri(strings.EqualFold(strings.TrimSpace(task.IpcMode), "host"))
+
+	return s
+}
+
+// ecsUserIsRoot reports whether an ECS `user` string resolves to uid 0.
+func ecsUserIsRoot(u string) bool {
+	u = strings.TrimSpace(u)
+	// "uid[:gid]" or "name[:group]": the leading field is the user.
+	if i := strings.IndexByte(u, ':'); i >= 0 {
+		u = u[:i]
+	}
+	return u == "0" || strings.EqualFold(u, "root")
+}

--- a/internal/host/scan/terraform_test.go
+++ b/internal/host/scan/terraform_test.go
@@ -1,0 +1,350 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+// tfHardenedPlan mimics `terraform show -json` for a plan whose kubernetes_deployment
+// is fully hardened (runAsNonRoot, drop ALL, read-only rootfs, RuntimeDefault
+// seccomp). The kubernetes provider models every block as a single-element array
+// with snake_case keys, and run_as_user as a string.
+const tfHardenedPlan = `{
+  "format_version": "1.2",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "kubernetes_deployment.web",
+          "type": "kubernetes_deployment",
+          "name": "web",
+          "values": {
+            "metadata": [{"name": "web", "namespace": "prod"}],
+            "spec": [{
+              "template": [{
+                "spec": [{
+                  "host_network": false,
+                  "host_pid": false,
+                  "host_ipc": false,
+                  "security_context": [{
+                    "run_as_non_root": true,
+                    "run_as_user": "1000",
+                    "seccomp_profile": [{"type": "RuntimeDefault"}]
+                  }],
+                  "container": [{
+                    "name": "web",
+                    "image": "web:1",
+                    "security_context": [{
+                      "run_as_non_root": true,
+                      "read_only_root_filesystem": true,
+                      "allow_privilege_escalation": false,
+                      "privileged": false,
+                      "capabilities": [{"drop": ["ALL"]}],
+                      "seccomp_profile": [{"type": "RuntimeDefault"}]
+                    }]
+                  }]
+                }]
+              }]
+            }]
+          }
+        }
+      ]
+    }
+  }
+}`
+
+// tfMixedPlan pairs a hardened Deployment with a privileged, host-namespace,
+// docker.sock Pod in a CHILD module, plus a partly hardened ECS task definition.
+// The aggregate must reflect the WEAKEST workload (the porous pod).
+const tfMixedPlan = `{
+  "format_version": "1.2",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "kubernetes_deployment.safe",
+          "type": "kubernetes_deployment_v1",
+          "name": "safe",
+          "values": {
+            "metadata": [{"name": "safe"}],
+            "spec": [{
+              "template": [{
+                "spec": [{
+                  "host_network": false,
+                  "host_pid": false,
+                  "host_ipc": false,
+                  "security_context": [{"run_as_non_root": true, "seccomp_profile": [{"type": "RuntimeDefault"}]}],
+                  "container": [{
+                    "name": "safe",
+                    "security_context": [{
+                      "run_as_non_root": true,
+                      "read_only_root_filesystem": true,
+                      "capabilities": [{"drop": ["ALL"]}],
+                      "seccomp_profile": [{"type": "RuntimeDefault"}]
+                    }]
+                  }]
+                }]
+              }]
+            }]
+          }
+        },
+        {
+          "address": "aws_ecs_task_definition.api",
+          "type": "aws_ecs_task_definition",
+          "name": "api",
+          "values": {
+            "family": "api",
+            "network_mode": "awsvpc",
+            "container_definitions": "[{\"name\":\"api\",\"user\":\"1000\",\"readonlyRootFilesystem\":true,\"privileged\":false,\"linuxParameters\":{\"capabilities\":{\"drop\":[\"ALL\"]}}}]"
+          }
+        }
+      ],
+      "child_modules": [
+        {
+          "address": "module.legacy",
+          "resources": [
+            {
+              "address": "module.legacy.kubernetes_pod.porous",
+              "type": "kubernetes_pod",
+              "name": "porous",
+              "values": {
+                "metadata": [{"name": "porous"}],
+                "spec": [{
+                  "host_network": true,
+                  "host_pid": true,
+                  "container": [{
+                    "name": "app",
+                    "image": "nginx",
+                    "security_context": [{"privileged": true}],
+                    "volume_mount": [{"name": "sock", "mount_path": "/var/run/docker.sock"}]
+                  }],
+                  "volume": [{"name": "sock", "host_path": [{"path": "/var/run/docker.sock"}]}]
+                }]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}`
+
+// tfCronState mimics `terraform show -json` of a STATE file (values, not
+// planned_values) with a kubernetes_cron_job (deepest nesting: job_template ->
+// spec -> template -> spec).
+const tfCronState = `{
+  "format_version": "1.2",
+  "values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "kubernetes_cron_job.nightly",
+          "type": "kubernetes_cron_job_v1",
+          "name": "nightly",
+          "values": {
+            "metadata": [{"name": "nightly"}],
+            "spec": [{
+              "job_template": [{
+                "spec": [{
+                  "template": [{
+                    "spec": [{
+                      "host_network": false,
+                      "host_pid": false,
+                      "host_ipc": false,
+                      "security_context": [{"run_as_non_root": true, "seccomp_profile": [{"type": "RuntimeDefault"}]}],
+                      "container": [{
+                        "name": "job",
+                        "security_context": [{
+                          "run_as_non_root": true,
+                          "read_only_root_filesystem": true,
+                          "capabilities": [{"drop": ["ALL"]}],
+                          "seccomp_profile": [{"type": "RuntimeDefault"}]
+                        }]
+                      }]
+                    }]
+                  }]
+                }]
+              }]
+            }]
+          }
+        }
+      ]
+    }
+  }
+}`
+
+func TestSpecsFromTerraform_HardenedDeployment(t *testing.T) {
+	specs, err := SpecsFromTerraform([]byte(tfHardenedPlan))
+	if err != nil {
+		t.Fatalf("SpecsFromTerraform: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("want 1 workload, got %d: %+v", len(specs), specs)
+	}
+	s := specs[0]
+	if s.Source != "terraform" {
+		t.Errorf("source: want terraform, got %q", s.Source)
+	}
+	if s.Target != "Deployment/web" {
+		t.Errorf("target: want Deployment/web, got %q", s.Target)
+	}
+	if s.RunAsNonRoot != Yes || s.CapDropAll != Yes || s.ReadonlyRoot != Yes {
+		t.Errorf("hardened posture not extracted: %+v", s)
+	}
+	if s.Seccomp != "confined" {
+		t.Errorf("seccomp: want confined (RuntimeDefault), got %q", s.Seccomp)
+	}
+}
+
+func TestAggregateTerraform_HardenedIsHighGrade(t *testing.T) {
+	specs, err := SpecsFromTerraform([]byte(tfHardenedPlan))
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, worst, err := AggregateTerraform(specs, "plan.json")
+	if err != nil {
+		t.Fatalf("AggregateTerraform: %v", err)
+	}
+	if report.Source != "terraform" || report.Target != "plan.json" {
+		t.Errorf("aggregate identity: source=%q target=%q", report.Source, report.Target)
+	}
+	// Network egress is the honest ceiling (no NetworkPolicy in a pod spec), so a
+	// fully hardened workload lands in B, not A — same ceiling as --helm.
+	if report.Grade != "B" {
+		t.Errorf("hardened plan grade: want B (network ceiling), got %s (score %d)", report.Grade, report.Score)
+	}
+	if worst.Target != "Deployment/web" {
+		t.Errorf("worst spec target: %q", worst.Target)
+	}
+	joined := strings.Join(report.Notes, "\n")
+	if !strings.Contains(joined, "graded 1 terraform workload(s)") {
+		t.Errorf("missing workload-count note: %q", joined)
+	}
+	if !strings.Contains(joined, "per-workload:") {
+		t.Errorf("missing per-workload roll-up: %q", joined)
+	}
+}
+
+func TestSpecsFromTerraform_WeakestWorkloadWinsAcrossModulesAndECS(t *testing.T) {
+	specs, err := SpecsFromTerraform([]byte(tfMixedPlan))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Deployment (root) + ECS container (root) + Pod (child module) = 3 workloads.
+	if len(specs) != 3 {
+		t.Fatalf("want 3 workloads, got %d: %+v", len(specs), targets(specs))
+	}
+	report, worst, err := AggregateTerraform(specs, "mixed")
+	if err != nil {
+		t.Fatalf("AggregateTerraform: %v", err)
+	}
+	if worst.Target != "Pod/porous" {
+		t.Errorf("weakest workload: want Pod/porous, got %q (all: %v)", worst.Target, targets(specs))
+	}
+	if report.Grade != "F" {
+		t.Errorf("mixed plan grade: want F (privileged host-ns pod), got %s (score %d)", report.Grade, report.Score)
+	}
+	// The porous pod's docker.sock + privileged + host namespaces must be seen.
+	if worst.DockerSock != Yes || worst.Privileged != Yes || worst.HostNetwork != Yes || worst.HostPID != Yes {
+		t.Errorf("porous pod posture not fully extracted: %+v", worst)
+	}
+}
+
+func TestSpecsFromTerraform_ECSTaskDefinition(t *testing.T) {
+	specs, err := SpecsFromTerraform([]byte(tfMixedPlan))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ecs *Spec
+	for i := range specs {
+		if strings.HasPrefix(specs[i].Target, "ecs/") {
+			ecs = &specs[i]
+		}
+	}
+	if ecs == nil {
+		t.Fatalf("no ECS workload found in %v", targets(specs))
+	}
+	if ecs.Target != "ecs/api/api" {
+		t.Errorf("ecs target: want ecs/api/api, got %q", ecs.Target)
+	}
+	if ecs.RunAsNonRoot != Yes || ecs.User != "1000" {
+		t.Errorf("ecs user not extracted: RunAsNonRoot=%v User=%q", ecs.RunAsNonRoot, ecs.User)
+	}
+	if ecs.CapDropAll != Yes || ecs.ReadonlyRoot != Yes {
+		t.Errorf("ecs caps/rootfs not extracted: %+v", ecs)
+	}
+	// awsvpc is an egress-capable NIC, not host: not "none", not "host".
+	if ecs.NetworkMode != "awsvpc" || ecs.HostNetwork != No {
+		t.Errorf("ecs network mode: %q hostNet=%v", ecs.NetworkMode, ecs.HostNetwork)
+	}
+	// ECS applies Docker's default seccomp profile: confined by default.
+	if ecs.Seccomp != "confined" {
+		t.Errorf("ecs seccomp: want confined (docker default), got %q", ecs.Seccomp)
+	}
+}
+
+func TestSpecsFromTerraform_CronJobStateNesting(t *testing.T) {
+	specs, err := SpecsFromTerraform([]byte(tfCronState))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("want 1 workload from state, got %d: %v", len(specs), targets(specs))
+	}
+	if specs[0].Target != "CronJob/nightly" {
+		t.Errorf("cronjob target: want CronJob/nightly, got %q", specs[0].Target)
+	}
+	if specs[0].CapDropAll != Yes || specs[0].RunAsNonRoot != Yes {
+		t.Errorf("cronjob deepest-nested pod spec not extracted: %+v", specs[0])
+	}
+}
+
+func TestAggregateTerraform_NoWorkloadsIsError(t *testing.T) {
+	// A plan with only non-container resources yields no gradeable workload.
+	const noWorkloads = `{"planned_values":{"root_module":{"resources":[
+	  {"type":"aws_s3_bucket","name":"b","values":{"bucket":"x"}}]}}}`
+	specs, err := SpecsFromTerraform([]byte(noWorkloads))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("want 0 workloads, got %d", len(specs))
+	}
+	if _, _, err := AggregateTerraform(specs, "empty"); err == nil {
+		t.Fatal("want error for empty workload set (fail-closed), got nil")
+	}
+}
+
+func TestSpecsFromTerraform_MalformedIsError(t *testing.T) {
+	if _, err := SpecsFromTerraform([]byte("not json")); err == nil {
+		t.Fatal("want parse error for malformed document, got nil")
+	}
+}
+
+func TestEcsUserIsRoot(t *testing.T) {
+	cases := map[string]bool{
+		"0":          true,
+		"root":       true,
+		"ROOT":       true,
+		"0:0":        true,
+		"root:wheel": true,
+		"1000":       false,
+		"1000:1000":  false,
+		"appuser":    false,
+		"":           false, // empty handled separately (unknown), not root here
+	}
+	for in, want := range cases {
+		if got := ecsUserIsRoot(in); got != want {
+			t.Errorf("ecsUserIsRoot(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// targets is a test helper: the Target of each spec, for readable failures.
+func targets(specs []Spec) []string {
+	out := make([]string, len(specs))
+	for i, s := range specs {
+		out[i] = s.Target
+	}
+	return out
+}


### PR DESCRIPTION
## What

Extends the `ironctl scan` wedge to Infrastructure-as-Code. `ironctl scan --terraform <path>` consumes `terraform show -json` output (a `plan.json`/`state.json` file, or a Terraform directory it runs `terraform show -json` against) and grades the container workloads it declares. Same **adapter pattern as `--helm` (IRO-501)**: consume, then grade the **weakest** workload through the existing k8s/container scorer. Not a new grader.

## Scope

- **`kubernetes_*` resources** — `kubernetes_pod`, `_deployment`, `_stateful_set`, `_daemon_set`, `_job`, `_cron_job`, `_replication_controller` (and `_v1` aliases). The terraform-provider-kubernetes JSON shape (list-wrapped, snake_case blocks) is decoded and converted to the **same internal `podSpec`** the `--k8s`/`--helm` paths grade via `specFromPodSpec` — byte-identical dimension scoring across artifact classes.
- **`aws_ecs_task_definition`** — each `container_definitions` entry is graded, with the task-level `network_mode`/`pid_mode`/`ipc_mode` (and any docker.sock host volume) folded in.
- Walks the **root module + every child module**. Aggregate = **weakest workload** (`AggregateTerraform` mirrors `AggregateHelm`). `workloadTarget` = `Kind/name` or `ecs/family/container`.
- **Fail-open** on missing terraform / unreadable path / malformed JSON (diagnostic + exit 0); `--min-score` still gates once workloads are graded. **`--json` + table + `--sarif` + `--badge` output parity** with existing modes.

## Refactor

Names the previously-anonymous k8s `securityContext`/`capabilities`/`seccompProfile`/`volumeMount` structs so the Terraform adapter can construct the same graded pod spec. Behavior-preserving — yaml tags unchanged; all existing k8s/helm tests pass.

## Tests / verification

- 10 new unit tests (fixtures: k8s all nestings incl. cron_job deepest, ECS, child modules, plan vs state, string `run_as_user`, weakest-link aggregate, fail-open, malformed). `go test ./internal/host/scan/ ./cmd/ironctl/` = **236 pass**, `go vet` clean, `CGO_ENABLED=1 go build ./...` green.
- E2E on a fixture plan: hardened Deployment = 89/B, privileged host-network ECS container = 15/F → plan grade = weakest (15/F). `--min-score 90` trips exit 1; `--json`/`--sarif` (7 rules, 6 results) emit; missing file / missing terraform-bin fail open (exit 0).

## Security lens

Read-only, local, daemon-free static analysis of IaC config; touches no trust boundary. Egress graded conservatively (no NetworkPolicy/security-group in a workload spec) — the honest static ceiling.

Docs: new **Grade a Terraform plan** section + supported-modes rows in `docs/scan.md` (also adds the missing `--helm` row).