### PR TITLE
feat(scan): ironctl scan --nomad grades container workloads in Nomad job specs (IRO-507)

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -45,6 +45,8 @@ func cmdScan(args []string) error {
 	helmBin := fs.String("helm-bin", envOrDefault("HELM", "helm"), "helm binary used to render the chart")
 	terraform := fs.String("terraform", "", "grade container workloads in a `terraform show -json` file (plan.json/state.json) or a Terraform dir")
 	terraformBin := fs.String("terraform-bin", envOrDefault("TERRAFORM", "terraform"), "terraform binary used to run `terraform show -json` on a dir/binary plan")
+	nomad := fs.String("nomad", "", "grade docker-driver tasks in a HashiCorp Nomad job spec (job.json, or a .hcl/.nomad file rendered via `nomad job run -output`)")
+	nomadBin := fs.String("nomad-bin", envOrDefault("NOMAD", "nomad"), "nomad binary used to render an HCL job to JSON (`nomad job run -output`)")
 	dockerfile := fs.Bool("dockerfile", false, "statically grade the positional Dockerfile(s) authoring-time posture (daemon-free)")
 	runtime := fs.String("runtime", envOrDefault("IRONCTL_SCAN_RUNTIME", "auto"), "container runtime: auto|docker|podman|nerdctl")
 	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker inspect`")
@@ -139,6 +141,25 @@ func cmdScan(args []string) error {
 			badgeJSON:    *badgeJSON,
 			sarif:        *sarif,
 			minScore:     *minScore,
+		})
+	}
+
+	// --nomad: consume a Nomad job spec (JSON directly, or a .hcl/.nomad file
+	// rendered to JSON via `nomad job run -output`) and grade the docker-driver
+	// tasks it declares, reusing the same docker/compose dimension mapping and
+	// weakest-link aggregate as --helm/--terraform. It loads JSON here then defers
+	// to the pure SpecsFromNomad + AggregateNomad scorer. Fail-OPEN on a
+	// load/parse failure; --min-score still gates once tasks are graded.
+	if *nomad != "" {
+		return runNomadScan(nomadArgs{
+			path:      *nomad,
+			nomadBin:  *nomadBin,
+			asJSON:    *asJSON,
+			md:        *md,
+			badge:     *badge,
+			badgeJSON: *badgeJSON,
+			sarif:     *sarif,
+			minScore:  *minScore,
 		})
 	}
 
@@ -629,6 +650,120 @@ func looksLikeJSON(raw []byte) bool {
 	return len(trimmed) > 0 && trimmed[0] == '{'
 }
 
+// nomadArgs carries the resolved inputs for a `scan --nomad` run.
+type nomadArgs struct {
+	path      string
+	nomadBin  string
+	asJSON    bool
+	md        bool
+	badge     string
+	badgeJSON string
+	sarif     string
+	minScore  int
+}
+
+// runNomadScan grades the docker-driver tasks declared in a HashiCorp Nomad job
+// spec, reusing the same docker/compose dimension mapping and weakest-link
+// aggregate as --helm/--terraform. It fails OPEN on a load/parse failure (nomad
+// absent for an HCL file, unreadable path, malformed JSON): it prints a clear
+// diagnostic to stderr and returns nil so an opt-in CI/Action step never crashes
+// the build over tooling issues. Once tasks are graded, scoring and the
+// --min-score CI gate apply exactly like --k8s/--helm/--terraform (a genuinely
+// low posture still fails the gate).
+func runNomadScan(a nomadArgs) error {
+	raw, err := loadNomadJSON(a.nomadBin, a.path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --nomad could not load %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	specs, err := scan.SpecsFromNomad(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --nomad could not parse %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregateNomad(specs, filepath.Base(a.path))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --nomad found nothing to grade in %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (tasks graded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// loadNomadJSON resolves a --nomad argument to Nomad job JSON bytes. A file that
+// already IS JSON (a `nomad job run -output` redirect, or a hand-authored API
+// job) is used verbatim — the daemon-free, dependency-free primary path. A
+// non-JSON file (an HCL2 `.hcl`/`.nomad` job) is converted with `nomad job run
+// -output <file>` when the nomad binary is on PATH. It is offline: `-output`
+// renders the job locally without submitting it to a cluster.
+func loadNomadJSON(nomadBin, path string) ([]byte, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if looksLikeJSON(raw) {
+		return raw, nil
+	}
+	if _, err := exec.LookPath(nomadBin); err != nil {
+		return nil, fmt.Errorf("nomad binary %q not found on PATH (install nomad, pass --nomad-bin, or pass a `nomad job run -output` JSON file directly): %w", nomadBin, err)
+	}
+	cmd := exec.Command(nomadBin, "job", "run", "-output", path)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("nomad job run -output failed: %s", msg)
+	}
+	return stdout.Bytes(), nil
+}
+
 // writeDockerfileSARIF renders the Dockerfile SARIF log to path, fail-open on error.
 func writeDockerfileSARIF(path string, r scan.Report, opts scan.SARIFOptions) error {
 	f, err := os.Create(path)
@@ -760,6 +895,7 @@ USAGE:
   ironctl scan --k8s FILE                     grade a Kubernetes pod/workload manifest
   ironctl scan --helm CHART                    render a Helm chart (dir or .tgz) and grade its workloads
   ironctl scan --terraform PATH                grade container workloads in a terraform show -json file/dir
+  ironctl scan --nomad PATH                     grade docker-driver tasks in a Nomad job spec (JSON or HCL)
   ironctl scan --dockerfile FILE...           grade Dockerfile(s) statically (no daemon, no pull)
   ironctl scan --compare A B                   diff two containers' isolation posture
 
@@ -777,6 +913,7 @@ FLAGS:
   --service NAME      compose service to grade (if the file has >1)
   --helm-bin BIN      helm binary for `+"`helm template`"+` (default: helm)
   --terraform-bin BIN terraform binary for `+"`terraform show -json`"+` (default: terraform)
+  --nomad-bin BIN     nomad binary for `+"`nomad job run -output`"+` (HCL->JSON; default: nomad)
   --docker-bin BIN    docker binary for `+"`docker inspect`"+` (default: docker)
   --podman-bin BIN    podman binary for `+"`podman inspect`"+` (default: podman)
   --nerdctl-bin BIN   nerdctl binary for `+"`nerdctl inspect`"+` (default: nerdctl)
@@ -806,6 +943,15 @@ workloads it declares: the kubernetes provider's pod/workload resources (mapped
 through the SAME pod-spec scorer as --k8s/--helm) and aws_ecs_task_definition
 container definitions. The plan grade is the WEAKEST workload; load/parse failures
 fail OPEN (diagnostic + exit 0). A successful parse still trips --min-score.
+
+--nomad grades the docker-driver tasks in a HashiCorp Nomad job spec, mapping each
+task's `+"`config`"+` block (privileged, cap_add/cap_drop, network_mode, volumes/mount,
+pid_mode/ipc_mode, security_opt, readonly_rootfs) through the SAME docker/compose
+dimension scorer. Pass a JSON job (a `+"`nomad job run -output`"+` redirect or an API
+job) for the daemon-free path, or a `+"`.hcl`/`.nomad`"+` file that is rendered to JSON
+via `+"`nomad job run -output`"+` when the nomad binary is on PATH. The job grade is the
+WEAKEST task; load/parse failures fail OPEN (diagnostic + exit 0). A successful
+parse still trips --min-score.
 
 --dockerfile grades a DIFFERENT, authoring-time dimension set (non-root USER,
 pinned base image, no secrets in ENV/ARG, COPY over remote/opaque ADD, no

--- a/internal/host/scan/nomad.go
+++ b/internal/host/scan/nomad.go
@@ -1,0 +1,318 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SpecsFromNomad parses a HashiCorp Nomad job specification in JSON form (the
+// output of `nomad job run -output job.hcl`, or a raw api.Job document) and
+// returns one graded Spec per docker-driver task across every task group.
+//
+// Nomad's docker task driver is Docker-flavored: its `config` block carries the
+// same isolation-relevant knobs as a `docker run` / compose service (privileged,
+// cap_add/cap_drop, network_mode, volumes/mount, pid_mode/ipc_mode, security_opt,
+// userns_mode, readonly_rootfs). We map each docker task's effective config onto
+// the SAME normalized Spec the docker/compose adapters produce, so a single
+// grading model serves every artifact class. Non-docker drivers (exec, raw_exec,
+// java, qemu, …) carry no comparable container-isolation posture and are skipped.
+//
+// It is pure and unit-testable: the caller loads the JSON (I/O) and passes the
+// bytes here. It fails OPEN on a malformed top-level document (returns the parse
+// error); the CLI wrapper turns that into a skip so an opt-in CI step never
+// crashes the build.
+func SpecsFromNomad(raw []byte) ([]Spec, error) {
+	// `nomad job run -output` wraps the job as {"Job": {...}} (the HTTP register
+	// request shape). A raw api.Job document (no wrapper) is also accepted.
+	var wrap nomadWrapper
+	if err := json.Unmarshal(raw, &wrap); err != nil {
+		return nil, fmt.Errorf("parse nomad job json: %w", err)
+	}
+	job := wrap.Job
+	if job == nil {
+		var j nomadJob
+		if err := json.Unmarshal(raw, &j); err != nil {
+			return nil, fmt.Errorf("parse nomad job json: %w", err)
+		}
+		job = &j
+	}
+
+	var specs []Spec
+	for _, g := range job.TaskGroups {
+		for _, t := range g.Tasks {
+			if s, ok := specFromNomadTask(g, t); ok {
+				specs = append(specs, s)
+			}
+		}
+	}
+	return specs, nil
+}
+
+// AggregateNomad folds the per-task specs of a Nomad job into a single Report
+// representing the job's isolation posture. Like AggregateHelm/AggregateTerraform,
+// the aggregate is the WEAKEST task (minimum score): a job is only as isolated as
+// its most-exposed container, so grading the weakest link is the honest,
+// fail-closed summary. target names the source job. It returns the aggregate
+// Report and the Spec that produced it (for SARIF anchoring). It is pure; the
+// caller injects Version/GeneratedAt. Fail-closed: an empty task set is an error
+// (a job that declares no gradeable docker task is not a pass).
+func AggregateNomad(specs []Spec, target string) (Report, Spec, error) {
+	if len(specs) == 0 {
+		return Report{}, Spec{}, fmt.Errorf("no gradeable container workloads found in nomad job (looked for tasks using the docker driver)")
+	}
+
+	all := make([]scoredWorkload, len(specs))
+	worst := 0
+	for i, s := range specs {
+		all[i] = scoredWorkload{spec: s, report: Score(s)}
+		if all[i].report.Score < all[worst].report.Score {
+			worst = i
+		}
+	}
+
+	agg := all[worst].report
+	worstSpec := all[worst].spec
+	if strings.TrimSpace(target) != "" {
+		agg.Target = target
+	}
+	agg.Source = "nomad"
+	agg.Notes = append(nomadSummaryNotes(all[worst], all), agg.Notes...)
+
+	return agg, worstSpec, nil
+}
+
+// nomadSummaryNotes builds the job-level roll-up notes for an aggregate Nomad
+// report: a headline naming the weakest task and a per-task score list.
+func nomadSummaryNotes(worst scoredWorkload, all []scoredWorkload) []string {
+	notes := []string{
+		fmt.Sprintf("graded %d nomad docker task(s); the job grade is the WEAKEST (a job is only as isolated as its most-exposed container). Weakest: %s at %d/100 (grade %s).",
+			len(all), nz(worst.spec.Target, "task"), worst.report.Score, worst.report.Grade),
+	}
+	sorted := make([]scoredWorkload, len(all))
+	copy(sorted, all)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].report.Score < sorted[j].report.Score })
+	rows := make([]string, len(sorted))
+	for i, w := range sorted {
+		rows[i] = fmt.Sprintf("%s = %d/100 (%s)", nz(w.spec.Target, "task"), w.report.Score, w.report.Grade)
+	}
+	notes = append(notes, "per-task: "+strings.Join(rows, "; "))
+	return notes
+}
+
+// --------------------------------------------------------------------------- //
+// Nomad job JSON document model (api.Job, capitalized field names).
+// --------------------------------------------------------------------------- //
+
+type nomadWrapper struct {
+	Job *nomadJob `json:"Job"`
+}
+
+type nomadJob struct {
+	ID         string           `json:"ID"`
+	Name       string           `json:"Name"`
+	TaskGroups []nomadTaskGroup `json:"TaskGroups"`
+}
+
+type nomadTaskGroup struct {
+	Name     string         `json:"Name"`
+	Networks []nomadNetwork `json:"Networks"`
+	Tasks    []nomadTask    `json:"Tasks"`
+}
+
+type nomadNetwork struct {
+	Mode string `json:"Mode"`
+}
+
+type nomadTask struct {
+	Name   string          `json:"Name"`
+	Driver string          `json:"Driver"`
+	User   string          `json:"User"`
+	Config json.RawMessage `json:"Config"`
+}
+
+// nomadDockerConfig is the security-relevant subset of a docker-driver task's
+// `config` block. Field names are the driver's HCL keys (lowercase). Scalars that
+// may arrive as a bool OR a quoted string (HCL2 vs. hand-authored JSON) decode
+// through nomadBool.
+type nomadDockerConfig struct {
+	Image          string             `json:"image"`
+	Privileged     nomadBool          `json:"privileged"`
+	CapAdd         []string           `json:"cap_add"`
+	CapDrop        []string           `json:"cap_drop"`
+	NetworkMode    string             `json:"network_mode"`
+	Volumes        []string           `json:"volumes"`
+	Mounts         []nomadDockerMount `json:"mount"`
+	PidMode        string             `json:"pid_mode"`
+	IpcMode        string             `json:"ipc_mode"`
+	SecurityOpt    []string           `json:"security_opt"`
+	UsernsMode     string             `json:"userns_mode"`
+	ReadonlyRootfs nomadBool          `json:"readonly_rootfs"`
+}
+
+// nomadDockerMount mirrors a docker-driver `mount` block. Only a bind mount whose
+// source is a host path can expose the control socket or a sensitive host path.
+type nomadDockerMount struct {
+	Type   string `json:"type"`
+	Target string `json:"target"`
+	Source string `json:"source"`
+}
+
+// nomadBool decodes a value that may be a JSON bool OR a quoted "true"/"false"
+// string. An absent/null/unparseable value decodes to a nil pointer (unknown),
+// so the scorers grade it fail-closed.
+type nomadBool struct{ v *bool }
+
+func (n *nomadBool) UnmarshalJSON(b []byte) error {
+	switch strings.Trim(strings.TrimSpace(string(b)), `"`) {
+	case "true":
+		t := true
+		n.v = &t
+	case "false":
+		f := false
+		n.v = &f
+	}
+	return nil
+}
+
+func (n nomadBool) ptr() *bool { return n.v }
+
+// specFromNomadTask maps one Nomad task (plus its group networking) to a graded
+// Spec. ok is false for a non-docker task (no container isolation posture to
+// grade). The mapping mirrors SpecFromCompose: the docker driver applies Docker's
+// defaults (default seccomp profile, default capability set, egress-capable
+// bridge network) unless the config overrides them.
+func specFromNomadTask(g nomadTaskGroup, t nomadTask) (Spec, bool) {
+	if !strings.EqualFold(strings.TrimSpace(t.Driver), "docker") {
+		return Spec{}, false
+	}
+	var cfg nomadDockerConfig
+	if len(t.Config) > 0 {
+		if err := json.Unmarshal(t.Config, &cfg); err != nil {
+			return Spec{}, false
+		}
+	}
+
+	target := nz(g.Name, "group") + "/" + nz(t.Name, "task")
+	s := Spec{Source: "nomad", Target: target, Image: cfg.Image}
+
+	// --- user (task-level User; docker driver runs the container as it) --------
+	switch u := strings.TrimSpace(t.User); {
+	case u == "":
+		s.RunAsNonRoot = Unknown
+		s.Notes = append(s.Notes, "no task user set; the image default may be root")
+	case u == "0" || strings.HasPrefix(u, "0:") || u == "root" || strings.HasPrefix(u, "root:"):
+		s.RunAsNonRoot = No
+		s.User = u
+	default:
+		s.RunAsNonRoot = Yes
+		s.User = u
+	}
+
+	// --- capabilities / privilege ------------------------------------------
+	s.Privileged = triFromPtr(cfg.Privileged.ptr())
+	s.CapDropAll = No
+	for _, c := range cfg.CapDrop {
+		if strings.EqualFold(strings.TrimSpace(c), "ALL") {
+			s.CapDropAll = Yes
+		}
+	}
+	for _, c := range cfg.CapAdd {
+		if c = strings.TrimSpace(c); c != "" {
+			s.CapAdd = append(s.CapAdd, strings.ToUpper(c))
+		}
+	}
+
+	// --- seccomp / no-new-privileges ---------------------------------------
+	// The docker driver applies Docker's DEFAULT seccomp profile unless a
+	// security_opt disables it (mirrors the compose/docker adapters).
+	s.Seccomp = "confined"
+	for _, opt := range cfg.SecurityOpt {
+		low := strings.ToLower(strings.TrimSpace(opt))
+		switch {
+		case strings.HasPrefix(low, "no-new-privileges"):
+			s.NoNewPrivs = Yes
+		case strings.HasPrefix(low, "seccomp"):
+			if strings.Contains(low, "unconfined") {
+				s.Seccomp = "unconfined"
+			} else {
+				s.Seccomp = "confined"
+			}
+		}
+	}
+	if s.Privileged == Yes {
+		// --privileged disables seccomp and grants the full capability set.
+		s.Seccomp = "unconfined"
+	}
+
+	// --- read-only rootfs ---------------------------------------------------
+	s.ReadonlyRoot = triFromPtr(cfg.ReadonlyRootfs.ptr())
+
+	// --- network ------------------------------------------------------------
+	// The docker driver's config.network_mode governs the container network. When
+	// it is unset and the group declares a network block, the task shares the
+	// group's namespace, so fall back to the group mode. Both unset = the default
+	// bridge network (egress-capable).
+	netMode := strings.TrimSpace(cfg.NetworkMode)
+	if netMode == "" && len(g.Networks) > 0 {
+		netMode = strings.TrimSpace(g.Networks[0].Mode)
+	}
+	switch strings.ToLower(netMode) {
+	case "none":
+		s.NetworkMode = "none"
+	case "host":
+		s.NetworkMode = "host"
+		s.HostNetwork = Yes
+	case "":
+		s.NetworkMode = "bridge"
+	default:
+		s.NetworkMode = netMode
+	}
+	if s.HostNetwork != Yes {
+		s.HostNetwork = No
+	}
+
+	// --- namespaces ---------------------------------------------------------
+	s.HostPID = boolTri(strings.EqualFold(strings.TrimSpace(cfg.PidMode), "host"))
+	s.HostIPC = boolTri(strings.EqualFold(strings.TrimSpace(cfg.IpcMode), "host"))
+	if strings.EqualFold(strings.TrimSpace(cfg.UsernsMode), "host") {
+		s.Notes = append(s.Notes, "userns_mode=host: the container shares the host user namespace (no uid remap)")
+	}
+
+	// --- docker.sock / host mounts ------------------------------------------
+	s.DockerSock = No
+	seen := map[string]bool{}
+	// volumes: "host:container[:mode]" (compose-style).
+	for _, v := range cfg.Volumes {
+		parts := strings.SplitN(v, ":", 3)
+		src := strings.TrimSpace(parts[0])
+		dst := ""
+		if len(parts) > 1 {
+			dst = strings.TrimSpace(parts[1])
+		}
+		if isControlSocket(src) || isControlSocket(dst) {
+			s.DockerSock = Yes
+		}
+		if isSensitiveHostPath(src) && !seen[src] {
+			seen[src] = true
+			s.HostPathMounts = append(s.HostPathMounts, src)
+		}
+	}
+	// mount blocks: only a bind mount exposes a host source path.
+	for _, m := range cfg.Mounts {
+		if !strings.EqualFold(strings.TrimSpace(m.Type), "bind") {
+			continue
+		}
+		src := strings.TrimSpace(m.Source)
+		if isControlSocket(src) || isControlSocket(strings.TrimSpace(m.Target)) {
+			s.DockerSock = Yes
+		}
+		if isSensitiveHostPath(src) && !seen[src] {
+			seen[src] = true
+			s.HostPathMounts = append(s.HostPathMounts, src)
+		}
+	}
+
+	return s, true
+}

--- a/internal/host/scan/nomad_test.go
+++ b/internal/host/scan/nomad_test.go
@@ -1,0 +1,271 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+// nomadHardenedJob mimics `nomad job run -output` for a job whose single docker
+// task is fully hardened: non-root user, drop ALL capabilities, default seccomp
+// profile, network=none, read-only rootfs, no docker.sock. The `-output` form
+// wraps the job as {"Job": {...}} and the driver `config` block uses lowercase
+// HCL keys.
+const nomadHardenedJob = `{
+  "Job": {
+    "ID": "web",
+    "Name": "web",
+    "TaskGroups": [
+      {
+        "Name": "app",
+        "Networks": [{"Mode": "none"}],
+        "Tasks": [
+          {
+            "Name": "server",
+            "Driver": "docker",
+            "User": "1000",
+            "Config": {
+              "image": "web:1",
+              "privileged": false,
+              "cap_drop": ["ALL"],
+              "network_mode": "none",
+              "readonly_rootfs": true,
+              "security_opt": ["no-new-privileges"]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}`
+
+// nomadPrivilegedJob mimics a raw api.Job document (no {"Job": ...} wrapper) with
+// a privileged docker task that host-mounts the docker socket and shares the host
+// network/PID namespaces — the worst posture.
+const nomadPrivilegedJob = `{
+  "ID": "legacy",
+  "Name": "legacy",
+  "TaskGroups": [
+    {
+      "Name": "ci",
+      "Tasks": [
+        {
+          "Name": "runner",
+          "Driver": "docker",
+          "Config": {
+            "image": "docker:dind",
+            "privileged": true,
+            "network_mode": "host",
+            "pid_mode": "host",
+            "volumes": ["/var/run/docker.sock:/var/run/docker.sock"]
+          }
+        }
+      ]
+    }
+  ]
+}`
+
+// nomadMixedJob pairs a hardened task with a porous one across two groups; the
+// aggregate must reflect the WEAKEST task. It also carries a non-docker (exec)
+// task that must be skipped.
+const nomadMixedJob = `{
+  "Job": {
+    "Name": "mixed",
+    "TaskGroups": [
+      {
+        "Name": "safe",
+        "Networks": [{"Mode": "none"}],
+        "Tasks": [
+          {
+            "Name": "api",
+            "Driver": "docker",
+            "User": "65532",
+            "Config": {
+              "image": "api:1",
+              "cap_drop": ["ALL"],
+              "network_mode": "none",
+              "readonly_rootfs": true
+            }
+          },
+          {
+            "Name": "sidecar",
+            "Driver": "exec",
+            "Config": {"command": "/bin/true"}
+          }
+        ]
+      },
+      {
+        "Name": "porous",
+        "Tasks": [
+          {
+            "Name": "worker",
+            "Driver": "docker",
+            "Config": {
+              "image": "worker:1",
+              "privileged": true,
+              "network_mode": "host",
+              "mount": [{"type": "bind", "source": "/var/run/docker.sock", "target": "/var/run/docker.sock"}]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}`
+
+// nomadBaselineJob is a docker task with NO security config at all: the docker
+// driver defaults apply (default seccomp profile, default capability set, bridge
+// network, image-default user, writable rootfs).
+const nomadBaselineJob = `{
+  "Job": {
+    "Name": "baseline",
+    "TaskGroups": [
+      {
+        "Name": "cache",
+        "Tasks": [
+          {"Name": "redis", "Driver": "docker", "Config": {"image": "redis:7"}}
+        ]
+      }
+    ]
+  }
+}`
+
+func gradeNomad(t *testing.T, raw string) (Report, Spec) {
+	t.Helper()
+	specs, err := SpecsFromNomad([]byte(raw))
+	if err != nil {
+		t.Fatalf("SpecsFromNomad: %v", err)
+	}
+	report, worst, err := AggregateNomad(specs, "job.nomad.json")
+	if err != nil {
+		t.Fatalf("AggregateNomad: %v", err)
+	}
+	return report, worst
+}
+
+func TestNomadHardenedJobGradesA(t *testing.T) {
+	report, _ := gradeNomad(t, nomadHardenedJob)
+	if report.Grade != "A" {
+		t.Fatalf("hardened nomad job: got grade %s (%d/100), want A; notes: %v", report.Grade, report.Score, report.Notes)
+	}
+	if report.Score != 100 {
+		t.Errorf("hardened nomad job: got %d/100, want 100", report.Score)
+	}
+	if report.Source != "nomad" {
+		t.Errorf("source = %q, want nomad", report.Source)
+	}
+}
+
+func TestNomadPrivilegedDockerSockGradesF(t *testing.T) {
+	report, worst := gradeNomad(t, nomadPrivilegedJob)
+	if report.Grade != "F" {
+		t.Fatalf("privileged nomad job: got grade %s (%d/100), want F", report.Grade, report.Score)
+	}
+	if worst.DockerSock != Yes {
+		t.Errorf("docker.sock not detected on privileged task: %+v", worst)
+	}
+	if worst.Privileged != Yes {
+		t.Errorf("privileged not detected: %+v", worst)
+	}
+	if worst.HostNetwork != Yes || worst.HostPID != Yes {
+		t.Errorf("host network/PID not detected: hostNet=%v hostPID=%v", worst.HostNetwork, worst.HostPID)
+	}
+}
+
+func TestNomadWeakestTaskWins(t *testing.T) {
+	report, worst := gradeNomad(t, nomadMixedJob)
+	if report.Grade != "F" {
+		t.Fatalf("mixed nomad job: got grade %s (%d/100), want F (weakest task governs)", report.Grade, report.Score)
+	}
+	if !strings.Contains(worst.Target, "worker") {
+		t.Errorf("weakest task = %q, want the porous worker", worst.Target)
+	}
+	// The exec sidecar and the hardened api task must both be present in the
+	// per-task roll-up; the exec task is skipped (only 2 docker tasks graded).
+	joined := strings.Join(report.Notes, " ")
+	if !strings.Contains(joined, "graded 2 nomad docker task") {
+		t.Errorf("expected 2 docker tasks graded (exec skipped); notes: %v", report.Notes)
+	}
+}
+
+func TestNomadHostNetworkPenalty(t *testing.T) {
+	// A docker task hardened in every dimension EXCEPT host networking must lose
+	// the network dimension relative to the fully hardened job.
+	const hostNet = `{"Job":{"Name":"n","TaskGroups":[{"Name":"g","Tasks":[
+      {"Name":"t","Driver":"docker","User":"1000","Config":{
+        "cap_drop":["ALL"],"network_mode":"host","readonly_rootfs":true}}]}]}}`
+	report, worst := gradeNomad(t, hostNet)
+	if worst.HostNetwork != Yes {
+		t.Fatalf("host network not detected: %+v", worst)
+	}
+	if report.Score >= 100 {
+		t.Errorf("host-network job should not reach 100; got %d", report.Score)
+	}
+	// host network zeroes both the network dimension and host-namespace dimension.
+	full, _ := gradeNomad(t, nomadHardenedJob)
+	if report.Score >= full.Score {
+		t.Errorf("host-network job (%d) should score below the network=none job (%d)", report.Score, full.Score)
+	}
+}
+
+func TestNomadBaselineDefaults(t *testing.T) {
+	// A bare docker task with no security config grades the docker DEFAULTS: the
+	// default seccomp profile PASSES (confined), the default capability set and
+	// bridge network are weak, user/rootfs unknown -> a mid/low D score.
+	report, worst := gradeNomad(t, nomadBaselineJob)
+	if worst.Seccomp != "confined" {
+		t.Errorf("baseline seccomp = %q, want confined (docker default profile)", worst.Seccomp)
+	}
+	if worst.NetworkMode != "bridge" {
+		t.Errorf("baseline network = %q, want bridge (docker default)", worst.NetworkMode)
+	}
+	if worst.RunAsNonRoot != Unknown {
+		t.Errorf("baseline user = %v, want Unknown (image default not pinned)", worst.RunAsNonRoot)
+	}
+	if report.Grade != "D" {
+		t.Errorf("baseline nomad task: got grade %s (%d/100), want D", report.Grade, report.Score)
+	}
+}
+
+func TestNomadBoolAsString(t *testing.T) {
+	// HCL2 renders bools as JSON bools, but a hand-authored API job may quote
+	// them. nomadBool must accept "true"/"false" strings.
+	const quoted = `{"Job":{"Name":"n","TaskGroups":[{"Name":"g","Tasks":[
+      {"Name":"t","Driver":"docker","Config":{
+        "privileged":"true","readonly_rootfs":"false"}}]}]}}`
+	specs, err := SpecsFromNomad([]byte(quoted))
+	if err != nil {
+		t.Fatalf("SpecsFromNomad: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("got %d specs, want 1", len(specs))
+	}
+	if specs[0].Privileged != Yes {
+		t.Errorf("privileged=\"true\" not decoded: %v", specs[0].Privileged)
+	}
+	if specs[0].ReadonlyRoot != No {
+		t.Errorf("readonly_rootfs=\"false\" not decoded: %v", specs[0].ReadonlyRoot)
+	}
+}
+
+func TestNomadNoDockerTasksIsError(t *testing.T) {
+	// A job with only non-docker drivers has nothing to grade: fail-closed (an
+	// error), not a silent pass.
+	const execOnly = `{"Job":{"Name":"n","TaskGroups":[{"Name":"g","Tasks":[
+      {"Name":"t","Driver":"exec","Config":{"command":"/bin/true"}}]}]}}`
+	specs, err := SpecsFromNomad([]byte(execOnly))
+	if err != nil {
+		t.Fatalf("SpecsFromNomad: %v", err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("exec task should be skipped; got %d specs", len(specs))
+	}
+	if _, _, err := AggregateNomad(specs, "job"); err == nil {
+		t.Error("AggregateNomad on an empty task set must error (fail-closed)")
+	}
+}
+
+func TestNomadMalformedJSONErrors(t *testing.T) {
+	if _, err := SpecsFromNomad([]byte("{not json")); err == nil {
+		t.Error("malformed JSON must return a parse error")
+	}
+}


### PR DESCRIPTION
## What

Extends the \`ironctl scan\` wedge to a new artifact class and audience — **HashiCorp Nomad** — with **zero new grader logic**. Same adapter-not-a-new-grader pattern as \`scan --helm\` (IRO-501) and \`scan --terraform\` (IRO-504): parse the artifact, extract each container workload's effective security config, grade with the existing container scorer, aggregate to the weakest workload.

## How

- **`SpecsFromNomad`** (`internal/host/scan/nomad.go`): parses a Nomad job JSON — the `nomad job run -output` wrapper `{"Job":{...}}` or a raw `api.Job` document — and maps every **docker-driver** task's `config` block onto the same normalized `Spec` the docker/compose adapters feed the scorer:
  - `privileged`, `cap_add`/`cap_drop`, `network_mode`, `volumes`/`mount`, `pid_mode`/`ipc_mode`, `security_opt` (seccomp / no-new-privileges), `userns_mode`, `readonly_rootfs`; task-level `User`.
  - Non-docker drivers (exec/raw_exec/java/qemu) carry no comparable container-isolation posture and are skipped.
  - `network_mode` falls back to the task group's `network { mode }` when unset; docker defaults apply otherwise (default seccomp profile, default capability set, egress-capable bridge).
- **`AggregateNomad`**: weakest-task rollup — a job is only as isolated as its most-exposed container (consistent with helm/terraform). Reports `<group>/<task>` as the workload target and lists every task's score in the notes.
- **CLI** (`cmd/ironctl/scan.go`): `--nomad PATH` (+ `--nomad-bin`) with `--json`/`--sarif`/`--badge`/`--badge-json`/`--md` and `--min-score` CI-gate parity. JSON is the daemon-free primary path; a `.hcl`/`.nomad` file is rendered via `nomad job run -output` when the nomad binary is on PATH. **Fail-OPEN** on load/parse/tooling errors (diagnostic + exit 0), but `--min-score` still gates once tasks are graded.
- `nomadBool` tolerates bool-or-quoted-string scalars (HCL2 vs. hand-authored API JSON) — the "provider fields can be STRING-typed" gotcha.

## Verification

- New `nomad_test.go` (8 tests): hardened job → **100/A**, privileged + docker.sock → **0/F**, weakest-task-wins, host-network penalty, docker-defaults baseline → **D**, bool-as-string decode, exec-only fail-closed (empty set errors), malformed JSON errors.
- `CGO_ENABLED=1 go test ./internal/host/scan/ ./cmd/ironctl/` → **244 passed**; `go vet` clean.
- End-to-end against the built binary: hardened job passes `--min-score 90`; privileged job scores 0/F and trips the gate (exit 1); missing-file and HCL-without-nomad-binary fail open (exit 0); `--json` parity confirmed.

## Security lenses

- **Fail-closed grading**: unknown postures score as insecure; a job with no gradeable docker task is an error, not a silent pass. No trust boundary touched — this is a local, read-only static analyzer over a config file (no control-plane, no daemon, no network).

Closes IRO-507.