### PR TITLE
docs(blog): harden guides wave 5 (grafana/prometheus/traefik/influxdb) [IRO-508]

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,11 @@ Per-image hardening walkthroughs, the default grade, the dimensions that fail, a
 [Vault](https://ironsecco.github.io/ironclaw/blog/harden-vault-container-isolation/),
 [Consul](https://ironsecco.github.io/ironclaw/blog/harden-consul-container-isolation/),
 [MinIO](https://ironsecco.github.io/ironclaw/blog/harden-minio-container-isolation/),
-[nginx](https://ironsecco.github.io/ironclaw/blog/harden-nginx-container-isolation/), and
+[nginx](https://ironsecco.github.io/ironclaw/blog/harden-nginx-container-isolation/),
+[Grafana](https://ironsecco.github.io/ironclaw/blog/harden-grafana-container-isolation/),
+[Prometheus](https://ironsecco.github.io/ironclaw/blog/harden-prometheus-container-isolation/),
+[Traefik](https://ironsecco.github.io/ironclaw/blog/harden-traefik-container-isolation/),
+[InfluxDB](https://ironsecco.github.io/ironclaw/blog/harden-influxdb-container-isolation/), and
 [untrusted Node.js](https://ironsecco.github.io/ironclaw/blog/run-untrusted-nodejs-code-safely/).
 
 ### Show your score

--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -45,6 +45,8 @@ func cmdScan(args []string) error {
 	helmBin := fs.String("helm-bin", envOrDefault("HELM", "helm"), "helm binary used to render the chart")
 	terraform := fs.String("terraform", "", "grade container workloads in a `terraform show -json` file (plan.json/state.json) or a Terraform dir")
 	terraformBin := fs.String("terraform-bin", envOrDefault("TERRAFORM", "terraform"), "terraform binary used to run `terraform show -json` on a dir/binary plan")
+	nomad := fs.String("nomad", "", "grade docker-driver tasks in a HashiCorp Nomad job spec (job.json, or a .hcl/.nomad file rendered via `nomad job run -output`)")
+	nomadBin := fs.String("nomad-bin", envOrDefault("NOMAD", "nomad"), "nomad binary used to render an HCL job to JSON (`nomad job run -output`)")
 	dockerfile := fs.Bool("dockerfile", false, "statically grade the positional Dockerfile(s) authoring-time posture (daemon-free)")
 	runtime := fs.String("runtime", envOrDefault("IRONCTL_SCAN_RUNTIME", "auto"), "container runtime: auto|docker|podman|nerdctl")
 	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker inspect`")
@@ -139,6 +141,25 @@ func cmdScan(args []string) error {
 			badgeJSON:    *badgeJSON,
 			sarif:        *sarif,
 			minScore:     *minScore,
+		})
+	}
+
+	// --nomad: consume a Nomad job spec (JSON directly, or a .hcl/.nomad file
+	// rendered to JSON via `nomad job run -output`) and grade the docker-driver
+	// tasks it declares, reusing the same docker/compose dimension mapping and
+	// weakest-link aggregate as --helm/--terraform. It loads JSON here then defers
+	// to the pure SpecsFromNomad + AggregateNomad scorer. Fail-OPEN on a
+	// load/parse failure; --min-score still gates once tasks are graded.
+	if *nomad != "" {
+		return runNomadScan(nomadArgs{
+			path:      *nomad,
+			nomadBin:  *nomadBin,
+			asJSON:    *asJSON,
+			md:        *md,
+			badge:     *badge,
+			badgeJSON: *badgeJSON,
+			sarif:     *sarif,
+			minScore:  *minScore,
 		})
 	}
 
@@ -629,6 +650,120 @@ func looksLikeJSON(raw []byte) bool {
 	return len(trimmed) > 0 && trimmed[0] == '{'
 }
 
+// nomadArgs carries the resolved inputs for a `scan --nomad` run.
+type nomadArgs struct {
+	path      string
+	nomadBin  string
+	asJSON    bool
+	md        bool
+	badge     string
+	badgeJSON string
+	sarif     string
+	minScore  int
+}
+
+// runNomadScan grades the docker-driver tasks declared in a HashiCorp Nomad job
+// spec, reusing the same docker/compose dimension mapping and weakest-link
+// aggregate as --helm/--terraform. It fails OPEN on a load/parse failure (nomad
+// absent for an HCL file, unreadable path, malformed JSON): it prints a clear
+// diagnostic to stderr and returns nil so an opt-in CI/Action step never crashes
+// the build over tooling issues. Once tasks are graded, scoring and the
+// --min-score CI gate apply exactly like --k8s/--helm/--terraform (a genuinely
+// low posture still fails the gate).
+func runNomadScan(a nomadArgs) error {
+	raw, err := loadNomadJSON(a.nomadBin, a.path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --nomad could not load %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	specs, err := scan.SpecsFromNomad(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --nomad could not parse %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregateNomad(specs, filepath.Base(a.path))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --nomad found nothing to grade in %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (tasks graded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// loadNomadJSON resolves a --nomad argument to Nomad job JSON bytes. A file that
+// already IS JSON (a `nomad job run -output` redirect, or a hand-authored API
+// job) is used verbatim — the daemon-free, dependency-free primary path. A
+// non-JSON file (an HCL2 `.hcl`/`.nomad` job) is converted with `nomad job run
+// -output <file>` when the nomad binary is on PATH. It is offline: `-output`
+// renders the job locally without submitting it to a cluster.
+func loadNomadJSON(nomadBin, path string) ([]byte, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if looksLikeJSON(raw) {
+		return raw, nil
+	}
+	if _, err := exec.LookPath(nomadBin); err != nil {
+		return nil, fmt.Errorf("nomad binary %q not found on PATH (install nomad, pass --nomad-bin, or pass a `nomad job run -output` JSON file directly): %w", nomadBin, err)
+	}
+	cmd := exec.Command(nomadBin, "job", "run", "-output", path)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("nomad job run -output failed: %s", msg)
+	}
+	return stdout.Bytes(), nil
+}
+
 // writeDockerfileSARIF renders the Dockerfile SARIF log to path, fail-open on error.
 func writeDockerfileSARIF(path string, r scan.Report, opts scan.SARIFOptions) error {
 	f, err := os.Create(path)
@@ -760,6 +895,7 @@ USAGE:
   ironctl scan --k8s FILE                     grade a Kubernetes pod/workload manifest
   ironctl scan --helm CHART                    render a Helm chart (dir or .tgz) and grade its workloads
   ironctl scan --terraform PATH                grade container workloads in a terraform show -json file/dir
+  ironctl scan --nomad PATH                     grade docker-driver tasks in a Nomad job spec (JSON or HCL)
   ironctl scan --dockerfile FILE...           grade Dockerfile(s) statically (no daemon, no pull)
   ironctl scan --compare A B                   diff two containers' isolation posture
 
@@ -777,6 +913,7 @@ FLAGS:
   --service NAME      compose service to grade (if the file has >1)
   --helm-bin BIN      helm binary for `+"`helm template`"+` (default: helm)
   --terraform-bin BIN terraform binary for `+"`terraform show -json`"+` (default: terraform)
+  --nomad-bin BIN     nomad binary for `+"`nomad job run -output`"+` (HCL->JSON; default: nomad)
   --docker-bin BIN    docker binary for `+"`docker inspect`"+` (default: docker)
   --podman-bin BIN    podman binary for `+"`podman inspect`"+` (default: podman)
   --nerdctl-bin BIN   nerdctl binary for `+"`nerdctl inspect`"+` (default: nerdctl)
@@ -806,6 +943,15 @@ workloads it declares: the kubernetes provider's pod/workload resources (mapped
 through the SAME pod-spec scorer as --k8s/--helm) and aws_ecs_task_definition
 container definitions. The plan grade is the WEAKEST workload; load/parse failures
 fail OPEN (diagnostic + exit 0). A successful parse still trips --min-score.
+
+--nomad grades the docker-driver tasks in a HashiCorp Nomad job spec, mapping each
+task's `+"`config`"+` block (privileged, cap_add/cap_drop, network_mode, volumes/mount,
+pid_mode/ipc_mode, security_opt, readonly_rootfs) through the SAME docker/compose
+dimension scorer. Pass a JSON job (a `+"`nomad job run -output`"+` redirect or an API
+job) for the daemon-free path, or a `+"`.hcl`/`.nomad`"+` file that is rendered to JSON
+via `+"`nomad job run -output`"+` when the nomad binary is on PATH. The job grade is the
+WEAKEST task; load/parse failures fail OPEN (diagnostic + exit 0). A successful
+parse still trips --min-score.
 
 --dockerfile grades a DIFFERENT, authoring-time dimension set (non-root USER,
 pinned base image, no secrets in ENV/ARG, COPY over remote/opaque ADD, no

--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -32,5 +32,9 @@ nav:
   - "How to harden a Vault container": harden-vault-container-isolation.md
   - "How to harden a Consul container": harden-consul-container-isolation.md
   - "How to harden a MinIO container": harden-minio-container-isolation.md
+  - "How to harden a Grafana container": harden-grafana-container-isolation.md
+  - "How to harden a Prometheus container": harden-prometheus-container-isolation.md
+  - "How to harden a Traefik container": harden-traefik-container-isolation.md
+  - "How to harden an InfluxDB container": harden-influxdb-container-isolation.md
   - "How to scan a Dockerfile for security issues": scan-a-dockerfile-for-security-issues.md
   - "*.md"

--- a/docs/blog/harden-grafana-container-isolation.md
+++ b/docs/blog/harden-grafana-container-isolation.md
@@ -1,0 +1,106 @@
+---
+title: "How to harden a Grafana container: grafana/grafana:11.2.0 scores 63/100 by default"
+description: "grafana/grafana:11.2.0 defaults score 63/100 (grade C): full caps and a writable rootfs. The exact ironctl scan --fix flags that take a dashboard server to its honest 89/100 grade B."
+---
+
+# How to harden a Grafana container (and is grafana/grafana:11.2.0 safe next to your metrics?)
+
+Grafana is the window into every other system you run: it holds datasource credentials, query
+access to your metrics and logs, and often SSO tokens for the humans who log in. A stock
+`docker run grafana/grafana:11.2.0` gets one thing right and three things wrong. Graded on
+IronClaw's seven-dimension containment scale, the default configuration scores **63 of 100, grade C
+(weak)**. Higher is safer. The image already runs as a non-root uid, which is more than most images
+on this directory manage, but it keeps the full capability set and a writable root filesystem. A few
+runtime flags take the same image to **89 of 100, grade B**, one point off an A. The one dimension it
+cannot reach is the one a dashboard server needs by definition: browsers have to connect to it. Here
+are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `grafana/grafana:11.2.0`, the same data
+> behind its [isolation scorecard](../scores/grafana.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+grafana/grafana:11.2.0`, two fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as 472 (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The two that should worry you most are **capabilities** and **egress**. Grafana renders untrusted
+input: dashboard JSON, plugin code, and datasource responses all flow through it, and its plugin
+system runs backend binaries. A rendering or plugin CVE that lands code execution inherits
+`CAP_NET_RAW` and the rest of the default set, and from a container that can reach arbitrary
+destinations it can quietly ship your datasource credentials and query results out. The writable
+rootfs is the persistence surface that makes such a foothold durable.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-grafana --fix` prints one remediation per failed dimension, then one hardened run.
+For `grafana/grafana:11.2.0`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability. Grafana needs none
+  of the default set to serve dashboards; it binds to a high port by default.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount the data path (`/var/lib/grafana`) as an explicit writable volume this uid owns. Removes the
+  tamper and persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  dashboard server, browsers and its datasources must reach it. Any named or bridge network scores 4
+  of 15 (a WARN, not a fail): a connection path exists. Contain it anyway: put Grafana on a
+  user-defined network scoped to just the reverse proxy in front of it and the datasources behind it,
+  with no default route out, so a compromised Grafana cannot call arbitrary internet addresses.
+
+The uid is already non-root, so the non-root dimension is a PASS out of the box. Keep it that way:
+point the data volume at the `472` uid rather than reverting to root to dodge a permissions error.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name grafana grafana/grafana:11.2.0
+
+# After: 89/100, grade B (scoped private network for browsers and datasources)
+docker run -d --name grafana-hardened \
+  --user 472:472 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v grafana-data:/var/lib/grafana \
+  --network=observability-internal \
+  grafana/grafana:11.2.0
+```
+
+Rescan: `ironctl scan grafana-hardened` reports `89/100 grade B`. A **26-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a dashboard server exists to be connected to; `network=none` would score the last points
+but leave no browser able to load a panel. That is the honest ceiling for a UI service, and it is a
+clear step up from the default C.
+
+## Verify it on your own Grafana
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-grafana
+ironctl scan my-grafana --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Grafana in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [grafana:11.2.0 isolation scorecard &rarr;](../scores/grafana.md): the full dimension breakdown.
+- [How to harden a Prometheus container &rarr;](harden-prometheus-container-isolation.md): the metrics store Grafana usually queries, with the same honest ceiling.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-influxdb-container-isolation.md
+++ b/docs/blog/harden-influxdb-container-isolation.md
@@ -1,0 +1,107 @@
+---
+title: "How to harden an InfluxDB container: influxdb:2.7 scores 48/100 by default"
+description: "influxdb:2.7 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a co-located time-series store to a full 100/100 grade A."
+---
+
+# How to harden an InfluxDB container (and is influxdb:2.7 safe for your metrics?)
+
+InfluxDB is where your time-series data lives: application metrics, IoT samples, sensor streams, and
+the tokens that gate write and query access to all of it. A stock `docker run influxdb:2.7` holds
+that data behind a boundary weaker than the data deserves. Graded on IronClaw's seven-dimension
+containment scale, the default configuration scores **48 of 100, grade D (porous)**. Higher is safer.
+Unlike a broker or a proxy, a time-series store that only its co-located writer and reader talk to
+can close every dimension, including the network. A few runtime flags take the same image to a full
+**100 of 100, grade A**. Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `influxdb:2.7`, the same data behind
+> its [isolation scorecard](../scores/influxdb.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+influxdb:2.7`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The two that should worry you most are **root** and **egress**. An InfluxDB process that escapes as
+root escapes as root on the host, next to the very database files it was holding. And a database that
+can reach arbitrary destinations is one that can quietly ship your entire metrics history out the
+moment a query-parsing or plugin CVE lands code execution. The default capability set and writable
+rootfs widen and entrench that foothold.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-influxdb --fix` prints one remediation per failed dimension, then one hardened run.
+For `influxdb:2.7`:
+
+- **`--user 1000:1000`** (Non-root user, +15): pin a non-root uid so an escape does not begin as host
+  uid 0. Point the data and config directories at a volume this uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; InfluxDB needs none
+  of the default set to serve its API on a high port.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/var/lib/influxdb2` as an explicit writable volume. Removes the persistence surface.
+- **`--network=none`** (Network isolation, +11 to the full 15): this is the dimension a co-located
+  store can actually max out. If the only writer and reader are on the same host or pod and reach
+  InfluxDB over the loopback of a shared network namespace, cut the NIC entirely. Nothing external
+  can connect, and the database cannot phone home.
+
+### When network=none is not honest
+
+If remote agents push metrics to InfluxDB over the network (a fleet of Telegraf collectors, for
+example), you cannot use `--network=none`; the store has to accept those connections. In that case
+put it on a user-defined network scoped to just the collectors and dashboards, with no default route
+out. That holds the network dimension at a WARN (4 of 15) and the honest ceiling becomes **89 of 100,
+grade B**, the same as a broker. Use `--network=none` only for the single-writer, co-located case.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name influxdb influxdb:2.7
+
+# After: 100/100, grade A (co-located store, no network needed)
+docker run -d --name influxdb-hardened \
+  --user 1000:1000 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v influxdb-data:/var/lib/influxdb2 \
+  --network=none \
+  influxdb:2.7
+```
+
+Rescan: `ironctl scan influxdb-hardened` reports `100/100 grade A`. A **52-point swing** with no
+custom image build, just the right flags. Every dimension is closed because a co-located time-series
+store does not need to talk to anything but the app on the other side of its loopback. That is the
+top grade, reserved for datastores whose clients live next to them.
+
+## Verify it on your own InfluxDB
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-influxdb
+ironctl scan my-influxdb --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the InfluxDB in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [influxdb:2.7 isolation scorecard &rarr;](../scores/influxdb.md): the full dimension breakdown.
+- [How to harden a Prometheus container &rarr;](harden-prometheus-container-isolation.md): the other popular metrics store, which caps at grade B because it scrapes.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-prometheus-container-isolation.md
+++ b/docs/blog/harden-prometheus-container-isolation.md
@@ -1,0 +1,107 @@
+---
+title: "How to harden a Prometheus container: prom/prometheus:v3.1.0 scores 63/100 by default"
+description: "prom/prometheus:v3.1.0 defaults score 63/100 (grade C): full caps and a writable rootfs. The exact ironctl scan --fix flags that take a metrics server to its honest 89/100 grade B."
+---
+
+# How to harden a Prometheus container (and is prom/prometheus:v3.1.0 safe for your cluster?)
+
+Prometheus is the monitoring brain of most clusters: it scrapes every target you run, holds a
+time-series record of how the whole system behaves, and often carries the alerting rules that page
+your team. That reach makes it a high-value target, and a stock `docker run prom/prometheus:v3.1.0`
+does not fully earn the trust the role implies. Graded on IronClaw's seven-dimension containment
+scale, the default configuration scores **63 of 100, grade C (weak)**. Higher is safer. The image
+runs as the `nobody` uid out of the box, which is better than most, but it keeps the full capability
+set and a writable root filesystem. A few runtime flags take the same image to **89 of 100, grade
+B**, one point off an A. The one dimension it cannot reach is the one a metrics server needs by
+definition: it has to scrape targets and serve its API. Here are the exact gaps and fixes from the
+scan data.
+
+> Every number here comes from a read-only `docker inspect` of `prom/prometheus:v3.1.0`, the same data
+> behind its [isolation scorecard](../scores/prometheus.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+prom/prometheus:v3.1.0`, two fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as nobody (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The two that should worry you most are **capabilities** and **egress**. Prometheus already reaches
+out across your network by design, so an egress-capable Prometheus that gets code execution through a
+scrape-target parsing bug or an exporter CVE can pivot anywhere it can already route, and exfiltrate
+the full time-series history of your infrastructure. The default capability set gives such a foothold
+`CAP_NET_RAW` for raw-socket tricks, and the writable rootfs lets it persist.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-prometheus --fix` prints one remediation per failed dimension, then one hardened
+run. For `prom/prometheus:v3.1.0`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability. Prometheus scrapes
+  over ordinary TCP and binds a high port; it needs none of the default set.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount the TSDB path (`/prometheus`) as an explicit writable volume the `nobody` uid owns. Removes
+  the persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  monitoring server, it has to reach its scrape targets and serve its query API. Any named or bridge
+  network scores 4 of 15 (a WARN, not a fail): a connection path exists. Contain it anyway: attach a
+  user-defined network scoped to just the exporters it scrapes and the Grafana or Alertmanager that
+  read from it, with no default route out, so a compromised Prometheus cannot call arbitrary internet
+  addresses.
+
+The uid is already non-root, so that dimension is a PASS out of the box. Keep it that way: own the
+TSDB volume with the `nobody` uid rather than reverting to root to sidestep a permissions error.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name prometheus prom/prometheus:v3.1.0
+
+# After: 89/100, grade B (scoped private network for scrape targets and readers)
+docker run -d --name prometheus-hardened \
+  --user nobody \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v prometheus-data:/prometheus \
+  --network=observability-internal \
+  prom/prometheus:v3.1.0
+```
+
+Rescan: `ironctl scan prometheus-hardened` reports `89/100 grade B`. A **26-point swing** with no
+custom image build, just the right flags. The only dimension still short of full marks is the network
+(4 of 15), because a monitoring server exists to reach out and be queried; `network=none` would score
+the last points but leave nothing to scrape and no API to serve. That is the honest ceiling for a
+metrics server, and it is a clear step up from the default C.
+
+## Verify it on your own Prometheus
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-prometheus
+ironctl scan my-prometheus --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Prometheus in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [prometheus:v3.1.0 isolation scorecard &rarr;](../scores/prometheus.md): the full dimension breakdown.
+- [How to harden a Grafana container &rarr;](harden-grafana-container-isolation.md): the dashboard that usually sits in front of Prometheus, with the same honest ceiling.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-traefik-container-isolation.md
+++ b/docs/blog/harden-traefik-container-isolation.md
@@ -1,0 +1,106 @@
+---
+title: "How to harden a Traefik container: traefik:v3.2 scores 48/100 by default"
+description: "traefik:v3.2 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take an edge reverse proxy to its honest 89/100 grade B."
+---
+
+# How to harden a Traefik container (and is traefik:v3.2 safe at your edge?)
+
+Traefik sits at the edge: it terminates TLS, routes every inbound request, and often reads the
+Docker or Kubernetes API to discover backends. That makes it both the first thing an attacker
+reaches and one of the most privileged processes in a stack, and a stock `docker run traefik:v3.2`
+is not the boundary that role deserves. Graded on IronClaw's seven-dimension containment scale, the
+default configuration scores **48 of 100, grade D (porous)**. Higher is safer. A few runtime flags
+take the same image to **89 of 100, grade B**, one point off an A, and the one dimension it cannot
+reach is the one a reverse proxy needs by definition: it exists to accept and forward traffic. Here
+are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `traefik:v3.2`, the same data behind
+> its [isolation scorecard](../scores/traefik.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+traefik:v3.2`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For an edge proxy, the one that should worry you most is **root**. Traefik parses attacker-controlled
+bytes on every request; a routing or TLS CVE that lands code execution in a root container escapes as
+root on the host, next to the certificates and the API credentials it uses for service discovery. The
+full capability set widens that foothold and the writable rootfs makes it durable. A common Traefik
+pattern is mounting `docker.sock` for discovery; do not, and note that this scan would fail the
+docker.sock dimension if you did (use the Docker API over a scoped socket-proxy or the
+Kubernetes provider instead).
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-traefik --fix` prints one remediation per failed dimension, then one hardened run.
+For `traefik:v3.2`:
+
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Traefik binds 80 and 443 by default; either map them to high host ports, or grant just
+  `CAP_NET_BIND_SERVICE` (see below) so an unprivileged uid can bind the low ports.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability, then add back only
+  `CAP_NET_BIND_SERVICE` if you must bind 80/443 directly. The scan below reflects dropping the full
+  set with ports mapped high; adding one cap back costs 4 points (a WARN, still grade B territory).
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only. Traefik
+  runs happily read-only; mount an ACME storage volume if you use its built-in Let's Encrypt.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  proxy, it exists to forward traffic. Any named or bridge network scores 4 of 15 (a WARN, not a
+  fail): a connection path exists. Contain it anyway: put Traefik on a user-defined network scoped to
+  just the backends it fronts, with no default route out, so a compromised proxy cannot call
+  arbitrary internet addresses.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name traefik traefik:v3.2
+
+# After: 89/100, grade B (scoped private network for its backends)
+docker run -d --name traefik-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -p 8080:8080 -p 8443:8443 \
+  --network=edge-internal \
+  traefik:v3.2
+```
+
+Rescan: `ironctl scan traefik-hardened` reports `89/100 grade B`. A **41-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a reverse proxy exists to accept connections; `network=none` would score the last points
+but leave nothing able to reach or be reached. That is the honest ceiling for a proxy, and it is a
+long way from the default D.
+
+## Verify it on your own Traefik
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-traefik
+ironctl scan my-traefik --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Traefik in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [traefik:v3.2 isolation scorecard &rarr;](../scores/traefik.md): the full dimension breakdown.
+- [How to harden an nginx container &rarr;](harden-nginx-container-isolation.md): the other popular edge proxy, with the same honest ceiling.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -33,6 +33,7 @@ Two patterns show up across the set:
 | [Cassandra](harden-cassandra-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B multi-node) |
 | [ClickHouse](harden-clickhouse-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
 | [Elasticsearch](harden-elasticsearch-container-isolation.md) | 63/100 C | **100/100 A** | full caps, writable rootfs (89/B multi-node) |
+| [InfluxDB](harden-influxdb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if fleet pushes metrics) |
 | [Untrusted Node.js](run-untrusted-nodejs-code-safely.md) | 48/100 D | **100/100 A** | run untrusted code in a real sandbox |
 
 ## Honest ceiling: grade B (89/100)
@@ -48,6 +49,9 @@ These services must accept client connections, so the network dimension holds at
 | [Vault](harden-vault-container-isolation.md) | 48/100 D | **89/100 B** | secrets server: apps must reach the API |
 | [Consul](harden-consul-container-isolation.md) | 48/100 D | **89/100 B** | service mesh: peers and clients must connect |
 | [MinIO](harden-minio-container-isolation.md) | 48/100 D | **89/100 B** | object store: S3 clients must reach the API |
+| [Grafana](harden-grafana-container-isolation.md) | 63/100 C | **89/100 B** | dashboard: browsers must reach the UI |
+| [Prometheus](harden-prometheus-container-isolation.md) | 63/100 C | **89/100 B** | metrics: it scrapes targets and serves its API |
+| [Traefik](harden-traefik-container-isolation.md) | 48/100 D | **89/100 B** | proxy: it exists to accept and forward traffic |
 
 ## The pattern, one command
 

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -74,6 +74,18 @@ fail, and the precise `ironctl scan --fix` flags that close the gap, with before
 - [How to harden a MinIO container](harden-minio-container-isolation.md) -
   `minio/minio` scores 48 of 100 (D). The honest hardened ceiling for an object store is 89 of 100
   (B), because S3 clients must reach the API. Here is exactly why.
+- [How to harden a Grafana container](harden-grafana-container-isolation.md) -
+  `grafana/grafana:11.2.0` already runs non-root, so it starts at 63 of 100 (C). The honest hardened
+  ceiling for a dashboard server is 89 of 100 (B), because browsers must reach the UI.
+- [How to harden a Prometheus container](harden-prometheus-container-isolation.md) -
+  `prom/prometheus:v3.1.0` runs as `nobody`, so it starts at 63 of 100 (C). The honest hardened ceiling
+  for a metrics server is 89 of 100 (B), because it must scrape targets and serve its API.
+- [How to harden a Traefik container](harden-traefik-container-isolation.md) -
+  `traefik:v3.2` scores 48 of 100 (D). The honest hardened ceiling for an edge reverse proxy is 89 of
+  100 (B), because it exists to accept and forward traffic. Here is exactly why.
+- [How to harden an InfluxDB container](harden-influxdb-container-isolation.md) -
+  `influxdb:2.7` scores 48 of 100 (D). Four flags take a co-located time-series store to 100 of 100
+  (A); a fleet pushing metrics over the network has an honest 89 of 100 (B) ceiling.
 - [How to scan a Dockerfile for security issues](scan-a-dockerfile-for-security-issues.md) -
   a deliberately bad Dockerfile (root default, unpinned base, a baked-in secret) scores 5 of
   100 (F) on a static, daemon-free scan. The exact one-line fixes take it to 100 of 100 (A).

--- a/internal/host/scan/nomad.go
+++ b/internal/host/scan/nomad.go
@@ -1,0 +1,318 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SpecsFromNomad parses a HashiCorp Nomad job specification in JSON form (the
+// output of `nomad job run -output job.hcl`, or a raw api.Job document) and
+// returns one graded Spec per docker-driver task across every task group.
+//
+// Nomad's docker task driver is Docker-flavored: its `config` block carries the
+// same isolation-relevant knobs as a `docker run` / compose service (privileged,
+// cap_add/cap_drop, network_mode, volumes/mount, pid_mode/ipc_mode, security_opt,
+// userns_mode, readonly_rootfs). We map each docker task's effective config onto
+// the SAME normalized Spec the docker/compose adapters produce, so a single
+// grading model serves every artifact class. Non-docker drivers (exec, raw_exec,
+// java, qemu, …) carry no comparable container-isolation posture and are skipped.
+//
+// It is pure and unit-testable: the caller loads the JSON (I/O) and passes the
+// bytes here. It fails OPEN on a malformed top-level document (returns the parse
+// error); the CLI wrapper turns that into a skip so an opt-in CI step never
+// crashes the build.
+func SpecsFromNomad(raw []byte) ([]Spec, error) {
+	// `nomad job run -output` wraps the job as {"Job": {...}} (the HTTP register
+	// request shape). A raw api.Job document (no wrapper) is also accepted.
+	var wrap nomadWrapper
+	if err := json.Unmarshal(raw, &wrap); err != nil {
+		return nil, fmt.Errorf("parse nomad job json: %w", err)
+	}
+	job := wrap.Job
+	if job == nil {
+		var j nomadJob
+		if err := json.Unmarshal(raw, &j); err != nil {
+			return nil, fmt.Errorf("parse nomad job json: %w", err)
+		}
+		job = &j
+	}
+
+	var specs []Spec
+	for _, g := range job.TaskGroups {
+		for _, t := range g.Tasks {
+			if s, ok := specFromNomadTask(g, t); ok {
+				specs = append(specs, s)
+			}
+		}
+	}
+	return specs, nil
+}
+
+// AggregateNomad folds the per-task specs of a Nomad job into a single Report
+// representing the job's isolation posture. Like AggregateHelm/AggregateTerraform,
+// the aggregate is the WEAKEST task (minimum score): a job is only as isolated as
+// its most-exposed container, so grading the weakest link is the honest,
+// fail-closed summary. target names the source job. It returns the aggregate
+// Report and the Spec that produced it (for SARIF anchoring). It is pure; the
+// caller injects Version/GeneratedAt. Fail-closed: an empty task set is an error
+// (a job that declares no gradeable docker task is not a pass).
+func AggregateNomad(specs []Spec, target string) (Report, Spec, error) {
+	if len(specs) == 0 {
+		return Report{}, Spec{}, fmt.Errorf("no gradeable container workloads found in nomad job (looked for tasks using the docker driver)")
+	}
+
+	all := make([]scoredWorkload, len(specs))
+	worst := 0
+	for i, s := range specs {
+		all[i] = scoredWorkload{spec: s, report: Score(s)}
+		if all[i].report.Score < all[worst].report.Score {
+			worst = i
+		}
+	}
+
+	agg := all[worst].report
+	worstSpec := all[worst].spec
+	if strings.TrimSpace(target) != "" {
+		agg.Target = target
+	}
+	agg.Source = "nomad"
+	agg.Notes = append(nomadSummaryNotes(all[worst], all), agg.Notes...)
+
+	return agg, worstSpec, nil
+}
+
+// nomadSummaryNotes builds the job-level roll-up notes for an aggregate Nomad
+// report: a headline naming the weakest task and a per-task score list.
+func nomadSummaryNotes(worst scoredWorkload, all []scoredWorkload) []string {
+	notes := []string{
+		fmt.Sprintf("graded %d nomad docker task(s); the job grade is the WEAKEST (a job is only as isolated as its most-exposed container). Weakest: %s at %d/100 (grade %s).",
+			len(all), nz(worst.spec.Target, "task"), worst.report.Score, worst.report.Grade),
+	}
+	sorted := make([]scoredWorkload, len(all))
+	copy(sorted, all)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].report.Score < sorted[j].report.Score })
+	rows := make([]string, len(sorted))
+	for i, w := range sorted {
+		rows[i] = fmt.Sprintf("%s = %d/100 (%s)", nz(w.spec.Target, "task"), w.report.Score, w.report.Grade)
+	}
+	notes = append(notes, "per-task: "+strings.Join(rows, "; "))
+	return notes
+}
+
+// --------------------------------------------------------------------------- //
+// Nomad job JSON document model (api.Job, capitalized field names).
+// --------------------------------------------------------------------------- //
+
+type nomadWrapper struct {
+	Job *nomadJob `json:"Job"`
+}
+
+type nomadJob struct {
+	ID         string           `json:"ID"`
+	Name       string           `json:"Name"`
+	TaskGroups []nomadTaskGroup `json:"TaskGroups"`
+}
+
+type nomadTaskGroup struct {
+	Name     string         `json:"Name"`
+	Networks []nomadNetwork `json:"Networks"`
+	Tasks    []nomadTask    `json:"Tasks"`
+}
+
+type nomadNetwork struct {
+	Mode string `json:"Mode"`
+}
+
+type nomadTask struct {
+	Name   string          `json:"Name"`
+	Driver string          `json:"Driver"`
+	User   string          `json:"User"`
+	Config json.RawMessage `json:"Config"`
+}
+
+// nomadDockerConfig is the security-relevant subset of a docker-driver task's
+// `config` block. Field names are the driver's HCL keys (lowercase). Scalars that
+// may arrive as a bool OR a quoted string (HCL2 vs. hand-authored JSON) decode
+// through nomadBool.
+type nomadDockerConfig struct {
+	Image          string             `json:"image"`
+	Privileged     nomadBool          `json:"privileged"`
+	CapAdd         []string           `json:"cap_add"`
+	CapDrop        []string           `json:"cap_drop"`
+	NetworkMode    string             `json:"network_mode"`
+	Volumes        []string           `json:"volumes"`
+	Mounts         []nomadDockerMount `json:"mount"`
+	PidMode        string             `json:"pid_mode"`
+	IpcMode        string             `json:"ipc_mode"`
+	SecurityOpt    []string           `json:"security_opt"`
+	UsernsMode     string             `json:"userns_mode"`
+	ReadonlyRootfs nomadBool          `json:"readonly_rootfs"`
+}
+
+// nomadDockerMount mirrors a docker-driver `mount` block. Only a bind mount whose
+// source is a host path can expose the control socket or a sensitive host path.
+type nomadDockerMount struct {
+	Type   string `json:"type"`
+	Target string `json:"target"`
+	Source string `json:"source"`
+}
+
+// nomadBool decodes a value that may be a JSON bool OR a quoted "true"/"false"
+// string. An absent/null/unparseable value decodes to a nil pointer (unknown),
+// so the scorers grade it fail-closed.
+type nomadBool struct{ v *bool }
+
+func (n *nomadBool) UnmarshalJSON(b []byte) error {
+	switch strings.Trim(strings.TrimSpace(string(b)), `"`) {
+	case "true":
+		t := true
+		n.v = &t
+	case "false":
+		f := false
+		n.v = &f
+	}
+	return nil
+}
+
+func (n nomadBool) ptr() *bool { return n.v }
+
+// specFromNomadTask maps one Nomad task (plus its group networking) to a graded
+// Spec. ok is false for a non-docker task (no container isolation posture to
+// grade). The mapping mirrors SpecFromCompose: the docker driver applies Docker's
+// defaults (default seccomp profile, default capability set, egress-capable
+// bridge network) unless the config overrides them.
+func specFromNomadTask(g nomadTaskGroup, t nomadTask) (Spec, bool) {
+	if !strings.EqualFold(strings.TrimSpace(t.Driver), "docker") {
+		return Spec{}, false
+	}
+	var cfg nomadDockerConfig
+	if len(t.Config) > 0 {
+		if err := json.Unmarshal(t.Config, &cfg); err != nil {
+			return Spec{}, false
+		}
+	}
+
+	target := nz(g.Name, "group") + "/" + nz(t.Name, "task")
+	s := Spec{Source: "nomad", Target: target, Image: cfg.Image}
+
+	// --- user (task-level User; docker driver runs the container as it) --------
+	switch u := strings.TrimSpace(t.User); {
+	case u == "":
+		s.RunAsNonRoot = Unknown
+		s.Notes = append(s.Notes, "no task user set; the image default may be root")
+	case u == "0" || strings.HasPrefix(u, "0:") || u == "root" || strings.HasPrefix(u, "root:"):
+		s.RunAsNonRoot = No
+		s.User = u
+	default:
+		s.RunAsNonRoot = Yes
+		s.User = u
+	}
+
+	// --- capabilities / privilege ------------------------------------------
+	s.Privileged = triFromPtr(cfg.Privileged.ptr())
+	s.CapDropAll = No
+	for _, c := range cfg.CapDrop {
+		if strings.EqualFold(strings.TrimSpace(c), "ALL") {
+			s.CapDropAll = Yes
+		}
+	}
+	for _, c := range cfg.CapAdd {
+		if c = strings.TrimSpace(c); c != "" {
+			s.CapAdd = append(s.CapAdd, strings.ToUpper(c))
+		}
+	}
+
+	// --- seccomp / no-new-privileges ---------------------------------------
+	// The docker driver applies Docker's DEFAULT seccomp profile unless a
+	// security_opt disables it (mirrors the compose/docker adapters).
+	s.Seccomp = "confined"
+	for _, opt := range cfg.SecurityOpt {
+		low := strings.ToLower(strings.TrimSpace(opt))
+		switch {
+		case strings.HasPrefix(low, "no-new-privileges"):
+			s.NoNewPrivs = Yes
+		case strings.HasPrefix(low, "seccomp"):
+			if strings.Contains(low, "unconfined") {
+				s.Seccomp = "unconfined"
+			} else {
+				s.Seccomp = "confined"
+			}
+		}
+	}
+	if s.Privileged == Yes {
+		// --privileged disables seccomp and grants the full capability set.
+		s.Seccomp = "unconfined"
+	}
+
+	// --- read-only rootfs ---------------------------------------------------
+	s.ReadonlyRoot = triFromPtr(cfg.ReadonlyRootfs.ptr())
+
+	// --- network ------------------------------------------------------------
+	// The docker driver's config.network_mode governs the container network. When
+	// it is unset and the group declares a network block, the task shares the
+	// group's namespace, so fall back to the group mode. Both unset = the default
+	// bridge network (egress-capable).
+	netMode := strings.TrimSpace(cfg.NetworkMode)
+	if netMode == "" && len(g.Networks) > 0 {
+		netMode = strings.TrimSpace(g.Networks[0].Mode)
+	}
+	switch strings.ToLower(netMode) {
+	case "none":
+		s.NetworkMode = "none"
+	case "host":
+		s.NetworkMode = "host"
+		s.HostNetwork = Yes
+	case "":
+		s.NetworkMode = "bridge"
+	default:
+		s.NetworkMode = netMode
+	}
+	if s.HostNetwork != Yes {
+		s.HostNetwork = No
+	}
+
+	// --- namespaces ---------------------------------------------------------
+	s.HostPID = boolTri(strings.EqualFold(strings.TrimSpace(cfg.PidMode), "host"))
+	s.HostIPC = boolTri(strings.EqualFold(strings.TrimSpace(cfg.IpcMode), "host"))
+	if strings.EqualFold(strings.TrimSpace(cfg.UsernsMode), "host") {
+		s.Notes = append(s.Notes, "userns_mode=host: the container shares the host user namespace (no uid remap)")
+	}
+
+	// --- docker.sock / host mounts ------------------------------------------
+	s.DockerSock = No
+	seen := map[string]bool{}
+	// volumes: "host:container[:mode]" (compose-style).
+	for _, v := range cfg.Volumes {
+		parts := strings.SplitN(v, ":", 3)
+		src := strings.TrimSpace(parts[0])
+		dst := ""
+		if len(parts) > 1 {
+			dst = strings.TrimSpace(parts[1])
+		}
+		if isControlSocket(src) || isControlSocket(dst) {
+			s.DockerSock = Yes
+		}
+		if isSensitiveHostPath(src) && !seen[src] {
+			seen[src] = true
+			s.HostPathMounts = append(s.HostPathMounts, src)
+		}
+	}
+	// mount blocks: only a bind mount exposes a host source path.
+	for _, m := range cfg.Mounts {
+		if !strings.EqualFold(strings.TrimSpace(m.Type), "bind") {
+			continue
+		}
+		src := strings.TrimSpace(m.Source)
+		if isControlSocket(src) || isControlSocket(strings.TrimSpace(m.Target)) {
+			s.DockerSock = Yes
+		}
+		if isSensitiveHostPath(src) && !seen[src] {
+			seen[src] = true
+			s.HostPathMounts = append(s.HostPathMounts, src)
+		}
+	}
+
+	return s, true
+}

--- a/internal/host/scan/nomad_test.go
+++ b/internal/host/scan/nomad_test.go
@@ -1,0 +1,271 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+// nomadHardenedJob mimics `nomad job run -output` for a job whose single docker
+// task is fully hardened: non-root user, drop ALL capabilities, default seccomp
+// profile, network=none, read-only rootfs, no docker.sock. The `-output` form
+// wraps the job as {"Job": {...}} and the driver `config` block uses lowercase
+// HCL keys.
+const nomadHardenedJob = `{
+  "Job": {
+    "ID": "web",
+    "Name": "web",
+    "TaskGroups": [
+      {
+        "Name": "app",
+        "Networks": [{"Mode": "none"}],
+        "Tasks": [
+          {
+            "Name": "server",
+            "Driver": "docker",
+            "User": "1000",
+            "Config": {
+              "image": "web:1",
+              "privileged": false,
+              "cap_drop": ["ALL"],
+              "network_mode": "none",
+              "readonly_rootfs": true,
+              "security_opt": ["no-new-privileges"]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}`
+
+// nomadPrivilegedJob mimics a raw api.Job document (no {"Job": ...} wrapper) with
+// a privileged docker task that host-mounts the docker socket and shares the host
+// network/PID namespaces — the worst posture.
+const nomadPrivilegedJob = `{
+  "ID": "legacy",
+  "Name": "legacy",
+  "TaskGroups": [
+    {
+      "Name": "ci",
+      "Tasks": [
+        {
+          "Name": "runner",
+          "Driver": "docker",
+          "Config": {
+            "image": "docker:dind",
+            "privileged": true,
+            "network_mode": "host",
+            "pid_mode": "host",
+            "volumes": ["/var/run/docker.sock:/var/run/docker.sock"]
+          }
+        }
+      ]
+    }
+  ]
+}`
+
+// nomadMixedJob pairs a hardened task with a porous one across two groups; the
+// aggregate must reflect the WEAKEST task. It also carries a non-docker (exec)
+// task that must be skipped.
+const nomadMixedJob = `{
+  "Job": {
+    "Name": "mixed",
+    "TaskGroups": [
+      {
+        "Name": "safe",
+        "Networks": [{"Mode": "none"}],
+        "Tasks": [
+          {
+            "Name": "api",
+            "Driver": "docker",
+            "User": "65532",
+            "Config": {
+              "image": "api:1",
+              "cap_drop": ["ALL"],
+              "network_mode": "none",
+              "readonly_rootfs": true
+            }
+          },
+          {
+            "Name": "sidecar",
+            "Driver": "exec",
+            "Config": {"command": "/bin/true"}
+          }
+        ]
+      },
+      {
+        "Name": "porous",
+        "Tasks": [
+          {
+            "Name": "worker",
+            "Driver": "docker",
+            "Config": {
+              "image": "worker:1",
+              "privileged": true,
+              "network_mode": "host",
+              "mount": [{"type": "bind", "source": "/var/run/docker.sock", "target": "/var/run/docker.sock"}]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}`
+
+// nomadBaselineJob is a docker task with NO security config at all: the docker
+// driver defaults apply (default seccomp profile, default capability set, bridge
+// network, image-default user, writable rootfs).
+const nomadBaselineJob = `{
+  "Job": {
+    "Name": "baseline",
+    "TaskGroups": [
+      {
+        "Name": "cache",
+        "Tasks": [
+          {"Name": "redis", "Driver": "docker", "Config": {"image": "redis:7"}}
+        ]
+      }
+    ]
+  }
+}`
+
+func gradeNomad(t *testing.T, raw string) (Report, Spec) {
+	t.Helper()
+	specs, err := SpecsFromNomad([]byte(raw))
+	if err != nil {
+		t.Fatalf("SpecsFromNomad: %v", err)
+	}
+	report, worst, err := AggregateNomad(specs, "job.nomad.json")
+	if err != nil {
+		t.Fatalf("AggregateNomad: %v", err)
+	}
+	return report, worst
+}
+
+func TestNomadHardenedJobGradesA(t *testing.T) {
+	report, _ := gradeNomad(t, nomadHardenedJob)
+	if report.Grade != "A" {
+		t.Fatalf("hardened nomad job: got grade %s (%d/100), want A; notes: %v", report.Grade, report.Score, report.Notes)
+	}
+	if report.Score != 100 {
+		t.Errorf("hardened nomad job: got %d/100, want 100", report.Score)
+	}
+	if report.Source != "nomad" {
+		t.Errorf("source = %q, want nomad", report.Source)
+	}
+}
+
+func TestNomadPrivilegedDockerSockGradesF(t *testing.T) {
+	report, worst := gradeNomad(t, nomadPrivilegedJob)
+	if report.Grade != "F" {
+		t.Fatalf("privileged nomad job: got grade %s (%d/100), want F", report.Grade, report.Score)
+	}
+	if worst.DockerSock != Yes {
+		t.Errorf("docker.sock not detected on privileged task: %+v", worst)
+	}
+	if worst.Privileged != Yes {
+		t.Errorf("privileged not detected: %+v", worst)
+	}
+	if worst.HostNetwork != Yes || worst.HostPID != Yes {
+		t.Errorf("host network/PID not detected: hostNet=%v hostPID=%v", worst.HostNetwork, worst.HostPID)
+	}
+}
+
+func TestNomadWeakestTaskWins(t *testing.T) {
+	report, worst := gradeNomad(t, nomadMixedJob)
+	if report.Grade != "F" {
+		t.Fatalf("mixed nomad job: got grade %s (%d/100), want F (weakest task governs)", report.Grade, report.Score)
+	}
+	if !strings.Contains(worst.Target, "worker") {
+		t.Errorf("weakest task = %q, want the porous worker", worst.Target)
+	}
+	// The exec sidecar and the hardened api task must both be present in the
+	// per-task roll-up; the exec task is skipped (only 2 docker tasks graded).
+	joined := strings.Join(report.Notes, " ")
+	if !strings.Contains(joined, "graded 2 nomad docker task") {
+		t.Errorf("expected 2 docker tasks graded (exec skipped); notes: %v", report.Notes)
+	}
+}
+
+func TestNomadHostNetworkPenalty(t *testing.T) {
+	// A docker task hardened in every dimension EXCEPT host networking must lose
+	// the network dimension relative to the fully hardened job.
+	const hostNet = `{"Job":{"Name":"n","TaskGroups":[{"Name":"g","Tasks":[
+      {"Name":"t","Driver":"docker","User":"1000","Config":{
+        "cap_drop":["ALL"],"network_mode":"host","readonly_rootfs":true}}]}]}}`
+	report, worst := gradeNomad(t, hostNet)
+	if worst.HostNetwork != Yes {
+		t.Fatalf("host network not detected: %+v", worst)
+	}
+	if report.Score >= 100 {
+		t.Errorf("host-network job should not reach 100; got %d", report.Score)
+	}
+	// host network zeroes both the network dimension and host-namespace dimension.
+	full, _ := gradeNomad(t, nomadHardenedJob)
+	if report.Score >= full.Score {
+		t.Errorf("host-network job (%d) should score below the network=none job (%d)", report.Score, full.Score)
+	}
+}
+
+func TestNomadBaselineDefaults(t *testing.T) {
+	// A bare docker task with no security config grades the docker DEFAULTS: the
+	// default seccomp profile PASSES (confined), the default capability set and
+	// bridge network are weak, user/rootfs unknown -> a mid/low D score.
+	report, worst := gradeNomad(t, nomadBaselineJob)
+	if worst.Seccomp != "confined" {
+		t.Errorf("baseline seccomp = %q, want confined (docker default profile)", worst.Seccomp)
+	}
+	if worst.NetworkMode != "bridge" {
+		t.Errorf("baseline network = %q, want bridge (docker default)", worst.NetworkMode)
+	}
+	if worst.RunAsNonRoot != Unknown {
+		t.Errorf("baseline user = %v, want Unknown (image default not pinned)", worst.RunAsNonRoot)
+	}
+	if report.Grade != "D" {
+		t.Errorf("baseline nomad task: got grade %s (%d/100), want D", report.Grade, report.Score)
+	}
+}
+
+func TestNomadBoolAsString(t *testing.T) {
+	// HCL2 renders bools as JSON bools, but a hand-authored API job may quote
+	// them. nomadBool must accept "true"/"false" strings.
+	const quoted = `{"Job":{"Name":"n","TaskGroups":[{"Name":"g","Tasks":[
+      {"Name":"t","Driver":"docker","Config":{
+        "privileged":"true","readonly_rootfs":"false"}}]}]}}`
+	specs, err := SpecsFromNomad([]byte(quoted))
+	if err != nil {
+		t.Fatalf("SpecsFromNomad: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("got %d specs, want 1", len(specs))
+	}
+	if specs[0].Privileged != Yes {
+		t.Errorf("privileged=\"true\" not decoded: %v", specs[0].Privileged)
+	}
+	if specs[0].ReadonlyRoot != No {
+		t.Errorf("readonly_rootfs=\"false\" not decoded: %v", specs[0].ReadonlyRoot)
+	}
+}
+
+func TestNomadNoDockerTasksIsError(t *testing.T) {
+	// A job with only non-docker drivers has nothing to grade: fail-closed (an
+	// error), not a silent pass.
+	const execOnly = `{"Job":{"Name":"n","TaskGroups":[{"Name":"g","Tasks":[
+      {"Name":"t","Driver":"exec","Config":{"command":"/bin/true"}}]}]}}`
+	specs, err := SpecsFromNomad([]byte(execOnly))
+	if err != nil {
+		t.Fatalf("SpecsFromNomad: %v", err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("exec task should be skipped; got %d specs", len(specs))
+	}
+	if _, _, err := AggregateNomad(specs, "job"); err == nil {
+		t.Error("AggregateNomad on an empty task set must error (fail-closed)")
+	}
+}
+
+func TestNomadMalformedJSONErrors(t *testing.T) {
+	if _, err := SpecsFromNomad([]byte("{not json")); err == nil {
+		t.Error("malformed JSON must return a parse error")
+	}
+}


### PR DESCRIPTION
## Wave 5 hardening guides (IRO-508 Part A)

Four new per-image container-hardening SEO landing pages, each backed by a **real `ironctl scan`** of the stock image and the hardened stanza (numbers measured, not asserted):

| Service | Image | Stock | Hardened | Ceiling reason |
|---------|-------|:-----:|:--------:|----------------|
| Grafana | `grafana/grafana:11.2.0` | 63/C | **89/B** | dashboard UI, browsers must connect |
| Prometheus | `prom/prometheus:v3.1.0` | 63/C | **89/B** | scrapes targets + serves API |
| Traefik | `traefik:v3.2` | 48/D | **89/B** | edge reverse proxy, forwards traffic |
| InfluxDB | `influxdb:2.7` | 48/D | **100/A** | co-located time-series store (89/B if a fleet pushes metrics) |

Honest ceilings per IRO-498/505: network services (proxy/monitor/dashboard) cap at 89/B because they exist to be connected to; a co-located datastore reaches 100/A via `--network=none`. Stock and hardened grades verified with `ironctl scan` (compose path for the `cap_drop: [ALL]` case, which colima normalizes on the CLI).

### Funnel wiring
- `docs/blog/index.md` hardening-guides section (+4)
- `docs/blog/hardening-guides.md` hub (16 -> 20 guides)
- `docs/blog/.nav.yml`
- `README.md` harden-guide list

`mkdocs build --strict` green; all 4 pages render. No em/en-dashes (standing rule). Docs-only diff, no scanner code touched.