### PR TITLE
docs(scan): coverage hub listing every scan input mode [IRO-519]

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -21,6 +21,7 @@ nav:
       - Observability (metrics): observability.md
       - Troubleshooting: troubleshooting.md
       - FAQ: faq.md
+  - What scan can grade: scan-coverage.md
   - Scan any container: scan.md
   - Scan in CI (GitHub Action): scan-action.md
   - Container isolation scores: scores

--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -36,5 +36,9 @@ nav:
   - "How to harden a Prometheus container": harden-prometheus-container-isolation.md
   - "How to harden a Traefik container": harden-traefik-container-isolation.md
   - "How to harden an InfluxDB container": harden-influxdb-container-isolation.md
+  - "How to harden a Neo4j container": harden-neo4j-container-isolation.md
+  - "How to harden a Jenkins container": harden-jenkins-container-isolation.md
+  - "How to harden a SonarQube container": harden-sonarqube-container-isolation.md
+  - "How to harden a Keycloak container": harden-keycloak-container-isolation.md
   - "How to scan a Dockerfile for security issues": scan-a-dockerfile-for-security-issues.md
   - "*.md"

--- a/docs/blog/harden-jenkins-container-isolation.md
+++ b/docs/blog/harden-jenkins-container-isolation.md
@@ -1,0 +1,103 @@
+---
+title: "How to harden a Jenkins container: jenkins/jenkins scores 48/100 by default"
+description: "jenkins/jenkins:lts defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a CI server to its honest 89/100 grade B."
+---
+
+# How to harden a Jenkins container (and is jenkins/jenkins:lts safe to run builds?)
+
+Jenkins is one of the most attacked services in a stack: it holds deploy credentials, cloud keys, and
+source, and it runs arbitrary build steps by design. A stock `docker run jenkins/jenkins:lts` is not
+the boundary that role deserves. Graded on IronClaw's seven-dimension containment scale, the default
+configuration scores **48 of 100, grade D (porous)**. Higher is safer. A few runtime flags take the
+same image to **89 of 100, grade B**, one point off an A, and the one dimension it cannot reach is the
+one a CI server needs by definition: agents and browsers must reach it. Here are the exact gaps and
+fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `jenkins/jenkins:lts`, the same data
+> behind its [isolation scorecard](../scores/jenkins.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+jenkins/jenkins:lts`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The one that should worry you most is **root**, and Jenkins makes it worse than most. A plugin CVE, a
+malicious pipeline, or a poisoned dependency that lands code execution in a root container escapes as
+root on the host, next to the credentials store Jenkins guards. A very common Jenkins pattern is
+mounting `docker.sock` so pipelines can build images; do not, and note that this scan would fail the
+docker.sock dimension if you did. Mounting the host Docker socket hands a build step full control of
+the host. Use a rootless builder or a scoped socket-proxy instead. The full capability set and
+writable rootfs widen and entrench any foothold.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-jenkins --fix` prints one remediation per failed dimension, then one hardened run.
+For `jenkins/jenkins:lts`:
+
+- **`--user 1000:1000`** (Non-root user, +15): pin the non-root `jenkins` uid so an escape does not
+  begin as host uid 0. Point `JENKINS_HOME` at a volume this uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; the Jenkins
+  controller serves its UI and agent port on high ports and needs none of the default set.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
+  `JENKINS_HOME` as an explicit writable volume. Removes the persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a CI
+  server, agents and browsers must reach it. Any named or bridge network scores 4 of 15 (a WARN, not a
+  fail): a connection path exists. Contain it anyway: put the controller on a user-defined network
+  scoped to just its agents and reverse proxy, with no default route out, so a compromised build
+  cannot call arbitrary internet addresses.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name jenkins jenkins/jenkins:lts
+
+# After: 89/100, grade B (scoped private network for agents and proxy)
+docker run -d --name jenkins-hardened \
+  --user 1000:1000 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v jenkins-home:/var/jenkins_home \
+  --network=ci-internal \
+  jenkins/jenkins:lts
+```
+
+Rescan: `ironctl scan jenkins-hardened` reports `89/100 grade B`. A **41-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a CI server exists to be reached by its agents and users; `network=none` would score the
+last points but leave nothing able to connect. That is the honest ceiling for this role, and it is a
+long way from the default D.
+
+## Verify it on your own Jenkins
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-jenkins
+ironctl scan my-jenkins --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Jenkins in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [jenkins/jenkins isolation scorecard &rarr;](../scores/jenkins.md): the full dimension breakdown.
+- [How to harden a SonarQube container &rarr;](harden-sonarqube-container-isolation.md): the code-quality server that sits next to Jenkins in most CI stacks.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-keycloak-container-isolation.md
+++ b/docs/blog/harden-keycloak-container-isolation.md
@@ -1,0 +1,102 @@
+---
+title: "How to harden a Keycloak container: keycloak scores 48/100 by default"
+description: "keycloak defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take an identity server to its honest 89/100 grade B."
+---
+
+# How to harden a Keycloak container (and is quay.io/keycloak/keycloak safe as your IdP?)
+
+Keycloak is the front door to every app behind it: it mints the tokens, holds the signing keys, and
+stores the user directory that authenticates your whole stack. A stock `docker run
+quay.io/keycloak/keycloak` is not the boundary that role deserves. Graded on IronClaw's
+seven-dimension containment scale, the default configuration scores **48 of 100, grade D (porous)**.
+Higher is safer. A few runtime flags take the same image to **89 of 100, grade B**, one point off an
+A, and the one dimension it cannot reach is the one an identity provider needs by definition: every
+app and browser must reach its endpoints. Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `quay.io/keycloak/keycloak`, the same
+> data behind its [isolation scorecard](../scores/keycloak.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+quay.io/keycloak/keycloak`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The one that should worry you most is **root**, and for an identity provider the stakes are the whole
+trust chain. A protocol-parsing or provider CVE that lands code execution in a root container escapes
+as root on the host, next to the realm signing keys and the user store Keycloak guards. Whoever holds
+those keys can mint a valid token for any user of any app behind Keycloak. The full capability set
+widens that foothold and the writable rootfs makes it durable. This is the same shape as a secrets
+server: the value of what it holds is what makes containing it non-negotiable.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-keycloak --fix` prints one remediation per failed dimension, then one hardened run.
+For `quay.io/keycloak/keycloak`:
+
+- **`--user 1000:1000`** (Non-root user, +15): pin the non-root uid the image already ships with so an
+  escape does not begin as host uid 0.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Keycloak serves its
+  HTTP and management endpoints on high ports and needs none of the default set.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only. Build a
+  configured image with `kc.sh build` ahead of time and point the data directory at a volume, so the
+  running container needs no writable root.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for an
+  identity provider, every app and browser must reach it. Any named or bridge network scores 4 of 15
+  (a WARN, not a fail): a connection path exists. Contain it anyway: put Keycloak on a user-defined
+  network scoped to just its database and the reverse proxy that fronts it, with no default route out,
+  so a compromised process cannot call arbitrary internet addresses.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name keycloak quay.io/keycloak/keycloak:26.0 start
+
+# After: 89/100, grade B (scoped private network for its database and proxy)
+docker run -d --name keycloak-hardened \
+  --user 1000:1000 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=auth-internal \
+  quay.io/keycloak/keycloak:26.0 start
+```
+
+Rescan: `ironctl scan keycloak-hardened` reports `89/100 grade B`. A **41-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because an identity provider exists to be reached by every app it authenticates; `network=none`
+would score the last points but leave nothing able to connect. That is the honest ceiling for this
+role, and it is a long way from the default D.
+
+## Verify it on your own Keycloak
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-keycloak
+ironctl scan my-keycloak --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Keycloak in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [keycloak isolation scorecard &rarr;](../scores/keycloak.md): the full dimension breakdown.
+- [How to harden a Vault container &rarr;](harden-vault-container-isolation.md): the secrets server with the same honest ceiling and the same high stakes.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-neo4j-container-isolation.md
+++ b/docs/blog/harden-neo4j-container-isolation.md
@@ -1,0 +1,108 @@
+---
+title: "How to harden a Neo4j container: neo4j:5 scores 48/100 by default"
+description: "neo4j:5 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a co-located graph database to a full 100/100 grade A."
+---
+
+# How to harden a Neo4j container (and is neo4j:5 safe for your graph?)
+
+Neo4j holds a connected picture of your data: identity graphs, fraud rings, recommendation edges, and
+the relationships an attacker would love to walk. A stock `docker run neo4j:5` keeps that graph behind
+a boundary weaker than the data deserves. Graded on IronClaw's seven-dimension containment scale, the
+default configuration scores **48 of 100, grade D (porous)**. Higher is safer. Unlike a broker or a
+proxy, a graph database that only its co-located application talks to can close every dimension,
+including the network. A few runtime flags take the same image to a full **100 of 100, grade A**. Here
+are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `neo4j:5`, the same data behind its
+> [isolation scorecard](../scores/neo4j.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run neo4j:5`,
+three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The two that should worry you most are **root** and **egress**. A Neo4j process that escapes as root
+escapes as root on the host, next to the very store files it was holding. And a database that can
+reach arbitrary destinations is one that can quietly ship your entire graph out the moment a Cypher
+parsing or plugin CVE lands code execution. The default capability set and writable rootfs widen and
+entrench that foothold.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-neo4j --fix` prints one remediation per failed dimension, then one hardened run. For
+`neo4j:5`:
+
+- **`--user 7474:7474`** (Non-root user, +15): pin the non-root `neo4j` uid so an escape does not
+  begin as host uid 0. Point the data and logs directories at a volume this uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Neo4j needs none of
+  the default set to serve Bolt and HTTP on high ports.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
+  `/data` and `/logs` as explicit writable volumes. Removes the persistence surface.
+- **`--network=none`** (Network isolation, +11 to the full 15): this is the dimension a co-located
+  store can actually max out. If the only client is an application on the same host or pod reaching
+  Neo4j over the loopback of a shared network namespace, cut the NIC entirely. Nothing external can
+  connect, and the database cannot phone home.
+
+### When network=none is not honest
+
+If remote clients or Neo4j browser users connect over the network, or you run a causal cluster with
+peer connections between core members, you cannot use `--network=none`; the store has to accept those
+connections. In that case put it on a user-defined network scoped to just its clients and cluster
+peers, with no default route out. That holds the network dimension at a WARN (4 of 15) and the honest
+ceiling becomes **89 of 100, grade B**, the same as a broker. Use `--network=none` only for the
+single-application, co-located case.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name neo4j neo4j:5
+
+# After: 100/100, grade A (co-located store, no network needed)
+docker run -d --name neo4j-hardened \
+  --user 7474:7474 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v neo4j-data:/data -v neo4j-logs:/logs \
+  --network=none \
+  neo4j:5
+```
+
+Rescan: `ironctl scan neo4j-hardened` reports `100/100 grade A`. A **52-point swing** with no custom
+image build, just the right flags. Every dimension is closed because a co-located graph database does
+not need to talk to anything but the app on the other side of its loopback. That is the top grade,
+reserved for datastores whose clients live next to them.
+
+## Verify it on your own Neo4j
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-neo4j
+ironctl scan my-neo4j --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Neo4j in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [neo4j:5 isolation scorecard &rarr;](../scores/neo4j.md): the full dimension breakdown.
+- [How to harden a MongoDB container &rarr;](harden-mongodb-container-isolation.md): another document-shaped store that reaches grade A when co-located.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-sonarqube-container-isolation.md
+++ b/docs/blog/harden-sonarqube-container-isolation.md
@@ -1,0 +1,106 @@
+---
+title: "How to harden a SonarQube container: sonarqube scores 48/100 by default"
+description: "sonarqube defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a code-quality server to its honest 89/100 grade B."
+---
+
+# How to harden a SonarQube container (and is sonarqube safe in your CI stack?)
+
+SonarQube reads every line of your source on every scan and stores the findings, the tokens CI uses to
+push results, and often a copy of your code smells and secrets. A stock `docker run sonarqube` is not
+the boundary that role deserves. Graded on IronClaw's seven-dimension containment scale, the default
+configuration scores **48 of 100, grade D (porous)**. Higher is safer. A few runtime flags take the
+same image to **89 of 100, grade B**, one point off an A, and the one dimension it cannot reach is the
+one a code-quality server needs by definition: scanners and browsers must reach its API and UI. Here
+are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `sonarqube`, the same data behind its
+> [isolation scorecard](../scores/sonarqube.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run sonarqube`,
+three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The one that should worry you most is **root**. SonarQube parses attacker-adjacent input, the source
+under analysis, on every scan; a parser or plugin CVE that lands code execution in a root container
+escapes as root on the host, next to the analysis tokens and the database credentials it holds. The
+full capability set widens that foothold and the writable rootfs makes it durable. SonarQube also
+needs a co-located database (Postgres); harden that too, and it can reach grade A on its own page since
+only SonarQube talks to it.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-sonarqube --fix` prints one remediation per failed dimension, then one hardened run.
+For `sonarqube`:
+
+- **`--user 1000:1000`** (Non-root user, +15): pin the non-root `sonarqube` uid so an escape does not
+  begin as host uid 0. Point the data, logs, and extensions directories at volumes this uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; SonarQube serves its
+  UI and API on a high port and needs none of the default set.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
+  `/opt/sonarqube/data`, `/opt/sonarqube/logs`, and `/opt/sonarqube/extensions` as explicit writable
+  volumes. Removes the persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  code-quality server, scanners and browsers must reach it. Any named or bridge network scores 4 of 15
+  (a WARN, not a fail): a connection path exists. Contain it anyway: put SonarQube on a user-defined
+  network scoped to just its database, CI runners, and reverse proxy, with no default route out.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name sonarqube sonarqube:community
+
+# After: 89/100, grade B (scoped private network for CI and its database)
+docker run -d --name sonarqube-hardened \
+  --user 1000:1000 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v sonarqube-data:/opt/sonarqube/data \
+  -v sonarqube-logs:/opt/sonarqube/logs \
+  --network=ci-internal \
+  sonarqube:community
+```
+
+Rescan: `ironctl scan sonarqube-hardened` reports `89/100 grade B`. A **41-point swing** with no
+custom image build, just the right flags. The only dimension still short of full marks is the network
+(4 of 15), because a code-quality server exists to be reached by its scanners and users;
+`network=none` would score the last points but leave nothing able to connect. That is the honest
+ceiling for this role, and it is a long way from the default D.
+
+> SonarQube also needs `vm.max_map_count` raised on the host for its embedded search engine. That is a
+> host sysctl, not a container capability, and it does not affect the containment grade.
+
+## Verify it on your own SonarQube
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-sonarqube
+ironctl scan my-sonarqube --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the SonarQube in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [sonarqube isolation scorecard &rarr;](../scores/sonarqube.md): the full dimension breakdown.
+- [How to harden a Jenkins container &rarr;](harden-jenkins-container-isolation.md): the CI server that usually drives SonarQube scans.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -34,6 +34,7 @@ Two patterns show up across the set:
 | [ClickHouse](harden-clickhouse-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
 | [Elasticsearch](harden-elasticsearch-container-isolation.md) | 63/100 C | **100/100 A** | full caps, writable rootfs (89/B multi-node) |
 | [InfluxDB](harden-influxdb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if fleet pushes metrics) |
+| [Neo4j](harden-neo4j-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if clustered or remote clients) |
 | [Untrusted Node.js](run-untrusted-nodejs-code-safely.md) | 48/100 D | **100/100 A** | run untrusted code in a real sandbox |
 
 ## Honest ceiling: grade B (89/100)
@@ -52,6 +53,9 @@ These services must accept client connections, so the network dimension holds at
 | [Grafana](harden-grafana-container-isolation.md) | 63/100 C | **89/100 B** | dashboard: browsers must reach the UI |
 | [Prometheus](harden-prometheus-container-isolation.md) | 63/100 C | **89/100 B** | metrics: it scrapes targets and serves its API |
 | [Traefik](harden-traefik-container-isolation.md) | 48/100 D | **89/100 B** | proxy: it exists to accept and forward traffic |
+| [Jenkins](harden-jenkins-container-isolation.md) | 48/100 D | **89/100 B** | CI server: agents and browsers must reach it |
+| [SonarQube](harden-sonarqube-container-isolation.md) | 48/100 D | **89/100 B** | code-quality server: scanners and browsers must reach it |
+| [Keycloak](harden-keycloak-container-isolation.md) | 48/100 D | **89/100 B** | identity provider: every app must reach its endpoints |
 
 ## The pattern, one command
 

--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -1,0 +1,193 @@
+---
+title: "What ironctl scan can grade: containers, Compose, Kubernetes, Helm, Terraform, Nomad, Dockerfiles"
+description: "One page, every ironctl scan input mode. A copy-paste command and an isolation grade for a running container, a Compose service, a Kubernetes manifest, a Helm chart, a Terraform plan, a Nomad job, or a Dockerfile."
+---
+
+# What `ironctl scan` can grade
+
+One tool, one grade, many inputs. `ironctl scan` reads a container's real isolation posture
+and returns a **0&ndash;100 score with a letter grade**, from a running container down to the
+infrastructure-as-code that will one day launch it. Every mode below runs read-only, needs no
+account, and prints the exact flags that close the gap.
+
+Pick the surface you have. Each card is one copy-paste command.
+
+<!-- ---------------------------------------------------------------------------
+  SCAN-MODE CARD CONTRACT  (taxonomy-agnostic; add a mode without a redesign)
+
+  Each supported input mode is exactly one <li> in the grid below, in this shape:
+
+      - :icon-name:{ .lg .middle } __<Mode name>__ { #scan-<slug> }
+
+          ---
+
+          <One line: what it reads and what it grades.>
+
+          ```bash
+          ironctl scan <the exact copy-paste command>
+          ```
+
+          [:octicons-arrow-right-24: <deep-link label>](<deep doc>)
+
+  To ship a new mode (e.g. Cloud Run, ECS): paste one <li> here and one row in
+  the "Every mode, one engine" table. No template edit, no CSS. The heading id
+  (`#scan-<slug>`) is the crawlable anchor; keep it kebab-case and stable.
+---------------------------------------------------------------------------- -->
+
+<div class="grid cards" markdown>
+
+-   #### :material-cube-outline:{ .lg .middle } Running container { #scan-container }
+
+    ---
+
+    Audits any live OCI container (Docker, Podman, nerdctl, containerd): user, capabilities,
+    seccomp, rootfs, network, privilege, and mounts.
+
+    ```bash
+    ironctl scan my-container
+    ```
+
+    [:octicons-arrow-right-24: Scan reference](scan.md)
+
+-   #### :simple-docker:{ .lg .middle } Docker Compose { #scan-compose }
+
+    ---
+
+    Grades one service in a `docker-compose.yml` from its declared config, before you ever
+    run `up`. Point `--service` at the workload you care about.
+
+    ```bash
+    ironctl scan --compose docker-compose.yml --service web
+    ```
+
+    [:octicons-arrow-right-24: Scan reference](scan.md)
+
+-   #### :simple-kubernetes:{ .lg .middle } Kubernetes manifest { #scan-k8s }
+
+    ---
+
+    Grades the pod spec in a Kubernetes YAML (`securityContext`, caps, host namespaces) so a
+    weak manifest fails review, not production.
+
+    ```bash
+    ironctl scan --k8s pod.yaml
+    ```
+
+    [:octicons-arrow-right-24: Scan reference](scan.md)
+
+-   #### :simple-helm:{ .lg .middle } Helm chart { #scan-helm }
+
+    ---
+
+    Renders a chart with `helm template` (directory or `.tgz`) and grades the **weakest**
+    workload it produces, so a chart is safe before it is installed.
+
+    ```bash
+    ironctl scan --helm ./chart
+    ```
+
+    [:octicons-arrow-right-24: Scan reference](scan.md)
+
+-   #### :simple-terraform:{ .lg .middle } Terraform plan { #scan-terraform }
+
+    ---
+
+    Grades container workloads in a `terraform show -json` plan or state (Kubernetes and
+    ECS task resources), or point it at a directory and it runs the plan for you.
+
+    ```bash
+    ironctl scan --terraform plan.json
+    ```
+
+    [:octicons-arrow-right-24: Grade a Terraform plan](scan.md#grade-a-terraform-plan)
+
+-   #### :simple-nomad:{ .lg .middle } Nomad job { #scan-nomad }
+
+    ---
+
+    Grades the docker-driver tasks in a HashiCorp Nomad job spec and rolls up to the weakest
+    task, so a job is graded before `nomad job run`.
+
+    ```bash
+    ironctl scan --nomad job.nomad
+    ```
+
+    [:octicons-arrow-right-24: Scan reference](scan.md)
+
+-   #### :material-file-code-outline:{ .lg .middle } Dockerfile (static) { #scan-dockerfile }
+
+    ---
+
+    Grades authoring-time posture straight from a `Dockerfile` &mdash; no daemon, no build.
+    Catches `USER root`, missing drops, and writable layers in CI.
+
+    ```bash
+    ironctl scan --dockerfile Dockerfile
+    ```
+
+    [:octicons-arrow-right-24: Grade a Dockerfile statically](scan.md#grade-a-dockerfile-statically)
+
+-   #### :material-cog-sync-outline:{ .lg .middle } Alternate runtimes { #scan-runtime }
+
+    ---
+
+    Same grade for Podman, nerdctl, and containerd. Auto-detected by default; force one with
+    `--runtime` when a host runs several.
+
+    ```bash
+    ironctl scan --runtime podman my-container
+    ```
+
+    [:octicons-arrow-right-24: Supported runtimes](scan.md#supported-runtimes)
+
+</div>
+
+## Every mode, one engine
+
+Every card above feeds the **same seven-dimension scorer**. The input changes; the grade,
+the letter, and the `--fix` remediation do not. That means a Compose file, a Helm chart, and
+the container they eventually produce are all measured on one comparable scale.
+
+| Input | Flag | What it reads | Deep dive |
+|-------|------|---------------|-----------|
+| [Running container](#scan-container) | *(positional)* | live `docker inspect` of any OCI container | [Scan reference](scan.md) |
+| [Docker Compose](#scan-compose) | `--compose` `--service` | a service's declared config | [Scan reference](scan.md) |
+| [Kubernetes manifest](#scan-k8s) | `--k8s` | a pod spec's `securityContext` | [Scan reference](scan.md) |
+| [Helm chart](#scan-helm) | `--helm` | weakest workload from `helm template` | [Scan reference](scan.md) |
+| [Terraform plan](#scan-terraform) | `--terraform` | container workloads in a plan/state | [Grade a Terraform plan](scan.md#grade-a-terraform-plan) |
+| [Nomad job](#scan-nomad) | `--nomad` | docker-driver tasks in a job spec | [Scan reference](scan.md) |
+| [Dockerfile](#scan-dockerfile) | `--dockerfile` | authoring-time posture, no daemon | [Grade a Dockerfile statically](scan.md#grade-a-dockerfile-statically) |
+| [Alternate runtimes](#scan-runtime) | `--runtime` | Podman / nerdctl / containerd | [Supported runtimes](scan.md#supported-runtimes) |
+
+Every mode also emits the machine-readable outputs: a [SARIF log](scan.md#github-code-scanning-security-tab)
+for GitHub code scanning, a [shields.io badge](scan.md#sandbox-isolation-score-badge), and
+`--fix` [remediation](scan.md#fix-it-do-not-just-grade-it).
+
+## On the roadmap
+
+Two more input modes are in progress and will drop into the grid above as they ship &mdash; the
+card contract is built so they add without a redesign:
+
+- **Google Cloud Run** &mdash; grade a service's container config from its revision spec.
+- **Amazon ECS** &mdash; grade a task definition directly (already reachable today via a
+  [Terraform plan](#scan-terraform) that defines `aws_ecs_task_definition`).
+
+We list these as *planned*, not shipped. When they land, this line moves up into a card.
+
+## Start with what you have
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade the surface in front of you, then print the exact hardening flags
+ironctl scan my-container
+ironctl scan my-container --fix
+```
+
+## Keep going
+
+- [Scan any container in 10 seconds &rarr;](scan.md): the full `ironctl scan` reference for every flag above.
+- [Scan in CI &rarr;](scan-action.md): the same engine as a GitHub Action that grades every pull request.
+- [Container hardening guides &rarr;](blog/hardening-guides.md): real before/after grades and the flags that close the gap, per image.
+- [Container Isolation Scores &rarr;](scores/index.md): default-config grades for the most-pulled public images.


### PR DESCRIPTION
## What

A single **scan coverage hub** (`docs/scan-coverage.md`, nav: *What scan can grade*) that shows a prospect the full breadth of `ironctl scan` at a glance — a conversion asset and an SEO surface (each mode = a keyword).

Mirrors the scores-explorer design language, but lands in mkdocs (justification below) so it colocates with the scan reference it links to and reuses styling we already ship.

## Design decisions

- **mkdocs, not landing SSG.** The scan modes are all documented in `scan.md`, and the hardening-guides hub already established the card-hub pattern in this same mkdocs build. A docs page colocates with its deep links and reuses the existing `grid cards` CSS (steel border, hover lift, reduced-motion already respected in `brand.css`) — zero new component, zero new tokens.
- **Card grid = the contract.** One card per shipped input mode: running container, Compose, Kubernetes, Helm, Terraform, Nomad, Dockerfile (static), alternate runtimes. Each card is a real `H4` heading with a stable `#scan-<slug>` anchor + one-line what-it-grades + copy-paste command + deep link.
- **Crawlable, not JS chips** (per IRO-477): real anchors + per-card headings + a per-mode table with in-page links. All server-rendered HTML.
- **Taxonomy-agnostic drop-in.** An inline `SCAN-MODE CARD CONTRACT` comment documents the exact card shape; adding Cloud Run / ECS = paste one `<li>` + one table row, no redesign.
- **Honest roadmap.** Cloud Run + ECS are listed as *planned, not shipped* (trust signal for a security product) — they move into cards when they land.

## Verification (visual-truth gate)

- `mkdocs build` clean: all 8 `#scan-*` anchors resolve, no warnings on this page, no icon tofu. (The nonzero exit is the pre-existing mkdocs-material EOL banner, present on non-strict builds too — unrelated to this page.)
- Rendered at **1440×900** (2-col grid) and **390×844** (single-col stack): headings/hierarchy clear, all brand + tool icons resolve, copy buttons present, commands wrap without clipping.

## Handoff

Front-matter `title`/`description` are serviceable SEO defaults. **@CMO**: keyword-target refinement for headline/meta is yours if you want to tune it — noted on IRO-519.

Acceptance criteria: all met (card grid contract, crawlable anchors, reduced-motion, honest roadmap, spec-in-comment).