### PR TITLE
feat(scan): ironctl scan --ecs grades live AWS ECS task definitions (IRO-517)

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -47,6 +47,7 @@ func cmdScan(args []string) error {
 	terraformBin := fs.String("terraform-bin", envOrDefault("TERRAFORM", "terraform"), "terraform binary used to run `terraform show -json` on a dir/binary plan")
 	nomad := fs.String("nomad", "", "grade docker-driver tasks in a HashiCorp Nomad job spec (job.json, or a .hcl/.nomad file rendered via `nomad job run -output`)")
 	nomadBin := fs.String("nomad-bin", envOrDefault("NOMAD", "nomad"), "nomad binary used to render an HCL job to JSON (`nomad job run -output`)")
+	ecs := fs.String("ecs", "", "grade an AWS ECS task definition: `aws ecs describe-task-definition` JSON, a raw registered task-def JSON, or a directory of task-def JSON files")
 	dockerfile := fs.Bool("dockerfile", false, "statically grade the positional Dockerfile(s) authoring-time posture (daemon-free)")
 	runtime := fs.String("runtime", envOrDefault("IRONCTL_SCAN_RUNTIME", "auto"), "container runtime: auto|docker|podman|nerdctl")
 	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker inspect`")
@@ -154,6 +155,24 @@ func cmdScan(args []string) error {
 		return runNomadScan(nomadArgs{
 			path:      *nomad,
 			nomadBin:  *nomadBin,
+			asJSON:    *asJSON,
+			md:        *md,
+			badge:     *badge,
+			badgeJSON: *badgeJSON,
+			sarif:     *sarif,
+			minScore:  *minScore,
+		})
+	}
+
+	// --ecs: consume an AWS ECS task definition (describe-task-definition JSON, a
+	// raw registered task def, or a directory of task-def JSON files) and grade the
+	// container contract, reusing the SHARED ECS scorer that the --terraform
+	// aws_ecs_task_definition path also uses. It loads JSON here then defers to the
+	// pure SpecsFromECS + AggregateECS scorer. Fail-OPEN on a load/parse failure;
+	// --min-score still gates once containers are graded.
+	if *ecs != "" {
+		return runECSScan(ecsArgs{
+			path:      *ecs,
 			asJSON:    *asJSON,
 			md:        *md,
 			badge:     *badge,
@@ -764,6 +783,126 @@ func loadNomadJSON(nomadBin, path string) ([]byte, error) {
 	return stdout.Bytes(), nil
 }
 
+// ecsArgs carries the resolved inputs for a `scan --ecs` run.
+type ecsArgs struct {
+	path      string
+	asJSON    bool
+	md        bool
+	badge     string
+	badgeJSON string
+	sarif     string
+	minScore  int
+}
+
+// runECSScan grades an AWS ECS task definition's container contract, reusing the
+// SHARED ECS scorer that the --terraform aws_ecs_task_definition path also uses. It
+// accepts a `aws ecs describe-task-definition` JSON, a raw registered task-def
+// JSON, or a directory of task-def JSON files (weakest-container rollup across the
+// lot). It fails OPEN on a load/parse failure (unreadable path, malformed JSON): it
+// prints a clear diagnostic to stderr and returns nil so an opt-in CI/Action step
+// never crashes the build over tooling issues. Once containers are graded, scoring
+// and the --min-score CI gate apply exactly like --k8s/--helm/--terraform/--nomad.
+func runECSScan(a ecsArgs) error {
+	specs, err := loadECSSpecs(a.path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --ecs could not load %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregateECS(specs, filepath.Base(strings.TrimRight(a.path, "/")))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --ecs found nothing to grade in %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (containers graded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// loadECSSpecs resolves a --ecs argument to graded Specs. A directory is a
+// weakest-container rollup: every *.json file in it is parsed and its container
+// specs are pooled, so `AggregateECS` grades the single most-exposed container
+// across the whole set. A single file is parsed directly. It is daemon-free and
+// offline: the JSON is read from disk (the user runs the aws CLI, if at all).
+func loadECSSpecs(path string) ([]scan.Spec, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil, rerr
+		}
+		return scan.SpecsFromECS(raw)
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	var specs []scan.Spec
+	for _, e := range entries {
+		if e.IsDir() || !strings.EqualFold(filepath.Ext(e.Name()), ".json") {
+			continue
+		}
+		raw, rerr := os.ReadFile(filepath.Join(path, e.Name()))
+		if rerr != nil {
+			return nil, rerr
+		}
+		fileSpecs, perr := scan.SpecsFromECS(raw)
+		if perr != nil {
+			// A single malformed file in a directory should not sink the rollup:
+			// skip it with a diagnostic and grade the rest (fail-open per file).
+			fmt.Fprintf(os.Stderr, "  warning: scan --ecs skipping %s (parse error): %v\n", e.Name(), perr)
+			continue
+		}
+		specs = append(specs, fileSpecs...)
+	}
+	return specs, nil
+}
+
 // writeDockerfileSARIF renders the Dockerfile SARIF log to path, fail-open on error.
 func writeDockerfileSARIF(path string, r scan.Report, opts scan.SARIFOptions) error {
 	f, err := os.Create(path)
@@ -896,6 +1035,7 @@ USAGE:
   ironctl scan --helm CHART                    render a Helm chart (dir or .tgz) and grade its workloads
   ironctl scan --terraform PATH                grade container workloads in a terraform show -json file/dir
   ironctl scan --nomad PATH                     grade docker-driver tasks in a Nomad job spec (JSON or HCL)
+  ironctl scan --ecs PATH                       grade an AWS ECS task definition (describe-task-definition JSON / dir)
   ironctl scan --dockerfile FILE...           grade Dockerfile(s) statically (no daemon, no pull)
   ironctl scan --compare A B                   diff two containers' isolation posture
 
@@ -952,6 +1092,19 @@ job) for the daemon-free path, or a `+"`.hcl`/`.nomad`"+` file that is rendered 
 via `+"`nomad job run -output`"+` when the nomad binary is on PATH. The job grade is the
 WEAKEST task; load/parse failures fail OPEN (diagnostic + exit 0). A successful
 parse still trips --min-score.
+
+--ecs grades an AWS ECS task definition's container contract, reusing the SAME ECS
+dimension mapping as the --terraform aws_ecs_task_definition path (privileged,
+readonlyRootFilesystem, user, linuxParameters.capabilities.{add,drop},
+dockerSecurityOptions, and the task-level networkMode/pidMode/ipcMode). It accepts
+the output of `+"`aws ecs describe-task-definition`"+` (a {taskDefinition:{...}}
+wrapper), a raw registered task-def JSON (containerDefinitions[] at the root), or a
+directory of task-def JSON files (weakest-container rollup across the lot). This is
+the LIVE counterpart to --terraform: it grades the registered JSON that AWS-console
+/CDK/Copilot users have but never express as terraform. networkMode host is worst;
+awsvpc/bridge are egress-capable NICs (not host); ECS default seccomp is confined.
+The task grade is the WEAKEST container; load/parse failures fail OPEN (diagnostic +
+exit 0). A successful parse still trips --min-score.
 
 --dockerfile grades a DIFFERENT, authoring-time dimension set (non-root USER,
 pinned base image, no secrets in ENV/ARG, COPY over remote/opaque ADD, no

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -67,6 +67,7 @@ inspect data, so probe-masking from inside the container cannot change the score
 | Kubernetes | `--k8s FILE` | grades a pod or workload manifest, no runtime needed |
 | Helm | `--helm CHART` | renders a chart with `helm template` and grades its workloads, no cluster needed |
 | Terraform | `--terraform PATH` | grades container workloads in a `terraform show -json` plan/state, no apply needed (see below) |
+| AWS ECS | `--ecs PATH` | grades a live `aws ecs describe-task-definition` (or registered) task definition, no AWS call needed (see below) |
 | Dockerfile | `--dockerfile FILE` | grades authoring-time posture statically, no daemon and no image pull (see below) |
 
 Selection and binaries:
@@ -132,6 +133,50 @@ Network egress depends on a `NetworkPolicy` (Kubernetes) or a security group
 honest static ceiling. Missing tooling or a malformed document fails **open** (a
 clear diagnostic and exit 0) so an opt-in CI step never crashes the build; once
 workloads are graded, `--min-score` still trips on a low posture.
+
+## Grade an AWS ECS task definition
+
+`--ecs PATH` grades the container contract of an AWS ECS task definition. This is
+the **live** counterpart to `--terraform`: Terraform grades an
+`aws_ecs_task_definition` expressed in HCL/plan, while `--ecs` grades the
+**registered** JSON that most AWS-console, CDK, and Copilot users actually have but
+never express as Terraform. No AWS API call is made by the scan itself; you feed it
+JSON you already have (or fetch once with the AWS CLI):
+
+```bash
+aws ecs describe-task-definition --task-definition webapp > taskdef.json
+ironctl scan --ecs taskdef.json
+ironctl scan --ecs taskdef.json --min-score 75    # CI gate
+ironctl scan --ecs taskdef.json --sarif ecs.sarif # GitHub code scanning
+
+ironctl scan --ecs ./taskdefs                      # weakest-container rollup over a dir
+```
+
+It accepts three input shapes:
+
+| Input | Shape |
+|---|---|
+| `aws ecs describe-task-definition` output | a top-level `{ "taskDefinition": { "containerDefinitions": [...] } }` wrapper |
+| a raw registered / authored task def | `containerDefinitions[]` at the JSON root (CDK / Copilot / hand-written API JSON) |
+| a directory | every `*.json` task def in it, graded as one **weakest-container** rollup |
+
+Each `containerDefinitions[]` entry is graded on the same dimensions as every other
+source: non-root `user`, `linuxParameters.capabilities.{add,drop}`, `privileged`,
+`readonlyRootFilesystem`, seccomp (via `dockerSecurityOptions`), and the task-level
+`networkMode` / `pidMode` / `ipcMode`. `networkMode: host` is the worst;
+`awsvpc` and `bridge` are egress-capable NICs (not host); ECS applies Docker's
+**default** seccomp profile unless a `dockerSecurityOption` disables it, so it is
+graded `confined` by default. A host volume whose source path is the Docker control
+socket is flagged as a full host-root escape primitive.
+
+The task grade is the **weakest** container: a task is only as isolated as its
+most-exposed container, and every container's score is listed in the notes. Because
+the shared ECS scorer is the same one the `--terraform` `aws_ecs_task_definition`
+path uses, the two entrypoints can never diverge. Network egress depends on a
+security group that a task definition does not carry, so it is graded
+conservatively, the honest static ceiling. A malformed document fails **open** (a
+clear diagnostic and exit 0) so an opt-in CI step never crashes the build; once
+containers are graded, `--min-score` still trips on a low posture.
 
 ## Grade a Dockerfile statically
 

--- a/internal/host/scan/ecs.go
+++ b/internal/host/scan/ecs.go
@@ -1,0 +1,284 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SpecsFromECS parses an AWS ECS task definition and returns one graded Spec per
+// container definition. It accepts the two JSON shapes a user actually has:
+//
+//   - `aws ecs describe-task-definition --task-definition NAME` output, which
+//     wraps the definition under a top-level {"taskDefinition": {...}} key.
+//   - a raw registered/authored task definition whose root object carries
+//     containerDefinitions[] directly (CDK / Copilot / hand-written API JSON).
+//
+// This is the LIVE counterpart to the terraform adapter's aws_ecs_task_definition
+// path (SpecsFromTerraform): terraform grades the definition expressed in HCL/plan
+// (where container_definitions is a JSON-encoded STRING), while --ecs grades the
+// registered JSON that most AWS-console/CDK/Copilot users have but never express as
+// terraform. Both decode into the SAME ecsContainerDef and grade through the SAME
+// ecsSpec mapper, so the two entrypoints can never diverge.
+//
+// It is pure and unit-testable: the caller reads the file / runs the aws CLI (I/O)
+// and passes the JSON here. It fails OPEN on a malformed top-level document
+// (returns the parse error); the CLI wrapper turns that into a skip so an opt-in CI
+// step never crashes the build.
+func SpecsFromECS(raw []byte) ([]Spec, error) {
+	var doc ecsDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parse ecs task definition JSON: %w", err)
+	}
+	// describe-task-definition wraps the definition; a raw registered task def puts
+	// containerDefinitions at the root. Prefer the wrapper when present.
+	td := doc.ecsTaskDef
+	if doc.TaskDefinition != nil && len(doc.TaskDefinition.ContainerDefinitions) > 0 {
+		td = *doc.TaskDefinition
+	}
+	if len(td.ContainerDefinitions) == 0 {
+		return nil, nil
+	}
+
+	family := nz(td.Family, "task")
+
+	// docker.sock exposure is a task-level property: an ECS host volume whose source
+	// path is the control socket is mountable into any container in the task.
+	dockerSock := No
+	for _, vol := range td.Volumes {
+		if vol.Host != nil && isControlSocket(vol.Host.SourcePath) {
+			dockerSock = Yes
+		}
+	}
+
+	modes := ecsTaskModes{NetworkMode: td.NetworkMode, PidMode: td.PidMode, IpcMode: td.IpcMode}
+	specs := make([]Spec, 0, len(td.ContainerDefinitions))
+	for _, d := range td.ContainerDefinitions {
+		specs = append(specs, ecsSpec("ecs", family, d, modes, dockerSock))
+	}
+	return specs, nil
+}
+
+// AggregateECS folds the per-container specs from one or more ECS task definitions
+// into a single Report. Like AggregateTerraform/AggregateNomad, the aggregate is
+// the WEAKEST container (minimum score): a task is only as isolated as its most
+// -exposed container, so grading the weakest link is the honest, fail-closed
+// summary. target names the source (task-def file base, or a directory rollup
+// label). It returns the aggregate Report and the Spec that produced it (for SARIF
+// anchoring). It is pure; the caller injects Version/GeneratedAt. Fail-closed: an
+// empty container set is an error (a task def that declares no container is not a
+// pass).
+func AggregateECS(specs []Spec, target string) (Report, Spec, error) {
+	if len(specs) == 0 {
+		return Report{}, Spec{}, fmt.Errorf("no gradeable container definitions found in ECS task definition(s) (looked for containerDefinitions[])")
+	}
+
+	all := make([]scoredWorkload, len(specs))
+	worst := 0
+	for i, s := range specs {
+		all[i] = scoredWorkload{spec: s, report: Score(s)}
+		if all[i].report.Score < all[worst].report.Score {
+			worst = i
+		}
+	}
+
+	agg := all[worst].report
+	worstSpec := all[worst].spec
+	if strings.TrimSpace(target) != "" {
+		agg.Target = target
+	}
+	agg.Source = "ecs"
+	agg.Notes = append(ecsSummaryNotes(all[worst], all), agg.Notes...)
+
+	return agg, worstSpec, nil
+}
+
+// ecsSummaryNotes builds the task-level roll-up notes for an aggregate ECS report:
+// a headline naming the weakest container and a per-container score list.
+func ecsSummaryNotes(worst scoredWorkload, all []scoredWorkload) []string {
+	notes := []string{
+		fmt.Sprintf("graded %d ECS container(s); the task grade is the WEAKEST (a task is only as isolated as its most-exposed container). Weakest: %s at %d/100 (grade %s).",
+			len(all), nz(worst.spec.Target, "container"), worst.report.Score, worst.report.Grade),
+	}
+	sorted := make([]scoredWorkload, len(all))
+	copy(sorted, all)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].report.Score < sorted[j].report.Score })
+	rows := make([]string, len(sorted))
+	for i, w := range sorted {
+		rows[i] = fmt.Sprintf("%s = %d/100 (%s)", nz(w.spec.Target, "container"), w.report.Score, w.report.Grade)
+	}
+	notes = append(notes, "per-container: "+strings.Join(rows, "; "))
+	return notes
+}
+
+// --------------------------------------------------------------------------- //
+// Live ECS task definition document model (`aws ecs describe-task-definition`)
+//
+// Unlike terraform's aws_ecs_task_definition (where the task-level fields are
+// snake_case and container_definitions is a JSON-encoded STRING), the registered
+// task definition is camelCase throughout and containerDefinitions is a real JSON
+// array — so it decodes straight into ecsContainerDef with no inner-string step.
+// --------------------------------------------------------------------------- //
+
+// ecsDoc accepts both input shapes at once: the describe-task-definition wrapper
+// (TaskDefinition) and a raw registered task def (the embedded ecsTaskDef fields at
+// the document root).
+type ecsDoc struct {
+	TaskDefinition *ecsTaskDef `json:"taskDefinition"`
+	ecsTaskDef
+}
+
+type ecsTaskDef struct {
+	Family               string            `json:"family"`
+	NetworkMode          string            `json:"networkMode"`
+	PidMode              string            `json:"pidMode"`
+	IpcMode              string            `json:"ipcMode"`
+	ContainerDefinitions []ecsContainerDef `json:"containerDefinitions"`
+	Volumes              []ecsVolume       `json:"volumes"`
+}
+
+type ecsVolume struct {
+	Name string `json:"name"`
+	Host *struct {
+		SourcePath string `json:"sourcePath"`
+	} `json:"host"`
+}
+
+// --------------------------------------------------------------------------- //
+// Shared ECS container scoring (used by BOTH --ecs and --terraform)
+//
+// container_definitions entries are camelCase and Docker-flavored in every ECS
+// surface (registered JSON and terraform's inner string alike). Grading them plus
+// the task-level network/pid/ipc modes lives here so the live and terraform
+// entrypoints stay byte-for-byte in sync.
+// --------------------------------------------------------------------------- //
+
+// ecsTaskModes carries the task-level isolation modes that apply to every
+// container in a task definition. Both the live JSON (camelCase) and terraform's
+// aws_ecs_task_definition (snake_case) adapters populate this struct so the shared
+// ecsSpec mapper sees one shape.
+type ecsTaskModes struct {
+	NetworkMode string
+	PidMode     string
+	IpcMode     string
+}
+
+// ecsContainerDef is one entry of an ECS task's containerDefinitions array. The
+// field shape is identical between a live `aws ecs describe-task-definition`
+// document and terraform's container_definitions (a JSON-encoded string), so both
+// adapters decode into this type and grade through ecsSpec.
+type ecsContainerDef struct {
+	Name                   string `json:"name"`
+	Privileged             *bool  `json:"privileged"`
+	ReadonlyRootFilesystem *bool  `json:"readonlyRootFilesystem"`
+	User                   string `json:"user"`
+	LinuxParameters        *struct {
+		Capabilities *struct {
+			Add  []string `json:"add"`
+			Drop []string `json:"drop"`
+		} `json:"capabilities"`
+		InitProcessEnabled *bool `json:"initProcessEnabled"`
+	} `json:"linuxParameters"`
+	DockerSecurityOptions []string `json:"dockerSecurityOptions"`
+}
+
+// ecsSpec maps one ECS container definition (plus the task-level modes) to a Spec.
+// source is the origin adapter ("ecs" for a live/registered task def, "terraform"
+// for an aws_ecs_task_definition resource) and only affects the report header;
+// every dimension is graded identically regardless of source.
+func ecsSpec(source, family string, d ecsContainerDef, modes ecsTaskModes, dockerSock Tristate) Spec {
+	target := "ecs/" + family
+	if strings.TrimSpace(d.Name) != "" {
+		target = "ecs/" + family + "/" + d.Name
+	}
+	s := Spec{Source: source, Target: target, DockerSock: dockerSock}
+
+	// --- user ---------------------------------------------------------------
+	// ECS `user` is a string: "", "0", "root", "1000", "1000:1000", "appuser".
+	switch u := strings.TrimSpace(d.User); {
+	case u == "":
+		s.RunAsNonRoot = Unknown
+		s.Notes = append(s.Notes, "no container user set; the image default may be root")
+	case ecsUserIsRoot(u):
+		s.RunAsNonRoot = No
+		s.User = u
+	default:
+		s.RunAsNonRoot = Yes
+		s.User = u
+	}
+
+	// --- capabilities / privilege ------------------------------------------
+	s.Privileged = triFromPtr(d.Privileged)
+	if d.LinuxParameters != nil && d.LinuxParameters.Capabilities != nil {
+		caps := d.LinuxParameters.Capabilities
+		for _, dr := range caps.Drop {
+			if strings.EqualFold(strings.TrimSpace(dr), "ALL") {
+				s.CapDropAll = Yes
+			}
+		}
+		if s.CapDropAll == Unknown {
+			s.CapDropAll = No
+		}
+		for _, a := range caps.Add {
+			if a = strings.TrimSpace(a); a != "" {
+				s.CapAdd = append(s.CapAdd, strings.ToUpper(a))
+			}
+		}
+	} else {
+		// No linuxParameters.capabilities: ECS keeps Docker's default capability
+		// set (fail-closed, same as the compose/docker default).
+		s.CapDropAll = No
+	}
+
+	// --- read-only rootfs ---------------------------------------------------
+	s.ReadonlyRoot = triFromPtr(d.ReadonlyRootFilesystem)
+
+	// --- seccomp ------------------------------------------------------------
+	// ECS applies Docker's DEFAULT seccomp profile unless a dockerSecurityOption
+	// disables it. Mirror the docker/compose adapters: default profile = confined.
+	s.Seccomp = "confined"
+	for _, opt := range d.DockerSecurityOptions {
+		o := strings.ToLower(strings.TrimSpace(opt))
+		if o == "seccomp=unconfined" || o == "seccomp:unconfined" {
+			s.Seccomp = "unconfined"
+		}
+		if o == "no-new-privileges" || o == "no-new-privileges:true" {
+			s.NoNewPrivs = Yes
+		}
+	}
+
+	// --- network ------------------------------------------------------------
+	switch nm := strings.ToLower(strings.TrimSpace(modes.NetworkMode)); nm {
+	case "none":
+		s.NetworkMode = "none"
+	case "host":
+		s.NetworkMode = "host"
+		s.HostNetwork = Yes
+	case "":
+		// ECS default network mode is bridge on EC2; egress-capable.
+		s.NetworkMode = "bridge"
+	default:
+		// awsvpc / bridge / default: an egress-capable NIC (not host).
+		s.NetworkMode = nm
+	}
+	if s.HostNetwork != Yes {
+		s.HostNetwork = No
+	}
+
+	// --- namespaces ---------------------------------------------------------
+	s.HostPID = boolTri(strings.EqualFold(strings.TrimSpace(modes.PidMode), "host"))
+	s.HostIPC = boolTri(strings.EqualFold(strings.TrimSpace(modes.IpcMode), "host"))
+
+	return s
+}
+
+// ecsUserIsRoot reports whether an ECS `user` string resolves to uid 0.
+func ecsUserIsRoot(u string) bool {
+	u = strings.TrimSpace(u)
+	// "uid[:gid]" or "name[:group]": the leading field is the user.
+	if i := strings.IndexByte(u, ':'); i >= 0 {
+		u = u[:i]
+	}
+	return u == "0" || strings.EqualFold(u, "root")
+}

--- a/internal/host/scan/ecs_test.go
+++ b/internal/host/scan/ecs_test.go
@@ -1,0 +1,285 @@
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A hardened container inside the `aws ecs describe-task-definition` wrapper:
+// non-root user, cap_drop ALL, read-only rootfs, no-new-privileges, awsvpc net.
+const ecsDescribeHardened = `{
+  "taskDefinition": {
+    "family": "webapp",
+    "networkMode": "awsvpc",
+    "containerDefinitions": [
+      {
+        "name": "web",
+        "user": "1000",
+        "privileged": false,
+        "readonlyRootFilesystem": true,
+        "linuxParameters": {
+          "capabilities": { "drop": ["ALL"] },
+          "initProcessEnabled": true
+        },
+        "dockerSecurityOptions": ["no-new-privileges"]
+      }
+    ]
+  }
+}`
+
+// A raw registered task def (no wrapper): a root, privileged, host-network,
+// host-PID container mounting the docker control socket — the worst case.
+const ecsRawPorous = `{
+  "family": "legacy",
+  "networkMode": "host",
+  "pidMode": "host",
+  "ipcMode": "host",
+  "containerDefinitions": [
+    {
+      "name": "agent",
+      "user": "0",
+      "privileged": true
+    }
+  ],
+  "volumes": [
+    { "name": "sock", "host": { "sourcePath": "/var/run/docker.sock" } }
+  ]
+}`
+
+func TestSpecsFromECS_DescribeWrapperHardened(t *testing.T) {
+	specs, err := SpecsFromECS([]byte(ecsDescribeHardened))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("want 1 container, got %d: %v", len(specs), targets(specs))
+	}
+	s := specs[0]
+	if s.Source != "ecs" {
+		t.Errorf("source: want ecs, got %q", s.Source)
+	}
+	if s.Target != "ecs/webapp/web" {
+		t.Errorf("target: want ecs/webapp/web, got %q", s.Target)
+	}
+	if s.RunAsNonRoot != Yes || s.User != "1000" {
+		t.Errorf("user: RunAsNonRoot=%v User=%q", s.RunAsNonRoot, s.User)
+	}
+	if s.CapDropAll != Yes || s.ReadonlyRoot != Yes || s.Privileged != No {
+		t.Errorf("caps/rootfs/privileged: %+v", s)
+	}
+	if s.NetworkMode != "awsvpc" || s.HostNetwork != No {
+		t.Errorf("network: %q hostNet=%v (awsvpc is a NIC, not host)", s.NetworkMode, s.HostNetwork)
+	}
+	if s.NoNewPrivs != Yes {
+		t.Errorf("no-new-privileges not extracted: %v", s.NoNewPrivs)
+	}
+	if s.Seccomp != "confined" {
+		t.Errorf("seccomp: want confined (ECS docker default), got %q", s.Seccomp)
+	}
+	// awsvpc has an egress-capable NIC (not "none"), so network isolation cannot
+	// pass — the honest ceiling for a hardened ECS container is high-B, not A.
+	if r := Score(s); r.Score < 80 {
+		t.Errorf("hardened container should grade high (network is the only gap), got %d/100 (%s)", r.Score, r.Grade)
+	}
+}
+
+func TestSpecsFromECS_RawRootPorous(t *testing.T) {
+	specs, err := SpecsFromECS([]byte(ecsRawPorous))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("want 1 container, got %d", len(specs))
+	}
+	s := specs[0]
+	if s.Target != "ecs/legacy/agent" {
+		t.Errorf("target: want ecs/legacy/agent, got %q", s.Target)
+	}
+	if s.RunAsNonRoot != No || s.Privileged != Yes {
+		t.Errorf("root/privileged not caught: RunAsNonRoot=%v Privileged=%v", s.RunAsNonRoot, s.Privileged)
+	}
+	if s.NetworkMode != "host" || s.HostNetwork != Yes {
+		t.Errorf("host network not caught: %q hostNet=%v", s.NetworkMode, s.HostNetwork)
+	}
+	if s.HostPID != Yes || s.HostIPC != Yes {
+		t.Errorf("host pid/ipc not caught: pid=%v ipc=%v", s.HostPID, s.HostIPC)
+	}
+	if s.DockerSock != Yes {
+		t.Errorf("docker.sock host volume not caught: %v", s.DockerSock)
+	}
+	// No linuxParameters.capabilities => ECS keeps docker's default set (fail-closed).
+	if s.CapDropAll != No {
+		t.Errorf("missing capabilities should be No (docker default), got %v", s.CapDropAll)
+	}
+	if r := Score(s); r.Score >= 25 {
+		t.Errorf("privileged root host-net container should grade near-zero, got %d/100 (%s)", r.Score, r.Grade)
+	}
+}
+
+func TestSpecsFromECS_NoUserIsUnknown(t *testing.T) {
+	const noUser = `{"family":"f","networkMode":"awsvpc","containerDefinitions":[{"name":"c"}]}`
+	specs, err := SpecsFromECS([]byte(noUser))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if specs[0].RunAsNonRoot != Unknown {
+		t.Errorf("absent user should be Unknown (fail-closed), got %v", specs[0].RunAsNonRoot)
+	}
+}
+
+func TestSpecsFromECS_SeccompUnconfined(t *testing.T) {
+	const unconf = `{"family":"f","containerDefinitions":[
+		{"name":"c","user":"1000","dockerSecurityOptions":["seccomp:unconfined"]}]}`
+	specs, err := SpecsFromECS([]byte(unconf))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if specs[0].Seccomp != "unconfined" {
+		t.Errorf("seccomp:unconfined not caught, got %q", specs[0].Seccomp)
+	}
+}
+
+func TestSpecsFromECS_CapAddWeakens(t *testing.T) {
+	const capAdd = `{"family":"f","containerDefinitions":[
+		{"name":"c","user":"1000","linuxParameters":{"capabilities":{"drop":["ALL"],"add":["NET_ADMIN","sys_admin"]}}}]}`
+	specs, err := SpecsFromECS([]byte(capAdd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := specs[0]
+	if s.CapDropAll != Yes {
+		t.Errorf("cap drop ALL not caught: %v", s.CapDropAll)
+	}
+	// Added caps are upper-cased regardless of source casing.
+	if len(s.CapAdd) != 2 || s.CapAdd[0] != "NET_ADMIN" || s.CapAdd[1] != "SYS_ADMIN" {
+		t.Errorf("cap_add not normalized: %v", s.CapAdd)
+	}
+}
+
+func TestSpecsFromECS_MultiContainerAndAggregate(t *testing.T) {
+	// One hardened container + one root container in the same task.
+	const twoContainers = `{
+	  "taskDefinition": {
+	    "family": "svc",
+	    "networkMode": "awsvpc",
+	    "containerDefinitions": [
+	      {"name":"good","user":"1000","readonlyRootFilesystem":true,
+	       "linuxParameters":{"capabilities":{"drop":["ALL"]}},"dockerSecurityOptions":["no-new-privileges"]},
+	      {"name":"bad","user":"0","privileged":true}
+	    ]
+	  }
+	}`
+	specs, err := SpecsFromECS([]byte(twoContainers))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("want 2 containers, got %d: %v", len(specs), targets(specs))
+	}
+	report, worst, err := AggregateECS(specs, "svc.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Source != "ecs" || report.Target != "svc.json" {
+		t.Errorf("aggregate header: source=%q target=%q", report.Source, report.Target)
+	}
+	// Weakest-container rollup: the root/privileged container sets the grade.
+	if worst.Target != "ecs/svc/bad" {
+		t.Errorf("weakest container: want ecs/svc/bad, got %q", worst.Target)
+	}
+	if !strings.Contains(strings.Join(report.Notes, " "), "per-container:") {
+		t.Errorf("aggregate notes missing per-container roll-up: %v", report.Notes)
+	}
+}
+
+// TestSpecsFromECS_DogfoodSample grades the committed sample describe-task-definition
+// JSON on disk (a partly-hardened real-world task: a hardened api container plus a
+// privileged log-router sidecar). It locks in the dogfood result: the task rolls up
+// to the WEAKEST container.
+func TestSpecsFromECS_DogfoodSample(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "ecs-describe-taskdef.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	specs, err := SpecsFromECS(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("want 2 containers, got %d: %v", len(specs), targets(specs))
+	}
+	report, worst, err := AggregateECS(specs, "ecs-describe-taskdef.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The privileged log-router sidecar is the weakest link and sets the grade.
+	if worst.Target != "ecs/orders-api/log-router" || report.Grade != "F" {
+		t.Errorf("weakest-link rollup: worst=%q grade=%q (want ecs/orders-api/log-router / F)", worst.Target, report.Grade)
+	}
+}
+
+func TestAggregateECS_EmptyIsError(t *testing.T) {
+	if _, _, err := AggregateECS(nil, "x"); err == nil {
+		t.Fatal("want fail-closed error for empty container set, got nil")
+	}
+}
+
+func TestSpecsFromECS_NoContainersIsNoSpecs(t *testing.T) {
+	const empty = `{"taskDefinition":{"family":"f","networkMode":"awsvpc"}}`
+	specs, err := SpecsFromECS([]byte(empty))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("want 0 specs for a task with no containers, got %d", len(specs))
+	}
+}
+
+func TestSpecsFromECS_MalformedIsError(t *testing.T) {
+	if _, err := SpecsFromECS([]byte("not json")); err == nil {
+		t.Fatal("want parse error for malformed document, got nil")
+	}
+}
+
+// TestECSTerraformParity locks the two ECS entrypoints together: the same
+// container contract graded via --terraform (container_definitions as a JSON
+// STRING) and via --ecs (registered JSON) must produce identical dimension verdicts
+// and the same score. Only Source differs.
+func TestECSTerraformParity(t *testing.T) {
+	// Registered JSON (the --ecs path).
+	const ecsJSON = `{"taskDefinition":{"family":"api","networkMode":"awsvpc",
+		"containerDefinitions":[{"name":"api","user":"1000","readonlyRootFilesystem":true,
+		"linuxParameters":{"capabilities":{"drop":["ALL"]}},"dockerSecurityOptions":["no-new-privileges"]}]}}`
+	ecsSpecs, err := SpecsFromECS([]byte(ecsJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The SAME contract expressed in a terraform plan (container_definitions is a
+	// JSON-encoded string on aws_ecs_task_definition).
+	const tfJSON = `{"planned_values":{"root_module":{"resources":[{
+		"address":"aws_ecs_task_definition.api","type":"aws_ecs_task_definition","name":"api",
+		"values":{"family":"api","network_mode":"awsvpc",
+		"container_definitions":"[{\"name\":\"api\",\"user\":\"1000\",\"readonlyRootFilesystem\":true,\"linuxParameters\":{\"capabilities\":{\"drop\":[\"ALL\"]}},\"dockerSecurityOptions\":[\"no-new-privileges\"]}]"}}]}}}`
+	tfSpecs, err := SpecsFromTerraform([]byte(tfJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ecsSpecs) != 1 || len(tfSpecs) != 1 {
+		t.Fatalf("want 1 spec each, got ecs=%d tf=%d", len(ecsSpecs), len(tfSpecs))
+	}
+	e, tf := ecsSpecs[0], tfSpecs[0]
+	if e.Source != "ecs" || tf.Source != "terraform" {
+		t.Errorf("source: ecs=%q tf=%q", e.Source, tf.Source)
+	}
+	if Score(e).Score != Score(tf).Score {
+		t.Errorf("parity broken: ecs=%d tf=%d", Score(e).Score, Score(tf).Score)
+	}
+	// Dimension verdicts must match regardless of source.
+	if e.RunAsNonRoot != tf.RunAsNonRoot || e.CapDropAll != tf.CapDropAll ||
+		e.ReadonlyRoot != tf.ReadonlyRoot || e.NetworkMode != tf.NetworkMode ||
+		e.Seccomp != tf.Seccomp || e.NoNewPrivs != tf.NoNewPrivs {
+		t.Errorf("dimension divergence:\n ecs=%+v\n tf =%+v", e, tf)
+	}
+}

--- a/internal/host/scan/terraform.go
+++ b/internal/host/scan/terraform.go
@@ -411,8 +411,10 @@ func (t *tfInt) ptr() *int64 {
 // AWS ECS task definition mapping
 //
 // container_definitions is a JSON-ENCODED STRING holding an array of container
-// definitions (camelCase, Docker-flavored). We decode the string, grade each
-// container, and fold in the task-level network_mode / pid_mode / ipc_mode.
+// definitions (camelCase, Docker-flavored). We decode the string and grade each
+// container through the SHARED ecsSpec mapper (see ecs.go), folding in the
+// task-level network_mode / pid_mode / ipc_mode. The live `--ecs` path decodes the
+// same ecsContainerDef from registered JSON, so the two entrypoints stay in sync.
 // --------------------------------------------------------------------------- //
 
 type tfEcsValues struct {
@@ -429,23 +431,10 @@ type tfEcsVol struct {
 	HostPath string `json:"host_path"`
 }
 
-type ecsContainerDef struct {
-	Name                   string `json:"name"`
-	Privileged             *bool  `json:"privileged"`
-	ReadonlyRootFilesystem *bool  `json:"readonlyRootFilesystem"`
-	User                   string `json:"user"`
-	LinuxParameters        *struct {
-		Capabilities *struct {
-			Add  []string `json:"add"`
-			Drop []string `json:"drop"`
-		} `json:"capabilities"`
-	} `json:"linuxParameters"`
-	DockerSecurityOptions []string `json:"dockerSecurityOptions"`
-}
-
 // specsFromTFECS decodes one aws_ecs_task_definition and returns a graded Spec per
 // container definition. The task-level network/pid/ipc modes and any docker.sock
-// host volume apply to every container in the task.
+// host volume apply to every container in the task. The per-container grading is
+// the SHARED ecsSpec (ecs.go), keyed with source "terraform".
 func specsFromTFECS(r tfResource) []Spec {
 	var v tfEcsValues
 	if err := json.Unmarshal(r.Values, &v); err != nil {
@@ -472,106 +461,10 @@ func specsFromTFECS(r tfResource) []Spec {
 		}
 	}
 
+	modes := ecsTaskModes{NetworkMode: v.NetworkMode, PidMode: v.PidMode, IpcMode: v.IpcMode}
 	specs := make([]Spec, 0, len(defs))
 	for _, d := range defs {
-		specs = append(specs, ecsSpec(family, d, v, dockerSock))
+		specs = append(specs, ecsSpec("terraform", family, d, modes, dockerSock))
 	}
 	return specs
-}
-
-// ecsSpec maps one ECS container definition (plus task-level modes) to a Spec.
-func ecsSpec(family string, d ecsContainerDef, task tfEcsValues, dockerSock Tristate) Spec {
-	target := "ecs/" + family
-	if strings.TrimSpace(d.Name) != "" {
-		target = "ecs/" + family + "/" + d.Name
-	}
-	s := Spec{Source: "terraform", Target: target, DockerSock: dockerSock}
-
-	// --- user ---------------------------------------------------------------
-	// ECS `user` is a string: "", "0", "root", "1000", "1000:1000", "appuser".
-	switch u := strings.TrimSpace(d.User); {
-	case u == "":
-		s.RunAsNonRoot = Unknown
-		s.Notes = append(s.Notes, "no container user set; the image default may be root")
-	case ecsUserIsRoot(u):
-		s.RunAsNonRoot = No
-		s.User = u
-	default:
-		s.RunAsNonRoot = Yes
-		s.User = u
-	}
-
-	// --- capabilities / privilege ------------------------------------------
-	s.Privileged = triFromPtr(d.Privileged)
-	if d.LinuxParameters != nil && d.LinuxParameters.Capabilities != nil {
-		caps := d.LinuxParameters.Capabilities
-		for _, dr := range caps.Drop {
-			if strings.EqualFold(strings.TrimSpace(dr), "ALL") {
-				s.CapDropAll = Yes
-			}
-		}
-		if s.CapDropAll == Unknown {
-			s.CapDropAll = No
-		}
-		for _, a := range caps.Add {
-			if a = strings.TrimSpace(a); a != "" {
-				s.CapAdd = append(s.CapAdd, strings.ToUpper(a))
-			}
-		}
-	} else {
-		// No linuxParameters.capabilities: ECS keeps Docker's default capability
-		// set (fail-closed, same as the compose/docker default).
-		s.CapDropAll = No
-	}
-
-	// --- read-only rootfs ---------------------------------------------------
-	s.ReadonlyRoot = triFromPtr(d.ReadonlyRootFilesystem)
-
-	// --- seccomp ------------------------------------------------------------
-	// ECS applies Docker's DEFAULT seccomp profile unless a dockerSecurityOption
-	// disables it. Mirror the docker/compose adapters: default profile = confined.
-	s.Seccomp = "confined"
-	for _, opt := range d.DockerSecurityOptions {
-		o := strings.ToLower(strings.TrimSpace(opt))
-		if o == "seccomp=unconfined" || o == "seccomp:unconfined" {
-			s.Seccomp = "unconfined"
-		}
-		if o == "no-new-privileges" || o == "no-new-privileges:true" {
-			s.NoNewPrivs = Yes
-		}
-	}
-
-	// --- network ------------------------------------------------------------
-	switch nm := strings.ToLower(strings.TrimSpace(task.NetworkMode)); nm {
-	case "none":
-		s.NetworkMode = "none"
-	case "host":
-		s.NetworkMode = "host"
-		s.HostNetwork = Yes
-	case "":
-		// ECS default network mode is bridge on EC2; egress-capable.
-		s.NetworkMode = "bridge"
-	default:
-		// awsvpc / bridge / default: an egress-capable NIC (not host).
-		s.NetworkMode = nm
-	}
-	if s.HostNetwork != Yes {
-		s.HostNetwork = No
-	}
-
-	// --- namespaces ---------------------------------------------------------
-	s.HostPID = boolTri(strings.EqualFold(strings.TrimSpace(task.PidMode), "host"))
-	s.HostIPC = boolTri(strings.EqualFold(strings.TrimSpace(task.IpcMode), "host"))
-
-	return s
-}
-
-// ecsUserIsRoot reports whether an ECS `user` string resolves to uid 0.
-func ecsUserIsRoot(u string) bool {
-	u = strings.TrimSpace(u)
-	// "uid[:gid]" or "name[:group]": the leading field is the user.
-	if i := strings.IndexByte(u, ':'); i >= 0 {
-		u = u[:i]
-	}
-	return u == "0" || strings.EqualFold(u, "root")
 }

--- a/internal/host/scan/testdata/ecs-describe-taskdef.json
+++ b/internal/host/scan/testdata/ecs-describe-taskdef.json
@@ -1,0 +1,25 @@
+{
+  "taskDefinition": {
+    "family": "orders-api",
+    "networkMode": "awsvpc",
+    "revision": 7,
+    "containerDefinitions": [
+      {
+        "name": "api",
+        "image": "1234.dkr.ecr.us-east-1.amazonaws.com/orders-api:1.4.2",
+        "user": "10001",
+        "readonlyRootFilesystem": true,
+        "linuxParameters": {
+          "capabilities": { "drop": ["ALL"] },
+          "initProcessEnabled": true
+        },
+        "dockerSecurityOptions": ["no-new-privileges"]
+      },
+      {
+        "name": "log-router",
+        "image": "amazon/aws-for-fluent-bit:stable",
+        "privileged": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

`ironctl scan --ecs <taskdef.json>` grades the container contract of an AWS ECS task definition on the shared 0-100, 7-dimension scorer.

**Distinct from `--terraform`:** terraform grades an `aws_ecs_task_definition` from HCL/plan; `--ecs` grades the **registered/live JSON** from `aws ecs describe-task-definition`, which most AWS-console / CDK / Copilot users have but never express as terraform.

## How

- **Shared scorer (no divergence):** factored the ECS container scorer out of `terraform.go` into a new `ecs.go` (`ecsSpec` + `ecsContainerDef` + `ecsUserIsRoot`). Both `--ecs` and the terraform `aws_ecs_task_definition` path now decode into the SAME `ecsContainerDef` and grade through the SAME `ecsSpec`. Locked by `TestECSTerraformParity` (same contract via both entrypoints → identical score + dimension verdicts; only `Source` differs).
- **Input forms** (`SpecsFromECS`):
  - `aws ecs describe-task-definition` output — top-level `{taskDefinition:{containerDefinitions:[...]}}` wrapper.
  - Raw registered task-def JSON — `containerDefinitions[]` at the root (CDK / Copilot / API JSON).
  - Directory → weakest-container rollup across every `*.json` (CLI `loadECSSpecs`).
- **Mapping:** `privileged`, `readonlyRootFilesystem`, `user`, `linuxParameters.capabilities.{add,drop}`, `dockerSecurityOptions` (seccomp / no-new-privileges), task-level `networkMode`/`pidMode`/`ipcMode`, and docker.sock host-volume detection. `networkMode: host` is worst; `awsvpc`/`bridge` are egress-capable NICs (not host); ECS default seccomp = confined.
- **CLI:** `--ecs` flag + `runECSScan` (re-parse-after-first-positional; fail-open on load/parse; `--min-score` CI gate; `--json`/`--md`/`--badge`/`--sarif`). `docs/scan.md` section + runtime-table row + usage text.

## Dogfood

Sample `describe-task-definition` (hardened `api` container + privileged `log-router` sidecar), committed as `testdata/ecs-describe-taskdef.json`:

```
score: 19/100 grade F (wide open)
per-container: ecs/orders-api/log-router = 19/100 (F); ecs/orders-api/api = 89/100 (B)
```

Weakest-container rollup: the privileged sidecar sets the task grade; the hardened container reaches the honest 89/B ceiling (awsvpc egress can't pass network isolation). `--min-score 75` trips (exit 1); malformed input fails open (exit 0 + diagnostic).

## Lenses

- **Fail-closed / fail-loud:** unknown dimensions graded insecure; empty container set is an error; low posture trips `--min-score`. Load/parse failures fail **open** (opt-in CI step never crashes the build).
- **Build-matrix fidelity:** 150 scan tests pass; `go build ./...` green with `CGO_ENABLED=1`.

## Verification

- `CGO_ENABLED=1 go test ./internal/host/scan/` → 150 passed.
- `CGO_ENABLED=1 go build ./...` clean; `go vet` clean; `gofmt` clean.
- Dogfood CLI runs above (table/JSON/dir-rollup/min-score gate/fail-open) exercised against the built binary.

Closes IRO-517.