### PR TITLE
feat(scan): ironctl scan --cloudrun grades Google Cloud Run service specs (IRO-516)

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -48,6 +48,7 @@ func cmdScan(args []string) error {
 	nomad := fs.String("nomad", "", "grade docker-driver tasks in a HashiCorp Nomad job spec (job.json, or a .hcl/.nomad file rendered via `nomad job run -output`)")
 	nomadBin := fs.String("nomad-bin", envOrDefault("NOMAD", "nomad"), "nomad binary used to render an HCL job to JSON (`nomad job run -output`)")
 	ecs := fs.String("ecs", "", "grade an AWS ECS task definition: `aws ecs describe-task-definition` JSON, a raw registered task-def JSON, or a directory of task-def JSON files")
+	cloudrun := fs.String("cloudrun", "", "grade Google Cloud Run service specs: a Knative Service YAML (`gcloud run services describe SVC --format=export`), or a directory of them")
 	dockerfile := fs.Bool("dockerfile", false, "statically grade the positional Dockerfile(s) authoring-time posture (daemon-free)")
 	runtime := fs.String("runtime", envOrDefault("IRONCTL_SCAN_RUNTIME", "auto"), "container runtime: auto|docker|podman|nerdctl")
 	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker inspect`")
@@ -173,6 +174,25 @@ func cmdScan(args []string) error {
 	if *ecs != "" {
 		return runECSScan(ecsArgs{
 			path:      *ecs,
+			asJSON:    *asJSON,
+			md:        *md,
+			badge:     *badge,
+			badgeJSON: *badgeJSON,
+			sarif:     *sarif,
+			minScore:  *minScore,
+		})
+	}
+
+	// --cloudrun: consume a Google Cloud Run service spec (a Knative Service YAML
+	// as emitted by `gcloud run services describe --format=export`, or a directory
+	// of them) and grade its revision containers, reusing the same pod-spec scorer
+	// as --k8s/--helm plus Cloud Run's managed-runtime guarantees. It loads YAML
+	// here (no external binary — Cloud Run specs are plain YAML) then defers to the
+	// pure SpecsFromCloudRun + AggregateCloudRun scorer. Fail-OPEN on a load/parse
+	// failure; --min-score still gates once services are graded.
+	if *cloudrun != "" {
+		return runCloudRunScan(cloudRunScanArgs{
+			path:      *cloudrun,
 			asJSON:    *asJSON,
 			md:        *md,
 			badge:     *badge,
@@ -903,6 +923,129 @@ func loadECSSpecs(path string) ([]scan.Spec, error) {
 	return specs, nil
 }
 
+// cloudRunScanArgs carries the resolved inputs for a `scan --cloudrun` run.
+type cloudRunScanArgs struct {
+	path      string
+	asJSON    bool
+	md        bool
+	badge     string
+	badgeJSON string
+	sarif     string
+	minScore  int
+}
+
+// runCloudRunScan grades the Google Cloud Run services declared in a Knative
+// Service YAML (or a directory of them), reusing the same pod-spec dimension
+// mapping and weakest-link aggregate as --helm/--terraform plus Cloud Run's
+// managed-runtime guarantees. Cloud Run specs are plain YAML, so there is no
+// external binary to shell out to. It fails OPEN on a load/parse failure
+// (unreadable path, malformed YAML): it prints a clear diagnostic to stderr and
+// returns nil so an opt-in CI/Action step never crashes the build. Once services
+// are graded, scoring and the --min-score CI gate apply exactly like
+// --k8s/--helm/--terraform/--nomad (a genuinely low posture still fails the gate).
+func runCloudRunScan(a cloudRunScanArgs) error {
+	raw, err := loadCloudRunYAML(a.path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --cloudrun could not load %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	specs, err := scan.SpecsFromCloudRun(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --cloudrun could not parse %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregateCloudRun(specs, filepath.Base(strings.TrimRight(a.path, "/")))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --cloudrun found nothing to grade in %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (services graded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// loadCloudRunYAML resolves a --cloudrun argument to a Knative Service YAML stream.
+// A file is read verbatim (it may itself be a multi-document `---`-separated
+// stream). A directory is walked for *.yaml/*.yml files, concatenated into one
+// document stream (weakest-service rollup across the deployment). It is offline
+// and daemon-free: Cloud Run specs are plain YAML, so there is nothing to shell
+// out to.
+func loadCloudRunYAML(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return os.ReadFile(path)
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	var docs [][]byte
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(e.Name()))
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+		raw, rerr := os.ReadFile(filepath.Join(path, e.Name()))
+		if rerr != nil {
+			return nil, rerr
+		}
+		docs = append(docs, raw)
+	}
+	if len(docs) == 0 {
+		return nil, fmt.Errorf("no .yaml/.yml files found in directory %q", path)
+	}
+	return bytes.Join(docs, []byte("\n---\n")), nil
+}
+
 // writeDockerfileSARIF renders the Dockerfile SARIF log to path, fail-open on error.
 func writeDockerfileSARIF(path string, r scan.Report, opts scan.SARIFOptions) error {
 	f, err := os.Create(path)
@@ -1036,6 +1179,7 @@ USAGE:
   ironctl scan --terraform PATH                grade container workloads in a terraform show -json file/dir
   ironctl scan --nomad PATH                     grade docker-driver tasks in a Nomad job spec (JSON or HCL)
   ironctl scan --ecs PATH                       grade an AWS ECS task definition (describe-task-definition JSON / dir)
+  ironctl scan --cloudrun PATH                  grade Google Cloud Run service specs (Knative Service YAML or dir)
   ironctl scan --dockerfile FILE...           grade Dockerfile(s) statically (no daemon, no pull)
   ironctl scan --compare A B                   diff two containers' isolation posture
 
@@ -1105,6 +1249,20 @@ the LIVE counterpart to --terraform: it grades the registered JSON that AWS-cons
 awsvpc/bridge are egress-capable NICs (not host); ECS default seccomp is confined.
 The task grade is the WEAKEST container; load/parse failures fail OPEN (diagnostic +
 exit 0). A successful parse still trips --min-score.
+
+--cloudrun grades a Google Cloud Run service spec — a Knative Service YAML
+(`+"`gcloud run services describe SVC --format=export`"+`), or a directory of them (weakest
+service governs). Cloud Run's revision template carries a Kubernetes-shaped pod
+spec, so it reuses the same pod-spec scorer as --k8s/--helm and then folds in
+Cloud Run's MANAGED-RUNTIME guarantees: the platform forbids privileged mode and
+host PID/IPC/network namespaces, never mounts a host docker.sock, and sandboxes
+every container (gen1 gVisor / gen2 microVM) so the syscall surface is filtered by
+default — those dimensions pass by construction. Non-root user and a read-only
+rootfs stay the spec's job (graded fail-closed when absent). Egress is managed
+(allowed by default, restrictable via VPC egress settings) and can never be
+network=none, so a fully hardened Cloud Run service tops out at 89/100 (grade B),
+the honest ceiling for an egress-capable managed runtime. Load/parse failures fail
+OPEN (diagnostic + exit 0). A successful parse still trips --min-score.
 
 --dockerfile grades a DIFFERENT, authoring-time dimension set (non-root USER,
 pinned base image, no secrets in ENV/ARG, COPY over remote/opaque ADD, no

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -68,6 +68,7 @@ inspect data, so probe-masking from inside the container cannot change the score
 | Helm | `--helm CHART` | renders a chart with `helm template` and grades its workloads, no cluster needed |
 | Terraform | `--terraform PATH` | grades container workloads in a `terraform show -json` plan/state, no apply needed (see below) |
 | AWS ECS | `--ecs PATH` | grades a live `aws ecs describe-task-definition` (or registered) task definition, no AWS call needed (see below) |
+| Cloud Run | `--cloudrun PATH` | grades a Google Cloud Run service spec (Knative Service YAML) or a directory of them, no account needed (see below) |
 | Dockerfile | `--dockerfile FILE` | grades authoring-time posture statically, no daemon and no image pull (see below) |
 
 Selection and binaries:
@@ -177,6 +178,48 @@ security group that a task definition does not carry, so it is graded
 conservatively, the honest static ceiling. A malformed document fails **open** (a
 clear diagnostic and exit 0) so an opt-in CI step never crashes the build; once
 containers are graded, `--min-score` still trips on a low posture.
+
+## Grade a Google Cloud Run service
+
+`--cloudrun PATH` grades a [Google Cloud Run](https://cloud.google.com/run)
+service spec — a Knative `Service` document (`serving.knative.dev/v1`) — before it
+reaches a project. Cloud Run specs are plain YAML, so it is structured and
+daemon-free, with no `gcloud` login and no external binary:
+
+```bash
+gcloud run services describe SVC --format=export > svc.yaml
+ironctl scan --cloudrun svc.yaml
+ironctl scan --cloudrun svc.yaml --min-score 80   # CI gate
+ironctl scan --cloudrun ./run-services            # a directory of service YAMLs
+```
+
+Pass a single Knative `Service` YAML (the `gcloud ... --format=export` output, or a
+hand-authored spec), a multi-document `---`-separated stream, or a directory of
+them (the weakest service governs). Cloud Run's revision template carries a
+Kubernetes-shaped pod spec at `spec.template.spec.containers[]`, so it reuses the
+same pod-spec dimension set as `--k8s`/`--helm` and then folds in Cloud Run's
+**managed-runtime guarantees**:
+
+| Dimension | How Cloud Run is graded |
+|---|---|
+| Non-root user | graded on the revision's `securityContext.runAsNonRoot` / `runAsUser`; unset means the image default (root), scored fail-closed. Cloud Run runs the container as its configured user. |
+| Dropped capabilities | the managed sandbox does not permit privileged mode or added capabilities, so the restricted managed set is credited unless the spec explicitly adds one. |
+| Seccomp | every container is sandboxed (gen1 gVisor / gen2 microVM), so the syscall surface is filtered by default — credited as confined unless the spec sets `seccompProfile: Unconfined`. |
+| Network isolation | Cloud Run egress is **managed**: allowed by default and restrictable via VPC egress settings, but never `network=none`. Graded as egress-capable (the honest ceiling). |
+| Read-only rootfs | graded on `securityContext.readOnlyRootFilesystem`; unset means writable, scored fail-closed. |
+| docker.sock | impossible on Cloud Run (no host bind mounts) — passes by construction. |
+| Host namespaces | privileged mode and host PID/IPC/network are not permitted — passes by construction. |
+
+Because the platform forbids privileged mode and host namespaces, blocks the
+docker socket, and sandboxes every container, a Cloud Run service starts from a
+strong floor. What stays your job is running as **non-root** with a **read-only
+rootfs**. A fully hardened service tops out at **89/100 (grade B)**: egress is
+managed and can never be `network=none`, the same honest ceiling any
+egress-capable managed runtime hits. The `gen1` execution environment is surfaced
+as gVisor (`runsc`) informationally; scoring stays runtime-agnostic. Load or parse
+failures fail **open** (a clear diagnostic and exit 0) so an opt-in CI step never
+crashes the build; once services are graded, `--min-score` still trips on a low
+posture.
 
 ## Grade a Dockerfile statically
 

--- a/internal/host/scan/cloudrun.go
+++ b/internal/host/scan/cloudrun.go
@@ -1,0 +1,291 @@
+package scan
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SpecsFromCloudRun parses a Google Cloud Run service specification — a Knative
+// Service document (apiVersion: serving.knative.dev/v1, kind: Service), as emitted
+// by `gcloud run services describe SVC --format=export` or hand-authored — and
+// returns one graded Spec per Service across a multi-document stream.
+//
+// Cloud Run's revision template carries a Kubernetes-shaped pod spec at
+// spec.template.spec.containers[], so we reuse the SAME specFromPodSpec scorer
+// path as --k8s/--helm and then fold in Cloud Run's MANAGED-RUNTIME guarantees:
+// the platform forbids privileged mode and host namespaces, never mounts a host
+// docker socket, and sandboxes every container (gen1 = gVisor, gen2 = microVM)
+// so the syscall surface is filtered by default. Those are genuine platform wins
+// the raw pod-spec grader cannot see, so we credit them explicitly. What stays the
+// user's job — running as non-root and a read-only rootfs — is graded on what the
+// spec expresses, fail-closed when absent. Cloud Run's egress is managed (allowed
+// by default, restrictable via VPC egress settings) and can never be network=none,
+// so a fully hardened service tops out at the same honest 89/B ceiling we document
+// for any egress-capable managed runtime.
+//
+// It is pure and unit-testable: the caller loads the YAML (I/O) and passes the
+// bytes here. It fails OPEN on a malformed document (returns the parse error); the
+// CLI wrapper turns that into a skip so an opt-in CI step never crashes the build.
+func SpecsFromCloudRun(raw []byte) ([]Spec, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	var specs []Spec
+	for {
+		var svc cloudRunService
+		err := dec.Decode(&svc)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse cloud run service yaml: %w", err)
+		}
+		if s, ok := specFromCloudRunService(svc); ok {
+			specs = append(specs, s)
+		}
+	}
+	return specs, nil
+}
+
+// AggregateCloudRun folds the per-service specs of a Cloud Run deployment into a
+// single Report. Like AggregateHelm/AggregateNomad, the aggregate is the WEAKEST
+// service (minimum score): a deployment is only as isolated as its most-exposed
+// service, so grading the weakest link is the honest, fail-closed summary. target
+// names the source (file/dir). It returns the aggregate Report and the Spec that
+// produced it (for SARIF anchoring). It is pure; the caller injects
+// Version/GeneratedAt. Fail-closed: an empty service set is an error (a document
+// that declares no gradeable Cloud Run service is not a pass).
+func AggregateCloudRun(specs []Spec, target string) (Report, Spec, error) {
+	if len(specs) == 0 {
+		return Report{}, Spec{}, fmt.Errorf("no gradeable Cloud Run services found (looked for Knative Service documents with spec.template.spec.containers)")
+	}
+
+	all := make([]scoredWorkload, len(specs))
+	worst := 0
+	for i, s := range specs {
+		all[i] = scoredWorkload{spec: s, report: Score(s)}
+		if all[i].report.Score < all[worst].report.Score {
+			worst = i
+		}
+	}
+
+	agg := all[worst].report
+	worstSpec := all[worst].spec
+	if strings.TrimSpace(target) != "" {
+		agg.Target = target
+	}
+	agg.Source = "cloudrun"
+	agg.Notes = append(cloudRunSummaryNotes(all[worst], all), agg.Notes...)
+
+	return agg, worstSpec, nil
+}
+
+// cloudRunSummaryNotes builds the deployment-level roll-up notes for an aggregate
+// Cloud Run report: a headline naming the weakest service and a per-service score
+// list.
+func cloudRunSummaryNotes(worst scoredWorkload, all []scoredWorkload) []string {
+	notes := []string{
+		fmt.Sprintf("graded %d Cloud Run service(s); the grade is the WEAKEST (a deployment is only as isolated as its most-exposed service). Weakest: %s at %d/100 (grade %s).",
+			len(all), nz(worst.spec.Target, "service"), worst.report.Score, worst.report.Grade),
+	}
+	sorted := make([]scoredWorkload, len(all))
+	copy(sorted, all)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].report.Score < sorted[j].report.Score })
+	rows := make([]string, len(sorted))
+	for i, w := range sorted {
+		rows[i] = fmt.Sprintf("%s = %d/100 (%s)", nz(w.spec.Target, "service"), w.report.Score, w.report.Grade)
+	}
+	notes = append(notes, "per-service: "+strings.Join(rows, "; "))
+	return notes
+}
+
+// --------------------------------------------------------------------------- //
+// Cloud Run / Knative Service document model.
+// --------------------------------------------------------------------------- //
+
+// cloudRunService is the security-relevant subset of a Knative Service document
+// (serving.knative.dev/v1). The revision template's spec is a Kubernetes-shaped
+// pod spec (containers[].securityContext, resources), so we decode it into the
+// SAME podSpec type the k8s/helm adapters use and grade it through specFromPodSpec.
+type cloudRunService struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Template struct {
+			Metadata struct {
+				Annotations map[string]string `yaml:"annotations"`
+			} `yaml:"metadata"`
+			// The revision template's spec IS a Kubernetes-shaped pod spec, so we
+			// decode it into the shared podSpec type and grade it via specFromPodSpec.
+			Spec podSpec `yaml:"spec"`
+		} `yaml:"template"`
+	} `yaml:"spec"`
+}
+
+// isKnativeService reports whether a decoded document is a Cloud Run / Knative
+// Service worth grading. It matches on kind (Service) and, when present, the
+// Knative serving API group, so an unrelated Kubernetes Service (v1) is not
+// mistaken for a Cloud Run revision.
+func (svc cloudRunService) isKnativeService() bool {
+	if !strings.EqualFold(strings.TrimSpace(svc.Kind), "Service") {
+		return false
+	}
+	api := strings.ToLower(strings.TrimSpace(svc.APIVersion))
+	if api == "" {
+		// Tolerate an export that omitted apiVersion but clearly carries a Cloud Run
+		// revision template (containers under spec.template.spec).
+		return len(svc.Spec.Template.Spec.Containers) > 0
+	}
+	return strings.Contains(api, "serving.knative.dev") || strings.Contains(api, "run.googleapis.com")
+}
+
+// specFromCloudRunService maps one Cloud Run / Knative Service to a graded Spec.
+// ok is false for a non-Service document or a Service with no revision container.
+// It grades the FIRST container's expressible posture via specFromPodSpec, then
+// folds in Cloud Run's managed-runtime guarantees.
+func specFromCloudRunService(svc cloudRunService) (Spec, bool) {
+	if !svc.isKnativeService() {
+		return Spec{}, false
+	}
+	ps := svc.Spec.Template.Spec
+	if len(ps.Containers) == 0 {
+		return Spec{}, false
+	}
+
+	name := strings.TrimSpace(svc.Metadata.Name)
+	// Grade the expressible pod-spec posture (non-root, read-only rootfs, any
+	// explicit capabilities/seccomp the revision declares) exactly like --k8s.
+	s := specFromPodSpec("cloudrun", name, ps)
+
+	// The k8s pod-spec grader appends two conservative notes that are WRONG for
+	// Cloud Run: it assumes seccomp is unconfined by default and that egress is
+	// governed by an invisible NetworkPolicy. Drop them; Cloud Run's managed
+	// runtime gives concrete, honest answers below.
+	s.Notes = dropNotesContaining(s.Notes, "seccompProfile set", "NetworkPolicy")
+
+	// --- managed-runtime guarantees (platform-enforced, not spec-visible) -----
+	// Cloud Run forbids privileged mode and host namespaces, and never mounts a
+	// host docker socket into a revision. These are genuine platform wins the raw
+	// pod-spec grader scores fail-closed (Unknown), so credit them explicitly.
+	s.Privileged = No
+	s.HostPID = No
+	s.HostIPC = No
+	s.HostNetwork = No
+	s.DockerSock = No
+
+	// The managed sandbox restricts the capability surface: a revision cannot run
+	// privileged and cannot ADD capabilities, so unless the spec explicitly adds
+	// some, the effective set is the restricted managed default. Credit it as a
+	// drop-all-equivalent when the spec adds nothing.
+	if len(s.CapAdd) == 0 {
+		s.CapDropAll = Yes
+	}
+
+	// Every Cloud Run container is sandboxed (gen1 = gVisor, gen2 = microVM), which
+	// filters the syscall surface by default. Mirror the ECS/docker "default
+	// profile = confined" mapping: an unset seccompProfile is confined here, not
+	// unconfined. Respect an explicit seccompProfile: Unconfined the spec set.
+	if strings.TrimSpace(s.Seccomp) == "" {
+		s.Seccomp = "confined"
+	}
+
+	// --- network (managed egress → honest 89/B ceiling) -----------------------
+	// Cloud Run egress is managed: allowed by default, restrictable via VPC egress
+	// settings, but never network=none. Grade it as egress-capable (the scorer's
+	// WARN tier), the same honest ceiling we document for any managed runtime.
+	s.NetworkMode = "cloudrun (managed egress)"
+
+	// --- managed-runtime + expressible-posture notes --------------------------
+	env := cloudRunExecEnv(svc)
+	switch env {
+	case "gen1":
+		// gen1 wraps every container in gVisor (runsc). Surface it informationally
+		// via the hardened-runtime path (scoring stays runtime-agnostic per IRO-429).
+		s.Runtime = "runsc"
+		s.Notes = append(s.Notes, "Cloud Run gen1 execution environment: every container runs in the gVisor (runsc) sandbox (userspace-kernel syscall interception)")
+	case "gen2":
+		s.Notes = append(s.Notes, "Cloud Run gen2 execution environment: every container runs in a microVM sandbox (hardware-virtualization isolation)")
+	default:
+		s.Notes = append(s.Notes, "Cloud Run managed sandbox isolates every container (gen1 gVisor / gen2 microVM); privileged mode and host namespaces are not permitted")
+	}
+	s.Notes = append(s.Notes,
+		"managed runtime: Cloud Run forbids privileged mode, host PID/IPC/network namespaces, and host docker.sock mounts — those dimensions pass by construction",
+		"network egress is managed (allowed by default, restrictable via VPC egress settings) and can never be network=none, so a fully hardened Cloud Run service tops out at 89/100 (grade B) — the honest ceiling for an egress-capable managed runtime")
+
+	// Resource limits are expressible on a revision but are NOT a containment
+	// dimension in the 7-dim scorer; surface them as evidence without awarding
+	// points (we do not invent a dimension).
+	if lims := cloudRunResourceLimits(svc); lims != "" {
+		s.Notes = append(s.Notes, "resource limits declared ("+lims+"); informational — not a containment dimension")
+	} else {
+		s.Notes = append(s.Notes, "no resources.limits declared; a runaway revision is bounded only by the Cloud Run platform defaults")
+	}
+
+	return s, true
+}
+
+// cloudRunExecEnv returns the revision's execution-environment ("gen1"/"gen2"), or
+// "" when the annotation is absent. Cloud Run carries it as the annotation
+// run.googleapis.com/execution-environment on the revision template.
+func cloudRunExecEnv(svc cloudRunService) string {
+	v := strings.ToLower(strings.TrimSpace(svc.Spec.Template.Metadata.Annotations["run.googleapis.com/execution-environment"]))
+	switch v {
+	case "gen1", "gen2":
+		return v
+	default:
+		return ""
+	}
+}
+
+// cloudRunResourceLimits renders the first revision container's resource limits as
+// a compact "cpu=1, memory=512Mi" string, or "" when none are declared.
+func cloudRunResourceLimits(svc cloudRunService) string {
+	conts := svc.Spec.Template.Spec.Containers
+	if len(conts) == 0 || conts[0].Resources == nil {
+		return ""
+	}
+	lims := conts[0].Resources.Limits
+	if len(lims) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(lims))
+	for k := range lims {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+lims[k])
+	}
+	return strings.Join(parts, ", ")
+}
+
+// dropNotesContaining returns notes with every entry that contains any of the
+// given substrings removed. Used to strip the k8s pod-spec grader's conservative
+// seccomp/NetworkPolicy notes, which do not apply to Cloud Run's managed runtime.
+func dropNotesContaining(notes []string, subs ...string) []string {
+	if len(notes) == 0 {
+		return notes
+	}
+	out := notes[:0:0]
+	for _, n := range notes {
+		drop := false
+		for _, sub := range subs {
+			if strings.Contains(n, sub) {
+				drop = true
+				break
+			}
+		}
+		if !drop {
+			out = append(out, n)
+		}
+	}
+	return out
+}

--- a/internal/host/scan/cloudrun_test.go
+++ b/internal/host/scan/cloudrun_test.go
@@ -1,0 +1,292 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+// cloudRunHardenedService is a Knative Service whose revision hardens everything a
+// Cloud Run spec CAN express: it runs as non-root and mounts a read-only rootfs.
+// Combined with Cloud Run's managed-runtime guarantees (no privileged, no host
+// namespaces, no docker.sock, sandboxed syscalls), this is the best a Cloud Run
+// service reaches — the honest 89/B ceiling (egress is managed, never none).
+const cloudRunHardenedService = `
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: web
+spec:
+  template:
+    metadata:
+      annotations:
+        run.googleapis.com/execution-environment: gen2
+    spec:
+      containers:
+        - image: gcr.io/proj/web
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+          resources:
+            limits:
+              cpu: "1"
+              memory: 512Mi
+`
+
+// cloudRunBaselineService declares no securityContext at all: it runs as the
+// image default (root) with a writable rootfs. The managed-runtime floors still
+// apply (caps restricted, seccomp confined, no privileged/host-ns/docker.sock), so
+// it lands mid-band rather than failing.
+const cloudRunBaselineService = `
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: legacy
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/proj/legacy
+`
+
+// cloudRunExportService mirrors `gcloud run services describe --format=export`:
+// it carries the gen1 execution-environment annotation and extra metadata the
+// grader must tolerate. gen1 wraps every container in gVisor (runsc).
+const cloudRunExportService = `
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: api
+  annotations:
+    run.googleapis.com/ingress: all
+spec:
+  template:
+    metadata:
+      annotations:
+        run.googleapis.com/execution-environment: gen1
+    spec:
+      containerConcurrency: 80
+      containers:
+        - image: gcr.io/proj/api
+          securityContext:
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
+`
+
+func gradeCloudRun(t *testing.T, raw string) (Report, Spec) {
+	t.Helper()
+	specs, err := SpecsFromCloudRun([]byte(raw))
+	if err != nil {
+		t.Fatalf("SpecsFromCloudRun: %v", err)
+	}
+	report, worst, err := AggregateCloudRun(specs, "service.yaml")
+	if err != nil {
+		t.Fatalf("AggregateCloudRun: %v", err)
+	}
+	return report, worst
+}
+
+func TestCloudRunHardenedHitsCeiling(t *testing.T) {
+	report, worst := gradeCloudRun(t, cloudRunHardenedService)
+	if report.Score != 89 || report.Grade != "B" {
+		t.Fatalf("hardened Cloud Run service: got %d/100 (grade %s), want 89 (B) — the managed-egress ceiling; notes: %v", report.Score, report.Grade, report.Notes)
+	}
+	if report.Source != "cloudrun" {
+		t.Errorf("source = %q, want cloudrun", report.Source)
+	}
+	// Managed-runtime guarantees must be credited, not fail-closed.
+	if worst.Privileged != No || worst.HostPID != No || worst.HostIPC != No || worst.HostNetwork != No {
+		t.Errorf("managed floors not applied: priv=%v hostPID=%v hostIPC=%v hostNet=%v", worst.Privileged, worst.HostPID, worst.HostIPC, worst.HostNetwork)
+	}
+	if worst.DockerSock != No {
+		t.Errorf("docker.sock should be impossible on Cloud Run: %v", worst.DockerSock)
+	}
+	if worst.CapDropAll != Yes {
+		t.Errorf("managed sandbox should credit dropped caps: %v", worst.CapDropAll)
+	}
+	if worst.Seccomp != "confined" {
+		t.Errorf("managed sandbox seccomp = %q, want confined", worst.Seccomp)
+	}
+}
+
+func TestCloudRunBaselineManagedFloors(t *testing.T) {
+	// No securityContext: non-root and read-only rootfs are unknown (fail-closed),
+	// but the managed floors keep the service out of the failing band.
+	report, worst := gradeCloudRun(t, cloudRunBaselineService)
+	if worst.RunAsNonRoot != Unknown {
+		t.Errorf("baseline user = %v, want Unknown (image default may be root)", worst.RunAsNonRoot)
+	}
+	if worst.ReadonlyRoot != Unknown {
+		t.Errorf("baseline rootfs = %v, want Unknown (writable by default)", worst.ReadonlyRoot)
+	}
+	// 20 (caps) + 15 (seccomp) + 4 (net) + 15 (sock) + 10 (host-ns) = 64.
+	if report.Score != 64 || report.Grade != "C" {
+		t.Fatalf("baseline Cloud Run service: got %d/100 (grade %s), want 64 (C); notes: %v", report.Score, report.Grade, report.Notes)
+	}
+}
+
+func TestCloudRunGen1SurfacesGVisor(t *testing.T) {
+	report, worst := gradeCloudRun(t, cloudRunExportService)
+	if worst.Runtime != "runsc" {
+		t.Errorf("gen1 runtime = %q, want runsc (gVisor)", worst.Runtime)
+	}
+	if !strings.Contains(strings.ToLower(report.HardenedRuntime), "gvisor") {
+		t.Errorf("gen1 should surface gVisor as a hardened runtime; got %q", report.HardenedRuntime)
+	}
+	// runAsUser: 1000 (non-zero) credits the non-root dimension.
+	if worst.RunAsNonRoot != Yes {
+		t.Errorf("runAsUser 1000 should grade non-root: %v", worst.RunAsNonRoot)
+	}
+}
+
+func TestCloudRunSeccompUnconfinedRespected(t *testing.T) {
+	const svc = `
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: risky
+spec:
+  template:
+    spec:
+      containers:
+        - image: x
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: Unconfined
+`
+	report, worst := gradeCloudRun(t, svc)
+	if worst.Seccomp != "unconfined" {
+		t.Fatalf("explicit seccompProfile Unconfined must be respected (fail-closed): %q", worst.Seccomp)
+	}
+	// 89 ceiling minus the 15-point seccomp dimension = 74.
+	if report.Score != 74 {
+		t.Errorf("unconfined seccomp: got %d/100, want 74 (89 - seccomp 15)", report.Score)
+	}
+}
+
+func TestCloudRunAddedCapsPenalized(t *testing.T) {
+	const svc = `
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: netadmin
+spec:
+  template:
+    spec:
+      containers:
+        - image: x
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              add: [NET_ADMIN]
+`
+	report, worst := gradeCloudRun(t, svc)
+	if worst.CapDropAll != No {
+		t.Errorf("an explicit added capability must not be masked by the managed floor: CapDropAll=%v", worst.CapDropAll)
+	}
+	if len(worst.CapAdd) != 1 || worst.CapAdd[0] != "NET_ADMIN" {
+		t.Errorf("added capability not surfaced: %v", worst.CapAdd)
+	}
+	// 89 ceiling minus the 20-point caps dimension = 69.
+	if report.Score != 69 {
+		t.Errorf("added caps: got %d/100, want 69 (89 - caps 20)", report.Score)
+	}
+}
+
+func TestCloudRunWeakestServiceWins(t *testing.T) {
+	// A deployment with one hardened and one baseline service must grade the WEAKEST.
+	multi := cloudRunHardenedService + "\n---\n" + cloudRunBaselineService
+	report, worst := gradeCloudRun(t, multi)
+	if report.Score != 64 || report.Grade != "C" {
+		t.Fatalf("multi-service deployment: got %d/100 (grade %s), want 64 (C) — the weakest service governs", report.Score, report.Grade)
+	}
+	if !strings.Contains(worst.Target, "legacy") {
+		t.Errorf("weakest service = %q, want the baseline 'legacy'", worst.Target)
+	}
+	joined := strings.Join(report.Notes, " ")
+	if !strings.Contains(joined, "graded 2 Cloud Run service") {
+		t.Errorf("expected 2 services graded; notes: %v", report.Notes)
+	}
+}
+
+func TestCloudRunNonServiceDocsSkipped(t *testing.T) {
+	// A plain Kubernetes Service (v1, a load balancer) and a ConfigMap in the same
+	// stream must NOT be mistaken for a Cloud Run revision.
+	stream := cloudRunHardenedService + `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8s-lb
+spec:
+  ports:
+    - port: 80
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cfg
+data:
+  x: "1"
+`
+	specs, err := SpecsFromCloudRun([]byte(stream))
+	if err != nil {
+		t.Fatalf("SpecsFromCloudRun: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("got %d specs, want 1 (only the Knative Service is gradeable)", len(specs))
+	}
+	if specs[0].Target != "web" {
+		t.Errorf("graded service = %q, want web", specs[0].Target)
+	}
+}
+
+func TestCloudRunResourceLimitsNoted(t *testing.T) {
+	_, worst := gradeCloudRun(t, cloudRunHardenedService)
+	joined := strings.Join(worst.Notes, " ")
+	if !strings.Contains(joined, "resource limits declared") || !strings.Contains(joined, "memory=512Mi") {
+		t.Errorf("expected a resource-limits note; got: %v", worst.Notes)
+	}
+	// The misleading k8s conservative notes must be gone.
+	if strings.Contains(joined, "NetworkPolicy") {
+		t.Errorf("k8s NetworkPolicy note must be dropped for Cloud Run: %v", worst.Notes)
+	}
+}
+
+func TestCloudRunManagedCeilingDocumented(t *testing.T) {
+	report, _ := gradeCloudRun(t, cloudRunHardenedService)
+	joined := strings.Join(report.Notes, " ")
+	if !strings.Contains(joined, "89/100") {
+		t.Errorf("the honest managed-egress ceiling (89/100) should be documented in the notes: %v", report.Notes)
+	}
+}
+
+func TestCloudRunNoServicesIsError(t *testing.T) {
+	// A document with no Cloud Run service has nothing to grade: fail-closed.
+	const cfgOnly = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cfg
+data:
+  x: "1"
+`
+	specs, err := SpecsFromCloudRun([]byte(cfgOnly))
+	if err != nil {
+		t.Fatalf("SpecsFromCloudRun: %v", err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("ConfigMap should be skipped; got %d specs", len(specs))
+	}
+	if _, _, err := AggregateCloudRun(specs, "svc"); err == nil {
+		t.Error("AggregateCloudRun on an empty service set must error (fail-closed)")
+	}
+}
+
+func TestCloudRunMalformedYAMLErrors(t *testing.T) {
+	if _, err := SpecsFromCloudRun([]byte("kind: Service\n\tbad: [indent")); err == nil {
+		t.Error("malformed YAML must return a parse error")
+	}
+}

--- a/internal/host/scan/k8s.go
+++ b/internal/host/scan/k8s.go
@@ -99,6 +99,16 @@ type k8sContainer struct {
 	Name            string           `yaml:"name"`
 	SecurityContext *containerSecCtx `yaml:"securityContext"`
 	VolumeMounts    []volumeMount    `yaml:"volumeMounts"`
+	// Resources mirrors a container resources block. Kubernetes and Cloud Run
+	// revisions both carry it; the 7-dim containment scorer does not grade it, but
+	// the Cloud Run adapter surfaces resources.limits as an informational note.
+	Resources *resourceReqs `yaml:"resources"`
+}
+
+// resourceReqs mirrors a container resources.{limits,requests} block. Only limits
+// are read (as informational evidence); requests do not bound isolation.
+type resourceReqs struct {
+	Limits map[string]string `yaml:"limits"`
 }
 
 type k8sVolume struct {


### PR DESCRIPTION
## What

Extends the `ironctl scan` wedge to **Google Cloud Run** — a no-account growth lever. `ironctl scan --cloudrun <svc.yaml|dir>` grades a Knative `Service` spec (`serving.knative.dev/v1`, the `gcloud run services describe SVC --format=export` output) on the existing 0-100 / 7-dim containment scorer, mirroring the merged `--helm` (#486), `--terraform` (#492), and `--nomad` (#494) adapters.

## How

Cloud Run's revision template carries a Kubernetes-shaped pod spec at `spec.template.spec.containers[]`, so the adapter **reuses `specFromPodSpec`** (same path as `--k8s`/`--helm`) and then folds in Cloud Run's managed-runtime guarantees:

- **privileged mode + host PID/IPC/network namespaces are not permitted** → pass by construction (genuine platform wins the raw pod-spec grader would score fail-closed)
- **no host bind mounts → docker.sock impossible** → pass
- **every container is sandboxed** (gen1 gVisor / gen2 microVM) → syscall surface filtered → seccomp `confined` unless the spec sets `seccompProfile: Unconfined`
- **managed sandbox restricts caps** (no privileged, no cap add) → dropped-caps credit unless the spec explicitly adds one
- **egress is managed** (never `network=none`) → egress-capable WARN tier

Non-root user and read-only rootfs stay the spec's job (graded fail-closed when absent). A fully hardened service tops out at the honest **89/100 (grade B)** ceiling — the same egress-capable managed-runtime ceiling documented for broker/cache workloads. `gen1` surfaces gVisor (`runsc`) informationally; scoring stays runtime-agnostic (IRO-429).

Input forms: a single Knative Service YAML, a multi-doc `---` stream, or a directory of YAMLs (weakest-service rollup). Fail-open on load/parse; `--min-score` gates once services are graded.

## Files

- `internal/host/scan/cloudrun.go` — new adapter (`SpecsFromCloudRun`, `AggregateCloudRun`)
- `internal/host/scan/cloudrun_test.go` — 11 table-driven tests (ceiling, baseline floors, gen1 gVisor, unconfined seccomp, added caps, weakest rollup, non-Service skip, fail-closed/fail-open, malformed)
- `internal/host/scan/k8s.go` — add `resources` to the shared container type (Cloud Run + k8s both carry it) for the informational resource-limits note
- `cmd/ironctl/scan.go` — CLI wiring (flag, dispatch, dir/file loader, usage)
- `docs/scan.md` — `--cloudrun` section + runtimes-table row

## Dogfood

| Input | Result |
|---|---|
| hardened service (`runAsNonRoot` + `readOnlyRootFilesystem`, gen2) | **89/100 grade B** — the documented ceiling |
| directory (hardened + baseline, gen1) | weakest governs → **64/100 grade C**, gVisor surfaced, trips `--min-score 90` |
| missing file | fail-open, exit 0 |

150 scan-package tests green (`CGO_ENABLED=1 go test ./internal/host/scan/`); `go vet` + `gofmt` clean.

## Security review lenses

Read-only, local, daemon-free static grader. Touches **no** trust boundary: no sandbox/queue/gateway/egress/key-custody code, no contract change. Grading logic is honest and fail-closed (unknown postures score as insecure; managed-runtime credits are documented platform guarantees, and a spec that declares a weaker posture — added caps, `seccompProfile: Unconfined` — overrides the floor).

Closes IRO-516.