### PR TITLE
docs(blog): harden guides wave 7 (couchdb/questdb/nats/gitea) [IRO-527]

### DIFF
--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -40,5 +40,9 @@ nav:
   - "How to harden a Jenkins container": harden-jenkins-container-isolation.md
   - "How to harden a SonarQube container": harden-sonarqube-container-isolation.md
   - "How to harden a Keycloak container": harden-keycloak-container-isolation.md
+  - "How to harden a CouchDB container": harden-couchdb-container-isolation.md
+  - "How to harden a QuestDB container": harden-questdb-container-isolation.md
+  - "How to harden a NATS container": harden-nats-container-isolation.md
+  - "How to harden a Gitea container": harden-gitea-container-isolation.md
   - "How to scan a Dockerfile for security issues": scan-a-dockerfile-for-security-issues.md
   - "*.md"

--- a/docs/blog/harden-couchdb-container-isolation.md
+++ b/docs/blog/harden-couchdb-container-isolation.md
@@ -1,0 +1,108 @@
+---
+title: "How to harden a CouchDB container: couchdb:3.4 scores 48/100 by default"
+description: "couchdb:3.4 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a co-located document database to a full 100/100 grade A."
+---
+
+# How to harden a CouchDB container (and is couchdb:3.4 safe for your documents?)
+
+CouchDB stores JSON documents that an application layer reads and writes all day: user profiles,
+configuration, offline-sync state, whatever your app persists. A stock `docker run couchdb:3.4` keeps
+that store behind a boundary weaker than the data deserves. Graded on IronClaw's seven-dimension
+containment scale, the default configuration scores **48 of 100, grade D (porous)**. Higher is safer.
+Unlike a broker or a proxy, a document database that only its co-located application talks to can
+close every dimension, including the network. A few runtime flags take the same image to a full
+**100 of 100, grade A**. Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `couchdb:3.4`, the same data behind its
+> [isolation scorecard](../scores/couchdb.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run couchdb:3.4`,
+three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The two that should worry you most are **root** and **egress**. A CouchDB process that escapes as root
+escapes as root on the host, right next to the `.couch` files it was serving. And a database that can
+reach arbitrary destinations is one that can quietly ship every document out the moment an HTTP-API or
+Erlang CVE lands code execution. The default capability set and writable rootfs widen and entrench
+that foothold.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-couchdb --fix` prints one remediation per failed dimension, then one hardened run. For
+`couchdb:3.4`:
+
+- **`--user 5984:5984`** (Non-root user, +15): pin the non-root `couchdb` uid so an escape does not
+  begin as host uid 0. Point the data directory at a volume this uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; CouchDB needs none of
+  the default set to serve its HTTP API on a high port.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
+  `/opt/couchdb/data` as an explicit writable volume. Removes the persistence surface.
+- **`--network=none`** (Network isolation, +11 to the full 15): this is the dimension a co-located
+  store can actually max out. If the only client is an application on the same host or pod reaching
+  CouchDB over the loopback of a shared network namespace, cut the NIC entirely. Nothing external can
+  connect, and the database cannot phone home.
+
+### When network=none is not honest
+
+If remote clients, Fauxton browser users, or a CouchDB cluster with peer connections between nodes
+need the network, you cannot use `--network=none`; the store has to accept those connections. In that
+case put it on a user-defined network scoped to just its clients and cluster peers, with no default
+route out. That holds the network dimension at a WARN (4 of 15) and the honest ceiling becomes
+**89 of 100, grade B**, the same as a broker. Use `--network=none` only for the single-application,
+co-located case.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name couchdb couchdb:3.4
+
+# After: 100/100, grade A (co-located store, no network needed)
+docker run -d --name couchdb-hardened \
+  --user 5984:5984 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v couchdb-data:/opt/couchdb/data \
+  --network=none \
+  couchdb:3.4
+```
+
+Rescan: `ironctl scan couchdb-hardened` reports `100/100 grade A`. A **52-point swing** with no custom
+image build, just the right flags. Every dimension is closed because a co-located document database
+does not need to talk to anything but the app on the other side of its loopback. That is the top
+grade, reserved for datastores whose clients live next to them.
+
+## Verify it on your own CouchDB
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-couchdb
+ironctl scan my-couchdb --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade the
+CouchDB in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [couchdb:3.4 isolation scorecard &rarr;](../scores/couchdb.md): the full dimension breakdown.
+- [How to harden a MongoDB container &rarr;](harden-mongodb-container-isolation.md): another document store that reaches grade A when co-located.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-gitea-container-isolation.md
+++ b/docs/blog/harden-gitea-container-isolation.md
@@ -1,0 +1,100 @@
+---
+title: "How to harden a Gitea container: gitea:1.22 scores 48/100 by default"
+description: "gitea:1.22 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take the git server to its honest 89/100 grade B ceiling."
+---
+
+# How to harden a Gitea container (and is gitea:1.22 safe for your repositories?)
+
+Gitea hosts your source: git repositories, access tokens, CI webhooks, and the web UI developers push
+and pull through all day. A stock `docker run gitea/gitea:1.22` keeps that server behind a boundary
+weaker than the code deserves. Graded on IronClaw's seven-dimension containment scale, the default
+configuration scores **48 of 100, grade D (porous)**. Higher is safer. A git server exists to be
+reached by browsers and git clients, so it cannot take `--network=none` the way a co-located database
+can. That sets an honest ceiling of **89 of 100, grade B**, and the flags below reach it. Here are the
+exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `gitea:1.22`, the same data behind its
+> [isolation scorecard](../scores/gitea.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run gitea/gitea:1.22`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The two that should worry you most are **root** and the writable rootfs. A Gitea process that escapes
+as root escapes as root on the host, right next to every repository and secret it was serving. A
+writable rootfs lets an attacker who lands code execution through a hook, webhook, or web CVE persist
+inside the image. The network dimension stays a WARN by design here, because a git server has to accept
+connections.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-gitea --fix` prints one remediation per failed dimension, then one hardened run. For
+`gitea:1.22`:
+
+- **`--user 1000:1000`** (Non-root user, +15): pin the non-root `git` uid so an escape does not begin
+  as host uid 0. Point the data directory at a volume this uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Gitea needs none of the
+  default set to serve HTTP and SSH on high ports.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
+  `/data` as an explicit writable volume. Removes the persistence surface.
+- **Scoped private network** (Network, held at WARN by design): a git server exists to be reached by
+  developers and CI, so `--network=none` would break it. Put Gitea on a user-defined network scoped to
+  just its reverse proxy and clients, with no default route out. The network dimension holds at a WARN
+  (4 of 15). That is the honest ceiling.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name gitea gitea/gitea:1.22
+
+# After: 89/100, grade B (scoped private network for proxy and clients)
+docker run -d --name gitea-hardened \
+  --user 1000:1000 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v gitea-data:/data \
+  --network=git-internal \
+  gitea/gitea:1.22
+```
+
+Rescan: `ironctl scan gitea-hardened` reports `89/100 grade B`. A **41-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a git server exists to be reached by its developers and CI; `network=none` would score the
+last points but leave nothing able to connect. That is the honest ceiling for this role, and it is a
+long way from the default D.
+
+## Verify it on your own Gitea
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-gitea
+ironctl scan my-gitea --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade the
+Gitea in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [gitea:1.22 isolation scorecard &rarr;](../scores/gitea.md): the full dimension breakdown.
+- [How to harden a Jenkins container &rarr;](harden-jenkins-container-isolation.md): another developer-facing server whose honest ceiling is grade B.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-nats-container-isolation.md
+++ b/docs/blog/harden-nats-container-isolation.md
@@ -1,0 +1,99 @@
+---
+title: "How to harden a NATS container: nats:2.10-alpine scores 48/100 by default"
+description: "nats:2.10-alpine defaults score 48/100 (grade D): full caps, writable rootfs. The exact ironctl scan --fix flags that take the messaging broker to its honest 89/100 grade B ceiling."
+---
+
+# How to harden a NATS container (and is nats:2.10-alpine safe for your messages?)
+
+NATS is the nervous system of an event-driven stack: every service publishes to it and subscribes from
+it, and with JetStream it also persists the stream. A stock `docker run nats:2.10-alpine` keeps that
+broker behind a boundary weaker than the traffic deserves. Graded on IronClaw's seven-dimension
+containment scale, the default configuration scores **48 of 100, grade D (porous)**. Higher is safer.
+A broker exists to be connected to, so it cannot take `--network=none` the way a co-located database
+can. That sets an honest ceiling of **89 of 100, grade B**, and the flags below reach it. Here are the
+exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `nats:2.10-alpine`, the same data behind
+> its [isolation scorecard](../scores/nats.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run nats:2.10-alpine`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The one that should worry you most is **root**. A NATS process that escapes as root escapes as root on
+the host, right next to every message flowing through it and, with JetStream, the persisted stream on
+disk. The default capability set and writable rootfs widen and entrench that foothold. The network
+dimension stays a WARN by design here, because a broker has to accept connections.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-nats --fix` prints one remediation per failed dimension, then one hardened run. For
+`nats:2.10-alpine`:
+
+- **`--user 1000:1000`** (Non-root user, +15): pin a non-root uid so an escape does not begin as host
+  uid 0. Point any JetStream store directory at a volume this uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; NATS needs none of the
+  default set to serve its client and monitoring ports.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
+  the JetStream data directory as an explicit writable volume. Removes the persistence surface.
+- **Scoped private network** (Network, held at WARN by design): a broker exists to be connected to, so
+  `--network=none` would break it. Put NATS on a user-defined network scoped to just its publishers,
+  subscribers, and cluster peers, with no default route out. The network dimension holds at a WARN
+  (4 of 15). That is the honest ceiling.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name nats nats:2.10-alpine
+
+# After: 89/100, grade B (scoped private network for clients and peers)
+docker run -d --name nats-hardened \
+  --user 1000:1000 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v nats-data:/data \
+  --network=messaging-internal \
+  nats:2.10-alpine
+```
+
+Rescan: `ironctl scan nats-hardened` reports `89/100 grade B`. A **41-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a broker exists to be reached by its publishers and subscribers; `network=none` would
+score the last points but leave nothing able to connect. That is the honest ceiling for this role, and
+it is a long way from the default D.
+
+## Verify it on your own NATS
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-nats
+ironctl scan my-nats --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade the
+NATS in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [nats:2.10-alpine isolation scorecard &rarr;](../scores/nats.md): the full dimension breakdown.
+- [How to harden a Kafka container &rarr;](harden-kafka-container-isolation.md): another broker whose honest ceiling is grade B.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-questdb-container-isolation.md
+++ b/docs/blog/harden-questdb-container-isolation.md
@@ -1,0 +1,107 @@
+---
+title: "How to harden a QuestDB container: questdb:8.2.1 scores 48/100 by default"
+description: "questdb:8.2.1 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a co-located time-series database to a full 100/100 grade A."
+---
+
+# How to harden a QuestDB container (and is questdb:8.2.1 safe for your metrics?)
+
+QuestDB ingests high-throughput time-series data: sensor readings, financial ticks, application
+metrics, the append-only history you query for trends. A stock `docker run questdb/questdb:8.2.1` keeps
+that store behind a boundary weaker than the data deserves. Graded on IronClaw's seven-dimension
+containment scale, the default configuration scores **48 of 100, grade D (porous)**. Higher is safer.
+Unlike a broker or a proxy, a time-series database that only its co-located application writes to can
+close every dimension, including the network. A few runtime flags take the same image to a full
+**100 of 100, grade A**. Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `questdb:8.2.1`, the same data behind
+> its [isolation scorecard](../scores/questdb.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run questdb/questdb:8.2.1`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The two that should worry you most are **root** and **egress**. A QuestDB process that escapes as root
+escapes as root on the host, right next to the column files it was serving. And a database that can
+reach arbitrary destinations is one that can quietly exfiltrate your entire history the moment an
+ingestion-protocol or HTTP-API CVE lands code execution. The default capability set and writable
+rootfs widen and entrench that foothold.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-questdb --fix` prints one remediation per failed dimension, then one hardened run. For
+`questdb:8.2.1`:
+
+- **`--user 10001:10001`** (Non-root user, +15): pin a non-root uid so an escape does not begin as host
+  uid 0. Point the data root at a volume this uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; QuestDB needs none of
+  the default set to serve its HTTP, PostgreSQL-wire, and InfluxDB-line ports.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
+  `/var/lib/questdb` as an explicit writable volume. Removes the persistence surface.
+- **`--network=none`** (Network isolation, +11 to the full 15): this is the dimension a co-located
+  store can actually max out. If the only writer is an application on the same host or pod reaching
+  QuestDB over the loopback of a shared network namespace, cut the NIC entirely. Nothing external can
+  connect, and the database cannot phone home.
+
+### When network=none is not honest
+
+If a remote fleet pushes metrics over the network, or dashboard users hit the web console and query
+API, you cannot use `--network=none`; the store has to accept those connections. In that case put it
+on a user-defined network scoped to just its writers and clients, with no default route out. That
+holds the network dimension at a WARN (4 of 15) and the honest ceiling becomes **89 of 100, grade B**,
+the same as a broker. Use `--network=none` only for the single-application, co-located case.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name questdb questdb/questdb:8.2.1
+
+# After: 100/100, grade A (co-located store, no network needed)
+docker run -d --name questdb-hardened \
+  --user 10001:10001 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v questdb-data:/var/lib/questdb \
+  --network=none \
+  questdb/questdb:8.2.1
+```
+
+Rescan: `ironctl scan questdb-hardened` reports `100/100 grade A`. A **52-point swing** with no custom
+image build, just the right flags. Every dimension is closed because a co-located time-series database
+does not need to talk to anything but the app on the other side of its loopback. That is the top
+grade, reserved for datastores whose clients live next to them.
+
+## Verify it on your own QuestDB
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-questdb
+ironctl scan my-questdb --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade the
+QuestDB in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [questdb:8.2.1 isolation scorecard &rarr;](../scores/questdb.md): the full dimension breakdown.
+- [How to harden an InfluxDB container &rarr;](harden-influxdb-container-isolation.md): another time-series store that reaches grade A when co-located.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -35,6 +35,8 @@ Two patterns show up across the set:
 | [Elasticsearch](harden-elasticsearch-container-isolation.md) | 63/100 C | **100/100 A** | full caps, writable rootfs (89/B multi-node) |
 | [InfluxDB](harden-influxdb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if fleet pushes metrics) |
 | [Neo4j](harden-neo4j-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if clustered or remote clients) |
+| [CouchDB](harden-couchdb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if clustered or remote clients) |
+| [QuestDB](harden-questdb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if a fleet pushes metrics) |
 | [Untrusted Node.js](run-untrusted-nodejs-code-safely.md) | 48/100 D | **100/100 A** | run untrusted code in a real sandbox |
 
 ## Honest ceiling: grade B (89/100)
@@ -56,6 +58,8 @@ These services must accept client connections, so the network dimension holds at
 | [Jenkins](harden-jenkins-container-isolation.md) | 48/100 D | **89/100 B** | CI server: agents and browsers must reach it |
 | [SonarQube](harden-sonarqube-container-isolation.md) | 48/100 D | **89/100 B** | code-quality server: scanners and browsers must reach it |
 | [Keycloak](harden-keycloak-container-isolation.md) | 48/100 D | **89/100 B** | identity provider: every app must reach its endpoints |
+| [NATS](harden-nats-container-isolation.md) | 48/100 D | **89/100 B** | broker: publishers and subscribers must connect |
+| [Gitea](harden-gitea-container-isolation.md) | 48/100 D | **89/100 B** | git server: developers and CI must reach it |
 
 ## The pattern, one command
 


### PR DESCRIPTION
## What
Container hardening SEO guides, wave 7. Continues the long-tail SEO flywheel (each guide ranks for "harden <image>"). Follows the wave-6 pattern (PR#504).

## 4 new guides
| Image | Default | Hardened | Role |
|-------|:-------:|:--------:|------|
| CouchDB | 48/100 D | **100/100 A** | co-located document store |
| QuestDB | 48/100 D | **100/100 A** | co-located time-series store |
| NATS | 48/100 D | **89/100 B** | broker, honest network ceiling |
| Gitea | 48/100 D | **89/100 B** | git server, honest network ceiling |

All picks verified to have an existing `docs/scores/<slug>.md` scorecard before selection.

## Proof
Hardened scores proven with `ironctl scan --compose` using raw YAML `cap_drop: [ALL]` (colima normalizes CLI `--cap-drop=ALL` into named caps). Datastores reach 100/A with `network: none`; services hold the network dimension at a WARN by design and cap at the honest 89/B.

## Hub + nav
- `docs/blog/hardening-guides.md`: 24 -> 28 rows (2 grade-A, 2 grade-B).
- `docs/blog/.nav.yml`: 4 new entries.

## Verification
- `mkdocs build --strict`: passes (only the Material EOL banner, not an error). All 4 pages render.
- No em/en-dashes in public copy.

[IRO-527]