### PR TITLE
feat(scan): ironctl scan --kustomize grades the weakest workload in kustomize build [IRO-525]

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -50,6 +50,9 @@ func cmdScan(args []string) error {
 	ecs := fs.String("ecs", "", "grade an AWS ECS task definition: `aws ecs describe-task-definition` JSON, a raw registered task-def JSON, or a directory of task-def JSON files")
 	cloudrun := fs.String("cloudrun", "", "grade Google Cloud Run service specs: a Knative Service YAML (`gcloud run services describe SVC --format=export`), or a directory of them")
 	cloudformation := fs.String("cloudformation", "", "grade AWS::ECS::TaskDefinition resources in a CloudFormation template (YAML or JSON), or a directory of them")
+	kustomize := fs.String("kustomize", "", "render a kustomization directory with `kustomize build` (or `kubectl kustomize`) and grade the isolation posture of its workloads")
+	kustomizeBin := fs.String("kustomize-bin", envOrDefault("KUSTOMIZE", "kustomize"), "kustomize binary used to render the directory (falls back to `kubectl kustomize` if absent)")
+	kubectlBin := fs.String("kubectl-bin", envOrDefault("KUBECTL", "kubectl"), "kubectl binary used for `kubectl kustomize` when the kustomize binary is absent")
 	dockerfile := fs.Bool("dockerfile", false, "statically grade the positional Dockerfile(s) authoring-time posture (daemon-free)")
 	runtime := fs.String("runtime", envOrDefault("IRONCTL_SCAN_RUNTIME", "auto"), "container runtime: auto|docker|podman|nerdctl")
 	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker inspect`")
@@ -219,6 +222,28 @@ func cmdScan(args []string) error {
 			badgeJSON: *badgeJSON,
 			sarif:     *sarif,
 			minScore:  *minScore,
+		})
+	}
+
+	// --kustomize: render a kustomization locally (`kustomize build`, or
+	// `kubectl kustomize` when the standalone binary is absent — no cluster,
+	// daemon-free) and grade the isolation posture of the flattened workloads,
+	// reusing the k8s dimension set. It renders (I/O) here, then defers to the pure
+	// SpecsFromKustomize + AggregateKustomize scorer (the same weakest-link rollup
+	// as --helm). Fail-OPEN on a render failure (kustomize/kubectl absent or build
+	// error) so an opt-in CI step never crashes the build; --min-score still gates
+	// once the kustomization renders.
+	if *kustomize != "" {
+		return runKustomizeScan(kustomizeArgs{
+			dir:          *kustomize,
+			kustomizeBin: *kustomizeBin,
+			kubectlBin:   *kubectlBin,
+			asJSON:       *asJSON,
+			md:           *md,
+			badge:        *badge,
+			badgeJSON:    *badgeJSON,
+			sarif:        *sarif,
+			minScore:     *minScore,
 		})
 	}
 
@@ -566,6 +591,127 @@ func renderHelmChart(helmBin, chart string) ([]byte, error) {
 			msg = err.Error()
 		}
 		return nil, fmt.Errorf("helm template failed: %s", msg)
+	}
+	return stdout.Bytes(), nil
+}
+
+// kustomizeArgs carries the resolved inputs for a `scan --kustomize` run.
+type kustomizeArgs struct {
+	dir          string
+	kustomizeBin string
+	kubectlBin   string
+	asJSON       bool
+	md           bool
+	badge        string
+	badgeJSON    string
+	sarif        string
+	minScore     int
+}
+
+// runKustomizeScan renders a kustomization directory with `kustomize build`
+// (falling back to `kubectl kustomize` when the standalone binary is absent — no
+// cluster, daemon-free) and grades the isolation posture of its flattened
+// workloads, reusing the k8s scorer. It fails OPEN on a render failure (neither
+// binary present, or the build errors): it prints a clear diagnostic to stderr
+// and returns nil so an opt-in CI/Action step never crashes the build over
+// tooling or overlay issues. Once the kustomization renders, scoring and the
+// --min-score CI gate apply exactly like --helm (a genuinely low posture still
+// fails the gate).
+func runKustomizeScan(a kustomizeArgs) error {
+	rendered, err := renderKustomize(a.kustomizeBin, a.kubectlBin, a.dir)
+	if err != nil {
+		// Fail-open: surface the reason, do not error out.
+		fmt.Fprintf(os.Stderr, "  warning: scan --kustomize could not render %q (scan skipped, exit 0): %v\n", a.dir, err)
+		return nil
+	}
+
+	specs, err := scan.SpecsFromKustomize(rendered)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --kustomize could not parse rendered manifests for %q (scan skipped, exit 0): %v\n", a.dir, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregateKustomize(specs, filepath.Base(strings.TrimRight(a.dir, "/")))
+	if err != nil {
+		// A kustomization that renders no gradeable workload is a fail-open skip,
+		// not a crash: nothing to grade is not the same as a low score.
+		fmt.Fprintf(os.Stderr, "  warning: scan --kustomize found nothing to grade in %q (scan skipped, exit 0): %v\n", a.dir, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		// Anchor at the kustomization with a logical location naming the weakest
+		// workload (the rendered stream has no stable source file/line to point at).
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (render succeeded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// renderKustomize renders a kustomization directory to a multi-document manifest
+// stream. It prefers the standalone `kustomize build <dir>` and falls back to
+// `kubectl kustomize <dir>` (the same renderer, vendored into kubectl) when the
+// kustomize binary is not on PATH. It is offline and daemon-free: no cluster
+// connection, only local overlay flattening.
+func renderKustomize(kustomizeBin, kubectlBin, dir string) ([]byte, error) {
+	if _, err := exec.LookPath(kustomizeBin); err == nil {
+		return runKustomizeRenderer(exec.Command(kustomizeBin, "build", dir), "kustomize build")
+	}
+	if _, err := exec.LookPath(kubectlBin); err == nil {
+		return runKustomizeRenderer(exec.Command(kubectlBin, "kustomize", dir), "kubectl kustomize")
+	}
+	return nil, fmt.Errorf("neither kustomize (%q) nor kubectl (%q) found on PATH (install one or pass --kustomize-bin/--kubectl-bin)", kustomizeBin, kubectlBin)
+}
+
+// runKustomizeRenderer runs a prepared render command and returns its stdout,
+// wrapping any failure with the renderer's stderr for a clear diagnostic.
+func runKustomizeRenderer(cmd *exec.Cmd, label string) ([]byte, error) {
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("%s failed: %s", label, msg)
 	}
 	return stdout.Bytes(), nil
 }
@@ -1339,6 +1485,7 @@ USAGE:
   ironctl scan --ecs PATH                       grade an AWS ECS task definition (describe-task-definition JSON / dir)
   ironctl scan --cloudrun PATH                  grade Google Cloud Run service specs (Knative Service YAML or dir)
   ironctl scan --cloudformation PATH            grade AWS::ECS::TaskDefinition in a CloudFormation template (YAML/JSON or dir)
+  ironctl scan --kustomize DIR                  render a kustomization (kustomize build) and grade its workloads
   ironctl scan --dockerfile FILE...           grade Dockerfile(s) statically (no daemon, no pull)
   ironctl scan --compare A B                   diff two containers' isolation posture
 
@@ -1357,6 +1504,8 @@ FLAGS:
   --helm-bin BIN      helm binary for `+"`helm template`"+` (default: helm)
   --terraform-bin BIN terraform binary for `+"`terraform show -json`"+` (default: terraform)
   --nomad-bin BIN     nomad binary for `+"`nomad job run -output`"+` (HCL->JSON; default: nomad)
+  --kustomize-bin BIN kustomize binary for `+"`kustomize build`"+` (default: kustomize)
+  --kubectl-bin BIN   kubectl binary for `+"`kubectl kustomize`"+` fallback (default: kubectl)
   --docker-bin BIN    docker binary for `+"`docker inspect`"+` (default: docker)
   --podman-bin BIN    podman binary for `+"`podman inspect`"+` (default: podman)
   --nerdctl-bin BIN   nerdctl binary for `+"`nerdctl inspect`"+` (default: nerdctl)
@@ -1435,6 +1584,16 @@ resolved without the deployed stack, so any graded field they cover is treated a
 unset and graded fail-closed (and noted). The template grade is the WEAKEST
 container; load/parse failures fail OPEN (diagnostic + exit 0). A successful parse
 still trips --min-score.
+
+--kustomize renders a kustomization directory locally with `+"`kustomize build`"+` (or
+`+"`kubectl kustomize`"+` when the standalone binary is absent — no cluster, daemon-free)
+and grades the flattened workloads with the same k8s dimension set as --helm. The
+build grade is the WEAKEST rendered workload (a kustomization is only as isolated
+as its most-exposed pod); every workload's score is listed in the notes. As with
+--helm, network egress depends on a NetworkPolicy a pod spec does not carry, so it
+is graded conservatively (the honest static ceiling). Render failures (neither
+kustomize nor kubectl on PATH / build error) fail OPEN (diagnostic + exit 0); a
+successful render still trips --min-score.
 
 --dockerfile grades a DIFFERENT, authoring-time dimension set (non-root USER,
 pinned base image, no secrets in ENV/ARG, COPY over remote/opaque ADD, no

--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -127,6 +127,19 @@ Pick the surface you have. Each card is one copy-paste command.
 
     [:octicons-arrow-right-24: Scan reference](scan.md)
 
+-   #### :simple-kubernetes:{ .lg .middle } Kustomize build { #scan-kustomize }
+
+    ---
+
+    Renders a kustomization with `kustomize build` (base plus overlays) and grades the
+    **weakest** flattened workload, so an overlay is graded after its patches apply.
+
+    ```bash
+    ironctl scan --kustomize ./overlays/prod
+    ```
+
+    [:octicons-arrow-right-24: Grade a kustomization](scan.md#grade-a-kustomization)
+
 -   #### :material-file-code-outline:{ .lg .middle } Dockerfile (static) { #scan-dockerfile }
 
     ---
@@ -170,6 +183,7 @@ the container they eventually produce are all measured on one comparable scale.
 | [Terraform plan](#scan-terraform) | `--terraform` | container workloads in a plan/state | [Grade a Terraform plan](scan.md#grade-a-terraform-plan) |
 | [CloudFormation](#scan-cloudformation) | `--cloudformation` | `AWS::ECS::TaskDefinition` in a template | [Grade a CloudFormation template](scan.md#grade-a-cloudformation-template) |
 | [Nomad job](#scan-nomad) | `--nomad` | docker-driver tasks in a job spec | [Scan reference](scan.md) |
+| [Kustomize build](#scan-kustomize) | `--kustomize` | weakest workload from `kustomize build` | [Grade a kustomization](scan.md#grade-a-kustomization) |
 | [Dockerfile](#scan-dockerfile) | `--dockerfile` | authoring-time posture, no daemon | [Grade a Dockerfile statically](scan.md#grade-a-dockerfile-statically) |
 | [Alternate runtimes](#scan-runtime) | `--runtime` | Podman / nerdctl / containerd | [Supported runtimes](scan.md#supported-runtimes) |
 

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -70,6 +70,7 @@ inspect data, so probe-masking from inside the container cannot change the score
 | AWS ECS | `--ecs PATH` | grades a live `aws ecs describe-task-definition` (or registered) task definition, no AWS call needed (see below) |
 | Cloud Run | `--cloudrun PATH` | grades a Google Cloud Run service spec (Knative Service YAML) or a directory of them, no account needed (see below) |
 | CloudFormation | `--cloudformation PATH` | grades `AWS::ECS::TaskDefinition` resources in a CloudFormation template (YAML/JSON) or a directory, no AWS call needed (see below) |
+| Kustomize | `--kustomize DIR` | renders a kustomization with `kustomize build` (or `kubectl kustomize`) and grades its workloads, no cluster needed (see below) |
 | Dockerfile | `--dockerfile FILE` | grades authoring-time posture statically, no daemon and no image pull (see below) |
 
 Selection and binaries:
@@ -263,6 +264,37 @@ as gVisor (`runsc`) informationally; scoring stays runtime-agnostic. Load or par
 failures fail **open** (a clear diagnostic and exit 0) so an opt-in CI step never
 crashes the build; once services are graded, `--min-score` still trips on a low
 posture.
+
+## Grade a kustomization
+
+`--kustomize DIR` renders a [Kustomize](https://kustomize.io/) directory with
+`kustomize build` (falling back to `kubectl kustomize` when the standalone binary
+is absent) and grades the isolation posture of the flattened workloads. It is
+offline and daemon-free: overlays are flattened locally, with no cluster and no
+`kubectl apply`:
+
+```bash
+ironctl scan --kustomize ./overlays/prod
+ironctl scan --kustomize ./overlays/prod --min-score 80   # CI gate
+ironctl scan --kustomize ./base --sarif scan.sarif        # upload to code-scanning
+```
+
+Kustomize flattens the base plus every overlay patch into the same multi-document
+manifest stream that `--k8s`/`--helm` grade, so `--kustomize` reuses the exact
+pod-spec dimension set and the same weakest-link rollup: the **build grade is the
+weakest rendered workload** (a kustomization is only as isolated as its
+most-exposed pod), and every workload's score is listed in the report notes. This
+grades the manifests **after** overlay patches apply — the same YAML the cluster
+would receive — so a `securityContext` a production overlay strips (or one it
+adds) is reflected in the grade.
+
+As with `--helm`, network egress depends on a `NetworkPolicy` that a pod spec does
+not carry, so it is graded conservatively (the honest static ceiling). Render
+failures (neither `kustomize` nor `kubectl` on your PATH, or a `build` error) fail
+**open** — a clear diagnostic and exit 0 — so an opt-in CI step never crashes the
+build; once the kustomization renders, `--min-score` still trips on a low posture.
+Point at a non-default renderer with `--kustomize-bin` / `--kubectl-bin` (or the
+`KUSTOMIZE` / `KUBECTL` environment variables).
 
 ## Grade a Dockerfile statically
 

--- a/internal/host/scan/helm.go
+++ b/internal/host/scan/helm.go
@@ -31,6 +31,14 @@ var workloadKinds = map[string]bool{
 // containers are skipped. Empty documents are tolerated. It is pure and
 // unit-testable: the caller runs the renderer (I/O) and passes the stream here.
 func SpecsFromK8sStream(rendered []byte) ([]Spec, error) {
+	return specsFromK8sStreamSource(rendered, "helm")
+}
+
+// specsFromK8sStreamSource is the shared implementation behind SpecsFromK8sStream
+// (helm) and SpecsFromKustomize (kustomize): identical multi-doc parsing and
+// workload selection, only the Spec.Source label differs so reports name the
+// input mode that produced the stream. Scoring is unaffected by the label.
+func specsFromK8sStreamSource(rendered []byte, source string) ([]Spec, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(rendered))
 	var specs []Spec
 	for {
@@ -51,7 +59,7 @@ func SpecsFromK8sStream(rendered []byte) ([]Spec, error) {
 		if !ok {
 			continue
 		}
-		s := specFromPodSpec("helm", workloadTarget(obj), ps)
+		s := specFromPodSpec(source, workloadTarget(obj), ps)
 		specs = append(specs, s)
 	}
 	return specs, nil
@@ -82,8 +90,19 @@ func workloadTarget(obj k8sObject) string {
 // pure; the caller injects Version/GeneratedAt. Fail-closed: an empty workload
 // set is an error (a chart that renders no gradeable workload is not a pass).
 func AggregateHelm(specs []Spec, chart string) (Report, Spec, error) {
+	return aggregateWeakestWorkload(specs, chart, "helm", "chart")
+}
+
+// aggregateWeakestWorkload folds a set of per-workload specs into a single
+// weakest-link Report. It backs AggregateHelm (source "helm", noun "chart") and
+// AggregateKustomize (source "kustomize", noun "kustomize build"): the rollup
+// logic is identical, only the report identity (source) and the roll-up prose
+// (noun) differ. target names the source unit for the report; a blank target
+// keeps the weakest workload's own target. Fail-closed: an empty workload set is
+// an error (a unit that renders no gradeable workload is not a pass).
+func aggregateWeakestWorkload(specs []Spec, target, source, noun string) (Report, Spec, error) {
 	if len(specs) == 0 {
-		return Report{}, Spec{}, fmt.Errorf("no gradeable workloads found in rendered chart (no Pod/Deployment/StatefulSet/DaemonSet/Job/CronJob with containers)")
+		return Report{}, Spec{}, fmt.Errorf("no gradeable workloads found in rendered %s (no Pod/Deployment/StatefulSet/DaemonSet/Job/CronJob with containers)", noun)
 	}
 
 	// Score every workload, then pick the weakest. Ties resolve to the first in
@@ -99,17 +118,17 @@ func AggregateHelm(specs []Spec, chart string) (Report, Spec, error) {
 
 	agg := all[worst].report
 	worstSpec := all[worst].spec
-	// Re-target the aggregate at the chart while keeping the weakest workload's
-	// identity visible in the notes below.
-	if strings.TrimSpace(chart) != "" {
-		agg.Target = chart
+	// Re-target the aggregate at the source unit while keeping the weakest
+	// workload's identity visible in the notes below.
+	if strings.TrimSpace(target) != "" {
+		agg.Target = target
 	}
-	agg.Source = "helm"
+	agg.Source = source
 
-	// Prepend a chart-level summary so the human/JSON output is honest about what
+	// Prepend a unit-level summary so the human/JSON output is honest about what
 	// was aggregated: how many workloads, which one set the grade, and the full
 	// per-workload roll-up. This mirrors the --dockerfile honesty pattern.
-	agg.Notes = append(chartSummaryNotes(all[worst], all), agg.Notes...)
+	agg.Notes = append(chartSummaryNotes(all[worst], all, noun), agg.Notes...)
 
 	return agg, worstSpec, nil
 }
@@ -120,12 +139,14 @@ type scoredWorkload struct {
 	report Report
 }
 
-// chartSummaryNotes builds the chart-level roll-up notes for an aggregate helm
-// report: a headline naming the weakest workload and a per-workload score list.
-func chartSummaryNotes(worst scoredWorkload, all []scoredWorkload) []string {
+// chartSummaryNotes builds the unit-level roll-up notes for an aggregate
+// weakest-link report: a headline naming the weakest workload and a per-workload
+// score list. noun names the source unit ("chart", "kustomize build") so the
+// prose is honest about what was aggregated.
+func chartSummaryNotes(worst scoredWorkload, all []scoredWorkload, noun string) []string {
 	notes := []string{
-		fmt.Sprintf("graded %d rendered workload(s); the chart grade is the WEAKEST (a chart is only as isolated as its most-exposed pod). Weakest: %s at %d/100 (grade %s).",
-			len(all), nz(worst.spec.Target, "workload"), worst.report.Score, worst.report.Grade),
+		fmt.Sprintf("graded %d rendered workload(s); the %s grade is the WEAKEST (a %s is only as isolated as its most-exposed pod). Weakest: %s at %d/100 (grade %s).",
+			len(all), noun, noun, nz(worst.spec.Target, "workload"), worst.report.Score, worst.report.Grade),
 	}
 	// Per-workload roll-up, sorted worst-first for a quick scan.
 	sorted := make([]scoredWorkload, len(all))

--- a/internal/host/scan/kustomize.go
+++ b/internal/host/scan/kustomize.go
@@ -1,0 +1,24 @@
+package scan
+
+// SpecsFromKustomize parses the multi-document Kubernetes YAML stream produced
+// by `kustomize build <dir>` (or `kubectl kustomize <dir>`) and returns one Spec
+// per gradeable workload, in document order. It is the kustomize-sourced twin of
+// SpecsFromK8sStream: identical multi-doc parsing and workload selection (the
+// same overlay-flattening render feeds the same k8s scorer), only the Spec.Source
+// label differs ("kustomize") so reports name the input mode. It is pure and
+// unit-testable: the caller runs `kustomize build` (I/O) and passes the stream.
+func SpecsFromKustomize(rendered []byte) ([]Spec, error) {
+	return specsFromK8sStreamSource(rendered, "kustomize")
+}
+
+// AggregateKustomize folds the per-workload specs of a rendered kustomization
+// into a single Report representing the build's isolation posture. Like
+// AggregateHelm it is the WEAKEST workload (minimum score): a kustomization is
+// only as isolated as its most-exposed pod, so grading the weakest link is the
+// honest, fail-closed summary. target names the source directory for the report.
+// It is pure; the caller injects Version/GeneratedAt. Fail-closed: an empty
+// workload set is an error (a build that renders no gradeable workload is not a
+// pass).
+func AggregateKustomize(specs []Spec, target string) (Report, Spec, error) {
+	return aggregateWeakestWorkload(specs, target, "kustomize", "kustomize build")
+}

--- a/internal/host/scan/kustomize_test.go
+++ b/internal/host/scan/kustomize_test.go
@@ -1,0 +1,140 @@
+package scan
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// kustomizeBuilt mimics `kustomize build <dir>` output: a base Deployment plus an
+// overlay-patched, host-namespace Pod, with a non-workload Service that must be
+// skipped. The flattened stream is byte-for-byte a plain multi-doc manifest, so
+// the kustomize path must agree with the raw --k8s path on the same YAML.
+const kustomizeBuilt = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports: [{port: 80}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: web
+          image: web:1
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: porous
+spec:
+  hostPID: true
+  hostNetwork: true
+  containers:
+    - name: app
+      image: nginx
+      securityContext:
+        privileged: true
+`
+
+func TestSpecsFromKustomize_LabelsSourceAndSkipsNonWorkloads(t *testing.T) {
+	specs, err := SpecsFromKustomize([]byte(kustomizeBuilt))
+	if err != nil {
+		t.Fatalf("SpecsFromKustomize: %v", err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("want 2 workloads (Deployment+Pod), got %d: %+v", len(specs), specs)
+	}
+	for _, s := range specs {
+		if s.Source != "kustomize" {
+			t.Errorf("source: want kustomize, got %q", s.Source)
+		}
+	}
+}
+
+// TestKustomize_ParityWithK8sStream is the acceptance parity test: the workloads
+// SpecsFromKustomize extracts must score identically to the same manifests parsed
+// by the shared k8s stream path. Only the Source label differs (kustomize vs
+// helm); every graded dimension and the resulting Score/Grade must match.
+func TestKustomize_ParityWithK8sStream(t *testing.T) {
+	kSpecs, err := SpecsFromKustomize([]byte(kustomizeBuilt))
+	if err != nil {
+		t.Fatalf("SpecsFromKustomize: %v", err)
+	}
+	hSpecs, err := SpecsFromK8sStream([]byte(kustomizeBuilt))
+	if err != nil {
+		t.Fatalf("SpecsFromK8sStream: %v", err)
+	}
+	if len(kSpecs) != len(hSpecs) {
+		t.Fatalf("workload count mismatch: kustomize=%d k8s-stream=%d", len(kSpecs), len(hSpecs))
+	}
+	for i := range kSpecs {
+		k, h := kSpecs[i], hSpecs[i]
+		if k.Target != h.Target {
+			t.Errorf("workload %d target mismatch: %q vs %q", i, k.Target, h.Target)
+		}
+		// Every graded field must match; only Source is expected to differ.
+		kr, hr := Score(k), Score(h)
+		if kr.Score != hr.Score || kr.Grade != hr.Grade {
+			t.Errorf("workload %d score mismatch: kustomize=%d/%s k8s=%d/%s",
+				i, kr.Score, kr.Grade, hr.Score, hr.Grade)
+		}
+		k.Source, h.Source = "", ""
+		if !reflect.DeepEqual(k, h) {
+			t.Errorf("workload %d spec mismatch (ignoring Source):\n kustomize=%+v\n k8s      =%+v", i, k, h)
+		}
+	}
+}
+
+func TestAggregateKustomize_WeakestWorkloadGovernsAndIdentity(t *testing.T) {
+	specs, err := SpecsFromKustomize([]byte(kustomizeBuilt))
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, worst, err := AggregateKustomize(specs, "overlays-prod")
+	if err != nil {
+		t.Fatalf("AggregateKustomize: %v", err)
+	}
+	if report.Source != "kustomize" || report.Target != "overlays-prod" {
+		t.Errorf("aggregate identity: source=%q target=%q", report.Source, report.Target)
+	}
+	// The privileged, host-namespace pod must set the build grade.
+	if worst.Target != "Pod/porous" {
+		t.Errorf("weakest workload: want Pod/porous, got %q", worst.Target)
+	}
+	if report.Grade != "F" {
+		t.Errorf("build grade: want F (privileged pod), got %s (score %d)", report.Grade, report.Score)
+	}
+	joined := strings.Join(report.Notes, "\n")
+	if !strings.Contains(joined, "graded 2 rendered workload(s)") {
+		t.Errorf("missing workload-count note: %q", joined)
+	}
+	if !strings.Contains(joined, "kustomize build") {
+		t.Errorf("roll-up note should name the kustomize build unit: %q", joined)
+	}
+	if !strings.Contains(joined, "per-workload:") {
+		t.Errorf("missing per-workload roll-up: %q", joined)
+	}
+}
+
+func TestAggregateKustomize_NoWorkloadsIsError(t *testing.T) {
+	if _, _, err := AggregateKustomize(nil, "empty"); err == nil {
+		t.Fatal("want error for empty workload set (fail-closed), got nil")
+	}
+}


### PR DESCRIPTION
## Objective
`ironctl scan --kustomize <dir>` grades the weakest workload in `kustomize build <dir>` output, extending the no-account scan wedge with another crawlable input mode.

## Approach (reuses existing patterns)
- Renders the kustomization with `kustomize build` (falls back to `kubectl kustomize` when the standalone binary is absent, no cluster, daemon-free), captures the multi-doc YAML stream.
- Feeds it through the same k8s scorer as `--helm` via a source-parameterized `specsFromK8sStreamSource` + a generic `aggregateWeakestWorkload` factored out of the helm path (helm behavior and note wording unchanged). Weakest-workload rollup. Fail-open on render error.
- CLI flag wired in `cmd/ironctl/scan.go` (interspersed-flag re-parse pattern already in repo).

## Deliverables
- `internal/host/scan/kustomize.go` + `_test.go` (parity test: `--kustomize` scores identically to the raw k8s stream path on the same rendered manifests; plus weakest-workload, source-label, fail-closed coverage).
- `--kustomize` / `--kustomize-bin` / `--kubectl-bin` flags + `docs/scan.md` section.
- Coverage card in `docs/scan-coverage.md` via the drop-in card contract (IRO-519 hub), `#scan-kustomize` anchor.

## Verification
- `CGO_ENABLED=1 go build ./...` clean; 270 scan/ironctl tests pass; `gofmt` clean; `mkdocs --strict` exit 0.
- Live smoke (kubectl kustomize fallback): a base kustomization scored **19/F**, its hardened prod overlay **79/B**, matching raw `scan --k8s` on the same rendered manifest (**79/B**). Fail-open returns exit 0 on a bad dir; `--min-score` trips exit 1 below threshold.

## Security lenses
Read-only static analysis of local manifests. No trust-boundary, queue, key-custody, or egress change. The renderer shells out to `kustomize`/`kubectl` for local overlay flattening only (no cluster connection). Fail-open on render error keeps an opt-in CI step from crashing; `--min-score` still gates a genuinely low posture.

Closes IRO-525.