### PR TITLE
feat(scan): ironctl scan --cloudformation grades AWS::ECS::TaskDefinition in CFN templates (IRO-526)

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -49,6 +49,7 @@ func cmdScan(args []string) error {
 	nomadBin := fs.String("nomad-bin", envOrDefault("NOMAD", "nomad"), "nomad binary used to render an HCL job to JSON (`nomad job run -output`)")
 	ecs := fs.String("ecs", "", "grade an AWS ECS task definition: `aws ecs describe-task-definition` JSON, a raw registered task-def JSON, or a directory of task-def JSON files")
 	cloudrun := fs.String("cloudrun", "", "grade Google Cloud Run service specs: a Knative Service YAML (`gcloud run services describe SVC --format=export`), or a directory of them")
+	cloudformation := fs.String("cloudformation", "", "grade AWS::ECS::TaskDefinition resources in a CloudFormation template (YAML or JSON), or a directory of them")
 	dockerfile := fs.Bool("dockerfile", false, "statically grade the positional Dockerfile(s) authoring-time posture (daemon-free)")
 	runtime := fs.String("runtime", envOrDefault("IRONCTL_SCAN_RUNTIME", "auto"), "container runtime: auto|docker|podman|nerdctl")
 	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker inspect`")
@@ -193,6 +194,25 @@ func cmdScan(args []string) error {
 	if *cloudrun != "" {
 		return runCloudRunScan(cloudRunScanArgs{
 			path:      *cloudrun,
+			asJSON:    *asJSON,
+			md:        *md,
+			badge:     *badge,
+			badgeJSON: *badgeJSON,
+			sarif:     *sarif,
+			minScore:  *minScore,
+		})
+	}
+
+	// --cloudformation: consume an AWS CloudFormation template (YAML or JSON, or a
+	// directory of them) and grade the AWS::ECS::TaskDefinition resources it
+	// declares, reusing the SHARED ECS scorer that the --ecs and --terraform
+	// aws_ecs_task_definition paths also use. It reads the template here (no external
+	// binary — CFN templates are plain YAML/JSON) then defers to the pure
+	// SpecsFromCloudFormation + AggregateCloudFormation scorer. Fail-OPEN on a
+	// load/parse failure; --min-score still gates once containers are graded.
+	if *cloudformation != "" {
+		return runCloudFormationScan(cloudFormationScanArgs{
+			path:      *cloudformation,
 			asJSON:    *asJSON,
 			md:        *md,
 			badge:     *badge,
@@ -1046,6 +1066,144 @@ func loadCloudRunYAML(path string) ([]byte, error) {
 	return bytes.Join(docs, []byte("\n---\n")), nil
 }
 
+// cloudFormationScanArgs carries the resolved inputs for a `scan --cloudformation` run.
+type cloudFormationScanArgs struct {
+	path      string
+	asJSON    bool
+	md        bool
+	badge     string
+	badgeJSON string
+	sarif     string
+	minScore  int
+}
+
+// runCloudFormationScan grades the AWS::ECS::TaskDefinition resources declared in a
+// CloudFormation template (YAML or JSON, or a directory of them), reusing the SHARED
+// ECS scorer that the --ecs and --terraform aws_ecs_task_definition paths also use.
+// CloudFormation templates are plain YAML/JSON, so there is no external binary to
+// shell out to. It fails OPEN on a load/parse failure (unreadable path, malformed
+// template): it prints a clear diagnostic to stderr and returns nil so an opt-in
+// CI/Action step never crashes the build. Once containers are graded, scoring and
+// the --min-score CI gate apply exactly like --ecs/--terraform. Unresolvable CFN
+// intrinsics (!Ref/!Sub/Fn::...) are graded fail-closed and noted on the report.
+func runCloudFormationScan(a cloudFormationScanArgs) error {
+	specs, usedIntrinsics, err := loadCFNSpecs(a.path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --cloudformation could not load %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregateCloudFormation(specs, filepath.Base(strings.TrimRight(a.path, "/")))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --cloudformation found nothing to grade in %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+	if usedIntrinsics {
+		report.Notes = append(report.Notes, "template uses CloudFormation intrinsics (!Ref/!Sub/Fn::...): unresolved values are graded as unset (fail-closed) — verify the deployed stack matches.")
+	}
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (containers graded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// loadCFNSpecs resolves a --cloudformation argument to graded Specs. A single file
+// is parsed directly. A directory is a weakest-container rollup: every
+// *.yaml/*.yml/*.json/*.template file in it is parsed and its container specs are
+// pooled, so AggregateCloudFormation grades the single most-exposed container across
+// the whole set. It is daemon-free and offline: templates are read from disk. The
+// bool reports whether any file used CloudFormation intrinsics that were skipped.
+func loadCFNSpecs(path string) ([]scan.Spec, bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, false, err
+	}
+	if !info.IsDir() {
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil, false, rerr
+		}
+		return scan.SpecsFromCloudFormation(raw)
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, false, err
+	}
+	var specs []scan.Spec
+	usedIntrinsics := false
+	for _, e := range entries {
+		if e.IsDir() || !isCFNTemplateExt(e.Name()) {
+			continue
+		}
+		raw, rerr := os.ReadFile(filepath.Join(path, e.Name()))
+		if rerr != nil {
+			return nil, false, rerr
+		}
+		fileSpecs, intr, perr := scan.SpecsFromCloudFormation(raw)
+		if perr != nil {
+			// A single malformed template in a directory should not sink the rollup:
+			// skip it with a diagnostic and grade the rest (fail-open per file).
+			fmt.Fprintf(os.Stderr, "  warning: scan --cloudformation skipping %s (parse error): %v\n", e.Name(), perr)
+			continue
+		}
+		specs = append(specs, fileSpecs...)
+		usedIntrinsics = usedIntrinsics || intr
+	}
+	return specs, usedIntrinsics, nil
+}
+
+// isCFNTemplateExt reports whether a filename has a CloudFormation template
+// extension (.yaml/.yml/.json/.template).
+func isCFNTemplateExt(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".yaml", ".yml", ".json", ".template":
+		return true
+	default:
+		return false
+	}
+}
+
 // writeDockerfileSARIF renders the Dockerfile SARIF log to path, fail-open on error.
 func writeDockerfileSARIF(path string, r scan.Report, opts scan.SARIFOptions) error {
 	f, err := os.Create(path)
@@ -1180,6 +1338,7 @@ USAGE:
   ironctl scan --nomad PATH                     grade docker-driver tasks in a Nomad job spec (JSON or HCL)
   ironctl scan --ecs PATH                       grade an AWS ECS task definition (describe-task-definition JSON / dir)
   ironctl scan --cloudrun PATH                  grade Google Cloud Run service specs (Knative Service YAML or dir)
+  ironctl scan --cloudformation PATH            grade AWS::ECS::TaskDefinition in a CloudFormation template (YAML/JSON or dir)
   ironctl scan --dockerfile FILE...           grade Dockerfile(s) statically (no daemon, no pull)
   ironctl scan --compare A B                   diff two containers' isolation posture
 
@@ -1263,6 +1422,19 @@ rootfs stay the spec's job (graded fail-closed when absent). Egress is managed
 network=none, so a fully hardened Cloud Run service tops out at 89/100 (grade B),
 the honest ceiling for an egress-capable managed runtime. Load/parse failures fail
 OPEN (diagnostic + exit 0). A successful parse still trips --min-score.
+
+--cloudformation grades the AWS::ECS::TaskDefinition resources in a CloudFormation
+template (YAML or JSON), reusing the SAME ECS dimension mapping as --ecs and the
+--terraform aws_ecs_task_definition path (privileged, readonlyRootFilesystem, user,
+linuxParameters.capabilities.{add,drop}, dockerSecurityOptions, and the task-level
+networkMode/pidMode/ipcMode). CloudFormation's PascalCase properties map onto the
+same task-def contract, so a template grades identically to the registered JSON of
+the same task. Pass a single template file or a directory of them (weakest-container
+rollup across the lot). CloudFormation intrinsics (`+"`!Ref`/`!Sub`/`Fn::*`"+`) cannot be
+resolved without the deployed stack, so any graded field they cover is treated as
+unset and graded fail-closed (and noted). The template grade is the WEAKEST
+container; load/parse failures fail OPEN (diagnostic + exit 0). A successful parse
+still trips --min-score.
 
 --dockerfile grades a DIFFERENT, authoring-time dimension set (non-root USER,
 pinned base image, no secrets in ENV/ARG, COPY over remote/opaque ADD, no

--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -101,6 +101,19 @@ Pick the surface you have. Each card is one copy-paste command.
 
     [:octicons-arrow-right-24: Grade a Terraform plan](scan.md#grade-a-terraform-plan)
 
+-   #### :material-aws:{ .lg .middle } CloudFormation { #scan-cloudformation }
+
+    ---
+
+    Grades the `AWS::ECS::TaskDefinition` resources in a CloudFormation template (YAML or
+    JSON) with the same ECS scorer as `--ecs`, rolling up to the **weakest** container.
+
+    ```bash
+    ironctl scan --cloudformation template.yaml
+    ```
+
+    [:octicons-arrow-right-24: Grade a CloudFormation template](scan.md#grade-a-cloudformation-template)
+
 -   #### :simple-nomad:{ .lg .middle } Nomad job { #scan-nomad }
 
     ---
@@ -155,6 +168,7 @@ the container they eventually produce are all measured on one comparable scale.
 | [Kubernetes manifest](#scan-k8s) | `--k8s` | a pod spec's `securityContext` | [Scan reference](scan.md) |
 | [Helm chart](#scan-helm) | `--helm` | weakest workload from `helm template` | [Scan reference](scan.md) |
 | [Terraform plan](#scan-terraform) | `--terraform` | container workloads in a plan/state | [Grade a Terraform plan](scan.md#grade-a-terraform-plan) |
+| [CloudFormation](#scan-cloudformation) | `--cloudformation` | `AWS::ECS::TaskDefinition` in a template | [Grade a CloudFormation template](scan.md#grade-a-cloudformation-template) |
 | [Nomad job](#scan-nomad) | `--nomad` | docker-driver tasks in a job spec | [Scan reference](scan.md) |
 | [Dockerfile](#scan-dockerfile) | `--dockerfile` | authoring-time posture, no daemon | [Grade a Dockerfile statically](scan.md#grade-a-dockerfile-statically) |
 | [Alternate runtimes](#scan-runtime) | `--runtime` | Podman / nerdctl / containerd | [Supported runtimes](scan.md#supported-runtimes) |

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -69,6 +69,7 @@ inspect data, so probe-masking from inside the container cannot change the score
 | Terraform | `--terraform PATH` | grades container workloads in a `terraform show -json` plan/state, no apply needed (see below) |
 | AWS ECS | `--ecs PATH` | grades a live `aws ecs describe-task-definition` (or registered) task definition, no AWS call needed (see below) |
 | Cloud Run | `--cloudrun PATH` | grades a Google Cloud Run service spec (Knative Service YAML) or a directory of them, no account needed (see below) |
+| CloudFormation | `--cloudformation PATH` | grades `AWS::ECS::TaskDefinition` resources in a CloudFormation template (YAML/JSON) or a directory, no AWS call needed (see below) |
 | Dockerfile | `--dockerfile FILE` | grades authoring-time posture statically, no daemon and no image pull (see below) |
 
 Selection and binaries:
@@ -176,6 +177,48 @@ the shared ECS scorer is the same one the `--terraform` `aws_ecs_task_definition
 path uses, the two entrypoints can never diverge. Network egress depends on a
 security group that a task definition does not carry, so it is graded
 conservatively, the honest static ceiling. A malformed document fails **open** (a
+clear diagnostic and exit 0) so an opt-in CI step never crashes the build; once
+containers are graded, `--min-score` still trips on a low posture.
+
+## Grade a CloudFormation template
+
+`--cloudformation PATH` grades the `AWS::ECS::TaskDefinition` resources declared in
+an [AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html)
+template, in YAML or JSON, straight from the file. It is the infrastructure-as-code
+sibling of `--ecs`: `--ecs` grades a **registered** task definition, `--cloudformation`
+grades the **template** that will create it, so a weak task fails review before the
+stack is ever deployed. No AWS API call is made:
+
+```bash
+ironctl scan --cloudformation template.yaml
+ironctl scan --cloudformation template.yaml --min-score 75    # CI gate
+ironctl scan --cloudformation template.json --sarif cfn.sarif # GitHub code scanning
+
+ironctl scan --cloudformation ./templates                     # weakest-container rollup over a dir
+```
+
+It accepts three input shapes:
+
+| Input | Shape |
+|---|---|
+| a CloudFormation template | YAML or JSON, with one or more `AWS::ECS::TaskDefinition` resources under `Resources` |
+| a template with several task defs | every task definition is graded and rolled up to the **weakest** container |
+| a directory | every `*.yaml` / `*.yml` / `*.json` / `*.template` file in it, graded as one **weakest-container** rollup |
+
+Each `ContainerDefinitions[]` entry is graded on the exact same dimensions as the
+`--ecs` and `--terraform` `aws_ecs_task_definition` paths, through the **shared ECS
+scorer**: non-root `User`, `LinuxParameters.Capabilities.{Add,Drop}`, `Privileged`,
+`ReadonlyRootFilesystem`, seccomp (via `DockerSecurityOptions`), and the task-level
+`NetworkMode` / `PidMode` / `IpcMode`. CloudFormation's PascalCase properties map
+onto the same contract, so a template grades **identically** to the registered JSON
+of the same task, and the three entrypoints can never diverge.
+
+CloudFormation intrinsics — `!Ref`, `!Sub`, `!GetAtt`, the `Fn::*` family, and their
+`{ "Ref": ... }` long forms — cannot be resolved without the deployed stack, so any
+graded field they cover is treated as **unset** and graded fail-closed (an unknown
+posture is insecure). The scan notes when a template used intrinsics so you can
+verify the resolved stack matches. The template grade is the **weakest** container,
+with every container's score in the notes. A malformed template fails **open** (a
 clear diagnostic and exit 0) so an opt-in CI step never crashes the build; once
 containers are graded, `--min-score` still trips on a low posture.
 

--- a/internal/host/scan/cloudformation.go
+++ b/internal/host/scan/cloudformation.go
@@ -1,0 +1,267 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SpecsFromCloudFormation parses an AWS CloudFormation template (YAML or JSON)
+// and returns one graded Spec per container definition of every
+// AWS::ECS::TaskDefinition resource it declares. It is the CFN counterpart to the
+// terraform aws_ecs_task_definition path (SpecsFromTerraform) and the live
+// registered-JSON path (SpecsFromECS): all three decode into the SAME ecsTaskDef /
+// ecsContainerDef and grade through the SAME ecsSpec mapper, so the entrypoints can
+// never diverge.
+//
+// The reuse is exact: a CloudFormation ECS task definition is the AWS ECS task
+// definition shape with PascalCase property names (ContainerDefinitions, Privileged,
+// ReadonlyRootFilesystem, User, LinuxParameters, DockerSecurityOptions, NetworkMode,
+// PidMode, IpcMode, Volumes...). Go's encoding/json matches object keys
+// case-insensitively, so each task-def's Properties subtree is re-marshaled to JSON
+// and decoded straight into ecsTaskDef (whose json tags are the camelCase live-ECS
+// names) — no parallel PascalCase struct, and byte-for-byte the same grading.
+//
+// CloudFormation intrinsics (!Ref / !Sub / !GetAtt / Fn::* / the {"Ref": ...} long
+// form) are tolerated best-effort: an intrinsic node is unresolvable without the
+// full stack context, so it is nullified before decoding. A graded field it covered
+// therefore decodes as unset and is graded fail-closed (an unknown posture is
+// insecure), and the second return value reports whether any intrinsic was skipped
+// so the caller can note it. This keeps the parser fail-OPEN: a template peppered
+// with intrinsics still grades the parts it can resolve rather than erroring out.
+//
+// It is pure and unit-testable: the caller reads the file (I/O) and passes the
+// bytes here. It fails OPEN on a malformed top-level document (returns the parse
+// error); the CLI wrapper turns that into a skip so an opt-in CI step never crashes
+// the build. A template with no AWS::ECS::TaskDefinition resource returns no specs.
+func SpecsFromCloudFormation(raw []byte) ([]Spec, bool, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(raw, &root); err != nil {
+		return nil, false, fmt.Errorf("parse cloudformation template: %w", err)
+	}
+	// yaml.Unmarshal into a Node yields a DocumentNode wrapping the root mapping.
+	doc := &root
+	if root.Kind == yaml.DocumentNode {
+		if len(root.Content) == 0 {
+			return nil, false, nil
+		}
+		doc = root.Content[0]
+	}
+
+	resources := cfnMappingValue(doc, "Resources")
+	if resources == nil || resources.Kind != yaml.MappingNode {
+		return nil, false, nil
+	}
+
+	var specs []Spec
+	skipped := 0
+	// A CloudFormation Resources block is a mapping of logical-id -> resource; a
+	// template may declare several ECS task definitions, so we pool every one and
+	// let AggregateCloudFormation grade the weakest container across the lot.
+	for i := 0; i+1 < len(resources.Content); i += 2 {
+		resVal := resources.Content[i+1]
+		typeNode := cfnMappingValue(resVal, "Type")
+		if typeNode == nil || typeNode.Value != "AWS::ECS::TaskDefinition" {
+			continue
+		}
+		props := cfnMappingValue(resVal, "Properties")
+		if props == nil {
+			continue
+		}
+		// Nullify unresolvable intrinsics so the typed decode below never fails on a
+		// !Ref/Fn:: where a scalar/bool/array was expected (best-effort tolerance).
+		skipped += sanitizeCFNIntrinsics(props)
+
+		var m map[string]interface{}
+		if err := props.Decode(&m); err != nil {
+			// Fail-open per resource: a single undecodable Properties block must not
+			// sink the whole template.
+			continue
+		}
+		js, err := json.Marshal(m)
+		if err != nil {
+			continue
+		}
+		ss, err := specsFromCFNTaskDef(js)
+		if err != nil {
+			continue
+		}
+		specs = append(specs, ss...)
+	}
+	return specs, skipped > 0, nil
+}
+
+// specsFromCFNTaskDef decodes one AWS::ECS::TaskDefinition's Properties (already
+// intrinsic-sanitized and re-marshaled to JSON) into the SHARED ecsTaskDef and
+// returns a graded Spec per container definition, keyed with source
+// "cloudformation". It mirrors SpecsFromECS's body exactly (task-level modes +
+// docker.sock host volume fold into every container) so the CFN grade is identical
+// to the live/terraform grade of the same task definition.
+func specsFromCFNTaskDef(propsJSON []byte) ([]Spec, error) {
+	var td ecsTaskDef
+	// Case-insensitive key matching maps CloudFormation's PascalCase properties
+	// (ContainerDefinitions, Privileged, ...) onto ecsTaskDef's camelCase json tags.
+	if err := json.Unmarshal(propsJSON, &td); err != nil {
+		return nil, err
+	}
+	if len(td.ContainerDefinitions) == 0 {
+		return nil, nil
+	}
+
+	family := nz(td.Family, "task")
+
+	// docker.sock exposure is a task-level property: an ECS host volume whose source
+	// path is the control socket is mountable into any container in the task.
+	dockerSock := No
+	for _, vol := range td.Volumes {
+		if vol.Host != nil && isControlSocket(vol.Host.SourcePath) {
+			dockerSock = Yes
+		}
+	}
+
+	modes := ecsTaskModes{NetworkMode: td.NetworkMode, PidMode: td.PidMode, IpcMode: td.IpcMode}
+	specs := make([]Spec, 0, len(td.ContainerDefinitions))
+	for _, d := range td.ContainerDefinitions {
+		specs = append(specs, ecsSpec("cloudformation", family, d, modes, dockerSock))
+	}
+	return specs, nil
+}
+
+// AggregateCloudFormation folds the per-container specs from a CloudFormation
+// template's ECS task definitions into a single Report. Like AggregateECS /
+// AggregateTerraform, the aggregate is the WEAKEST container (minimum score): a
+// template is only as isolated as its most-exposed container, so grading the
+// weakest link is the honest, fail-closed summary. target names the source
+// (template file base, or a directory rollup label). It returns the aggregate
+// Report and the Spec that produced it (for SARIF anchoring). It is pure; the
+// caller injects Version/GeneratedAt. Fail-closed: an empty container set is an
+// error (a template that declares no gradeable ECS container is not a pass).
+func AggregateCloudFormation(specs []Spec, target string) (Report, Spec, error) {
+	if len(specs) == 0 {
+		return Report{}, Spec{}, fmt.Errorf("no gradeable container definitions found in CloudFormation template(s) (looked for AWS::ECS::TaskDefinition resources with ContainerDefinitions)")
+	}
+
+	all := make([]scoredWorkload, len(specs))
+	worst := 0
+	for i, s := range specs {
+		all[i] = scoredWorkload{spec: s, report: Score(s)}
+		if all[i].report.Score < all[worst].report.Score {
+			worst = i
+		}
+	}
+
+	agg := all[worst].report
+	worstSpec := all[worst].spec
+	if strings.TrimSpace(target) != "" {
+		agg.Target = target
+	}
+	agg.Source = "cloudformation"
+	agg.Notes = append(cfnSummaryNotes(all[worst], all), agg.Notes...)
+
+	return agg, worstSpec, nil
+}
+
+// cfnSummaryNotes builds the template-level roll-up notes for an aggregate
+// CloudFormation report: a headline naming the weakest container and a
+// per-container score list.
+func cfnSummaryNotes(worst scoredWorkload, all []scoredWorkload) []string {
+	notes := []string{
+		fmt.Sprintf("graded %d CloudFormation ECS container(s); the template grade is the WEAKEST (a template is only as isolated as its most-exposed container). Weakest: %s at %d/100 (grade %s).",
+			len(all), nz(worst.spec.Target, "container"), worst.report.Score, worst.report.Grade),
+	}
+	sorted := make([]scoredWorkload, len(all))
+	copy(sorted, all)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].report.Score < sorted[j].report.Score })
+	rows := make([]string, len(sorted))
+	for i, w := range sorted {
+		rows[i] = fmt.Sprintf("%s = %d/100 (%s)", nz(w.spec.Target, "container"), w.report.Score, w.report.Grade)
+	}
+	notes = append(notes, "per-container: "+strings.Join(rows, "; "))
+	return notes
+}
+
+// --------------------------------------------------------------------------- //
+// CloudFormation intrinsic tolerance
+//
+// CloudFormation templates carry unresolvable references — !Ref, !Sub, !GetAtt,
+// the Fn::* family, and their {"Ref": ...} / {"Fn::Sub": ...} long forms. Without
+// the deployed stack we cannot resolve them, so we nullify each intrinsic node
+// before the typed decode. A graded field an intrinsic covered then reads as unset
+// and is graded fail-closed. This keeps decoding robust (a !Ref where a bool/array
+// was expected never errors) and honest (an unknown posture scores as insecure).
+// --------------------------------------------------------------------------- //
+
+// cfnMappingValue returns the value node for key in a YAML mapping node, or nil.
+func cfnMappingValue(n *yaml.Node, key string) *yaml.Node {
+	if n == nil || n.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if n.Content[i].Value == key {
+			return n.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// sanitizeCFNIntrinsics walks a YAML node tree and replaces every CloudFormation
+// intrinsic node (short-tag !Ref/!Sub/... on any node, or a single-key {"Ref": ...}
+// / {"Fn::*": ...} / {"Condition": ...} mapping) with a null scalar. It returns the
+// number of intrinsics nullified so the caller can note that some values were
+// skipped. Nullifying (rather than erroring) is what makes the CFN parser fail-open.
+func sanitizeCFNIntrinsics(n *yaml.Node) int {
+	if n == nil {
+		return 0
+	}
+	if isIntrinsicNode(n) {
+		nullifyNode(n)
+		return 1
+	}
+	count := 0
+	for _, c := range n.Content {
+		count += sanitizeCFNIntrinsics(c)
+	}
+	return count
+}
+
+// isIntrinsicNode reports whether a node is a CloudFormation intrinsic: a scalar or
+// collection carrying a short-form intrinsic tag (!Ref, !Sub, !If, ...), or a
+// single-key mapping whose key is an intrinsic (Ref, Condition, or Fn::*).
+func isIntrinsicNode(n *yaml.Node) bool {
+	if isIntrinsicTag(n.Tag) {
+		return true
+	}
+	if n.Kind == yaml.MappingNode && len(n.Content) == 2 &&
+		n.Content[0].Kind == yaml.ScalarNode && isIntrinsicKey(n.Content[0].Value) {
+		return true
+	}
+	return false
+}
+
+// isIntrinsicTag reports whether a YAML tag is a CloudFormation short-form
+// intrinsic (!Ref, !Sub, !GetAtt, !If, ...). Standard resolved YAML tags are the
+// "!!str"/"!!int"/"!!bool"/"!!null"/"!!map"/"!!seq" double-bang forms; a single
+// leading "!" that is not "!!" is a custom (intrinsic) tag.
+func isIntrinsicTag(tag string) bool {
+	return len(tag) > 1 && tag[0] == '!' && tag[1] != '!'
+}
+
+// isIntrinsicKey reports whether a mapping key is a CloudFormation long-form
+// intrinsic (Ref, Condition, or any Fn::* function). This covers JSON templates
+// and YAML long-form intrinsics alike.
+func isIntrinsicKey(k string) bool {
+	return k == "Ref" || k == "Condition" || strings.HasPrefix(k, "Fn::")
+}
+
+// nullifyNode rewrites a node in place to the YAML null scalar, discarding any
+// intrinsic value. A null decodes to a zero value (empty string / nil pointer / nil
+// slice), i.e. the "unset" posture the scorer grades fail-closed.
+func nullifyNode(n *yaml.Node) {
+	n.Kind = yaml.ScalarNode
+	n.Tag = "!!null"
+	n.Value = ""
+	n.Content = nil
+}

--- a/internal/host/scan/cloudformation_test.go
+++ b/internal/host/scan/cloudformation_test.go
@@ -1,0 +1,294 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+// A hardened ECS task definition expressed in a CloudFormation YAML template:
+// non-root user, cap_drop ALL, read-only rootfs, no-new-privileges, awsvpc net.
+const cfnYAMLHardened = `AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  WebTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: webapp
+      NetworkMode: awsvpc
+      ContainerDefinitions:
+        - Name: web
+          Image: example/web:1.2.3
+          User: "1000"
+          Privileged: false
+          ReadonlyRootFilesystem: true
+          LinuxParameters:
+            Capabilities:
+              Drop: [ALL]
+            InitProcessEnabled: true
+          DockerSecurityOptions:
+            - no-new-privileges
+`
+
+// The worst case in a JSON CloudFormation template: a root, privileged,
+// host-network, host-PID container mounting the docker control socket.
+const cfnJSONPorous = `{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "LegacyTask": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "Family": "legacy",
+        "NetworkMode": "host",
+        "PidMode": "host",
+        "IpcMode": "host",
+        "ContainerDefinitions": [
+          { "Name": "agent", "User": "0", "Privileged": true }
+        ],
+        "Volumes": [
+          { "Name": "sock", "Host": { "SourcePath": "/var/run/docker.sock" } }
+        ]
+      }
+    }
+  }
+}`
+
+func TestSpecsFromCloudFormation_YAMLHardened(t *testing.T) {
+	specs, intr, err := SpecsFromCloudFormation([]byte(cfnYAMLHardened))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if intr {
+		t.Errorf("no intrinsics in this template; intr should be false")
+	}
+	if len(specs) != 1 {
+		t.Fatalf("want 1 container, got %d: %v", len(specs), targets(specs))
+	}
+	s := specs[0]
+	if s.Source != "cloudformation" {
+		t.Errorf("source: want cloudformation, got %q", s.Source)
+	}
+	if s.Target != "ecs/webapp/web" {
+		t.Errorf("target: want ecs/webapp/web, got %q", s.Target)
+	}
+	if s.RunAsNonRoot != Yes || s.User != "1000" {
+		t.Errorf("user: RunAsNonRoot=%v User=%q", s.RunAsNonRoot, s.User)
+	}
+	if s.CapDropAll != Yes || s.ReadonlyRoot != Yes || s.Privileged != No {
+		t.Errorf("caps/rootfs/privileged: %+v", s)
+	}
+	if s.NetworkMode != "awsvpc" || s.HostNetwork != No {
+		t.Errorf("network: %q hostNet=%v (awsvpc is a NIC, not host)", s.NetworkMode, s.HostNetwork)
+	}
+	if s.NoNewPrivs != Yes {
+		t.Errorf("no-new-privileges not extracted: %v", s.NoNewPrivs)
+	}
+	if s.Seccomp != "confined" {
+		t.Errorf("seccomp: want confined (ECS docker default), got %q", s.Seccomp)
+	}
+	// awsvpc is an egress-capable NIC (not network=none), so a fully hardened ECS
+	// task tops out at the honest 89/100 (grade B) ceiling.
+	if r := Score(s); r.Score < 89 {
+		t.Errorf("hardened task should grade high, got %d/100 (%s)", r.Score, r.Grade)
+	}
+}
+
+func TestSpecsFromCloudFormation_JSONPorous(t *testing.T) {
+	specs, _, err := SpecsFromCloudFormation([]byte(cfnJSONPorous))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("want 1 container, got %d", len(specs))
+	}
+	s := specs[0]
+	if s.Source != "cloudformation" || s.Target != "ecs/legacy/agent" {
+		t.Errorf("header: source=%q target=%q", s.Source, s.Target)
+	}
+	if s.Privileged != Yes {
+		t.Errorf("privileged not extracted: %v", s.Privileged)
+	}
+	if s.RunAsNonRoot != No {
+		t.Errorf("user 0 should be root: %v", s.RunAsNonRoot)
+	}
+	if s.HostNetwork != Yes || s.NetworkMode != "host" {
+		t.Errorf("host network not extracted: mode=%q hostNet=%v", s.NetworkMode, s.HostNetwork)
+	}
+	if s.HostPID != Yes || s.HostIPC != Yes {
+		t.Errorf("host namespaces not extracted: pid=%v ipc=%v", s.HostPID, s.HostIPC)
+	}
+	if s.DockerSock != Yes {
+		t.Errorf("docker.sock host volume not detected: %v", s.DockerSock)
+	}
+	if r := Score(s); r.Score > 20 {
+		t.Errorf("worst-case task should grade low, got %d/100 (%s)", r.Score, r.Grade)
+	}
+}
+
+// TestSpecsFromCloudFormation_IntrinsicsTolerated proves a template full of
+// intrinsics still parses fail-open: a graded field behind a !Ref reads as unset
+// (fail-closed) and the intrinsic flag is raised, rather than erroring out.
+func TestSpecsFromCloudFormation_IntrinsicsTolerated(t *testing.T) {
+	const tmpl = `Resources:
+  Task:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Ref FamilyName
+      NetworkMode: !Sub "${NetMode}"
+      ContainerDefinitions:
+        - Name: app
+          Image: !Ref ImageUri
+          Privileged: !If [IsDev, true, false]
+          User: !Ref RunUser
+`
+	specs, intr, err := SpecsFromCloudFormation([]byte(tmpl))
+	if err != nil {
+		t.Fatalf("intrinsics must not error (fail-open): %v", err)
+	}
+	if !intr {
+		t.Errorf("intr flag should be true (template uses !Ref/!Sub/!If)")
+	}
+	if len(specs) != 1 {
+		t.Fatalf("want 1 container, got %d", len(specs))
+	}
+	s := specs[0]
+	// Family unresolved -> the family folds to the "task" fallback; the container
+	// name is still literal.
+	if s.Target != "ecs/task/app" {
+		t.Errorf("target with unresolved family: want ecs/task/app, got %q", s.Target)
+	}
+	// User behind !Ref is unknown -> fail-closed (not credited as non-root).
+	if s.RunAsNonRoot == Yes {
+		t.Errorf("unresolved !Ref user must not be credited as non-root: %v", s.RunAsNonRoot)
+	}
+	// Privileged behind !If is unknown -> triFromPtr(nil) == Unknown.
+	if s.Privileged == Yes {
+		t.Errorf("unresolved !If privileged should not be Yes: %v", s.Privileged)
+	}
+}
+
+// TestSpecsFromCloudFormation_MultiResourceAggregate grades a template with two
+// task definitions and confirms the aggregate is the WEAKEST container.
+func TestSpecsFromCloudFormation_MultiResourceAggregate(t *testing.T) {
+	const tmpl = `Resources:
+  HardTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: hard
+      NetworkMode: awsvpc
+      ContainerDefinitions:
+        - Name: safe
+          User: "1000"
+          ReadonlyRootFilesystem: true
+          LinuxParameters:
+            Capabilities:
+              Drop: [ALL]
+          DockerSecurityOptions: [no-new-privileges]
+  SoftTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: soft
+      NetworkMode: host
+      ContainerDefinitions:
+        - Name: risky
+          User: "0"
+          Privileged: true
+  NotAnEcsResource:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: irrelevant
+`
+	specs, _, err := SpecsFromCloudFormation([]byte(tmpl))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("want 2 containers (S3 ignored), got %d: %v", len(specs), targets(specs))
+	}
+	report, worst, err := AggregateCloudFormation(specs, "stack.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Source != "cloudformation" || report.Target != "stack.yaml" {
+		t.Errorf("aggregate header: source=%q target=%q", report.Source, report.Target)
+	}
+	if worst.Target != "ecs/soft/risky" {
+		t.Errorf("weakest container: want ecs/soft/risky, got %q", worst.Target)
+	}
+	if !strings.Contains(strings.Join(report.Notes, " "), "WEAKEST") {
+		t.Errorf("aggregate should note the weakest-link rollup: %v", report.Notes)
+	}
+}
+
+func TestSpecsFromCloudFormation_NoEcsResourceIsNoSpecs(t *testing.T) {
+	const tmpl = `Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: some-bucket
+`
+	specs, _, err := SpecsFromCloudFormation([]byte(tmpl))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("want 0 specs for a template with no ECS task def, got %d", len(specs))
+	}
+	if _, _, err := AggregateCloudFormation(specs, "empty.yaml"); err == nil {
+		t.Errorf("aggregate of no containers should be a fail-closed error")
+	}
+}
+
+func TestSpecsFromCloudFormation_MalformedIsError(t *testing.T) {
+	// A tab-indented YAML mapping is a hard parse error (fail-open surfaces it).
+	if _, _, err := SpecsFromCloudFormation([]byte("Resources:\n\t- bad: [unclosed")); err == nil {
+		t.Errorf("malformed template should return a parse error")
+	}
+}
+
+// TestCloudFormationECSParity locks the CFN entrypoint to the live --ecs
+// entrypoint: the SAME container contract graded from a CloudFormation template
+// (PascalCase properties) and from registered ECS JSON (camelCase) must produce
+// identical dimension verdicts and the same score. Only Source differs.
+func TestCloudFormationECSParity(t *testing.T) {
+	const cfn = `Resources:
+  Api:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: api
+      NetworkMode: awsvpc
+      ContainerDefinitions:
+        - Name: api
+          User: "1000"
+          ReadonlyRootFilesystem: true
+          LinuxParameters:
+            Capabilities:
+              Drop: [ALL]
+          DockerSecurityOptions: [no-new-privileges]
+`
+	cfnSpecs, _, err := SpecsFromCloudFormation([]byte(cfn))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The SAME contract expressed as a registered ECS task definition.
+	const ecsJSON = `{"taskDefinition":{"family":"api","networkMode":"awsvpc",
+		"containerDefinitions":[{"name":"api","user":"1000","readonlyRootFilesystem":true,
+		"linuxParameters":{"capabilities":{"drop":["ALL"]}},"dockerSecurityOptions":["no-new-privileges"]}]}}`
+	ecsSpecs, err := SpecsFromECS([]byte(ecsJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfnSpecs) != 1 || len(ecsSpecs) != 1 {
+		t.Fatalf("want 1 spec each, got cfn=%d ecs=%d", len(cfnSpecs), len(ecsSpecs))
+	}
+	cf, e := cfnSpecs[0], ecsSpecs[0]
+	if cf.Source != "cloudformation" || e.Source != "ecs" {
+		t.Errorf("source: cfn=%q ecs=%q", cf.Source, e.Source)
+	}
+	if Score(cf).Score != Score(e).Score {
+		t.Errorf("parity broken: cfn=%d ecs=%d", Score(cf).Score, Score(e).Score)
+	}
+	if cf.RunAsNonRoot != e.RunAsNonRoot || cf.CapDropAll != e.CapDropAll ||
+		cf.ReadonlyRoot != e.ReadonlyRoot || cf.NetworkMode != e.NetworkMode ||
+		cf.Seccomp != e.Seccomp || cf.NoNewPrivs != e.NoNewPrivs || cf.Target != e.Target {
+		t.Errorf("dimension divergence:\n cfn=%+v\n ecs=%+v", cf, e)
+	}
+}


### PR DESCRIPTION
## What

Adds a **CloudFormation** input mode to `ironctl scan` — the infrastructure-as-code sibling of `--ecs`. Grades every `AWS::ECS::TaskDefinition` resource in a CloudFormation template (YAML or JSON) before the stack is deployed. Extends the no-account scan wedge.

```bash
ironctl scan --cloudformation template.yaml
ironctl scan --cloudformation ./templates --min-score 75   # dir rollup + CI gate
```

## How (reuse, not reinvent)

- `SpecsFromCloudFormation` parses the template, locates `AWS::ECS::TaskDefinition` resources, and decodes each `Properties` subtree into the **shared** `ecsTaskDef`/`ecsContainerDef` — reused via `encoding/json`'s case-insensitive key matching (CFN PascalCase → ECS camelCase) — then grades through the **same `ecsSpec` mapper** the `--ecs` and `--terraform` `aws_ecs_task_definition` paths use. The three entrypoints can never diverge.
- `AggregateCloudFormation` rolls up to the **weakest** container across all task defs in the template (and, via the CLI, across a directory of templates).
- **CFN intrinsics** (`!Ref`/`!Sub`/`!GetAtt`/`Fn::*` and their `{"Ref":…}` long forms) are tolerated best-effort: each intrinsic node is nullified before decode, so a graded field it covers reads as unset and is graded **fail-closed**, and the scan **notes** when a template used intrinsics. Malformed templates fail **open** (diagnostic + exit 0).

## Tests

- `cloudformation_test.go`: YAML + JSON forms, intrinsic tolerance, multi-resource weakest-link aggregate, no-ECS-resource skip, malformed-is-error, and a **parity test** locking the CFN grade to `--ecs` on equivalent input (identical dimension verdicts + score; only `Source` differs).
- `go build ./...` clean with `CGO_ENABLED=1`; full `internal/host/scan` suite **168 pass**; `go vet` + `gofmt` clean.
- CLI smoke: `scan --cloudformation` on a template with `!Ref`/`!Sub` → 89/100 B (awsvpc egress ceiling), intrinsic note shown, `--min-score 95` trips exit 1.
- `mkdocs build --strict` clean; `#scan-cloudformation` card + anchor render with resolved SVG icon.

## Lenses

- **Reproducibility / fidelity** — pure, offline, daemon-free parse; no AWS call. Same scorer as `--ecs`/`--terraform` → one comparable scale.
- **Fail-loud/closed** — unresolved intrinsics graded fail-closed; empty task-def set is a hard error; malformed template fails open (skip, never a misleading green).

## Docs
`docs/scan.md` reference section + top table; `docs/scan-coverage.md` coverage card (`#scan-cloudformation`) + reference-table row.

Closes IRO-526.