### PR TITLE
docs(blog): harden guides wave 8 (cockroachdb/timescaledb/valkey/haproxy) [IRO-533]

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,11 @@ Per-image hardening walkthroughs, the default grade, the dimensions that fail, a
 [Grafana](https://ironsecco.github.io/ironclaw/blog/harden-grafana-container-isolation/),
 [Prometheus](https://ironsecco.github.io/ironclaw/blog/harden-prometheus-container-isolation/),
 [Traefik](https://ironsecco.github.io/ironclaw/blog/harden-traefik-container-isolation/),
-[InfluxDB](https://ironsecco.github.io/ironclaw/blog/harden-influxdb-container-isolation/), and
+[InfluxDB](https://ironsecco.github.io/ironclaw/blog/harden-influxdb-container-isolation/),
+[CockroachDB](https://ironsecco.github.io/ironclaw/blog/harden-cockroachdb-container-isolation/),
+[TimescaleDB](https://ironsecco.github.io/ironclaw/blog/harden-timescaledb-container-isolation/),
+[Valkey](https://ironsecco.github.io/ironclaw/blog/harden-valkey-container-isolation/),
+[HAProxy](https://ironsecco.github.io/ironclaw/blog/harden-haproxy-container-isolation/), and
 [untrusted Node.js](https://ironsecco.github.io/ironclaw/blog/run-untrusted-nodejs-code-safely/).
 
 ### Show your score

--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -44,5 +44,9 @@ nav:
   - "How to harden a QuestDB container": harden-questdb-container-isolation.md
   - "How to harden a NATS container": harden-nats-container-isolation.md
   - "How to harden a Gitea container": harden-gitea-container-isolation.md
+  - "How to harden a CockroachDB container": harden-cockroachdb-container-isolation.md
+  - "How to harden a TimescaleDB container": harden-timescaledb-container-isolation.md
+  - "How to harden a Valkey container": harden-valkey-container-isolation.md
+  - "How to harden a HAProxy container": harden-haproxy-container-isolation.md
   - "How to scan a Dockerfile for security issues": scan-a-dockerfile-for-security-issues.md
   - "*.md"

--- a/docs/blog/harden-cockroachdb-container-isolation.md
+++ b/docs/blog/harden-cockroachdb-container-isolation.md
@@ -1,0 +1,108 @@
+---
+title: "How to harden a CockroachDB container: cockroach scores 48/100 by default"
+description: "cockroachdb/cockroach defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a co-located SQL database to a full 100/100 grade A."
+---
+
+# How to harden a CockroachDB container (and is cockroachdb/cockroach safe for your data?)
+
+CockroachDB is where your transactional data of record lives: accounts, ledgers, orders, the rows an
+attacker most wants to read or rewrite. A stock `docker run cockroachdb/cockroach:latest` keeps that
+store behind a boundary weaker than the data deserves. Graded on IronClaw's seven-dimension
+containment scale, the default configuration scores **48 of 100, grade D (porous)**. Higher is safer.
+Unlike a broker or a proxy, a single-node SQL database that only its co-located application talks to
+can close every dimension, including the network. A few runtime flags take the same image to a full
+**100 of 100, grade A**. Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `cockroachdb/cockroach:latest`, the
+> same data behind its [isolation scorecard](../scores/cockroach.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+cockroachdb/cockroach:latest`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The two that should worry you most are **root** and **egress**. A CockroachDB process that escapes as
+root escapes as root on the host, next to the very store files it was holding. And a database that can
+reach arbitrary destinations is one that can quietly ship your entire dataset out the moment a SQL
+parsing or dependency CVE lands code execution. The default capability set and writable rootfs widen
+and entrench that foothold.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-cockroach --fix` prints one remediation per failed dimension, then one hardened run.
+For `cockroachdb/cockroach:latest`:
+
+- **`--user 1000:1000`** (Non-root user, +15): pin a non-root uid so an escape does not begin as host
+  uid 0. Point `/cockroach/cockroach-data` at a volume this uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; CockroachDB needs
+  none of the default set to serve SQL and its console on high ports.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
+  the data directory as an explicit writable volume. Removes the persistence surface.
+- **`--network=none`** (Network isolation, +11 to the full 15): this is the dimension a co-located
+  store can actually max out. If the only client is an application on the same host or pod reaching
+  CockroachDB over the loopback of a shared network namespace, cut the NIC entirely. Nothing external
+  can connect, and the database cannot phone home.
+
+### When network=none is not honest
+
+CockroachDB is often run as a distributed cluster: nodes gossip and replicate ranges to each other
+over the network, and SQL clients may connect remotely. If you run more than one node, or accept
+remote clients, you cannot use `--network=none`; the store has to accept those connections. In that
+case put every node on a user-defined network scoped to just its peers and clients, with no default
+route out. That holds the network dimension at a WARN (4 of 15) and the honest ceiling becomes **89 of
+100, grade B**, the same as a broker. Use `--network=none` only for the single-node, co-located case.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name cockroach cockroachdb/cockroach:latest start-single-node --insecure
+
+# After: 100/100, grade A (single node, co-located app, no network needed)
+docker run -d --name cockroach-hardened \
+  --user 1000:1000 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v cockroach-data:/cockroach/cockroach-data \
+  --network=none \
+  cockroachdb/cockroach:latest start-single-node --insecure
+```
+
+Rescan: `ironctl scan cockroach-hardened` reports `100/100 grade A`. A **52-point swing** with no
+custom image build, just the right flags. Every dimension is closed because a co-located single-node
+database does not need to talk to anything but the app on the other side of its loopback. That is the
+top grade, reserved for datastores whose clients live next to them.
+
+## Verify it on your own CockroachDB
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-cockroach
+ironctl scan my-cockroach --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the CockroachDB in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [cockroach isolation scorecard &rarr;](../scores/cockroach.md): the full dimension breakdown.
+- [How to harden a Postgres container &rarr;](harden-postgres-container-isolation.md): the other SQL store that reaches grade A when co-located.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-haproxy-container-isolation.md
+++ b/docs/blog/harden-haproxy-container-isolation.md
@@ -1,0 +1,102 @@
+---
+title: "How to harden a HAProxy container: haproxy:3.1-alpine scores 63/100 by default"
+description: "haproxy:3.1-alpine defaults score 63/100 (grade C): full caps, writable rootfs. The exact ironctl scan --fix flags that take a load balancer to its honest 89/100 grade B."
+---
+
+# How to harden a HAProxy container (and is haproxy:3.1-alpine safe at your edge?)
+
+HAProxy sits in the request path: it terminates TLS, load-balances every inbound connection, and is
+the first thing an attacker reaches. A stock `docker run haproxy:3.1-alpine` is better than most edge
+images out of the box, but it is not yet the boundary that role deserves. Graded on IronClaw's
+seven-dimension containment scale, the default configuration scores **63 of 100, grade C (partial)**.
+Higher is safer. A few runtime flags take the same image to **89 of 100, grade B**, one point off an
+A, and the one dimension it cannot reach is the one a load balancer needs by definition: it exists to
+accept and forward traffic. Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `haproxy:3.1-alpine`, the same data
+> behind its [isolation scorecard](../scores/haproxy.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+haproxy:3.1-alpine`, two fail and one warns. It already runs as a non-root user, which is why it
+starts a full grade above most edge images:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as haproxy (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+HAProxy already gets the hardest dimension right by dropping to a non-root uid. The two that remain are
+the **full capability set** and the **writable rootfs**. HAProxy parses attacker-controlled bytes on
+every request; a routing or TLS CVE that lands code execution keeps CAP_NET_RAW to craft raw packets
+and a writable rootfs to persist, unless you take them away. Neither is needed to forward traffic.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-haproxy --fix` prints one remediation per failed dimension, then one hardened run.
+For `haproxy:3.1-alpine`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability, then add back only
+  `CAP_NET_BIND_SERVICE` if you must bind 80/443 directly. The scan below reflects dropping the full
+  set with ports mapped high; adding one cap back costs 4 points (a WARN, still grade B territory).
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only. HAProxy
+  runs happily read-only; mount a writable volume only if you use its runtime state or maps.
+- **`--user 99:99`** (Non-root user, already +15): the image already drops to the `haproxy` uid, so
+  this dimension is closed by default. Keep it pinned if you override the entrypoint.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a load
+  balancer, it exists to forward traffic. Any named or bridge network scores 4 of 15 (a WARN, not a
+  fail): a connection path exists. Contain it anyway: put HAProxy on a user-defined network scoped to
+  just the backends it fronts, with no default route out, so a compromised proxy cannot call arbitrary
+  internet addresses.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name haproxy haproxy:3.1-alpine
+
+# After: 89/100, grade B (scoped private network for its backends)
+docker run -d --name haproxy-hardened \
+  --user 99:99 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -p 8080:8080 -p 8443:8443 \
+  --network=edge-internal \
+  haproxy:3.1-alpine
+```
+
+Rescan: `ironctl scan haproxy-hardened` reports `89/100 grade B`. A **26-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a load balancer exists to accept connections; `network=none` would score the last points
+but leave nothing able to reach or be reached. That is the honest ceiling for a proxy, and a solid
+grade B.
+
+## Verify it on your own HAProxy
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-haproxy
+ironctl scan my-haproxy --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the HAProxy in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [haproxy isolation scorecard &rarr;](../scores/haproxy.md): the full dimension breakdown.
+- [How to harden a Traefik container &rarr;](harden-traefik-container-isolation.md): the other popular edge proxy, with the same honest ceiling.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-timescaledb-container-isolation.md
+++ b/docs/blog/harden-timescaledb-container-isolation.md
@@ -1,0 +1,108 @@
+---
+title: "How to harden a TimescaleDB container: timescaledb scores 48/100 by default"
+description: "timescale/timescaledb defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a co-located time-series database to a full 100/100 grade A."
+---
+
+# How to harden a TimescaleDB container (and is timescale/timescaledb safe for your metrics?)
+
+TimescaleDB holds your time-series of record: sensor readings, financial ticks, application metrics,
+the append-only history an attacker would love to tamper with or exfiltrate. Built on Postgres, a
+stock `docker run timescale/timescaledb` inherits the same porous defaults. Graded on IronClaw's
+seven-dimension containment scale, the default configuration scores **48 of 100, grade D (porous)**.
+Higher is safer. Unlike a broker or a proxy, a database that only its co-located application talks to
+can close every dimension, including the network. A few runtime flags take the same image to a full
+**100 of 100, grade A**. Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `timescale/timescaledb:2.17.2-pg17`,
+> the same data behind its [isolation scorecard](../scores/timescaledb.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+timescale/timescaledb:2.17.2-pg17`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The two that should worry you most are **root** and **egress**. A Postgres process that escapes as
+root escapes as root on the host, next to the very store files it was holding. And a database that can
+reach arbitrary destinations is one that can quietly ship your entire history out the moment a SQL
+parsing or extension CVE lands code execution. The default capability set and writable rootfs widen
+and entrench that foothold.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-timescaledb --fix` prints one remediation per failed dimension, then one hardened
+run. For `timescale/timescaledb:2.17.2-pg17`:
+
+- **`--user 999:999`** (Non-root user, +15): pin the non-root `postgres` uid so an escape does not
+  begin as host uid 0. Point `/var/lib/postgresql/data` at a volume this uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Postgres needs none
+  of the default set to serve on its port.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
+  the data directory as an explicit writable volume. Removes the persistence surface.
+- **`--network=none`** (Network isolation, +11 to the full 15): this is the dimension a co-located
+  store can actually max out. If the only client is an application on the same host or pod reaching
+  TimescaleDB over the loopback of a shared network namespace, cut the NIC entirely. Nothing external
+  can connect, and the database cannot phone home.
+
+### When network=none is not honest
+
+If remote clients connect over the network, or you run streaming replication to standby replicas, you
+cannot use `--network=none`; the store has to accept those connections. In that case put it on a
+user-defined network scoped to just its clients and replicas, with no default route out. That holds
+the network dimension at a WARN (4 of 15) and the honest ceiling becomes **89 of 100, grade B**, the
+same as a broker. Use `--network=none` only for the single-instance, co-located case.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name timescaledb -e POSTGRES_PASSWORD=x timescale/timescaledb:2.17.2-pg17
+
+# After: 100/100, grade A (co-located app, no network needed)
+docker run -d --name timescaledb-hardened \
+  --user 999:999 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -e POSTGRES_PASSWORD=x \
+  -v timescaledb-data:/var/lib/postgresql/data \
+  --network=none \
+  timescale/timescaledb:2.17.2-pg17
+```
+
+Rescan: `ironctl scan timescaledb-hardened` reports `100/100 grade A`. A **52-point swing** with no
+custom image build, just the right flags. Every dimension is closed because a co-located time-series
+database does not need to talk to anything but the app on the other side of its loopback. That is the
+top grade, reserved for datastores whose clients live next to them.
+
+## Verify it on your own TimescaleDB
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-timescaledb
+ironctl scan my-timescaledb --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the TimescaleDB in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [timescaledb isolation scorecard &rarr;](../scores/timescaledb.md): the full dimension breakdown.
+- [How to harden a Postgres container &rarr;](harden-postgres-container-isolation.md): the base image TimescaleDB extends, with the same grade-A path.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-valkey-container-isolation.md
+++ b/docs/blog/harden-valkey-container-isolation.md
@@ -1,0 +1,107 @@
+---
+title: "How to harden a Valkey container: valkey:8 scores 48/100 by default"
+description: "valkey:8 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a co-located cache to a full 100/100 grade A."
+---
+
+# How to harden a Valkey container (and is valkey:8 safe in your stack?)
+
+Valkey is the community-driven Redis fork: the same in-memory key-value store used as a co-located
+cache, session store, and rate limiter. Fast, and often holding session tokens and cached PII an
+attacker would love to read. A stock `docker run valkey/valkey:8` keeps that store behind a boundary
+weaker than the data deserves. Graded on IronClaw's seven-dimension containment scale, the default
+configuration scores **48 of 100, grade D (porous)**. Higher is safer. When only its co-located
+application talks to it over loopback, a cache can close every dimension, including the network. A few
+runtime flags take the same image to a full **100 of 100, grade A**. Here are the exact gaps and fixes
+from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `valkey/valkey:8`, the same data behind
+> its [isolation scorecard](../scores/valkey.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+valkey/valkey:8`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The two that should worry you most are **root** and **egress**. A Valkey process that escapes as root
+escapes as root on the host. And a cache that can reach arbitrary destinations is one that can quietly
+ship every cached session and secret out the moment a parsing or Lua-scripting CVE lands code
+execution. The default capability set and writable rootfs widen and entrench that foothold.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-valkey --fix` prints one remediation per failed dimension, then one hardened run. For
+`valkey/valkey:8`:
+
+- **`--user 999:999`** (Non-root user, +15): pin the non-root `valkey` uid so an escape does not begin
+  as host uid 0. Point `/data` at a volume this uid owns if you persist an RDB/AOF snapshot.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Valkey needs none of
+  the default set to serve on its port.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
+  the data directory as an explicit writable volume. Removes the persistence surface.
+- **`--network=none`** (Network isolation, +11 to the full 15): this is the dimension a co-located
+  cache can max out. If the only client is an application on the same host or pod reaching Valkey over
+  the loopback of a shared network namespace, cut the NIC entirely. Nothing external can connect, and
+  the cache cannot phone home.
+
+### When network=none is not honest
+
+If Valkey is a shared cache that many services across the network connect to, or you run replication
+to replicas, you cannot use `--network=none`; it has to accept those connections. In that case put it
+on a user-defined network scoped to just its clients and replicas, with no default route out. That
+holds the network dimension at a WARN (4 of 15) and the honest ceiling becomes **89 of 100, grade B**,
+the same as a broker. Use `--network=none` only for the single-application, co-located case.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name valkey valkey/valkey:8
+
+# After: 100/100, grade A (co-located app on loopback, no network needed)
+docker run -d --name valkey-hardened \
+  --user 999:999 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v valkey-data:/data \
+  --network=none \
+  valkey/valkey:8
+```
+
+Rescan: `ironctl scan valkey-hardened` reports `100/100 grade A`. A **52-point swing** with no custom
+image build, just the right flags. Every dimension is closed because a co-located cache does not need
+to talk to anything but the app on the other side of its loopback. Run it as a shared network cache
+instead and the honest ceiling is **89/100, grade B**, called out above.
+
+## Verify it on your own Valkey
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-valkey
+ironctl scan my-valkey --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Valkey in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [valkey isolation scorecard &rarr;](../scores/valkey.md): the full dimension breakdown.
+- [How to harden a Redis container &rarr;](harden-redis-container-isolation.md): the store Valkey forked, with the same grade-A path.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -37,6 +37,9 @@ Two patterns show up across the set:
 | [Neo4j](harden-neo4j-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if clustered or remote clients) |
 | [CouchDB](harden-couchdb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if clustered or remote clients) |
 | [QuestDB](harden-questdb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if a fleet pushes metrics) |
+| [CockroachDB](harden-cockroachdb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if clustered or remote clients) |
+| [TimescaleDB](harden-timescaledb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B with replicas or remote clients) |
+| [Valkey](harden-valkey-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B as a shared network cache) |
 | [Untrusted Node.js](run-untrusted-nodejs-code-safely.md) | 48/100 D | **100/100 A** | run untrusted code in a real sandbox |
 
 ## Honest ceiling: grade B (89/100)
@@ -60,6 +63,7 @@ These services must accept client connections, so the network dimension holds at
 | [Keycloak](harden-keycloak-container-isolation.md) | 48/100 D | **89/100 B** | identity provider: every app must reach its endpoints |
 | [NATS](harden-nats-container-isolation.md) | 48/100 D | **89/100 B** | broker: publishers and subscribers must connect |
 | [Gitea](harden-gitea-container-isolation.md) | 48/100 D | **89/100 B** | git server: developers and CI must reach it |
+| [HAProxy](harden-haproxy-container-isolation.md) | 63/100 C | **89/100 B** | load balancer: it exists to accept and forward traffic |
 
 ## The pattern, one command
 


### PR DESCRIPTION
## Wave 8 hardening guides (IRO-533)

Continues the SEO harden-guides flywheel (wave 7 = PR #510). Four new before/after container hardening guides, each backed by a real `ironctl scan` grade.

| Guide | Default | Hardened | Class |
|-------|:-------:|:--------:|-------|
| CockroachDB (`cockroachdb/cockroach:latest`) | 48/D | **100/A** | co-located SQL store (89/B if clustered) |
| TimescaleDB (`timescale/timescaledb:2.17.2-pg17`) | 48/D | **100/A** | co-located time-series store (89/B with replicas) |
| Valkey (`valkey/valkey:8`) | 48/D | **100/A** | co-located cache (89/B as shared network cache) |
| HAProxy (`haproxy:3.1-alpine`) | 63/C | **89/B** | load balancer, honest network ceiling |

Grades proven via `ironctl scan --compose` with raw `cap_drop: [ALL]` (colima normalizes CLI `--cap-drop=ALL` to named caps -> use compose):
- cockroach hardened+network:none -> `100/100 grade A`
- timescaledb hardened+network:none -> `100/100 grade A`
- valkey hardened+network:none -> `100/100 grade A`; without network:none -> `89/100 grade B`
- haproxy hardened (proxy, bridge) -> `89/100 grade B`

### Wiring
- Hub `docs/blog/hardening-guides.md`: +3 rows grade-A table, +1 row grade-B table (28 -> 32 cards).
- `docs/blog/.nav.yml`: 4 explicit nav entries.
- `README.md`: 4 links added to the hardening-guides list.

Each guide scorecard exists at `docs/scores/<slug>.md` (verified before pick). No em/en-dashes in copy.