### PR TITLE
docs(scan): group scan-coverage hub by category [IRO-535]

### DIFF
--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -1,6 +1,6 @@
 ---
-title: "What ironctl scan can grade: containers, Compose, Kubernetes, Helm, Terraform, Nomad, Dockerfiles"
-description: "One page, every ironctl scan input mode. A copy-paste command and an isolation grade for a running container, a Compose service, a Kubernetes manifest, a Helm chart, a Terraform plan, a Nomad job, or a Dockerfile."
+title: "What ironctl scan can grade: containers, Compose, Kubernetes, Helm, Kustomize, Terraform, CloudFormation, Cloud Run, ECS, Nomad, Dockerfiles"
+description: "One page, every ironctl scan input mode, grouped by category. A copy-paste command and an isolation grade for a running container, a Compose service, a Kubernetes or Kustomize manifest, a Helm chart, a Terraform plan, a CloudFormation template, a Cloud Run service, an ECS task, a Nomad job, or a Dockerfile."
 ---
 
 # What `ironctl scan` can grade
@@ -10,14 +10,17 @@ and returns a **0&ndash;100 score with a letter grade**, from a running containe
 infrastructure-as-code that will one day launch it. Every mode below runs read-only, needs no
 account, and prints the exact flags that close the gap.
 
-Pick the surface you have. Each card is one copy-paste command.
+The modes are grouped by **the artifact you already have** &mdash; a live container, an
+orchestrator manifest, a cloud runtime spec, or the infrastructure-as-code that defines it.
+Jump to your category, then copy one command.
 
 <!-- ---------------------------------------------------------------------------
   SCAN-MODE CARD CONTRACT  (taxonomy-agnostic; add a mode without a redesign)
 
-  Each supported input mode is exactly one <li> in the grid below, in this shape:
+  Each supported input mode is exactly one <li> in one of the category grids
+  below, in this shape:
 
-      - :icon-name:{ .lg .middle } __<Mode name>__ { #scan-<slug> }
+      - #### :icon-name:{ .lg .middle } <Mode name> { #scan-<slug> }
 
           ---
 
@@ -29,10 +32,18 @@ Pick the surface you have. Each card is one copy-paste command.
 
           [:octicons-arrow-right-24: <deep-link label>](<deep doc>)
 
-  To ship a new mode (e.g. Cloud Run, ECS): paste one <li> here and one row in
-  the "Every mode, one engine" table. No template edit, no CSS. The heading id
-  (`#scan-<slug>`) is the crawlable anchor; keep it kebab-case and stable.
+  To ship a new mode: paste ONE <li> into the grid under the RIGHT category H3
+  (Containers & images / Compose & orchestrators / Cloud runtimes /
+  Infrastructure-as-Code), and add one row to the "Every mode, one engine"
+  table. No template edit, no CSS. The heading id (`#scan-<slug>`) is the
+  crawlable anchor; keep it kebab-case and stable. If a new mode does not fit an
+  existing category, add a new H3 (a crawlable section) rather than overflowing
+  a grid past ~5 cards.
 ---------------------------------------------------------------------------- -->
+
+### Containers &amp; images { #modes-containers }
+
+The container in front of you, whatever runtime launched it, and the Dockerfile that builds it.
 
 <div class="grid cards" markdown>
 
@@ -48,6 +59,41 @@ Pick the surface you have. Each card is one copy-paste command.
     ```
 
     [:octicons-arrow-right-24: Scan reference](scan.md)
+
+-   #### :material-cog-sync-outline:{ .lg .middle } Alternate runtimes { #scan-runtime }
+
+    ---
+
+    Same grade for Podman, nerdctl, and containerd. Auto-detected by default; force one with
+    `--runtime` when a host runs several.
+
+    ```bash
+    ironctl scan --runtime podman my-container
+    ```
+
+    [:octicons-arrow-right-24: Supported runtimes](scan.md#supported-runtimes)
+
+-   #### :material-file-code-outline:{ .lg .middle } Dockerfile (static) { #scan-dockerfile }
+
+    ---
+
+    Grades authoring-time posture straight from a `Dockerfile` &mdash; no daemon, no build.
+    Catches `USER root`, missing drops, and writable layers in CI.
+
+    ```bash
+    ironctl scan --dockerfile Dockerfile
+    ```
+
+    [:octicons-arrow-right-24: Grade a Dockerfile statically](scan.md#grade-a-dockerfile-statically)
+
+</div>
+
+### Compose &amp; orchestrators { #modes-orchestrators }
+
+Declared workloads, before you ever run `up`, `apply`, or `job run`. Multi-workload inputs
+roll up to the **weakest** workload they produce.
+
+<div class="grid cards" markdown>
 
 -   #### :simple-docker:{ .lg .middle } Docker Compose { #scan-compose }
 
@@ -88,31 +134,18 @@ Pick the surface you have. Each card is one copy-paste command.
 
     [:octicons-arrow-right-24: Scan reference](scan.md)
 
--   #### :simple-terraform:{ .lg .middle } Terraform plan { #scan-terraform }
+-   #### :material-layers-triple-outline:{ .lg .middle } Kustomize overlay { #scan-kustomize }
 
     ---
 
-    Grades container workloads in a `terraform show -json` plan or state (Kubernetes and
-    ECS task resources), or point it at a directory and it runs the plan for you.
+    Renders an overlay with `kustomize build` (or `kubectl kustomize`) and grades the
+    **weakest** workload it produces, so a patched overlay is graded before it hits a cluster.
 
     ```bash
-    ironctl scan --terraform plan.json
+    ironctl scan --kustomize ./overlays/prod
     ```
 
-    [:octicons-arrow-right-24: Grade a Terraform plan](scan.md#grade-a-terraform-plan)
-
--   #### :material-aws:{ .lg .middle } CloudFormation { #scan-cloudformation }
-
-    ---
-
-    Grades the `AWS::ECS::TaskDefinition` resources in a CloudFormation template (YAML or
-    JSON) with the same ECS scorer as `--ecs`, rolling up to the **weakest** container.
-
-    ```bash
-    ironctl scan --cloudformation template.yaml
-    ```
-
-    [:octicons-arrow-right-24: Grade a CloudFormation template](scan.md#grade-a-cloudformation-template)
+    [:octicons-arrow-right-24: Grade a kustomization](scan.md#grade-a-kustomization)
 
 -   #### :simple-nomad:{ .lg .middle } Nomad job { #scan-nomad }
 
@@ -127,44 +160,75 @@ Pick the surface you have. Each card is one copy-paste command.
 
     [:octicons-arrow-right-24: Scan reference](scan.md)
 
--   #### :simple-kubernetes:{ .lg .middle } Kustomize build { #scan-kustomize }
+</div>
+
+### Cloud runtimes { #modes-cloud }
+
+Managed container runtimes, graded from their service or task spec &mdash; no cloud account,
+no API call.
+
+<div class="grid cards" markdown>
+
+-   #### :simple-googlecloud:{ .lg .middle } Google Cloud Run { #scan-cloudrun }
 
     ---
 
-    Renders a kustomization with `kustomize build` (base plus overlays) and grades the
-    **weakest** flattened workload, so an overlay is graded after its patches apply.
+    Grades a Cloud Run service's container config straight from its Knative Service YAML
+    (`gcloud run services describe --format=export`), no Google account needed.
 
     ```bash
-    ironctl scan --kustomize ./overlays/prod
+    ironctl scan --cloudrun svc.yaml
     ```
 
-    [:octicons-arrow-right-24: Grade a kustomization](scan.md#grade-a-kustomization)
+    [:octicons-arrow-right-24: Grade a Cloud Run service](scan.md#grade-a-google-cloud-run-service)
 
--   #### :material-file-code-outline:{ .lg .middle } Dockerfile (static) { #scan-dockerfile }
+-   #### :fontawesome-brands-aws:{ .lg .middle } Amazon ECS { #scan-ecs }
 
     ---
 
-    Grades authoring-time posture straight from a `Dockerfile` &mdash; no daemon, no build.
-    Catches `USER root`, missing drops, and writable layers in CI.
+    Grades an ECS task definition's container contract from a live or registered
+    `describe-task-definition`, no AWS call needed. Rolls up to the weakest container.
 
     ```bash
-    ironctl scan --dockerfile Dockerfile
+    ironctl scan --ecs taskdef.json
     ```
 
-    [:octicons-arrow-right-24: Grade a Dockerfile statically](scan.md#grade-a-dockerfile-statically)
+    [:octicons-arrow-right-24: Grade an ECS task definition](scan.md#grade-an-aws-ecs-task-definition)
 
--   #### :material-cog-sync-outline:{ .lg .middle } Alternate runtimes { #scan-runtime }
+</div>
+
+### Infrastructure-as-Code { #modes-iac }
+
+The code that will one day launch the container, graded before it deploys. Container workloads
+roll up to the **weakest** one the code defines.
+
+<div class="grid cards" markdown>
+
+-   #### :simple-terraform:{ .lg .middle } Terraform plan { #scan-terraform }
 
     ---
 
-    Same grade for Podman, nerdctl, and containerd. Auto-detected by default; force one with
-    `--runtime` when a host runs several.
+    Grades container workloads in a `terraform show -json` plan or state (Kubernetes and
+    ECS task resources), or point it at a directory and it runs the plan for you.
 
     ```bash
-    ironctl scan --runtime podman my-container
+    ironctl scan --terraform plan.json
     ```
 
-    [:octicons-arrow-right-24: Supported runtimes](scan.md#supported-runtimes)
+    [:octicons-arrow-right-24: Grade a Terraform plan](scan.md#grade-a-terraform-plan)
+
+-   #### :material-aws:{ .lg .middle } CloudFormation template { #scan-cloudformation }
+
+    ---
+
+    Grades every `AWS::ECS::TaskDefinition` in a CloudFormation template (YAML or JSON) and
+    rolls up to the weakest, so a template is graded before the stack deploys.
+
+    ```bash
+    ironctl scan --cloudformation template.yaml
+    ```
+
+    [:octicons-arrow-right-24: Grade a CloudFormation template](scan.md#grade-a-cloudformation-template)
 
 </div>
 
@@ -174,18 +238,20 @@ Every card above feeds the **same seven-dimension scorer**. The input changes; t
 the letter, and the `--fix` remediation do not. That means a Compose file, a Helm chart, and
 the container they eventually produce are all measured on one comparable scale.
 
-| Input | Flag | What it reads | Deep dive |
-|-------|------|---------------|-----------|
-| [Running container](#scan-container) | *(positional)* | live `docker inspect` of any OCI container | [Scan reference](scan.md) |
-| [Docker Compose](#scan-compose) | `--compose` `--service` | a service's declared config | [Scan reference](scan.md) |
-| [Kubernetes manifest](#scan-k8s) | `--k8s` | a pod spec's `securityContext` | [Scan reference](scan.md) |
-| [Helm chart](#scan-helm) | `--helm` | weakest workload from `helm template` | [Scan reference](scan.md) |
-| [Terraform plan](#scan-terraform) | `--terraform` | container workloads in a plan/state | [Grade a Terraform plan](scan.md#grade-a-terraform-plan) |
-| [CloudFormation](#scan-cloudformation) | `--cloudformation` | `AWS::ECS::TaskDefinition` in a template | [Grade a CloudFormation template](scan.md#grade-a-cloudformation-template) |
-| [Nomad job](#scan-nomad) | `--nomad` | docker-driver tasks in a job spec | [Scan reference](scan.md) |
-| [Kustomize build](#scan-kustomize) | `--kustomize` | weakest workload from `kustomize build` | [Grade a kustomization](scan.md#grade-a-kustomization) |
-| [Dockerfile](#scan-dockerfile) | `--dockerfile` | authoring-time posture, no daemon | [Grade a Dockerfile statically](scan.md#grade-a-dockerfile-statically) |
-| [Alternate runtimes](#scan-runtime) | `--runtime` | Podman / nerdctl / containerd | [Supported runtimes](scan.md#supported-runtimes) |
+| Category | Input | Flag | What it reads | Deep dive |
+|----------|-------|------|---------------|-----------|
+| Containers &amp; images | [Running container](#scan-container) | *(positional)* | live `docker inspect` of any OCI container | [Scan reference](scan.md) |
+| Containers &amp; images | [Alternate runtimes](#scan-runtime) | `--runtime` | Podman / nerdctl / containerd | [Supported runtimes](scan.md#supported-runtimes) |
+| Containers &amp; images | [Dockerfile](#scan-dockerfile) | `--dockerfile` | authoring-time posture, no daemon | [Grade a Dockerfile statically](scan.md#grade-a-dockerfile-statically) |
+| Compose &amp; orchestrators | [Docker Compose](#scan-compose) | `--compose` `--service` | a service's declared config | [Scan reference](scan.md) |
+| Compose &amp; orchestrators | [Kubernetes manifest](#scan-k8s) | `--k8s` | a pod spec's `securityContext` | [Scan reference](scan.md) |
+| Compose &amp; orchestrators | [Helm chart](#scan-helm) | `--helm` | weakest workload from `helm template` | [Scan reference](scan.md) |
+| Compose &amp; orchestrators | [Kustomize overlay](#scan-kustomize) | `--kustomize` | weakest workload from `kustomize build` | [Grade a kustomization](scan.md#grade-a-kustomization) |
+| Compose &amp; orchestrators | [Nomad job](#scan-nomad) | `--nomad` | docker-driver tasks in a job spec | [Scan reference](scan.md) |
+| Cloud runtimes | [Cloud Run](#scan-cloudrun) | `--cloudrun` | a Knative Service's container config | [Grade a Cloud Run service](scan.md#grade-a-google-cloud-run-service) |
+| Cloud runtimes | [Amazon ECS](#scan-ecs) | `--ecs` | a task definition's container contract | [Grade an ECS task definition](scan.md#grade-an-aws-ecs-task-definition) |
+| Infrastructure-as-Code | [Terraform plan](#scan-terraform) | `--terraform` | container workloads in a plan/state | [Grade a Terraform plan](scan.md#grade-a-terraform-plan) |
+| Infrastructure-as-Code | [CloudFormation](#scan-cloudformation) | `--cloudformation` | ECS task defs in a CFN template | [Grade a CloudFormation template](scan.md#grade-a-cloudformation-template) |
 
 Every mode also emits the machine-readable outputs: a [SARIF log](scan.md#github-code-scanning-security-tab)
 for GitHub code scanning, a [shields.io badge](scan.md#sandbox-isolation-score-badge), and
@@ -193,14 +259,16 @@ for GitHub code scanning, a [shields.io badge](scan.md#sandbox-isolation-score-b
 
 ## On the roadmap
 
-Two more input modes are in progress and will drop into the grid above as they ship &mdash; the
-card contract is built so they add without a redesign:
+More input modes are in progress and will drop into the category grids above as they ship
+&mdash; the card contract adds them without a redesign:
 
-- **Google Cloud Run** &mdash; grade a service's container config from its revision spec.
-- **Amazon ECS** &mdash; grade a task definition directly (already reachable today via a
-  [Terraform plan](#scan-terraform) that defines `aws_ecs_task_definition`).
+- **Pulumi** &mdash; grade container workloads in a `pulumi preview --json` program, alongside
+  Terraform and CloudFormation in **Infrastructure-as-Code**.
+- **Azure Container Instances** &mdash; grade a container group spec, alongside Cloud Run and
+  ECS in **Cloud runtimes**.
 
-We list these as *planned*, not shipped. When they land, this line moves up into a card.
+We list these as *planned*, not shipped. When they land, each moves up into a card in its
+category.
 
 ## Start with what you have
 


### PR DESCRIPTION
## What

Groups the scan-coverage hub (`docs/scan-coverage.md`, IRO-519) into **4 crawlable H3 categories** instead of one flat card grid, which stopped being scannable past ~12 modes.

| Category | Modes |
|---|---|
| Containers & images | Running container · Alternate runtimes · Dockerfile |
| Compose & orchestrators | Compose · Kubernetes · Helm · **Kustomize** · Nomad |
| Cloud runtimes | **Cloud Run** · **Amazon ECS** |
| Infrastructure-as-Code | Terraform · **CloudFormation** |

Bold = modes shipped after IRO-519 (Kustomize/Cloud Run/ECS/CloudFormation) that were never carded on the hub. This PR adds their cards too, so the hub finally matches the 12 modes on `main`.

## Design rationale (lenses)

- **Chunking / Miller's Law** — 12 flat items → 4 groups of ≤5, grouped by *the artifact you already have*.
- **Gestalt Common Region** — each category is its own `grid cards` block under an H3.
- **Serial Position** — most-common entry (live container) first, forward-looking IaC last.
- **Information Scent** — keyword-rich H3 labels double as the right-sidebar TOC and crawlable section headers (SEO-positive).

## Contract preserved

- Every `#scan-<slug>` anchor is unchanged (container/runtime/dockerfile/compose/k8s/helm/kustomize/nomad/cloudrun/ecs/terraform/cloudformation).
- The **drop-in card contract** comment is kept and updated: add a mode = paste one `<li>` into the right category grid + one table row. No template edit, no CSS.
- **No new CSS, no new animation** → reduced-motion inherited from IRO-519.
- The "Every mode, one engine" table gains a **Category** column.
- Roadmap refreshed from shipped Cloud Run/ECS to **Pulumi + Azure Container Instances**.

## Verification (visual-truth gate)

Rendered in mkdocs (`mkdocs build`; EOL banner warning only, not an error) and screenshotted at:
- Desktop **1440x900** — 4 category sections, 2-col grids, nested TOC ✓
- Mobile **390x844** — single-column stacks per category, icons render ✓

All 12 mode icons render (ECS uses `:fontawesome-brands-aws:`, CloudFormation `:material-aws:` — the `:simple-amazon*:` slugs are not in this Material bundle).

Closes IRO-535.