### PR TITLE
feat(scan): ironctl scan --pulumi grades K8s/ECS workloads in Pulumi programs (IRO-531)

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -50,6 +50,7 @@ func cmdScan(args []string) error {
 	ecs := fs.String("ecs", "", "grade an AWS ECS task definition: `aws ecs describe-task-definition` JSON, a raw registered task-def JSON, or a directory of task-def JSON files")
 	cloudrun := fs.String("cloudrun", "", "grade Google Cloud Run service specs: a Knative Service YAML (`gcloud run services describe SVC --format=export`), or a directory of them")
 	cloudformation := fs.String("cloudformation", "", "grade AWS::ECS::TaskDefinition resources in a CloudFormation template (YAML or JSON), or a directory of them")
+	pulumi := fs.String("pulumi", "", "grade container workloads in a Pulumi `pulumi stack export` / `pulumi preview --json` file (or a directory of them): kubernetes:* workloads and aws ECS task definitions")
 	kustomize := fs.String("kustomize", "", "render a kustomization directory with `kustomize build` (or `kubectl kustomize`) and grade the isolation posture of its workloads")
 	kustomizeBin := fs.String("kustomize-bin", envOrDefault("KUSTOMIZE", "kustomize"), "kustomize binary used to render the directory (falls back to `kubectl kustomize` if absent)")
 	kubectlBin := fs.String("kubectl-bin", envOrDefault("KUBECTL", "kubectl"), "kubectl binary used for `kubectl kustomize` when the kustomize binary is absent")
@@ -216,6 +217,27 @@ func cmdScan(args []string) error {
 	if *cloudformation != "" {
 		return runCloudFormationScan(cloudFormationScanArgs{
 			path:      *cloudformation,
+			asJSON:    *asJSON,
+			md:        *md,
+			badge:     *badge,
+			badgeJSON: *badgeJSON,
+			sarif:     *sarif,
+			minScore:  *minScore,
+		})
+	}
+
+	// --pulumi: consume Pulumi program output (`pulumi stack export` checkpoint or
+	// `pulumi preview --json`, or a directory of them) and grade the container
+	// workloads it declares — kubernetes:* pods/workloads and aws ECS task
+	// definitions — reusing the SHARED k8s and ECS scorers that the --k8s/--helm and
+	// --ecs/--terraform paths also use. Pulumi output is plain JSON, so there is no
+	// external binary to shell out to. It reads the file(s) here then defers to the
+	// pure SpecsFromPulumi + AggregatePulumi scorer (the same weakest-link rollup as
+	// --terraform). Fail-OPEN on a load/parse failure so an opt-in CI/Action step
+	// never crashes the build; --min-score still gates once workloads are graded.
+	if *pulumi != "" {
+		return runPulumiScan(pulumiScanArgs{
+			path:      *pulumi,
 			asJSON:    *asJSON,
 			md:        *md,
 			badge:     *badge,
@@ -1350,6 +1372,127 @@ func isCFNTemplateExt(name string) bool {
 	}
 }
 
+// pulumiScanArgs carries the resolved inputs for a `scan --pulumi` run.
+type pulumiScanArgs struct {
+	path      string
+	asJSON    bool
+	md        bool
+	badge     string
+	badgeJSON string
+	sarif     string
+	minScore  int
+}
+
+// runPulumiScan grades the container workloads declared in Pulumi program output
+// (a `pulumi stack export` checkpoint or `pulumi preview --json`, or a directory
+// of them), reusing the SHARED k8s and ECS scorers that the --k8s/--helm and
+// --ecs/--terraform paths also use. Pulumi output is plain JSON, so there is no
+// external binary to shell out to. It fails OPEN on a load/parse failure
+// (unreadable path, malformed JSON): it prints a clear diagnostic to stderr and
+// returns nil so an opt-in CI/Action step never crashes the build. Once workloads
+// are graded, scoring and the --min-score CI gate apply exactly like
+// --terraform/--ecs.
+func runPulumiScan(a pulumiScanArgs) error {
+	specs, err := loadPulumiSpecs(a.path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --pulumi could not load %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregatePulumi(specs, filepath.Base(strings.TrimRight(a.path, "/")))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --pulumi found nothing to grade in %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (workloads graded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// loadPulumiSpecs resolves a --pulumi argument to graded Specs. A single file is
+// parsed directly. A directory is a weakest-workload rollup: every *.json file in
+// it is parsed and its workload specs are pooled, so AggregatePulumi grades the
+// single most-exposed container across the whole set. It is daemon-free and
+// offline: Pulumi output is read from disk.
+func loadPulumiSpecs(path string) ([]scan.Spec, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil, rerr
+		}
+		return scan.SpecsFromPulumi(raw)
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	var specs []scan.Spec
+	for _, e := range entries {
+		if e.IsDir() || strings.ToLower(filepath.Ext(e.Name())) != ".json" {
+			continue
+		}
+		raw, rerr := os.ReadFile(filepath.Join(path, e.Name()))
+		if rerr != nil {
+			return nil, rerr
+		}
+		fileSpecs, perr := scan.SpecsFromPulumi(raw)
+		if perr != nil {
+			// A single malformed file in a directory should not sink the rollup:
+			// skip it with a diagnostic and grade the rest (fail-open per file).
+			fmt.Fprintf(os.Stderr, "  warning: scan --pulumi skipping %s (parse error): %v\n", e.Name(), perr)
+			continue
+		}
+		specs = append(specs, fileSpecs...)
+	}
+	return specs, nil
+}
+
 // writeDockerfileSARIF renders the Dockerfile SARIF log to path, fail-open on error.
 func writeDockerfileSARIF(path string, r scan.Report, opts scan.SARIFOptions) error {
 	f, err := os.Create(path)
@@ -1485,6 +1628,7 @@ USAGE:
   ironctl scan --ecs PATH                       grade an AWS ECS task definition (describe-task-definition JSON / dir)
   ironctl scan --cloudrun PATH                  grade Google Cloud Run service specs (Knative Service YAML or dir)
   ironctl scan --cloudformation PATH            grade AWS::ECS::TaskDefinition in a CloudFormation template (YAML/JSON or dir)
+  ironctl scan --pulumi PATH                     grade container workloads in Pulumi stack-export / preview --json output (or dir)
   ironctl scan --kustomize DIR                  render a kustomization (kustomize build) and grade its workloads
   ironctl scan --dockerfile FILE...           grade Dockerfile(s) statically (no daemon, no pull)
   ironctl scan --compare A B                   diff two containers' isolation posture
@@ -1594,6 +1738,17 @@ as its most-exposed pod); every workload's score is listed in the notes. As with
 is graded conservatively (the honest static ceiling). Render failures (neither
 kustomize nor kubectl on PATH / build error) fail OPEN (diagnostic + exit 0); a
 successful render still trips --min-score.
+
+--pulumi grades the container workloads declared in Pulumi program output — a
+`+"`pulumi stack export`"+` checkpoint or `+"`pulumi preview --json`"+` (or a directory of
+them) — reusing the SAME scorers as the other input modes. Pulumi's kubernetes
+inputs ARE the Kubernetes API object, so kubernetes:* pods/workloads map through
+the SAME pod-spec scorer as --k8s/--helm; aws ECS task definitions (classic
+`+"`aws:ecs/taskDefinition:TaskDefinition`"+` and `+"`aws-native:ecs:TaskDefinition`"+`) map
+through the SAME ECS scorer as --ecs/--terraform. A program therefore grades
+identically to the equivalent terraform/ECS/k8s input of the same workload. The
+program grade is the WEAKEST workload; load/parse failures fail OPEN (diagnostic +
+exit 0). A successful parse still trips --min-score.
 
 --dockerfile grades a DIFFERENT, authoring-time dimension set (non-root USER,
 pinned base image, no secrets in ENV/ARG, COPY over remote/opaque ADD, no

--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -230,6 +230,20 @@ roll up to the **weakest** one the code defines.
 
     [:octicons-arrow-right-24: Grade a CloudFormation template](scan.md#grade-a-cloudformation-template)
 
+-   #### :simple-pulumi:{ .lg .middle } Pulumi program { #scan-pulumi }
+
+    ---
+
+    Grades the container workloads in a `pulumi stack export` or `pulumi preview --json`
+    (Kubernetes and ECS resources) with the same scorers as `--k8s` and `--ecs`, rolling up
+    to the **weakest** workload, so a program is graded before `pulumi up`.
+
+    ```bash
+    ironctl scan --pulumi stack.json
+    ```
+
+    [:octicons-arrow-right-24: Grade a Pulumi program](scan.md#grade-a-pulumi-program)
+
 </div>
 
 ## Every mode, one engine
@@ -252,6 +266,7 @@ the container they eventually produce are all measured on one comparable scale.
 | Cloud runtimes | [Amazon ECS](#scan-ecs) | `--ecs` | a task definition's container contract | [Grade an ECS task definition](scan.md#grade-an-aws-ecs-task-definition) |
 | Infrastructure-as-Code | [Terraform plan](#scan-terraform) | `--terraform` | container workloads in a plan/state | [Grade a Terraform plan](scan.md#grade-a-terraform-plan) |
 | Infrastructure-as-Code | [CloudFormation](#scan-cloudformation) | `--cloudformation` | ECS task defs in a CFN template | [Grade a CloudFormation template](scan.md#grade-a-cloudformation-template) |
+| Infrastructure-as-Code | [Pulumi program](#scan-pulumi) | `--pulumi` | K8s &amp; ECS workloads in stack-export / preview JSON | [Grade a Pulumi program](scan.md#grade-a-pulumi-program) |
 
 Every mode also emits the machine-readable outputs: a [SARIF log](scan.md#github-code-scanning-security-tab)
 for GitHub code scanning, a [shields.io badge](scan.md#sandbox-isolation-score-badge), and
@@ -262,8 +277,6 @@ for GitHub code scanning, a [shields.io badge](scan.md#sandbox-isolation-score-b
 More input modes are in progress and will drop into the category grids above as they ship
 &mdash; the card contract adds them without a redesign:
 
-- **Pulumi** &mdash; grade container workloads in a `pulumi preview --json` program, alongside
-  Terraform and CloudFormation in **Infrastructure-as-Code**.
 - **Azure Container Instances** &mdash; grade a container group spec, alongside Cloud Run and
   ECS in **Cloud runtimes**.
 

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -223,6 +223,54 @@ with every container's score in the notes. A malformed template fails **open** (
 clear diagnostic and exit 0) so an opt-in CI step never crashes the build; once
 containers are graded, `--min-score` still trips on a low posture.
 
+## Grade a Pulumi program
+
+`--pulumi PATH` grades the container workloads a [Pulumi](https://www.pulumi.com/)
+program declares — **before** `pulumi up` — straight from the program's own JSON
+output. It is the Pulumi sibling of `--terraform`: Terraform grades a
+`terraform show -json` plan; Pulumi grades a `pulumi stack export` checkpoint or a
+`pulumi preview --json` plan. No cloud credentials and no external binary are
+needed — the output is plain JSON you already have:
+
+```bash
+pulumi stack export > stack.json
+ironctl scan --pulumi stack.json
+ironctl scan --pulumi stack.json --min-score 75      # CI gate
+
+pulumi preview --json > preview.json
+ironctl scan --pulumi preview.json                   # grade the plan before apply
+
+ironctl scan --pulumi ./stacks                        # weakest-workload rollup over a dir
+```
+
+It accepts the shapes a Pulumi user actually has:
+
+| Input | Shape |
+|---|---|
+| `pulumi stack export` | a checkpoint whose `deployment.resources[]` carry each resource's typed inputs |
+| `pulumi preview --json` | a plan whose `steps[].newState` carry the same per-resource shape |
+| a directory | every `*.json` file in it, graded as one **weakest-workload** rollup |
+
+Two resource classes are graded, each through the **shared scorer** the matching
+input mode already uses — so a program grades **identically** to the equivalent
+Terraform / ECS / Kubernetes input of the same workload:
+
+- **Kubernetes** (`kubernetes:*:Pod` / `Deployment` / `StatefulSet` / `DaemonSet` /
+  `ReplicaSet` / `ReplicationController` / `Job` / `CronJob`). Pulumi's kubernetes
+  inputs **are** the Kubernetes API object, so they map through the same pod-spec
+  dimension set as `--k8s` / `--helm`.
+- **AWS ECS task definitions** — the classic `aws:ecs/taskDefinition:TaskDefinition`
+  (where `containerDefinitions` is a JSON-encoded string, exactly like Terraform)
+  and the native `aws-native:ecs:TaskDefinition` (a real array, like the live/CFN
+  shape). Both fold into the same ECS scorer as `--ecs` / `--terraform`.
+
+The program grade is the **weakest** workload (a program is only as isolated as its
+most-exposed container), with every workload's score in the report notes. As with
+`--k8s`/`--helm`, Kubernetes egress depends on a `NetworkPolicy` a pod spec does not
+carry, so it is graded conservatively (the honest static ceiling). A malformed file
+fails **open** (a clear diagnostic and exit 0) so an opt-in CI step never crashes
+the build; once workloads are graded, `--min-score` still trips on a low posture.
+
 ## Grade a Google Cloud Run service
 
 `--cloudrun PATH` grades a [Google Cloud Run](https://cloud.google.com/run)

--- a/internal/host/scan/pulumi.go
+++ b/internal/host/scan/pulumi.go
@@ -1,0 +1,351 @@
+package scan
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SpecsFromPulumi parses Pulumi program output and returns one graded Spec per
+// container workload it recognizes. It accepts the two JSON shapes a user
+// actually has to hand:
+//
+//   - `pulumi stack export` — a checkpoint whose deployment.resources[] carries
+//     every registered resource with its typed inputs/outputs.
+//   - `pulumi preview --json` — a plan whose steps[].newState carries the same
+//     per-resource shape for what WILL be applied.
+//
+// A bare {"resources": [...]} array is also accepted so a hand-extracted resource
+// list works. It grades two workload classes that carry a container isolation
+// posture:
+//
+//   - the Kubernetes provider's workload resources (kubernetes:*:Pod /
+//     Deployment / StatefulSet / DaemonSet / ReplicaSet / ReplicationController /
+//     Job / CronJob). Pulumi's kubernetes inputs mirror the Kubernetes API object
+//     verbatim (camelCase apiVersion/kind/metadata/spec), so they decode into the
+//     SAME k8sObject the --k8s / --helm paths grade and score through the SAME
+//     specFromPodSpec mapper.
+//   - AWS ECS task definitions (aws:ecs/taskDefinition:TaskDefinition from the
+//     classic provider, where containerDefinitions is a JSON-encoded STRING like
+//     terraform; and aws-native:ecs:TaskDefinition, where it is a real array like
+//     the live/CFN shape). Both fold into the SHARED ecsSpec mapper (ecs.go).
+//
+// This is the Pulumi counterpart to the terraform adapter (SpecsFromTerraform):
+// it reuses the identical scorers so a Pulumi program grades byte-for-byte the
+// same as the equivalent terraform/ECS input of the same workload.
+//
+// It is pure and unit-testable: the caller runs `pulumi stack export` /
+// `pulumi preview --json` (I/O) and passes the JSON here. Non-container resources
+// are ignored. It fails OPEN on a malformed top-level document (returns the parse
+// error); the CLI wrapper turns that into a skip so an opt-in CI step never
+// crashes the build.
+func SpecsFromPulumi(raw []byte) ([]Spec, error) {
+	var doc pulumiDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parse pulumi output JSON: %w", err)
+	}
+
+	var specs []Spec
+	for _, r := range doc.resources() {
+		switch {
+		case pulumiK8sKind(r.Type) != "":
+			if s, ok := specFromPulumiK8s(r); ok {
+				specs = append(specs, s)
+			}
+		case isPulumiECSType(r.Type):
+			specs = append(specs, specsFromPulumiECS(r)...)
+		}
+	}
+	return specs, nil
+}
+
+// AggregatePulumi folds the per-workload specs from a Pulumi program into a single
+// Report representing the program's isolation posture. Like AggregateTerraform,
+// the aggregate is the WEAKEST workload (minimum score): a program is only as
+// isolated as its most-exposed container, so grading the weakest link is the
+// honest, fail-closed summary. target names the source (stack-export/preview file
+// base, or a directory rollup label). It returns the aggregate Report and the Spec
+// that produced it (for SARIF anchoring). It is pure; the caller injects
+// Version/GeneratedAt. Fail-closed: an empty workload set is an error (a program
+// that declares no gradeable container workload is not a pass).
+func AggregatePulumi(specs []Spec, target string) (Report, Spec, error) {
+	if len(specs) == 0 {
+		return Report{}, Spec{}, fmt.Errorf("no gradeable container workloads found in pulumi output (looked for kubernetes:* pod/workload resources and aws:ecs/taskDefinition:TaskDefinition)")
+	}
+
+	all := make([]scoredWorkload, len(specs))
+	worst := 0
+	for i, s := range specs {
+		all[i] = scoredWorkload{spec: s, report: Score(s)}
+		if all[i].report.Score < all[worst].report.Score {
+			worst = i
+		}
+	}
+
+	agg := all[worst].report
+	worstSpec := all[worst].spec
+	if strings.TrimSpace(target) != "" {
+		agg.Target = target
+	}
+	agg.Source = "pulumi"
+	agg.Notes = append(pulumiSummaryNotes(all[worst], all), agg.Notes...)
+
+	return agg, worstSpec, nil
+}
+
+// pulumiSummaryNotes builds the program-level roll-up notes for an aggregate
+// Pulumi report: a headline naming the weakest workload and a per-workload score
+// list.
+func pulumiSummaryNotes(worst scoredWorkload, all []scoredWorkload) []string {
+	notes := []string{
+		fmt.Sprintf("graded %d pulumi workload(s); the program grade is the WEAKEST (a program is only as isolated as its most-exposed container). Weakest: %s at %d/100 (grade %s).",
+			len(all), nz(worst.spec.Target, "workload"), worst.report.Score, worst.report.Grade),
+	}
+	sorted := make([]scoredWorkload, len(all))
+	copy(sorted, all)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].report.Score < sorted[j].report.Score })
+	rows := make([]string, len(sorted))
+	for i, w := range sorted {
+		rows[i] = fmt.Sprintf("%s = %d/100 (%s)", nz(w.spec.Target, "workload"), w.report.Score, w.report.Grade)
+	}
+	notes = append(notes, "per-workload: "+strings.Join(rows, "; "))
+	return notes
+}
+
+// --------------------------------------------------------------------------- //
+// Pulumi document model (stack export / preview --json)
+// --------------------------------------------------------------------------- //
+
+// pulumiDoc accepts the three input shapes at once: a `pulumi stack export`
+// checkpoint (deployment.resources[]), a `pulumi preview --json` plan
+// (steps[].newState), and a bare {"resources": [...]} list.
+type pulumiDoc struct {
+	Deployment *struct {
+		Resources []pulumiResource `json:"resources"`
+	} `json:"deployment"`
+	Steps []struct {
+		NewState *pulumiResource `json:"newState"`
+	} `json:"steps"`
+	Resources []pulumiResource `json:"resources"`
+}
+
+// resources flattens whichever of the three shapes is populated into a single
+// resource slice. A stack export (deployment.resources) is preferred, then a
+// preview plan (steps[].newState), then a bare resources list.
+func (d pulumiDoc) resources() []pulumiResource {
+	if d.Deployment != nil && len(d.Deployment.Resources) > 0 {
+		return d.Deployment.Resources
+	}
+	if len(d.Steps) > 0 {
+		out := make([]pulumiResource, 0, len(d.Steps))
+		for _, s := range d.Steps {
+			if s.NewState != nil {
+				out = append(out, *s.NewState)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	return d.Resources
+}
+
+// pulumiResource is one registered/planned Pulumi resource. Type is the Pulumi
+// token ("kubernetes:apps/v1:Deployment", "aws:ecs/taskDefinition:TaskDefinition").
+// Inputs carries what the program set; Outputs the resolved state — we grade
+// Inputs (the authored, pre-deploy posture) and fall back to Outputs only when a
+// resource carries no inputs.
+type pulumiResource struct {
+	URN     string          `json:"urn"`
+	Type    string          `json:"type"`
+	Inputs  json.RawMessage `json:"inputs"`
+	Outputs json.RawMessage `json:"outputs"`
+}
+
+// gradeable returns the JSON to grade for a resource: its inputs, or its outputs
+// when inputs are absent.
+func (r pulumiResource) gradeable() json.RawMessage {
+	if len(bytes.TrimSpace(r.Inputs)) > 0 {
+		return r.Inputs
+	}
+	return r.Outputs
+}
+
+// --------------------------------------------------------------------------- //
+// Kubernetes provider mapping (pulumi-kubernetes)
+//
+// Pulumi's kubernetes inputs ARE the Kubernetes API object (camelCase
+// apiVersion/kind/metadata/spec) — the resource type token supplies the Kind. So
+// the inputs decode straight into the SAME k8sObject the --k8s/--helm paths grade
+// (yaml.v3 parses JSON), and score through the SAME specFromPodSpec mapper.
+// --------------------------------------------------------------------------- //
+
+// pulumiK8sKind maps a Pulumi kubernetes resource token to the Kubernetes Kind it
+// represents, or "" when the token is not a gradeable workload. The token shape is
+// "kubernetes:<group>/<version>:<Kind>", so the Kind is the segment after the last
+// colon.
+func pulumiK8sKind(typ string) string {
+	if !strings.HasPrefix(typ, "kubernetes:") {
+		return ""
+	}
+	kind := typ[strings.LastIndex(typ, ":")+1:]
+	if workloadKinds[kind] {
+		return kind
+	}
+	return ""
+}
+
+// specFromPulumiK8s decodes one kubernetes:* resource's inputs into a k8sObject,
+// resolves its pod spec (bare Pod / workload template / CronJob jobTemplate), and
+// grades it with the shared specFromPodSpec mapper. ok is false when the resource
+// has no container to grade.
+func specFromPulumiK8s(r pulumiResource) (Spec, bool) {
+	raw := r.gradeable()
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return Spec{}, false
+	}
+	var obj k8sObject
+	if err := yaml.Unmarshal(raw, &obj); err != nil {
+		return Spec{}, false
+	}
+	ps, ok := obj.podSpecOf()
+	if !ok {
+		return Spec{}, false
+	}
+	kind := pulumiK8sKind(r.Type)
+	name := strings.TrimSpace(obj.Metadata.Name)
+	if name == "" {
+		name = pulumiURNName(r.URN)
+	}
+	target := kind
+	if name != "" {
+		target = kind + "/" + name
+	}
+	return specFromPodSpec("pulumi", target, ps), true
+}
+
+// --------------------------------------------------------------------------- //
+// AWS ECS task definition mapping (pulumi-aws / pulumi-aws-native)
+//
+// The classic aws provider mirrors terraform: containerDefinitions is a
+// JSON-ENCODED STRING and the task-level fields are camelCase. The aws-native
+// provider mirrors CloudFormation/live ECS: containerDefinitions is a real array
+// and fields are PascalCase (matched case-insensitively by encoding/json). Both
+// decode their container definitions into the SHARED ecsContainerDef and grade
+// through the SHARED ecsSpec mapper, keyed with source "pulumi".
+// --------------------------------------------------------------------------- //
+
+// isPulumiECSType reports whether a Pulumi resource token is an ECS task
+// definition from either the classic or native AWS provider.
+func isPulumiECSType(typ string) bool {
+	return typ == "aws:ecs/taskDefinition:TaskDefinition" || typ == "aws-native:ecs:TaskDefinition"
+}
+
+// pulumiECSInputs decodes an ECS task definition's inputs from either AWS
+// provider. encoding/json matches keys case-insensitively, so the camelCase
+// classic properties and the PascalCase aws-native properties both land here.
+// ContainerDefinitions stays a RawMessage because the classic provider encodes it
+// as a JSON string while aws-native carries a real array.
+type pulumiECSInputs struct {
+	Family               string          `json:"family"`
+	NetworkMode          string          `json:"networkMode"`
+	PidMode              string          `json:"pidMode"`
+	IpcMode              string          `json:"ipcMode"`
+	ContainerDefinitions json.RawMessage `json:"containerDefinitions"`
+	Volumes              []pulumiECSVol  `json:"volumes"`
+}
+
+// pulumiECSVol carries a task volume from either provider: the classic provider
+// models a host volume as {name, hostPath: "<path>"}, while aws-native nests it as
+// {name, host: {sourcePath: "<path>"}}.
+type pulumiECSVol struct {
+	Name     string `json:"name"`
+	HostPath string `json:"hostPath"`
+	Host     *struct {
+		SourcePath string `json:"sourcePath"`
+	} `json:"host"`
+}
+
+// specsFromPulumiECS decodes one ECS task definition resource and returns a graded
+// Spec per container definition. The task-level network/pid/ipc modes and any
+// docker.sock host volume apply to every container. Per-container grading is the
+// SHARED ecsSpec (ecs.go), keyed with source "pulumi".
+func specsFromPulumiECS(r pulumiResource) []Spec {
+	raw := r.gradeable()
+	var in pulumiECSInputs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil
+	}
+	defs, err := pulumiECSContainerDefs(in.ContainerDefinitions)
+	if err != nil || len(defs) == 0 {
+		return nil
+	}
+
+	family := nz(nz(in.Family, pulumiURNName(r.URN)), "task")
+
+	// docker.sock exposure is a task-level property: a host volume whose source
+	// path is the control socket is mountable into any container in the task.
+	dockerSock := No
+	for _, v := range in.Volumes {
+		if isControlSocket(v.HostPath) {
+			dockerSock = Yes
+		}
+		if v.Host != nil && isControlSocket(v.Host.SourcePath) {
+			dockerSock = Yes
+		}
+	}
+
+	modes := ecsTaskModes{NetworkMode: in.NetworkMode, PidMode: in.PidMode, IpcMode: in.IpcMode}
+	specs := make([]Spec, 0, len(defs))
+	for _, d := range defs {
+		specs = append(specs, ecsSpec("pulumi", family, d, modes, dockerSock))
+	}
+	return specs
+}
+
+// pulumiECSContainerDefs decodes an ECS containerDefinitions value that is EITHER
+// a JSON-encoded string (classic aws provider, like terraform) or a real JSON
+// array (aws-native, like CloudFormation/live). It returns nil for an absent or
+// empty value.
+func pulumiECSContainerDefs(raw json.RawMessage) ([]ecsContainerDef, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil, nil
+	}
+	// A leading quote means the classic provider encoded the array as a string;
+	// unquote it, then decode the inner JSON.
+	if trimmed[0] == '"' {
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(s) == "" {
+			return nil, nil
+		}
+		var defs []ecsContainerDef
+		if err := json.Unmarshal([]byte(s), &defs); err != nil {
+			return nil, err
+		}
+		return defs, nil
+	}
+	var defs []ecsContainerDef
+	if err := json.Unmarshal(trimmed, &defs); err != nil {
+		return nil, err
+	}
+	return defs, nil
+}
+
+// pulumiURNName extracts the resource name from a Pulumi URN
+// (urn:pulumi:<stack>::<project>::<type>::<name>): the segment after the last
+// "::". Returns "" for an empty URN.
+func pulumiURNName(urn string) string {
+	if strings.TrimSpace(urn) == "" {
+		return ""
+	}
+	parts := strings.Split(urn, "::")
+	return strings.TrimSpace(parts[len(parts)-1])
+}

--- a/internal/host/scan/pulumi_test.go
+++ b/internal/host/scan/pulumi_test.go
@@ -1,0 +1,389 @@
+package scan
+
+import (
+	"reflect"
+	"testing"
+)
+
+// A Pulumi stack export (checkpoint) whose deployment.resources[] carry a
+// hardened Kubernetes Deployment and a porous one. Pulumi's kubernetes inputs ARE
+// the Kubernetes API object (camelCase apiVersion/kind/metadata/spec).
+const pulumiK8sStackExport = `{
+  "version": 3,
+  "deployment": {
+    "manifest": {},
+    "resources": [
+      {
+        "urn": "urn:pulumi:dev::proj::pulumi:pulumi:Stack::proj-dev",
+        "type": "pulumi:pulumi:Stack"
+      },
+      {
+        "urn": "urn:pulumi:dev::proj::kubernetes:apps/v1:Deployment::hardened",
+        "custom": true,
+        "type": "kubernetes:apps/v1:Deployment",
+        "inputs": {
+          "apiVersion": "apps/v1",
+          "kind": "Deployment",
+          "metadata": { "name": "hardened" },
+          "spec": {
+            "template": {
+              "spec": {
+                "securityContext": { "runAsNonRoot": true, "runAsUser": 1000 },
+                "containers": [
+                  {
+                    "name": "app",
+                    "securityContext": {
+                      "privileged": false,
+                      "readOnlyRootFilesystem": true,
+                      "allowPrivilegeEscalation": false,
+                      "runAsNonRoot": true,
+                      "capabilities": { "drop": ["ALL"] },
+                      "seccompProfile": { "type": "RuntimeDefault" }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "urn": "urn:pulumi:dev::proj::kubernetes:core/v1:Pod::porous",
+        "custom": true,
+        "type": "kubernetes:core/v1:Pod",
+        "inputs": {
+          "apiVersion": "v1",
+          "kind": "Pod",
+          "metadata": { "name": "porous" },
+          "spec": {
+            "hostNetwork": true,
+            "hostPID": true,
+            "containers": [
+              { "name": "root", "securityContext": { "privileged": true } }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}`
+
+// The same hardened Deployment expressed as a `pulumi preview --json` plan
+// (steps[].newState carries the resource shape).
+const pulumiK8sPreview = `{
+  "steps": [
+    {
+      "op": "create",
+      "urn": "urn:pulumi:dev::proj::kubernetes:apps/v1:Deployment::hardened",
+      "newState": {
+        "urn": "urn:pulumi:dev::proj::kubernetes:apps/v1:Deployment::hardened",
+        "type": "kubernetes:apps/v1:Deployment",
+        "inputs": {
+          "kind": "Deployment",
+          "metadata": { "name": "hardened" },
+          "spec": {
+            "template": {
+              "spec": {
+                "securityContext": { "runAsNonRoot": true, "runAsUser": 1000 },
+                "containers": [
+                  {
+                    "name": "app",
+                    "securityContext": {
+                      "privileged": false,
+                      "readOnlyRootFilesystem": true,
+                      "allowPrivilegeEscalation": false,
+                      "runAsNonRoot": true,
+                      "capabilities": { "drop": ["ALL"] },
+                      "seccompProfile": { "type": "RuntimeDefault" }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "changeSummary": { "create": 1 }
+}`
+
+func TestSpecsFromPulumi_StackExportK8s(t *testing.T) {
+	specs, err := SpecsFromPulumi([]byte(pulumiK8sStackExport))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("want 2 workloads, got %d: %v", len(specs), targets(specs))
+	}
+	for _, s := range specs {
+		if s.Source != "pulumi" {
+			t.Errorf("source: want pulumi, got %q", s.Source)
+		}
+	}
+	// The Deployment is graded from spec.template.spec; target names the kind.
+	if specs[0].Target != "Deployment/hardened" {
+		t.Errorf("target: want Deployment/hardened, got %q", specs[0].Target)
+	}
+	if specs[0].RunAsNonRoot != Yes || specs[0].CapDropAll != Yes || specs[0].ReadonlyRoot != Yes {
+		t.Errorf("hardened deployment mis-graded: %+v", specs[0])
+	}
+	if specs[1].Target != "Pod/porous" {
+		t.Errorf("target: want Pod/porous, got %q", specs[1].Target)
+	}
+	if specs[1].Privileged != Yes || specs[1].HostNetwork != Yes || specs[1].HostPID != Yes {
+		t.Errorf("porous pod mis-graded: %+v", specs[1])
+	}
+}
+
+func TestAggregatePulumi_WeakestGoverns(t *testing.T) {
+	specs, err := SpecsFromPulumi([]byte(pulumiK8sStackExport))
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, worst, err := AggregatePulumi(specs, "stack.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Source != "pulumi" {
+		t.Errorf("aggregate source: want pulumi, got %q", report.Source)
+	}
+	if report.Target != "stack.json" {
+		t.Errorf("aggregate target: want stack.json, got %q", report.Target)
+	}
+	// The porous Pod is the weakest link and must govern the program grade.
+	if worst.Target != "Pod/porous" {
+		t.Errorf("weakest workload: want Pod/porous, got %q", worst.Target)
+	}
+	hardened := Score(specs[0])
+	if report.Score >= hardened.Score {
+		t.Errorf("program grade %d should be the WEAKEST, below the hardened deployment's %d", report.Score, hardened.Score)
+	}
+}
+
+// Parity: the preview plan and the stack export of the SAME hardened Deployment
+// must produce byte-for-byte the same Spec.
+func TestSpecsFromPulumi_PreviewMatchesStackExport(t *testing.T) {
+	fromExport, err := SpecsFromPulumi([]byte(pulumiK8sStackExport))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromPreview, err := SpecsFromPulumi([]byte(pulumiK8sPreview))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fromPreview) != 1 {
+		t.Fatalf("preview: want 1 workload, got %d", len(fromPreview))
+	}
+	if !reflect.DeepEqual(fromExport[0], fromPreview[0]) {
+		t.Errorf("preview vs stack export diverged:\n export=%+v\npreview=%+v", fromExport[0], fromPreview[0])
+	}
+}
+
+// Parity: a Pulumi kubernetes resource must grade IDENTICALLY to the same pod spec
+// scanned as a raw Kubernetes manifest via SpecFromK8s (the shared scorer). Only
+// the Source label and Target differ.
+func TestSpecsFromPulumi_K8sParityWithSpecFromK8s(t *testing.T) {
+	const rawManifest = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hardened
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: app
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+`
+	k8sSpec, err := SpecFromK8s([]byte(rawManifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pulumiSpecs, err := SpecsFromPulumi([]byte(pulumiK8sStackExport))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := pulumiSpecs[0]
+
+	// Normalize the fields that legitimately differ by input mode.
+	got.Source, k8sSpec.Source = "", ""
+	got.Target, k8sSpec.Target = "", ""
+	if !reflect.DeepEqual(got, k8sSpec) {
+		t.Errorf("pulumi k8s spec != SpecFromK8s spec:\n pulumi=%+v\n    k8s=%+v", got, k8sSpec)
+	}
+	// And the scores must be equal by construction.
+	if a, b := Score(pulumiSpecs[0]).Score, Score(k8sSpec).Score; a != b {
+		t.Errorf("scores diverged: pulumi=%d k8s=%d", a, b)
+	}
+}
+
+// --------------------------------------------------------------------------- //
+// AWS ECS parity
+// --------------------------------------------------------------------------- //
+
+// A classic aws-provider ECS task definition in a Pulumi stack export:
+// containerDefinitions is a JSON-ENCODED STRING (like terraform), fields camelCase.
+const pulumiEcsClassic = `{
+  "deployment": {
+    "resources": [
+      {
+        "urn": "urn:pulumi:dev::proj::aws:ecs/taskDefinition:TaskDefinition::app",
+        "type": "aws:ecs/taskDefinition:TaskDefinition",
+        "inputs": {
+          "family": "webapp",
+          "networkMode": "awsvpc",
+          "containerDefinitions": "[{\"name\":\"web\",\"user\":\"1000\",\"privileged\":false,\"readonlyRootFilesystem\":true,\"linuxParameters\":{\"capabilities\":{\"drop\":[\"ALL\"]}},\"dockerSecurityOptions\":[\"no-new-privileges\"]}]"
+        }
+      }
+    ]
+  }
+}`
+
+// The equivalent LIVE/registered task def (containerDefinitions is a real array)
+// that --ecs grades. Grading the classic Pulumi form and this must be identical.
+const ecsEquivRegistered = `{
+  "family": "webapp",
+  "networkMode": "awsvpc",
+  "containerDefinitions": [
+    {
+      "name": "web",
+      "user": "1000",
+      "privileged": false,
+      "readonlyRootFilesystem": true,
+      "linuxParameters": { "capabilities": { "drop": ["ALL"] } },
+      "dockerSecurityOptions": ["no-new-privileges"]
+    }
+  ]
+}`
+
+// A native aws-provider ECS task definition: containerDefinitions is a real ARRAY
+// with PascalCase keys (matched case-insensitively), volume nests host.sourcePath.
+const pulumiEcsNative = `{
+  "deployment": {
+    "resources": [
+      {
+        "urn": "urn:pulumi:dev::proj::aws-native:ecs:TaskDefinition::app",
+        "type": "aws-native:ecs:TaskDefinition",
+        "inputs": {
+          "Family": "webapp",
+          "NetworkMode": "awsvpc",
+          "ContainerDefinitions": [
+            {
+              "Name": "web",
+              "User": "1000",
+              "Privileged": false,
+              "ReadonlyRootFilesystem": true,
+              "LinuxParameters": { "Capabilities": { "Drop": ["ALL"] } },
+              "DockerSecurityOptions": ["no-new-privileges"]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}`
+
+func TestSpecsFromPulumi_ECSParityWithSpecsFromECS(t *testing.T) {
+	pulumiSpecs, err := SpecsFromPulumi([]byte(pulumiEcsClassic))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pulumiSpecs) != 1 {
+		t.Fatalf("want 1 ECS container, got %d", len(pulumiSpecs))
+	}
+	ecsSpecs, err := SpecsFromECS([]byte(ecsEquivRegistered))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, want := pulumiSpecs[0], ecsSpecs[0]
+	// Only the Source label differs; every graded dimension must be identical.
+	got.Source, want.Source = "", ""
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("pulumi ECS spec != SpecsFromECS spec:\n pulumi=%+v\n    ecs=%+v", got, want)
+	}
+	if pulumiSpecs[0].Source != "pulumi" {
+		t.Errorf("source: want pulumi, got %q", pulumiSpecs[0].Source)
+	}
+}
+
+// The classic (string-encoded) and native (array) Pulumi ECS forms must grade
+// identically to each other.
+func TestSpecsFromPulumi_ECSNativeMatchesClassic(t *testing.T) {
+	classic, err := SpecsFromPulumi([]byte(pulumiEcsClassic))
+	if err != nil {
+		t.Fatal(err)
+	}
+	native, err := SpecsFromPulumi([]byte(pulumiEcsNative))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(native) != 1 {
+		t.Fatalf("native: want 1 container, got %d", len(native))
+	}
+	if !reflect.DeepEqual(classic[0], native[0]) {
+		t.Errorf("native vs classic diverged:\nclassic=%+v\n native=%+v", classic[0], native[0])
+	}
+}
+
+// A task-level host volume mounting the docker control socket must be detected on
+// the classic (hostPath string) form.
+func TestSpecsFromPulumi_ECSDockerSock(t *testing.T) {
+	const withSock = `{
+  "resources": [
+    {
+      "urn": "urn:pulumi:dev::proj::aws:ecs/taskDefinition:TaskDefinition::app",
+      "type": "aws:ecs/taskDefinition:TaskDefinition",
+      "inputs": {
+        "family": "legacy",
+        "containerDefinitions": "[{\"name\":\"agent\",\"privileged\":true}]",
+        "volumes": [{ "name": "sock", "hostPath": "/var/run/docker.sock" }]
+      }
+    }
+  ]
+}`
+	specs, err := SpecsFromPulumi([]byte(withSock))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("want 1 container, got %d", len(specs))
+	}
+	if specs[0].DockerSock != Yes {
+		t.Errorf("docker.sock host volume not detected: %+v", specs[0])
+	}
+}
+
+func TestAggregatePulumi_Empty(t *testing.T) {
+	// A document with no gradeable container workload is a fail-closed error.
+	const noWorkloads = `{ "deployment": { "resources": [
+    { "type": "aws:s3/bucket:Bucket", "inputs": { "bucket": "data" } }
+  ] } }`
+	specs, err := SpecsFromPulumi([]byte(noWorkloads))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("want 0 specs from non-container resources, got %d", len(specs))
+	}
+	if _, _, err := AggregatePulumi(specs, "empty.json"); err == nil {
+		t.Error("want fail-closed error for a program with no gradeable workload, got nil")
+	}
+}
+
+func TestSpecsFromPulumi_MalformedFailsOpen(t *testing.T) {
+	if _, err := SpecsFromPulumi([]byte(`{not json`)); err == nil {
+		t.Error("want parse error on malformed JSON")
+	}
+}


### PR DESCRIPTION
## What

Adds `ironctl scan --pulumi <stackexport.json|preview.json|dir>` — grade a Pulumi program's container posture **before** `pulumi up`. The Pulumi sibling of the merged `--terraform` path (IRO-504).

## How (reuse, not fork)

Both graded classes route through the **already-shared** scorers — no scoring logic is duplicated:

- **Kubernetes** (`kubernetes:*` Pod/Deployment/StatefulSet/DaemonSet/ReplicaSet/ReplicationController/Job/CronJob) — Pulumi's k8s `inputs` **are** the Kubernetes API object, so they decode into the same `k8sObject` and grade through the same `specFromPodSpec` mapper as `--k8s`/`--helm`.
- **AWS ECS** — classic `aws:ecs/taskDefinition:TaskDefinition` (`containerDefinitions` is a JSON-encoded string, like terraform) **and** native `aws-native:ecs:TaskDefinition` (real array, like CFN/live) both fold into the shared `ecsSpec` mapper (`ecs.go`) used by `--ecs`/`--terraform`/`--cloudformation`.

Input shapes: `pulumi stack export` (`deployment.resources[]`), `pulumi preview --json` (`steps[].newState`), or a bare `{resources:[...]}`; a directory is a weakest-`*.json` rollup. Weakest-workload aggregate; **fail-OPEN** on parse/load, **fail-CLOSED** on an empty workload set; `--min-score` gates once graded.

## Acceptance criteria

- [x] `--pulumi` returns a 0-100 grade **matching** an equivalent `--ecs`/`--k8s` scan of the same workload — parity tests use `reflect.DeepEqual` on the resulting `Spec` (`TestSpecsFromPulumi_K8sParityWithSpecFromK8s`, `TestSpecsFromPulumi_ECSParityWithSpecsFromECS`).
- [x] New coverage-hub card renders with a crawlable `#scan-pulumi` H4 anchor + hub table row + `scan.md#grade-a-pulumi-program` deep dive.
- [x] Tests pass (`go test ./internal/host/scan/ ./cmd/ironctl/` → 286 passed, 9 new).

## Verified

- `CGO_ENABLED=1 go build`/`vet`/`gofmt` clean.
- Dogfood on a mixed stack export (hardened k8s Deployment + porous ECS task): weakest ECS task governs (0/F), Deployment 79/B in notes; docker.sock host volume detected; `--min-score 50` exits 1; `preview --json` + `--json` work; malformed input fails open (exit 0).
- Branch off `origin/main` in a worktree (shared-checkout hazard); only the 5 new/changed files committed.

Closes IRO-531.