### PR TITLE
feat(scan): ironctl scan --azure grades Azure Container Instances [IRO-532]

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -51,6 +51,7 @@ func cmdScan(args []string) error {
 	cloudrun := fs.String("cloudrun", "", "grade Google Cloud Run service specs: a Knative Service YAML (`gcloud run services describe SVC --format=export`), or a directory of them")
 	cloudformation := fs.String("cloudformation", "", "grade AWS::ECS::TaskDefinition resources in a CloudFormation template (YAML or JSON), or a directory of them")
 	pulumi := fs.String("pulumi", "", "grade container workloads in a Pulumi `pulumi stack export` / `pulumi preview --json` file (or a directory of them): kubernetes:* workloads and aws ECS task definitions")
+	azure := fs.String("azure", "", "grade Microsoft.ContainerInstance/containerGroups in an Azure ARM template / `az container show` JSON, or a directory of them")
 	kustomize := fs.String("kustomize", "", "render a kustomization directory with `kustomize build` (or `kubectl kustomize`) and grade the isolation posture of its workloads")
 	kustomizeBin := fs.String("kustomize-bin", envOrDefault("KUSTOMIZE", "kustomize"), "kustomize binary used to render the directory (falls back to `kubectl kustomize` if absent)")
 	kubectlBin := fs.String("kubectl-bin", envOrDefault("KUBECTL", "kubectl"), "kubectl binary used for `kubectl kustomize` when the kustomize binary is absent")
@@ -238,6 +239,26 @@ func cmdScan(args []string) error {
 	if *pulumi != "" {
 		return runPulumiScan(pulumiScanArgs{
 			path:      *pulumi,
+			asJSON:    *asJSON,
+			md:        *md,
+			badge:     *badge,
+			badgeJSON: *badgeJSON,
+			sarif:     *sarif,
+			minScore:  *minScore,
+		})
+	}
+
+	// --azure: consume an Azure Container Instances definition (an ARM template,
+	// an `az container show`/deployment JSON, or a directory of them) and grade the
+	// Microsoft.ContainerInstance/containerGroups it declares, reusing the SAME
+	// pod-spec scorer as --k8s/--cloudrun plus ACI's managed-runtime floors. It
+	// reads the JSON here (no external binary) then defers to the pure
+	// SpecsFromAzure + AggregateAzure scorer. Fail-OPEN on a load/parse failure;
+	// --min-score still gates once containers are graded. Unresolvable ARM
+	// expressions ("[...]") are graded fail-closed and noted on the report.
+	if *azure != "" {
+		return runAzureScan(azureScanArgs{
+			path:      *azure,
 			asJSON:    *asJSON,
 			md:        *md,
 			badge:     *badge,
@@ -1493,7 +1514,133 @@ func loadPulumiSpecs(path string) ([]scan.Spec, error) {
 	return specs, nil
 }
 
-// writeDockerfileSARIF renders the Dockerfile SARIF log to path, fail-open on error.
+// azureScanArgs carries the resolved inputs for a `scan --azure` run.
+type azureScanArgs struct {
+	path      string
+	asJSON    bool
+	md        bool
+	badge     string
+	badgeJSON string
+	sarif     string
+	minScore  int
+}
+
+// runAzureScan grades the Microsoft.ContainerInstance/containerGroups declared in an
+// Azure ARM template, an `az container show`/deployment JSON, or a directory of them,
+// reusing the SAME pod-spec scorer as --k8s/--cloudrun plus ACI's managed-runtime
+// floors. ARM/az output is plain JSON, so there is no external binary to shell out
+// to. It fails OPEN on a load/parse failure (unreadable path, malformed JSON): it
+// prints a clear diagnostic to stderr and returns nil so an opt-in CI/Action step
+// never crashes the build. Once containers are graded, scoring and the --min-score CI
+// gate apply exactly like --cloudrun/--ecs. Unresolvable ARM expressions ("[...]")
+// are graded fail-closed and noted on the report.
+func runAzureScan(a azureScanArgs) error {
+	specs, usedExpressions, err := loadAzureSpecs(a.path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --azure could not load %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregateAzure(specs, filepath.Base(strings.TrimRight(a.path, "/")))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --azure found nothing to grade in %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+	if usedExpressions {
+		report.Notes = append(report.Notes, "template uses ARM expressions (\"[parameters(...)]\"/\"[variables(...)]\"): unresolved values are graded as unset (fail-closed) — verify the deployed group matches.")
+	}
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (containers graded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// loadAzureSpecs resolves a --azure argument to graded Specs. A single file is
+// parsed directly. A directory is a weakest-container rollup: every *.json file in it
+// is parsed and its container specs are pooled, so AggregateAzure grades the single
+// most-exposed container across the whole set. It is daemon-free and offline: ARM/az
+// output is read from disk. The bool reports whether any file used ARM expressions
+// that were skipped.
+func loadAzureSpecs(path string) ([]scan.Spec, bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, false, err
+	}
+	if !info.IsDir() {
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil, false, rerr
+		}
+		return scan.SpecsFromAzure(raw)
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, false, err
+	}
+	var specs []scan.Spec
+	usedExpressions := false
+	for _, e := range entries {
+		if e.IsDir() || strings.ToLower(filepath.Ext(e.Name())) != ".json" {
+			continue
+		}
+		raw, rerr := os.ReadFile(filepath.Join(path, e.Name()))
+		if rerr != nil {
+			return nil, false, rerr
+		}
+		fileSpecs, expr, perr := scan.SpecsFromAzure(raw)
+		if perr != nil {
+			// A single malformed file in a directory should not sink the rollup: skip
+			// it with a diagnostic and grade the rest (fail-open per file).
+			fmt.Fprintf(os.Stderr, "  warning: scan --azure skipping %s (parse error): %v\n", e.Name(), perr)
+			continue
+		}
+		specs = append(specs, fileSpecs...)
+		usedExpressions = usedExpressions || expr
+	}
+	return specs, usedExpressions, nil
+}
+
 func writeDockerfileSARIF(path string, r scan.Report, opts scan.SARIFOptions) error {
 	f, err := os.Create(path)
 	if err != nil {
@@ -1629,6 +1776,7 @@ USAGE:
   ironctl scan --cloudrun PATH                  grade Google Cloud Run service specs (Knative Service YAML or dir)
   ironctl scan --cloudformation PATH            grade AWS::ECS::TaskDefinition in a CloudFormation template (YAML/JSON or dir)
   ironctl scan --pulumi PATH                     grade container workloads in Pulumi stack-export / preview --json output (or dir)
+  ironctl scan --azure PATH                     grade Azure Container Instances (ARM template / az container show JSON or dir)
   ironctl scan --kustomize DIR                  render a kustomization (kustomize build) and grade its workloads
   ironctl scan --dockerfile FILE...           grade Dockerfile(s) statically (no daemon, no pull)
   ironctl scan --compare A B                   diff two containers' isolation posture
@@ -1728,6 +1876,20 @@ resolved without the deployed stack, so any graded field they cover is treated a
 unset and graded fail-closed (and noted). The template grade is the WEAKEST
 container; load/parse failures fail OPEN (diagnostic + exit 0). A successful parse
 still trips --min-score.
+
+--azure grades the Microsoft.ContainerInstance/containerGroups declared in an Azure
+ARM template, an `+"`az container show`"+`/deployment JSON, or a directory of them,
+reusing the SAME pod-spec scorer as --k8s/--cloudrun plus Azure Container Instances'
+managed-runtime floors: each container group runs in a dedicated Hyper-V-isolated VM,
+so host PID/IPC/network namespaces and a host docker.sock are unreachable, privileged
+is not permitted on the Standard SKU, and a default seccomp profile is applied.
+Egress is managed (never network=none). ACI's securityContext does NOT express a
+read-only root filesystem, and a container may ADD capabilities, so a fully hardened
+ACI container tops out at 79/100 (grade B) — one dimension below Cloud Run's 89/B.
+ARM expressions (`+"`\"[parameters(...)]\"`"+`) cannot be resolved without the deployment, so
+any graded field they cover is treated as unset and graded fail-closed (and noted).
+The grade is the WEAKEST container in the group; load/parse failures fail OPEN
+(diagnostic + exit 0). A successful parse still trips --min-score.
 
 --kustomize renders a kustomization directory locally with `+"`kustomize build`"+` (or
 `+"`kubectl kustomize`"+` when the standalone binary is absent — no cluster, daemon-free)

--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -195,6 +195,20 @@ no API call.
 
     [:octicons-arrow-right-24: Grade an ECS task definition](scan.md#grade-an-aws-ecs-task-definition)
 
+-   #### :material-microsoft-azure:{ .lg .middle } Azure Container Instances { #scan-azure }
+
+    ---
+
+    Grades the `Microsoft.ContainerInstance/containerGroups` in an ARM template or
+    `az container show` JSON with the managed-runtime model, rolling up to the **weakest**
+    container in the group.
+
+    ```bash
+    ironctl scan --azure containergroup.json
+    ```
+
+    [:octicons-arrow-right-24: Grade an Azure container group](scan.md#grade-an-azure-container-group)
+
 </div>
 
 ### Infrastructure-as-Code { #modes-iac }
@@ -264,6 +278,7 @@ the container they eventually produce are all measured on one comparable scale.
 | Compose &amp; orchestrators | [Nomad job](#scan-nomad) | `--nomad` | docker-driver tasks in a job spec | [Scan reference](scan.md) |
 | Cloud runtimes | [Cloud Run](#scan-cloudrun) | `--cloudrun` | a Knative Service's container config | [Grade a Cloud Run service](scan.md#grade-a-google-cloud-run-service) |
 | Cloud runtimes | [Amazon ECS](#scan-ecs) | `--ecs` | a task definition's container contract | [Grade an ECS task definition](scan.md#grade-an-aws-ecs-task-definition) |
+| Cloud runtimes | [Azure Container Instances](#scan-azure) | `--azure` | weakest container in an ARM `containerGroups` | [Grade an Azure container group](scan.md#grade-an-azure-container-group) |
 | Infrastructure-as-Code | [Terraform plan](#scan-terraform) | `--terraform` | container workloads in a plan/state | [Grade a Terraform plan](scan.md#grade-a-terraform-plan) |
 | Infrastructure-as-Code | [CloudFormation](#scan-cloudformation) | `--cloudformation` | ECS task defs in a CFN template | [Grade a CloudFormation template](scan.md#grade-a-cloudformation-template) |
 | Infrastructure-as-Code | [Pulumi program](#scan-pulumi) | `--pulumi` | K8s &amp; ECS workloads in stack-export / preview JSON | [Grade a Pulumi program](scan.md#grade-a-pulumi-program) |
@@ -271,17 +286,6 @@ the container they eventually produce are all measured on one comparable scale.
 Every mode also emits the machine-readable outputs: a [SARIF log](scan.md#github-code-scanning-security-tab)
 for GitHub code scanning, a [shields.io badge](scan.md#sandbox-isolation-score-badge), and
 `--fix` [remediation](scan.md#fix-it-do-not-just-grade-it).
-
-## On the roadmap
-
-More input modes are in progress and will drop into the category grids above as they ship
-&mdash; the card contract adds them without a redesign:
-
-- **Azure Container Instances** &mdash; grade a container group spec, alongside Cloud Run and
-  ECS in **Cloud runtimes**.
-
-We list these as *planned*, not shipped. When they land, each moves up into a card in its
-category.
 
 ## Start with what you have
 

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -313,6 +313,51 @@ failures fail **open** (a clear diagnostic and exit 0) so an opt-in CI step neve
 crashes the build; once services are graded, `--min-score` still trips on a low
 posture.
 
+## Grade an Azure container group
+
+`--azure PATH` grades the `Microsoft.ContainerInstance/containerGroups` declared in
+an [Azure Resource Manager](https://learn.microsoft.com/azure/container-instances/)
+template, an `az container show` / deployment JSON, or a bare containerGroup object.
+It completes the big-3 cloud coverage alongside `--cloudrun` (GCP) and `--ecs` (AWS).
+Azure output is plain JSON, so it is structured and daemon-free, with no `az` login
+and no external binary:
+
+```bash
+az container show -g rg -n mygroup > containergroup.json
+ironctl scan --azure containergroup.json
+ironctl scan --azure arm-template.json --min-score 75   # CI gate
+ironctl scan --azure ./deployments                      # a directory of *.json
+```
+
+Pass a single ARM template, an `az container show` object, or a directory of JSON
+files (the weakest container in the weakest group governs). Each container's
+`securityContext` is graded through the **same pod-spec scorer** as `--k8s` /
+`--cloudrun`, then Azure Container Instances' **managed-runtime floors** are folded
+in:
+
+| Dimension | How ACI is graded |
+|---|---|
+| Non-root user | graded on `securityContext.runAsUser`; unset means the image default (root), scored fail-closed. |
+| Dropped capabilities | graded on `securityContext.capabilities.{add,drop}`. ACI **lets a container add capabilities**, so cap-drop is NOT credited by the platform — express `capabilities.drop: [ALL]` to earn it. |
+| Seccomp | the managed runtime applies a default profile — credited as confined unless overridden; a custom `seccompProfile` string counts as applied. |
+| Network isolation | ACI egress is **managed** (public or private IP), never `network=none`. Graded as egress-capable (the honest ceiling). |
+| Read-only rootfs | **not expressible** — ACI's `securityContext` has no read-only-rootfs field, so this dimension is always graded fail-closed. |
+| docker.sock | impossible on ACI (no host bind mounts) — passes by construction. |
+| Host namespaces | each container group runs in a dedicated **Hyper-V-isolated VM**; host PID/IPC/network are unreachable — passes by construction. Privileged is not permitted on the Standard SKU. |
+
+Because the platform blocks host namespaces and the docker socket and forbids
+privileged (unless the spec explicitly sets it), an ACI container starts from a
+strong floor. What stays your job is running as **non-root** and dropping
+**capabilities**. A fully hardened ACI container tops out at **79/100 (grade B)** —
+one dimension (read-only rootfs, 10 pts) below Cloud Run's 89/B, because ACI cannot
+express a read-only root filesystem. ARM expressions (`"[parameters(...)]"` /
+`"[variables(...)]"`) cannot be resolved without the deployment, so any graded field
+they cover is treated as **unset** and graded fail-closed; the scan notes when a
+template used them. The group grade is the **weakest** container, with every
+container's score in the notes. Load or parse failures fail **open** (a clear
+diagnostic and exit 0) so an opt-in CI step never crashes the build; once containers
+are graded, `--min-score` still trips on a low posture.
+
 ## Grade a kustomization
 
 `--kustomize DIR` renders a [Kustomize](https://kustomize.io/) directory with

--- a/internal/host/scan/azure.go
+++ b/internal/host/scan/azure.go
@@ -1,0 +1,331 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SpecsFromAzure parses an Azure Container Instances definition — an ARM template
+// JSON, an `az container show` / deployment JSON document, or a bare containerGroup
+// object — and returns one graded Spec per container of every
+// Microsoft.ContainerInstance/containerGroups resource it declares. It is the Azure
+// counterpart to the --cloudrun (GCP) and --ecs (AWS) managed-runtime paths, so the
+// wedge covers the big-3 clouds.
+//
+// The mapping reuses the SAME specFromPodSpec scorer as --k8s/--cloudrun: an ACI
+// container's securityContext (privileged, runAsUser, capabilities.add/drop,
+// seccompProfile) is adapted onto the shared container securityContext, graded, and
+// then ACI's managed-runtime floors are folded in — each container GROUP runs in a
+// dedicated Hyper-V-isolated VM, so host PID/IPC/network namespaces and a host
+// docker.sock are unreachable, privileged is not permitted on the Standard SKU, and
+// a default seccomp profile is applied. Egress is managed (allowed by default, never
+// network=none), so the network dimension caps at the WARN tier.
+//
+// Two ACI-specific honesty notes drive the ceiling below Cloud Run's 89/B:
+//   - ACI's securityContext does NOT express a read-only root filesystem, so that
+//     dimension is always graded fail-closed (unlike Cloud Run's pod spec).
+//   - ACI lets a container ADD capabilities, so cap-drop is NOT credited by the
+//     platform (the user must express capabilities.drop=[ALL]).
+//
+// A fully hardened ACI container therefore tops out at 79/100 (grade B) — one
+// dimension (read-only rootfs, 10 pts) below Cloud Run's egress-capable 89/B.
+//
+// ARM template expressions ("[parameters('x')]" / "[variables('y')]") are
+// unresolvable without the deployment context, so each is nullified before decoding
+// (same fail-open posture as the CloudFormation intrinsic handling). A graded field
+// an expression covered then reads as unset and is graded fail-closed; the second
+// return value reports whether any expression was skipped so the caller can note it.
+//
+// It is pure and unit-testable: the caller reads the file / runs the az CLI (I/O)
+// and passes the JSON here. It fails OPEN on a malformed top-level document (returns
+// the parse error); the CLI wrapper turns that into a skip so an opt-in CI step never
+// crashes the build. A document with no containerGroups resource returns no specs.
+func SpecsFromAzure(raw []byte) ([]Spec, bool, error) {
+	var root interface{}
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return nil, false, fmt.Errorf("parse azure arm/aci json: %w", err)
+	}
+	skipped := sanitizeARMExpressions(&root)
+
+	groups := collectContainerGroups(root)
+	var specs []Spec
+	for _, g := range groups {
+		js, err := json.Marshal(g)
+		if err != nil {
+			continue
+		}
+		var cg aciContainerGroup
+		// Case-insensitive key matching maps ARM's property names onto the json tags.
+		if err := json.Unmarshal(js, &cg); err != nil {
+			// Fail-open per resource: one undecodable containerGroup must not sink the
+			// whole document.
+			continue
+		}
+		specs = append(specs, specsFromACIGroup(cg)...)
+	}
+	return specs, skipped > 0, nil
+}
+
+// AggregateAzure folds the per-container specs from one or more ACI containerGroups
+// into a single Report. Like AggregateECS / AggregateCloudRun, the aggregate is the
+// WEAKEST container (minimum score): a group is only as isolated as its most-exposed
+// container, so grading the weakest link is the honest, fail-closed summary. target
+// names the source (file base, or a directory rollup label). It returns the
+// aggregate Report and the Spec that produced it (for SARIF anchoring). It is pure;
+// the caller injects Version/GeneratedAt. Fail-closed: an empty container set is an
+// error (a document that declares no gradeable ACI container is not a pass).
+func AggregateAzure(specs []Spec, target string) (Report, Spec, error) {
+	if len(specs) == 0 {
+		return Report{}, Spec{}, fmt.Errorf("no gradeable containers found (looked for Microsoft.ContainerInstance/containerGroups resources with properties.containers)")
+	}
+
+	all := make([]scoredWorkload, len(specs))
+	worst := 0
+	for i, s := range specs {
+		all[i] = scoredWorkload{spec: s, report: Score(s)}
+		if all[i].report.Score < all[worst].report.Score {
+			worst = i
+		}
+	}
+
+	agg := all[worst].report
+	worstSpec := all[worst].spec
+	if strings.TrimSpace(target) != "" {
+		agg.Target = target
+	}
+	agg.Source = "azure"
+	agg.Notes = append(azureSummaryNotes(all[worst], all), agg.Notes...)
+
+	return agg, worstSpec, nil
+}
+
+// azureSummaryNotes builds the group-level roll-up notes for an aggregate Azure
+// report: a headline naming the weakest container and a per-container score list.
+func azureSummaryNotes(worst scoredWorkload, all []scoredWorkload) []string {
+	notes := []string{
+		fmt.Sprintf("graded %d ACI container(s); the grade is the WEAKEST (a container group is only as isolated as its most-exposed container). Weakest: %s at %d/100 (grade %s).",
+			len(all), nz(worst.spec.Target, "container"), worst.report.Score, worst.report.Grade),
+	}
+	sorted := make([]scoredWorkload, len(all))
+	copy(sorted, all)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].report.Score < sorted[j].report.Score })
+	rows := make([]string, len(sorted))
+	for i, w := range sorted {
+		rows[i] = fmt.Sprintf("%s = %d/100 (%s)", nz(w.spec.Target, "container"), w.report.Score, w.report.Grade)
+	}
+	notes = append(notes, "per-container: "+strings.Join(rows, "; "))
+	return notes
+}
+
+// --------------------------------------------------------------------------- //
+// Azure Container Instances containerGroup document model.
+//
+// An ARM resource of type Microsoft.ContainerInstance/containerGroups carries its
+// containers under properties.containers[], each with a nested properties block
+// holding the image and (optionally) a securityContext. The az-CLI `az container
+// show` output and a bare containerGroup object share this exact shape.
+// --------------------------------------------------------------------------- //
+
+type aciContainerGroup struct {
+	Name       string        `json:"name"`
+	Type       string        `json:"type"`
+	Properties aciGroupProps `json:"properties"`
+}
+
+type aciGroupProps struct {
+	OsType     string         `json:"osType"`
+	Sku        string         `json:"sku"`
+	Containers []aciContainer `json:"containers"`
+}
+
+type aciContainer struct {
+	Name       string            `json:"name"`
+	Properties aciContainerProps `json:"properties"`
+}
+
+type aciContainerProps struct {
+	Image           string     `json:"image"`
+	SecurityContext *aciSecCtx `json:"securityContext"`
+}
+
+// aciSecCtx mirrors an ACI container securityContext. Unlike Kubernetes/Cloud Run,
+// ACI has NO readOnlyRootFilesystem field (that dimension is unexpressible and thus
+// always fail-closed), and its seccompProfile is a (base64) custom-profile STRING
+// rather than an object. capabilities is the shared add/drop shape.
+type aciSecCtx struct {
+	Privileged               *bool         `json:"privileged"`
+	AllowPrivilegeEscalation *bool         `json:"allowPrivilegeEscalation"`
+	RunAsGroup               *int64        `json:"runAsGroup"`
+	RunAsUser                *int64        `json:"runAsUser"`
+	Capabilities             *capabilities `json:"capabilities"`
+	SeccompProfile           *string       `json:"seccompProfile"`
+}
+
+// collectContainerGroups walks a decoded JSON tree and returns every object whose
+// "type" is Microsoft.ContainerInstance/containerGroups. This handles all three
+// input shapes at once: an ARM template (resources[] array), an `az container show`
+// / bare containerGroup object at the root, and a nested deployment whose resources
+// carry the group deeper in the tree.
+func collectContainerGroups(n interface{}) []map[string]interface{} {
+	var out []map[string]interface{}
+	switch v := n.(type) {
+	case map[string]interface{}:
+		if t, _ := v["type"].(string); strings.EqualFold(strings.TrimSpace(t), "Microsoft.ContainerInstance/containerGroups") {
+			out = append(out, v)
+		}
+		for _, val := range v {
+			out = append(out, collectContainerGroups(val)...)
+		}
+	case []interface{}:
+		for _, e := range v {
+			out = append(out, collectContainerGroups(e)...)
+		}
+	}
+	return out
+}
+
+// specsFromACIGroup grades every container in a containerGroup, keyed with source
+// "azure". It returns one Spec per container so AggregateAzure can grade the weakest.
+func specsFromACIGroup(cg aciContainerGroup) []Spec {
+	if len(cg.Properties.Containers) == 0 {
+		return nil
+	}
+	group := nz(cg.Name, "containergroup")
+	specs := make([]Spec, 0, len(cg.Properties.Containers))
+	for _, c := range cg.Properties.Containers {
+		specs = append(specs, specFromACIContainer(group, c))
+	}
+	return specs
+}
+
+// specFromACIContainer maps one ACI container to a graded Spec. It adapts the ACI
+// securityContext onto the shared container securityContext, grades the expressible
+// posture through specFromPodSpec (exactly like --k8s/--cloudrun), then folds in
+// ACI's managed-runtime floors.
+func specFromACIContainer(group string, c aciContainer) Spec {
+	name := strings.TrimSpace(c.Name)
+	target := "azure/" + nz(group, "containergroup")
+	if name != "" {
+		target = "azure/" + nz(group, "containergroup") + "/" + name
+	}
+
+	// Adapt ACI's securityContext to the shared container securityContext. ACI has no
+	// hostPath volumes (managed runtime, no host mounts), so the pod spec carries a
+	// single container and no volumes. Note ACI has NO readOnlyRootFilesystem field,
+	// so ReadOnlyRootFilesystem stays nil → graded fail-closed.
+	csc := &containerSecCtx{}
+	sc := c.Properties.SecurityContext
+	if sc != nil {
+		csc.Privileged = sc.Privileged
+		csc.AllowPrivilegeEscalation = sc.AllowPrivilegeEscalation
+		csc.RunAsUser = sc.RunAsUser
+		csc.Capabilities = sc.Capabilities
+		if sc.SeccompProfile != nil && strings.TrimSpace(*sc.SeccompProfile) != "" {
+			// ACI carries a custom seccomp profile as a (base64) string; its presence
+			// means a profile IS applied to the container.
+			csc.SeccompProfile = &seccompProfile{Type: "Localhost"}
+		}
+	}
+	ps := podSpec{Containers: []k8sContainer{{Name: name, SecurityContext: csc}}}
+	s := specFromPodSpec("azure", target, ps)
+
+	// The k8s pod-spec grader appends conservative notes that are WRONG for ACI's
+	// managed runtime (it assumes an invisible NetworkPolicy governs egress and that
+	// seccomp is unconfined by default). Drop them; the managed floors below give
+	// concrete, honest answers.
+	s.Notes = dropNotesContaining(s.Notes, "NetworkPolicy", "unconfined by default")
+
+	// --- managed-runtime floors (platform-enforced, not spec-visible) ----------
+	// Each ACI container GROUP runs in a dedicated Hyper-V-isolated VM. There is no
+	// tenant host to share, so host PID/IPC/network namespaces and a host docker
+	// socket are unreachable — credit them explicitly (the raw pod-spec grader scores
+	// them fail-closed / Unknown).
+	s.HostPID = No
+	s.HostIPC = No
+	s.HostNetwork = No
+	s.DockerSock = No
+
+	// ACI Standard does not permit privileged containers; an unset privileged flag is
+	// the managed default (not privileged). Respect an explicit privileged:true (the
+	// worse posture) if the spec set it.
+	if s.Privileged == Unknown {
+		s.Privileged = No
+	}
+
+	// The managed runtime applies a default seccomp profile (like Docker/ECS): an
+	// unset seccompProfile is confined here, not unconfined.
+	if strings.TrimSpace(s.Seccomp) == "" {
+		s.Seccomp = "confined"
+	}
+
+	// --- network (managed egress → honest B ceiling) ---------------------------
+	// ACI containers are egress-capable by default (public or private IP) and can
+	// never be network=none, so grade egress-capable (WARN) — the same honest ceiling
+	// as any managed runtime.
+	s.NetworkMode = "aci (managed egress)"
+
+	// --- managed-runtime + expressible-posture notes ---------------------------
+	s.Notes = append(s.Notes,
+		"Azure Container Instances runs each container group in a dedicated Hyper-V-isolated VM; host PID/IPC/network namespaces and a host docker.sock are not reachable — those dimensions pass by construction",
+		"managed runtime: ACI Standard does not permit privileged containers, and applies a default seccomp profile unless a custom profile is supplied",
+		"ACI's container securityContext does not express a read-only root filesystem, so that dimension is always graded fail-closed; a fully hardened ACI container therefore tops out at 79/100 (grade B) — one dimension (read-only rootfs) below Cloud Run's egress-capable 89/B ceiling",
+		"network egress is managed (allowed by default) and can never be network=none")
+	if sc == nil {
+		s.Notes = append(s.Notes, "no container securityContext declared; user, capabilities, and privilege posture are graded fail-closed (harden via properties.securityContext: runAsUser + capabilities.drop=[ALL])")
+	} else if sc.AllowPrivilegeEscalation != nil && !*sc.AllowPrivilegeEscalation {
+		s.Notes = append(s.Notes, "allowPrivilegeEscalation: false declared (informational — not a separate containment dimension in the 7-dim scorer)")
+	}
+
+	return s
+}
+
+// --------------------------------------------------------------------------- //
+// ARM template expression tolerance
+//
+// ARM templates carry unresolvable references as string expressions wrapped in
+// square brackets — "[parameters('image')]", "[variables('cpu')]", "[concat(...)]".
+// Without the deployment we cannot resolve them, so each is nullified before the
+// typed decode. A graded field an expression covered then reads as unset and is
+// graded fail-closed. This keeps decoding robust (an expression where a bool/int was
+// expected never errors) and honest (an unknown posture scores as insecure). An
+// escaped literal "[[..." (ARM's way to emit a literal leading bracket) is not an
+// expression and is left intact.
+// --------------------------------------------------------------------------- //
+
+// sanitizeARMExpressions walks a decoded JSON tree and replaces every ARM template
+// expression string ("[...]") with nil, in place. It returns the number of
+// expressions nullified so the caller can note that some values were skipped.
+func sanitizeARMExpressions(n *interface{}) int {
+	switch v := (*n).(type) {
+	case map[string]interface{}:
+		count := 0
+		for k, val := range v {
+			vv := val
+			count += sanitizeARMExpressions(&vv)
+			v[k] = vv
+		}
+		return count
+	case []interface{}:
+		count := 0
+		for i := range v {
+			count += sanitizeARMExpressions(&v[i])
+		}
+		return count
+	case string:
+		if isARMExpression(v) {
+			*n = nil
+			return 1
+		}
+	}
+	return 0
+}
+
+// isARMExpression reports whether a string is an ARM template expression: wrapped in
+// a single pair of square brackets ("[...]"). ARM escapes a literal leading bracket
+// as "[[...", which is NOT an expression.
+func isARMExpression(s string) bool {
+	s = strings.TrimSpace(s)
+	return len(s) >= 2 && s[0] == '[' && s[len(s)-1] == ']' && !strings.HasPrefix(s, "[[")
+}

--- a/internal/host/scan/azure_test.go
+++ b/internal/host/scan/azure_test.go
@@ -1,0 +1,339 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+// A hardened ACI container group expressed as an ARM template resource: non-root
+// runAsUser, capabilities.drop ALL, a custom seccomp profile, allowPrivilegeEscalation
+// off. This is the best an ACI container can express — note ACI has NO
+// readOnlyRootFilesystem field, so that dimension is always fail-closed.
+const armHardened = `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "resources": [
+    {
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "apiVersion": "2023-05-01",
+      "name": "webgroup",
+      "properties": {
+        "osType": "Linux",
+        "sku": "Standard",
+        "containers": [
+          {
+            "name": "web",
+            "properties": {
+              "image": "example/web:1.2.3",
+              "securityContext": {
+                "privileged": false,
+                "allowPrivilegeEscalation": false,
+                "runAsUser": 1000,
+                "capabilities": { "drop": ["ALL"] },
+                "seccompProfile": "eyJkZWZhdWx0QWN0aW9uIjoiU0NNUF9BQ1RfRVJSTk8ifQ=="
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}`
+
+// An `az container show` single-object document with a root, privileged container.
+const aciShowPorous = `{
+  "id": "/subscriptions/0000/resourceGroups/rg/providers/Microsoft.ContainerInstance/containerGroups/legacy",
+  "name": "legacy",
+  "type": "Microsoft.ContainerInstance/containerGroups",
+  "location": "eastus",
+  "properties": {
+    "osType": "Linux",
+    "containers": [
+      {
+        "name": "agent",
+        "properties": {
+          "image": "legacy:latest",
+          "securityContext": { "privileged": true, "runAsUser": 0 }
+        }
+      }
+    ]
+  }
+}`
+
+func TestSpecsFromAzure_ARMHardened(t *testing.T) {
+	specs, expr, err := SpecsFromAzure([]byte(armHardened))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expr {
+		t.Errorf("no ARM expressions in this template; expr should be false")
+	}
+	if len(specs) != 1 {
+		t.Fatalf("want 1 container, got %d: %v", len(specs), targets(specs))
+	}
+	s := specs[0]
+	if s.Source != "azure" {
+		t.Errorf("source: want azure, got %q", s.Source)
+	}
+	if s.Target != "azure/webgroup/web" {
+		t.Errorf("target: want azure/webgroup/web, got %q", s.Target)
+	}
+	if s.RunAsNonRoot != Yes {
+		t.Errorf("user: runAsUser 1000 should be non-root: %v", s.RunAsNonRoot)
+	}
+	if s.CapDropAll != Yes || len(s.CapAdd) != 0 {
+		t.Errorf("caps: want drop-all none-added, CapDropAll=%v CapAdd=%v", s.CapDropAll, s.CapAdd)
+	}
+	if s.Seccomp != "confined" {
+		t.Errorf("seccomp: custom profile should grade confined, got %q", s.Seccomp)
+	}
+	// Managed floors: no host namespaces, no docker.sock, privileged forced off.
+	if s.Privileged != No || s.HostPID != No || s.HostIPC != No || s.HostNetwork != No || s.DockerSock != No {
+		t.Errorf("managed floors not applied: %+v", s)
+	}
+	// ACI cannot express a read-only root filesystem: always fail-closed.
+	if s.ReadonlyRoot != Unknown {
+		t.Errorf("readonly rootfs is unexpressible on ACI; want Unknown, got %v", s.ReadonlyRoot)
+	}
+	// The honest ACI ceiling is 79/100 (grade B): one dimension (read-only rootfs,
+	// 10 pts) below Cloud Run's egress-capable 89/B ceiling.
+	r := Score(s)
+	if r.Score != 79 || r.Grade != "B" {
+		t.Errorf("hardened ACI ceiling: want 79/B, got %d/%s", r.Score, r.Grade)
+	}
+	if !strings.Contains(strings.Join(r.Notes, " "), "read-only root filesystem") {
+		t.Errorf("expected a note explaining the read-only-rootfs ceiling gap: %v", r.Notes)
+	}
+}
+
+func TestSpecsFromAzure_AzShowPorous(t *testing.T) {
+	specs, _, err := SpecsFromAzure([]byte(aciShowPorous))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("want 1 container, got %d", len(specs))
+	}
+	s := specs[0]
+	if s.Source != "azure" || s.Target != "azure/legacy/agent" {
+		t.Errorf("header: source=%q target=%q", s.Source, s.Target)
+	}
+	// An explicit privileged:true is the WORSE posture and must be respected over the
+	// managed floor.
+	if s.Privileged != Yes {
+		t.Errorf("explicit privileged:true must be respected over the floor: %v", s.Privileged)
+	}
+	if s.RunAsNonRoot != No {
+		t.Errorf("runAsUser 0 should be root: %v", s.RunAsNonRoot)
+	}
+	if r := Score(s); r.Score > 25 {
+		t.Errorf("privileged root container should grade low, got %d/100 (%s)", r.Score, r.Grade)
+	}
+}
+
+// TestSpecsFromAzure_BareIsFailClosed proves a container group with NO securityContext
+// grades every user/cap/privilege dimension fail-closed while still crediting the
+// managed floors (seccomp default, no host ns, no docker.sock).
+func TestSpecsFromAzure_BareIsFailClosed(t *testing.T) {
+	const bare = `{
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "name": "bare",
+      "properties": { "containers": [ { "name": "c", "properties": { "image": "x:1" } } ] }
+    }`
+	specs, _, err := SpecsFromAzure([]byte(bare))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("want 1 container, got %d", len(specs))
+	}
+	s := specs[0]
+	if s.RunAsNonRoot != Unknown || s.CapDropAll != Unknown {
+		t.Errorf("bare container should grade user/caps fail-closed: user=%v caps=%v", s.RunAsNonRoot, s.CapDropAll)
+	}
+	// seccomp default confined (15) + network WARN (4) + docker.sock (15) + host ns (10) = 44.
+	r := Score(s)
+	if r.Score != 44 {
+		t.Errorf("bare ACI container: want 44 (floors only), got %d/%s", r.Score, r.Grade)
+	}
+	if !strings.Contains(strings.Join(r.Notes, " "), "no container securityContext declared") {
+		t.Errorf("expected a note prompting securityContext hardening: %v", r.Notes)
+	}
+}
+
+// TestSpecsFromAzure_ExpressionsTolerated proves an ARM template full of "[...]"
+// expressions still parses fail-open: a graded field behind an expression reads as
+// unset (fail-closed) and the expression flag is raised, rather than erroring out.
+func TestSpecsFromAzure_ExpressionsTolerated(t *testing.T) {
+	const tmpl = `{
+      "resources": [
+        {
+          "type": "Microsoft.ContainerInstance/containerGroups",
+          "name": "[parameters('groupName')]",
+          "properties": {
+            "containers": [
+              {
+                "name": "app",
+                "properties": {
+                  "image": "[parameters('img')]",
+                  "securityContext": {
+                    "runAsUser": "[parameters('uid')]",
+                    "privileged": "[parameters('priv')]"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }`
+	specs, expr, err := SpecsFromAzure([]byte(tmpl))
+	if err != nil {
+		t.Fatalf("ARM expressions must not error (fail-open): %v", err)
+	}
+	if !expr {
+		t.Errorf("expr flag should be true (template uses [parameters(...)])")
+	}
+	if len(specs) != 1 {
+		t.Fatalf("want 1 container, got %d", len(specs))
+	}
+	s := specs[0]
+	// Group name unresolved -> the fallback label; the container name is still literal.
+	if s.Target != "azure/containergroup/app" {
+		t.Errorf("target with unresolved group name: want azure/containergroup/app, got %q", s.Target)
+	}
+	// runAsUser behind an expression is unknown -> fail-closed (not credited non-root).
+	if s.RunAsNonRoot == Yes {
+		t.Errorf("unresolved runAsUser must not be credited non-root: %v", s.RunAsNonRoot)
+	}
+	// privileged behind an expression is unknown -> the managed floor makes it No
+	// (not Yes): an unresolved flag must never be treated as privileged.
+	if s.Privileged == Yes {
+		t.Errorf("unresolved privileged expression must not grade Yes: %v", s.Privileged)
+	}
+}
+
+// TestSpecsFromAzure_MultiContainerAggregate grades a group with a hardened and a
+// porous container and confirms the aggregate is the WEAKEST container.
+func TestSpecsFromAzure_MultiContainerAggregate(t *testing.T) {
+	const grp = `{
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "name": "mixed",
+      "properties": {
+        "containers": [
+          {
+            "name": "safe",
+            "properties": { "securityContext": {
+              "runAsUser": 1000, "capabilities": { "drop": ["ALL"] }, "seccompProfile": "abc=="
+            } }
+          },
+          {
+            "name": "risky",
+            "properties": { "securityContext": { "privileged": true, "runAsUser": 0 } }
+          }
+        ]
+      }
+    }`
+	specs, _, err := SpecsFromAzure([]byte(grp))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("want 2 containers, got %d: %v", len(specs), targets(specs))
+	}
+	report, worst, err := AggregateAzure(specs, "group.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Source != "azure" || report.Target != "group.json" {
+		t.Errorf("aggregate header: source=%q target=%q", report.Source, report.Target)
+	}
+	if worst.Target != "azure/mixed/risky" {
+		t.Errorf("weakest container: want azure/mixed/risky, got %q", worst.Target)
+	}
+	if !strings.Contains(strings.Join(report.Notes, " "), "WEAKEST") {
+		t.Errorf("aggregate should note the weakest-link rollup: %v", report.Notes)
+	}
+}
+
+func TestSpecsFromAzure_NoContainerGroupIsNoSpecs(t *testing.T) {
+	const tmpl = `{ "resources": [ { "type": "Microsoft.Storage/storageAccounts", "name": "sa" } ] }`
+	specs, _, err := SpecsFromAzure([]byte(tmpl))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("want 0 specs for a document with no containerGroups, got %d", len(specs))
+	}
+	if _, _, err := AggregateAzure(specs, "empty.json"); err == nil {
+		t.Errorf("aggregate of no containers should be a fail-closed error")
+	}
+}
+
+func TestSpecsFromAzure_MalformedIsError(t *testing.T) {
+	if _, _, err := SpecsFromAzure([]byte("{ not json")); err == nil {
+		t.Errorf("malformed JSON should return a parse error (fail-open surfaces it)")
+	}
+}
+
+// TestAzureManagedFloorsMatchCloudRun locks the SHARED managed-runtime floors: for
+// the dimensions ACI and Cloud Run both floor (host namespaces, docker.sock, default
+// seccomp, egress-capable network), an equivalently-configured ACI container and
+// Cloud Run service must agree. They diverge ONLY on the two ACI-specific limits
+// (read-only rootfs unexpressible, capabilities addable), which is why the ACI
+// ceiling is 79/B vs Cloud Run's 89/B.
+func TestAzureManagedFloorsMatchCloudRun(t *testing.T) {
+	const aci = `{
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "name": "g",
+      "properties": { "containers": [ { "name": "c", "properties": {
+        "securityContext": { "runAsUser": 1000, "capabilities": { "drop": ["ALL"] } }
+      } } ] }
+    }`
+	aciSpecs, _, err := SpecsFromAzure([]byte(aci))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const cr = `apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: g
+spec:
+  template:
+    spec:
+      containers:
+        - image: x:1
+          securityContext:
+            runAsUser: 1000
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+`
+	crSpecs, err := SpecsFromCloudRun([]byte(cr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(aciSpecs) != 1 || len(crSpecs) != 1 {
+		t.Fatalf("want 1 spec each, got aci=%d cr=%d", len(aciSpecs), len(crSpecs))
+	}
+	a, c := aciSpecs[0], crSpecs[0]
+	// Shared managed floors agree exactly.
+	if a.HostPID != c.HostPID || a.HostIPC != c.HostIPC || a.HostNetwork != c.HostNetwork ||
+		a.DockerSock != c.DockerSock || a.Privileged != c.Privileged || a.Seccomp != c.Seccomp {
+		t.Errorf("managed floors diverge:\n aci=%+v\n cr=%+v", a, c)
+	}
+	// Both are egress-capable (never network=none) → the network dimension caps both.
+	if got := gradeVerdict(gradeNetwork, a); got != VerdictWarn {
+		t.Errorf("ACI network should be WARN (egress-capable), got %v", got)
+	}
+	// The 10-point read-only-rootfs gap is the whole ceiling difference.
+	if Score(c).Score-Score(a).Score != 10 {
+		t.Errorf("ceiling gap should be exactly the 10-pt read-only rootfs dimension: aci=%d cr=%d",
+			Score(a).Score, Score(c).Score)
+	}
+}
+
+// gradeVerdict runs a single dimension scorer and returns its verdict (test helper).
+func gradeVerdict(fn func(Spec) (int, Verdict, string), s Spec) Verdict {
+	_, v, _ := fn(s)
+	return v
+}


### PR DESCRIPTION
Adds the **Azure** leg of the big-3 cloud scan wedge, completing GCP Cloud Run (IRO-516) + AWS ECS (IRO-517).

## What
`ironctl scan --azure PATH` grades `Microsoft.ContainerInstance/containerGroups` from an **ARM template**, an **`az container show`/deployment JSON**, or a bare containerGroup object. It reuses the SAME `specFromPodSpec` scorer as `--k8s`/`--cloudrun`, then folds in ACI's managed-runtime floors. The **weakest container in the group** governs.

## Managed-runtime model (mirrors --cloudrun)
- Each container group runs in a dedicated **Hyper-V-isolated VM** → host PID/IPC/network + docker.sock unreachable (pass by construction).
- Privileged forbidden on Standard SKU (floor `No`; an explicit `privileged: true` is still respected as the worse posture).
- Default seccomp profile → confined; managed egress → egress-capable (never `network=none`).

## Honest ceiling: 79/B (not 89/B)
Two genuine ACI platform limits keep it one dimension below Cloud Run:
- ACI's `securityContext` **cannot express a read-only root filesystem** → that dimension is always fail-closed (−10 pts).
- ACI **lets a container add capabilities**, so cap-drop is not platform-credited (the user must set `capabilities.drop: [ALL]`).

A fully hardened ACI container tops out at **79/100 (grade B)**. I chose to document this divergence rather than fudge the score green — flagging for review since this is a managed-runtime trust-model call.

## Fail-open / fail-closed
- ARM expressions (`"[parameters(...)]"`) nullified before decode → graded fail-closed, mirroring the CloudFormation intrinsic handling (IRO-526). Case-insensitive JSON decode maps ARM PascalCase onto the shared struct tags.
- Malformed/unreadable input fails **open** (diagnostic + exit 0); `--min-score` still gates once containers are graded.

## Verification
- `go test ./internal/host/scan/` → **180 passed** (8 new: hardened 79/B, porous, bare fail-closed 44, ARM-expression tolerance, weakest-link aggregate, no-group error, malformed error, **managed-floor parity vs --cloudrun** proving the exact 10-pt read-only-rootfs gap).
- `go vet` clean, `gofmt` clean, CGO build green; CLI smoke-tested (hardened / porous / ARM-expression / dir).
- Coverage-hub card `#scan-azure` + table row + `scan.md` deep-dive section.

## Lenses
Build-matrix fidelity (CGO green), fail-closed (unknown posture insecure; honest ceiling not weakened to go green). No signing/attestation/CI-permission surface touched.

Closes IRO-532.