### PR TITLE
docs(blog): harden guides wave 9 (loki/tempo/meilisearch/dragonfly) [IRO-544]

### DIFF
--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -48,5 +48,9 @@ nav:
   - "How to harden a TimescaleDB container": harden-timescaledb-container-isolation.md
   - "How to harden a Valkey container": harden-valkey-container-isolation.md
   - "How to harden a HAProxy container": harden-haproxy-container-isolation.md
+  - "How to harden a Loki container": harden-loki-container-isolation.md
+  - "How to harden a Tempo container": harden-tempo-container-isolation.md
+  - "How to harden a Meilisearch container": harden-meilisearch-container-isolation.md
+  - "How to harden a Dragonfly container": harden-dragonfly-container-isolation.md
   - "How to scan a Dockerfile for security issues": scan-a-dockerfile-for-security-issues.md
   - "*.md"

--- a/docs/blog/harden-dragonfly-container-isolation.md
+++ b/docs/blog/harden-dragonfly-container-isolation.md
@@ -1,0 +1,109 @@
+---
+title: "How to harden a Dragonfly container: dragonfly:latest scores 48/100 by default"
+description: "dragonflydb/dragonfly:latest defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a co-located in-memory store to a full 100/100 grade A."
+---
+
+# How to harden a Dragonfly container (and is dragonfly:latest safe for your cache?)
+
+Dragonfly is a drop-in Redis and Memcached replacement: it holds session state, cache entries,
+queues, and often the working set of data your app reaches for on every request. A stock `docker run
+dragonflydb/dragonfly:latest` holds that data behind a boundary weaker than the data deserves. Graded
+on IronClaw's seven-dimension containment scale, the default configuration scores **48 of 100, grade
+D (porous)**. Higher is safer. Unlike a broker or a shared network cache, an in-memory store that only
+its co-located application talks to over the loopback can close every dimension, including the
+network. A few runtime flags take the same image to a full **100 of 100, grade A**. Here are the
+exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of
+> `docker.dragonflydb.io/dragonflydb/dragonfly:latest`, the same data behind its [isolation
+> scorecard](../scores/dragonfly.md). No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+dragonflydb/dragonfly:latest`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The two that should worry you most are **root** and **egress**. A Dragonfly process that escapes as
+root escapes as root on the host, next to the very data it was holding in memory and its snapshot
+files on disk. And a store that can reach arbitrary destinations is one that can quietly ship your
+cached data out the moment a protocol-parsing CVE lands code execution. The default capability set and
+writable rootfs widen and entrench that foothold.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-dragonfly --fix` prints one remediation per failed dimension, then one hardened run.
+For `dragonflydb/dragonfly:latest`:
+
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the snapshot directory at a volume this uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Dragonfly needs none
+  of the default set to serve its Redis-compatible protocol on a high port.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/data` as an explicit writable volume for snapshots. Removes the persistence surface.
+- **`--network=none`** (Network isolation, +11 to the full 15): this is the dimension a co-located
+  store can actually max out. If the only client is the app on the same host or pod and reaches
+  Dragonfly over the loopback of a shared network namespace, cut the NIC entirely. Nothing external
+  can connect, and the store cannot phone home.
+
+### When network=none is not honest
+
+If Dragonfly is a shared cache that many services across the network connect to, or you run
+replication to replicas, you cannot use `--network=none`; it has to accept those connections. In that
+case put it on a user-defined network scoped to just its clients and replicas, with no default route
+out. That holds the network dimension at a WARN (4 of 15) and the honest ceiling becomes **89 of 100,
+grade B**, the same as a broker. Use `--network=none` only for the single-application, co-located
+case.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name dragonfly docker.dragonflydb.io/dragonflydb/dragonfly:latest
+
+# After: 100/100, grade A (co-located app on loopback, no network needed)
+docker run -d --name dragonfly-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v dragonfly-data:/data \
+  --network=none \
+  docker.dragonflydb.io/dragonflydb/dragonfly:latest
+```
+
+Rescan: `ironctl scan dragonfly-hardened` reports `100/100 grade A`. A **52-point swing** with no
+custom image build, just the right flags. Every dimension is closed because a co-located in-memory
+store does not need to talk to anything but the app on the other side of its loopback. Run it as a
+shared network cache instead and the honest ceiling is **89/100, grade B**, called out above.
+
+## Verify it on your own Dragonfly
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-dragonfly
+ironctl scan my-dragonfly --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Dragonfly in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [dragonfly isolation scorecard &rarr;](../scores/dragonfly.md): the full dimension breakdown.
+- [How to harden a Redis container &rarr;](harden-redis-container-isolation.md): the store Dragonfly is a drop-in replacement for, with the same grade-A path.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-loki-container-isolation.md
+++ b/docs/blog/harden-loki-container-isolation.md
@@ -1,0 +1,108 @@
+---
+title: "How to harden a Loki container: loki:3.3.2 scores 63/100 by default"
+description: "grafana/loki:3.3.2 defaults score 63/100 (grade C): full caps, writable rootfs, bridge egress. The exact ironctl scan --fix flags that take a co-located log store to a full 100/100 grade A."
+---
+
+# How to harden a Grafana Loki container (and is loki:3.3.2 safe for your logs?)
+
+Loki is where your logs land: application traces, access records, and often the credentials and PII
+that leak into log lines nobody meant to keep. A stock `docker run grafana/loki:3.3.2` already runs
+as a non-root uid, which is a good start, but it still holds that data behind three weak boundaries.
+Graded on IronClaw's seven-dimension containment scale, the default configuration scores **63 of 100,
+grade C (partial)**. Higher is safer. Unlike a broker or a proxy, a log store that only its
+co-located agent and query reader talk to can close every remaining dimension, including the network.
+A few runtime flags take the same image to a full **100 of 100, grade A**. Here are the exact gaps
+and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `grafana/loki:3.3.2`, the same data
+> behind its [isolation scorecard](../scores/loki.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+grafana/loki:3.3.2`, two fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as 10001 (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+Loki already ships a non-root uid, so the two that should worry you most are **egress** and the
+**default capability set**. A log store that can reach arbitrary destinations is one that can quietly
+ship your entire log history out the moment a query-parsing or plugin CVE lands code execution. The
+retained capabilities and writable rootfs widen and entrench that foothold.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-loki --fix` prints one remediation per failed dimension, then one hardened run. For
+`grafana/loki:3.3.2`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Loki needs none of
+  the default set to serve its API and write chunks on a high port.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/loki` as an explicit writable volume. Removes the persistence surface.
+- **`--user 65532:65532`** (Non-root user, already PASS): keep the non-root uid and point the data
+  and WAL directories at a volume this uid owns.
+- **`--network=none`** (Network isolation, +11 to the full 15): this is the dimension a co-located
+  store can actually max out. If the only writer and reader are on the same host or pod and reach
+  Loki over the loopback of a shared network namespace, cut the NIC entirely. Nothing external can
+  connect, and the store cannot phone home.
+
+### When network=none is not honest
+
+If remote agents push logs to Loki over the network (a fleet of Promtail or Grafana Alloy collectors,
+for example), you cannot use `--network=none`; the store has to accept those connections. In that
+case put it on a user-defined network scoped to just the collectors and the Grafana that queries it,
+with no default route out. That holds the network dimension at a WARN (4 of 15) and the honest
+ceiling becomes **89 of 100, grade B**, the same as a broker. Use `--network=none` only for the
+single-writer, co-located case.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name loki grafana/loki:3.3.2
+
+# After: 100/100, grade A (co-located store, no network needed)
+docker run -d --name loki-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v loki-data:/loki \
+  --network=none \
+  grafana/loki:3.3.2
+```
+
+Rescan: `ironctl scan loki-hardened` reports `100/100 grade A`. A **37-point swing** with no custom
+image build, just the right flags. Every dimension is closed because a co-located log store does not
+need to talk to anything but the app on the other side of its loopback. That is the top grade,
+reserved for datastores whose clients live next to them.
+
+## Verify it on your own Loki
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-loki
+ironctl scan my-loki --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Loki in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [loki:3.3.2 isolation scorecard &rarr;](../scores/loki.md): the full dimension breakdown.
+- [How to harden a Grafana container &rarr;](harden-grafana-container-isolation.md): the dashboard that queries Loki, which caps at grade B because browsers must reach it.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-meilisearch-container-isolation.md
+++ b/docs/blog/harden-meilisearch-container-isolation.md
@@ -1,0 +1,108 @@
+---
+title: "How to harden a Meilisearch container: meilisearch:v1.11 scores 48/100 by default"
+description: "getmeili/meilisearch:v1.11 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a co-located search store to a full 100/100 grade A."
+---
+
+# How to harden a Meilisearch container (and is meilisearch:v1.11 safe for your index?)
+
+Meilisearch is where your search index lives: product catalogs, user records, documents, and the API
+keys that gate read and write access to all of it. A stock `docker run getmeili/meilisearch:v1.11`
+holds that data behind a boundary weaker than the data deserves. Graded on IronClaw's seven-dimension
+containment scale, the default configuration scores **48 of 100, grade D (porous)**. Higher is safer.
+Unlike a broker or a proxy, a search store that only its co-located application talks to can close
+every dimension, including the network. A few runtime flags take the same image to a full **100 of
+100, grade A**. Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `getmeili/meilisearch:v1.11`, the same
+> data behind its [isolation scorecard](../scores/meilisearch.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+getmeili/meilisearch:v1.11`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The two that should worry you most are **root** and **egress**. A Meilisearch process that escapes as
+root escapes as root on the host, next to the very index files it was holding. And a search engine
+that can reach arbitrary destinations is one that can quietly ship your entire indexed dataset out the
+moment a query-parsing CVE lands code execution. The default capability set and writable rootfs widen
+and entrench that foothold.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-meilisearch --fix` prints one remediation per failed dimension, then one hardened
+run. For `getmeili/meilisearch:v1.11`:
+
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the data directory at a volume this uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Meilisearch needs
+  none of the default set to serve its API on a high port.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/meili_data` as an explicit writable volume. Removes the persistence surface.
+- **`--network=none`** (Network isolation, +11 to the full 15): this is the dimension a co-located
+  store can actually max out. If the only client is the app on the same host or pod and reaches
+  Meilisearch over the loopback of a shared network namespace, cut the NIC entirely. Nothing external
+  can connect, and the store cannot phone home.
+
+### When network=none is not honest
+
+If remote services query Meilisearch over the network (a browser-facing search box hitting it
+directly, or many backends across the network), you cannot use `--network=none`; it has to accept
+those connections. In that case put it on a user-defined network scoped to just its clients, with no
+default route out. That holds the network dimension at a WARN (4 of 15) and the honest ceiling becomes
+**89 of 100, grade B**, the same as a broker. Use `--network=none` only for the single-application,
+co-located case.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name meilisearch getmeili/meilisearch:v1.11
+
+# After: 100/100, grade A (co-located store, no network needed)
+docker run -d --name meilisearch-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v meili-data:/meili_data \
+  --network=none \
+  getmeili/meilisearch:v1.11
+```
+
+Rescan: `ironctl scan meilisearch-hardened` reports `100/100 grade A`. A **52-point swing** with no
+custom image build, just the right flags. Every dimension is closed because a co-located search store
+does not need to talk to anything but the app on the other side of its loopback. That is the top
+grade, reserved for datastores whose clients live next to them.
+
+## Verify it on your own Meilisearch
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-meilisearch
+ironctl scan my-meilisearch --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Meilisearch in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [meilisearch:v1.11 isolation scorecard &rarr;](../scores/meilisearch.md): the full dimension breakdown.
+- [How to harden an Elasticsearch container &rarr;](harden-elasticsearch-container-isolation.md): the other popular search store, with the same single-node grade-A path.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-tempo-container-isolation.md
+++ b/docs/blog/harden-tempo-container-isolation.md
@@ -1,0 +1,109 @@
+---
+title: "How to harden a Tempo container: tempo:2.6.1 scores 63/100 by default"
+description: "grafana/tempo:2.6.1 defaults score 63/100 (grade C): full caps, writable rootfs, bridge egress. The exact ironctl scan --fix flags that take a co-located trace store to a full 100/100 grade A."
+---
+
+# How to harden a Grafana Tempo container (and is tempo:2.6.1 safe for your traces?)
+
+Tempo is where your distributed traces live: request spans, service dependencies, and the metadata
+that maps out exactly how your internal systems call each other. A stock `docker run
+grafana/tempo:2.6.1` already runs as a non-root uid, which is a good start, but it still holds that
+data behind three weak boundaries. Graded on IronClaw's seven-dimension containment scale, the
+default configuration scores **63 of 100, grade C (partial)**. Higher is safer. Unlike a broker or a
+proxy, a trace store that only its co-located writer and query reader talk to can close every
+remaining dimension, including the network. A few runtime flags take the same image to a full **100
+of 100, grade A**. Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `grafana/tempo:2.6.1`, the same data
+> behind its [isolation scorecard](../scores/tempo.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+grafana/tempo:2.6.1`, two fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as 10001:10001 (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+Tempo already ships a non-root uid, so the two that should worry you most are **egress** and the
+**default capability set**. A trace store that can reach arbitrary destinations is one that can
+quietly ship your entire trace history, a live map of your internal topology, out the moment an
+ingest-parsing or plugin CVE lands code execution. The retained capabilities and writable rootfs
+widen and entrench that foothold.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-tempo --fix` prints one remediation per failed dimension, then one hardened run. For
+`grafana/tempo:2.6.1`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Tempo needs none of
+  the default set to accept spans and serve its API on a high port.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/var/tempo` as an explicit writable volume. Removes the persistence surface.
+- **`--user 65532:65532`** (Non-root user, already PASS): keep the non-root uid and point the trace
+  storage directory at a volume this uid owns.
+- **`--network=none`** (Network isolation, +11 to the full 15): this is the dimension a co-located
+  store can actually max out. If the only writer and reader are on the same host or pod and reach
+  Tempo over the loopback of a shared network namespace, cut the NIC entirely. Nothing external can
+  connect, and the store cannot phone home.
+
+### When network=none is not honest
+
+If remote agents push spans to Tempo over the network (a fleet of OpenTelemetry collectors, for
+example), you cannot use `--network=none`; the store has to accept those OTLP connections. In that
+case put it on a user-defined network scoped to just the collectors and the Grafana that queries it,
+with no default route out. That holds the network dimension at a WARN (4 of 15) and the honest
+ceiling becomes **89 of 100, grade B**, the same as a broker. Use `--network=none` only for the
+single-writer, co-located case.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name tempo grafana/tempo:2.6.1
+
+# After: 100/100, grade A (co-located store, no network needed)
+docker run -d --name tempo-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v tempo-data:/var/tempo \
+  --network=none \
+  grafana/tempo:2.6.1
+```
+
+Rescan: `ironctl scan tempo-hardened` reports `100/100 grade A`. A **37-point swing** with no custom
+image build, just the right flags. Every dimension is closed because a co-located trace store does
+not need to talk to anything but the app on the other side of its loopback. That is the top grade,
+reserved for datastores whose clients live next to them.
+
+## Verify it on your own Tempo
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-tempo
+ironctl scan my-tempo --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Tempo in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [tempo:2.6.1 isolation scorecard &rarr;](../scores/tempo.md): the full dimension breakdown.
+- [How to harden a Loki container &rarr;](harden-loki-container-isolation.md): the log store from the same Grafana stack, with the same grade-A path.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -40,6 +40,10 @@ Two patterns show up across the set:
 | [CockroachDB](harden-cockroachdb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if clustered or remote clients) |
 | [TimescaleDB](harden-timescaledb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B with replicas or remote clients) |
 | [Valkey](harden-valkey-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B as a shared network cache) |
+| [Loki](harden-loki-container-isolation.md) | 63/100 C | **100/100 A** | full caps, writable rootfs (89/B if a fleet pushes logs) |
+| [Tempo](harden-tempo-container-isolation.md) | 63/100 C | **100/100 A** | full caps, writable rootfs (89/B if a fleet pushes traces) |
+| [Meilisearch](harden-meilisearch-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if remote clients) |
+| [Dragonfly](harden-dragonfly-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B as a shared network cache) |
 | [Untrusted Node.js](run-untrusted-nodejs-code-safely.md) | 48/100 D | **100/100 A** | run untrusted code in a real sandbox |
 
 ## Honest ceiling: grade B (89/100)


### PR DESCRIPTION
## Wave 9 hardening guides

Four more container hardening SEO guides, each with before/after `docker run` config and a real grade jump graded from the read-only `docker inspect` data behind each image's isolation scorecard.

| Guide | Default | Hardened | Note |
|-------|:-------:|:--------:|------|
| Loki | 63/100 C | **100/100 A** | co-located log store; 89/B if a fleet pushes logs |
| Tempo | 63/100 C | **100/100 A** | co-located trace store; 89/B if a fleet pushes traces |
| Meilisearch | 48/100 D | **100/100 A** | co-located search store; 89/B if remote clients |
| Dragonfly | 48/100 D | **100/100 A** | co-located in-memory store; 89/B as shared cache |

All four are co-located datastores, so each reaches grade A per the standing rules (network none maxes the network dimension). The 89/B ceiling case is called out honestly on every page. Every claim maps to the shipped scorecard numbers; no inflated grades.

### Wiring
- Added 4 rows to the hardening hub grade-A table (`docs/blog/hardening-guides.md`); hub now lists **36** guides (up from 32).
- Added 4 entries to `docs/blog/.nav.yml`.

### Verification
- `mkdocs build --strict` exits 0, no broken links from the new pages.
- No em/en dashes (public-copy rule).
- Scorecard link targets (`docs/scores/{loki,tempo,meilisearch,dragonfly}.md`) all exist.

Refs prior waves 1-8 in `docs/blog/`. [IRO-544]