### PR TITLE
feat(scan): ironctl scan --bicep grades Azure Bicep container groups [IRO-543]

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -53,6 +53,9 @@ func cmdScan(args []string) error {
 	pulumi := fs.String("pulumi", "", "grade container workloads in a Pulumi `pulumi stack export` / `pulumi preview --json` file (or a directory of them): kubernetes:* workloads and aws ECS task definitions")
 	azure := fs.String("azure", "", "grade Microsoft.ContainerInstance/containerGroups in an Azure ARM template / `az container show` JSON, or a directory of them")
 	appRunner := fs.String("app-runner", "", "grade an AWS App Runner service: `aws apprunner describe-service` JSON, a raw Service object, or a directory of them")
+	bicep := fs.String("bicep", "", "compile an Azure Bicep template (.bicep file or a directory of them) to ARM and grade the Microsoft.ContainerInstance/containerGroups it declares")
+	bicepBin := fs.String("bicep-bin", envOrDefault("BICEP", "bicep"), "standalone bicep binary used to compile a .bicep to ARM (`bicep build --stdout`); falls back to `az bicep build` if absent")
+	azBin := fs.String("az-bin", envOrDefault("AZ", "az"), "azure-cli binary used for the `az bicep build` fallback when the standalone bicep binary is absent")
 	kustomize := fs.String("kustomize", "", "render a kustomization directory with `kustomize build` (or `kubectl kustomize`) and grade the isolation posture of its workloads")
 	kustomizeBin := fs.String("kustomize-bin", envOrDefault("KUSTOMIZE", "kustomize"), "kustomize binary used to render the directory (falls back to `kubectl kustomize` if absent)")
 	kubectlBin := fs.String("kubectl-bin", envOrDefault("KUBECTL", "kubectl"), "kubectl binary used for `kubectl kustomize` when the kustomize binary is absent")
@@ -281,6 +284,29 @@ func cmdScan(args []string) error {
 	if *appRunner != "" {
 		return runAppRunnerScan(appRunnerScanArgs{
 			path:      *appRunner,
+			asJSON:    *asJSON,
+			md:        *md,
+			badge:     *badge,
+			badgeJSON: *badgeJSON,
+			sarif:     *sarif,
+			minScore:  *minScore,
+		})
+	}
+
+	// --bicep: compile an Azure Bicep template (a .bicep file or a directory of
+	// them) to ARM JSON with `bicep build --stdout` (or `az bicep build` when the
+	// standalone binary is absent), then grade the
+	// Microsoft.ContainerInstance/containerGroups it declares by reusing the SAME
+	// ACI managed-runtime path as --azure. It compiles (I/O) here, then defers to the
+	// pure SpecsFromBicepARM + AggregateBicep scorer. Fail-OPEN on a compile/parse
+	// failure (bicep/az absent or a bad template) so an opt-in CI step never crashes
+	// the build; --min-score still gates once containers are graded. Unresolvable ARM
+	// expressions ("[...]") are graded fail-closed and noted on the report.
+	if *bicep != "" {
+		return runBicepScan(bicepScanArgs{
+			path:      *bicep,
+			bicepBin:  *bicepBin,
+			azBin:     *azBin,
 			asJSON:    *asJSON,
 			md:        *md,
 			badge:     *badge,
@@ -1674,6 +1700,19 @@ type appRunnerScanArgs struct {
 	minScore  int
 }
 
+// bicepScanArgs carries the resolved inputs for a `scan --bicep` run.
+type bicepScanArgs struct {
+	path      string
+	bicepBin  string
+	azBin     string
+	asJSON    bool
+	md        bool
+	badge     string
+	badgeJSON string
+	sarif     string
+	minScore  int
+}
+
 // runAppRunnerScan grades an AWS App Runner service, reusing the SAME pod-spec scorer
 // as --cloudrun/--azure plus App Runner's managed-runtime floors. App Runner output
 // is plain JSON, so there is no external binary to shell out to. It accepts an
@@ -1781,6 +1820,149 @@ func loadAppRunnerSpecs(path string) ([]scan.Spec, error) {
 		specs = append(specs, fileSpecs...)
 	}
 	return specs, nil
+}
+
+// runBicepScan compiles an Azure Bicep template (a .bicep file or a directory of
+// them) to ARM JSON and grades the Microsoft.ContainerInstance/containerGroups it
+// declares, reusing the SAME ACI managed-runtime scorer as --azure (Bicep transpiles
+// 1:1 to ARM). It fails OPEN on a compile/parse failure (bicep/az absent, unreadable
+// path, malformed template): it prints a clear diagnostic to stderr and returns nil so
+// an opt-in CI/Action step never crashes the build over tooling issues. Once
+// containers are graded, scoring and the --min-score CI gate apply exactly like
+// --azure. Unresolvable ARM expressions ("[...]") are graded fail-closed and noted.
+func runBicepScan(a bicepScanArgs) error {
+	specs, usedExpressions, err := loadBicepSpecs(a.bicepBin, a.azBin, a.path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --bicep could not compile/load %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregateBicep(specs, filepath.Base(strings.TrimRight(a.path, "/")))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --bicep found nothing to grade in %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+	if usedExpressions {
+		report.Notes = append(report.Notes, "template uses ARM expressions (\"[parameters(...)]\"/\"[variables(...)]\") after compilation: unresolved values are graded as unset (fail-closed) — verify the deployed group matches.")
+	}
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (containers graded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// loadBicepSpecs resolves a --bicep argument to graded Specs. A single .bicep file is
+// compiled to ARM and parsed directly. A directory is a weakest-container rollup:
+// every *.bicep file in it is compiled and its container specs are pooled, so
+// AggregateBicep grades the single most-exposed container across the whole set. It is
+// offline: the bicep compiler transpiles locally without contacting Azure. The bool
+// reports whether any compiled template used ARM expressions that were skipped.
+func loadBicepSpecs(bicepBin, azBin, path string) ([]scan.Spec, bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, false, err
+	}
+	if !info.IsDir() {
+		arm, cerr := compileBicep(bicepBin, azBin, path)
+		if cerr != nil {
+			return nil, false, cerr
+		}
+		return scan.SpecsFromBicepARM(arm)
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, false, err
+	}
+	var specs []scan.Spec
+	usedExpressions := false
+	compiledAny := false
+	for _, e := range entries {
+		if e.IsDir() || !isBicepFileExt(e.Name()) {
+			continue
+		}
+		arm, cerr := compileBicep(bicepBin, azBin, filepath.Join(path, e.Name()))
+		if cerr != nil {
+			// A single template that fails to compile should not sink the rollup: skip
+			// it with a diagnostic and grade the rest (fail-open per file).
+			fmt.Fprintf(os.Stderr, "  warning: scan --bicep skipping %s (compile error): %v\n", e.Name(), cerr)
+			continue
+		}
+		compiledAny = true
+		fileSpecs, expr, perr := scan.SpecsFromBicepARM(arm)
+		if perr != nil {
+			fmt.Fprintf(os.Stderr, "  warning: scan --bicep skipping %s (parse error): %v\n", e.Name(), perr)
+			continue
+		}
+		specs = append(specs, fileSpecs...)
+		usedExpressions = usedExpressions || expr
+	}
+	if !compiledAny {
+		return nil, false, fmt.Errorf("no compilable .bicep files found in directory")
+	}
+	return specs, usedExpressions, nil
+}
+
+// compileBicep transpiles a single .bicep file to ARM JSON on stdout. It prefers the
+// standalone `bicep build --stdout <file>` and falls back to `az bicep build --file
+// <file> --stdout` (the same compiler, shipped as an Azure CLI extension) when the
+// bicep binary is not on PATH. It is offline and daemon-free: compilation is local, no
+// Azure connection.
+func compileBicep(bicepBin, azBin, file string) ([]byte, error) {
+	if _, err := exec.LookPath(bicepBin); err == nil {
+		return runKustomizeRenderer(exec.Command(bicepBin, "build", "--stdout", file), "bicep build --stdout")
+	}
+	if _, err := exec.LookPath(azBin); err == nil {
+		return runKustomizeRenderer(exec.Command(azBin, "bicep", "build", "--file", file, "--stdout"), "az bicep build")
+	}
+	return nil, fmt.Errorf("neither the standalone bicep binary (%q) nor the azure-cli (%q) found on PATH (install one, or pass --bicep-bin/--az-bin)", bicepBin, azBin)
+}
+
+// isBicepFileExt reports whether a filename has the Bicep source extension (.bicep).
+// A .bicepparam parameter file is not a deployable template on its own and is excluded
+// from a directory rollup.
+func isBicepFileExt(name string) bool {
+	return strings.ToLower(filepath.Ext(name)) == ".bicep"
 }
 
 func writeDockerfileSARIF(path string, r scan.Report, opts scan.SARIFOptions) error {

--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -272,6 +272,20 @@ roll up to the **weakest** one the code defines.
 
     [:octicons-arrow-right-24: Grade a Pulumi program](scan.md#grade-a-pulumi-program)
 
+-   #### :material-microsoft-azure:{ .lg .middle } Azure Bicep template { #scan-bicep }
+
+    ---
+
+    Compiles a `.bicep` file (or a directory of them) to ARM with `bicep build` and grades the
+    `Microsoft.ContainerInstance/containerGroups` it declares, reusing the `--azure` ACI path
+    and rolling up to the **weakest** container, so a template is graded before `az deployment`.
+
+    ```bash
+    ironctl scan --bicep main.bicep
+    ```
+
+    [:octicons-arrow-right-24: Grade an Azure Bicep template](scan.md#grade-an-azure-bicep-template)
+
 </div>
 
 ## Every mode, one engine
@@ -297,6 +311,7 @@ the container they eventually produce are all measured on one comparable scale.
 | Infrastructure-as-Code | [Terraform plan](#scan-terraform) | `--terraform` | container workloads in a plan/state | [Grade a Terraform plan](scan.md#grade-a-terraform-plan) |
 | Infrastructure-as-Code | [CloudFormation](#scan-cloudformation) | `--cloudformation` | ECS task defs in a CFN template | [Grade a CloudFormation template](scan.md#grade-a-cloudformation-template) |
 | Infrastructure-as-Code | [Pulumi program](#scan-pulumi) | `--pulumi` | K8s &amp; ECS workloads in stack-export / preview JSON | [Grade a Pulumi program](scan.md#grade-a-pulumi-program) |
+| Infrastructure-as-Code | [Azure Bicep template](#scan-bicep) | `--bicep` | weakest `containerGroups` container, compiled to ARM | [Grade an Azure Bicep template](scan.md#grade-an-azure-bicep-template) |
 
 Every mode also emits the machine-readable outputs: a [SARIF log](scan.md#github-code-scanning-security-tab)
 for GitHub code scanning, a [shields.io badge](scan.md#sandbox-isolation-score-badge), and

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -399,6 +399,36 @@ Load or parse failures fail **open** (a clear diagnostic and exit 0) so an opt-i
 step never crashes the build; once a service is graded, `--min-score` still trips on a
 low posture.
 
+## Grade an Azure Bicep template
+
+`--bicep PATH` compiles an [Azure Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/)
+template to ARM and grades the `Microsoft.ContainerInstance/containerGroups` it
+declares. Bicep transpiles **1:1** to an ARM deployment template, so once compiled it
+is graded through the **exact same** managed-runtime path as `--azure`. Point it at a
+`.bicep` file or a directory of them:
+
+```bash
+ironctl scan --bicep main.bicep
+ironctl scan --bicep main.bicep --min-score 75   # CI gate
+ironctl scan --bicep ./infra                     # a directory of *.bicep
+```
+
+Compilation prefers the standalone `bicep build --stdout` and falls back to
+`az bicep build` (the Bicep compiler shipped as an Azure CLI extension) when the
+standalone binary is absent — pass `--bicep-bin` / `--az-bin` to override. It is
+offline and daemon-free: the compiler transpiles locally with no Azure login. Because
+the input compiles to the same ARM `containerGroups` document `--azure` grades, the
+scoring is identical: each container's `securityContext` runs through the shared
+pod-spec scorer, ACI's managed-runtime floors are folded in, and a fully hardened ACI
+container tops out at **79/100 (grade B)** — see [Grade an Azure container
+group](#grade-an-azure-container-group) for the per-dimension breakdown. The template
+grade is the **weakest** container across the compiled groups. ARM expressions that
+survive compilation (`"[parameters(...)]"`) are graded fail-closed and noted. A
+compile or parse failure (the `bicep`/`az` binary is absent or the template is
+malformed) fails **open** — a clear diagnostic and exit 0 — so an opt-in CI step never
+crashes the build; once containers are graded, `--min-score` still trips on a low
+posture.
+
 ## Grade a kustomization
 
 `--kustomize DIR` renders a [Kustomize](https://kustomize.io/) directory with

--- a/internal/host/scan/bicep.go
+++ b/internal/host/scan/bicep.go
@@ -1,0 +1,36 @@
+package scan
+
+// SpecsFromBicepARM grades an Azure Bicep template that has already been compiled to
+// ARM JSON. Bicep is a domain-specific language that transpiles 1:1 to an ARM
+// deployment template (`az bicep build` / the standalone `bicep build` emit exactly
+// the ARM JSON that ARM itself consumes), so a Bicep file that declares a
+// Microsoft.ContainerInstance/containerGroups resource compiles to the SAME ARM
+// document the --azure path already grades. This is therefore a deliberately thin
+// seam over SpecsFromAzure: it takes the compiled ARM bytes (the CLI wrapper runs the
+// bicep compiler — the I/O) and returns one graded Spec per ACI container, with the
+// identical managed-runtime model, ARM PascalCase case-insensitive decode, and
+// "[...]" expression fail-closed handling.
+//
+// Keeping it a named entry point (rather than calling SpecsFromAzure directly from the
+// CLI) gives the --bicep mode a stable seam a parity test can pin against the sibling
+// --azure mode: the same compiled ARM must grade identically through both.
+func SpecsFromBicepARM(compiledARM []byte) ([]Spec, bool, error) {
+	return SpecsFromAzure(compiledARM)
+}
+
+// AggregateBicep folds the per-container specs from one or more compiled-Bicep ACI
+// containerGroups into a single Report. It is the AggregateAzure weakest-container
+// rollup (a group is only as isolated as its most-exposed container) with the Source
+// re-labelled "bicep" so the report names the input mode the user actually ran. It is
+// pure; the caller injects Version/GeneratedAt.
+func AggregateBicep(specs []Spec, target string) (Report, Spec, error) {
+	report, worst, err := AggregateAzure(specs, target)
+	if err != nil {
+		return Report{}, Spec{}, err
+	}
+	report.Source = "bicep"
+	report.Notes = append([]string{
+		"input compiled from Azure Bicep to ARM JSON (az bicep build / bicep build); grading is identical to the --azure ACI path once compiled",
+	}, report.Notes...)
+	return report, worst, nil
+}

--- a/internal/host/scan/bicep_test.go
+++ b/internal/host/scan/bicep_test.go
@@ -1,0 +1,84 @@
+package scan
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestBicepARMParityWithAzure locks the core contract of the --bicep mode: because
+// Bicep transpiles 1:1 to ARM, the SAME compiled ARM document must grade IDENTICALLY
+// through the --bicep entry point (SpecsFromBicepARM / AggregateBicep) and the sibling
+// --azure entry point (SpecsFromAzure / AggregateAzure) — the only allowed difference
+// is the reported Source label. If the two ever diverge, the bicep path has grown its
+// own scoring behaviour and the parity guarantee is broken.
+func TestBicepARMParityWithAzure(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		arm  string
+	}{
+		{"hardened", armHardened},
+		{"porous_show", aciShowPorous},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bicepSpecs, bicepExpr, berr := SpecsFromBicepARM([]byte(tc.arm))
+			azSpecs, azExpr, aerr := SpecsFromAzure([]byte(tc.arm))
+			if berr != nil || aerr != nil {
+				t.Fatalf("parse errors: bicep=%v azure=%v", berr, aerr)
+			}
+			if bicepExpr != azExpr {
+				t.Fatalf("expression-skipped flag differs: bicep=%v azure=%v", bicepExpr, azExpr)
+			}
+			if !reflect.DeepEqual(bicepSpecs, azSpecs) {
+				t.Fatalf("specs diverge between bicep and azure entry points:\nbicep=%+v\nazure=%+v", bicepSpecs, azSpecs)
+			}
+
+			bReport, bWorst, berr := AggregateBicep(bicepSpecs, "example")
+			aReport, aWorst, aerr := AggregateAzure(azSpecs, "example")
+			if berr != nil || aerr != nil {
+				t.Fatalf("aggregate errors: bicep=%v azure=%v", berr, aerr)
+			}
+			if bReport.Score != aReport.Score || bReport.Grade != aReport.Grade {
+				t.Fatalf("grade diverges: bicep=%d/%s azure=%d/%s", bReport.Score, bReport.Grade, aReport.Score, aReport.Grade)
+			}
+			if !reflect.DeepEqual(bWorst, aWorst) {
+				t.Fatalf("worst spec diverges between bicep and azure")
+			}
+			// The one intentional difference: the Source label names the input mode.
+			if bReport.Source != "bicep" {
+				t.Fatalf("bicep report Source = %q, want %q", bReport.Source, "bicep")
+			}
+			if aReport.Source != "azure" {
+				t.Fatalf("azure report Source = %q, want %q", aReport.Source, "azure")
+			}
+		})
+	}
+}
+
+// TestBicepHardenedGrade pins the concrete grade a fully hardened, compiled-Bicep ACI
+// container earns: the same honest 79/100 (grade B) ceiling as --azure — one dimension
+// (read-only rootfs, which ACI's securityContext cannot express) below Cloud Run's
+// 89/B.
+func TestBicepHardenedGrade(t *testing.T) {
+	specs, _, err := SpecsFromBicepARM([]byte(armHardened))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	report, _, err := AggregateBicep(specs, "webgroup.bicep")
+	if err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+	if report.Score != 79 || report.Grade != "B" {
+		t.Fatalf("hardened compiled-bicep ACI = %d/%s, want 79/B", report.Score, report.Grade)
+	}
+	if report.Source != "bicep" {
+		t.Fatalf("Source = %q, want bicep", report.Source)
+	}
+}
+
+// TestBicepAggregateEmptyFailsClosed confirms an ARM document with no gradeable ACI
+// container is an error (fail-closed), not a silent pass.
+func TestBicepAggregateEmptyFailsClosed(t *testing.T) {
+	if _, _, err := AggregateBicep(nil, "empty"); err == nil {
+		t.Fatal("expected an error for zero gradeable containers, got nil")
+	}
+}


### PR DESCRIPTION
## What

Adds `ironctl scan --bicep` grading Azure Bicep templates that declare `Microsoft.ContainerInstance/containerGroups`.

Bicep transpiles **1:1** to ARM, so the mode compiles a `.bicep` file (or a directory of them) to ARM JSON with `bicep build --stdout` — falling back to `az bicep build` when the standalone binary is absent — then reuses the existing `--azure` ACI path: the shared pod-spec scorer + managed-runtime floors, ARM PascalCase case-insensitive decode, and `[...]` expression fail-closed handling.

## Changes
- **internal/host/scan/bicep.go** — thin `SpecsFromBicepARM` / `AggregateBicep` seam over the azure scorer (`Source` re-labelled `bicep`), giving `--bicep` a stable entry point to pin against `--azure`.
- **cmd/ironctl/scan.go** — `--bicep` / `--bicep-bin` / `--az-bin` flags; compile + load for a single file and a directory (weakest-container rollup); fail-open on a compile/parse failure; `--min-score` gate once graded.
- **bicep_test.go** — parity test: the same compiled ARM grades **identically** through `--bicep` and `--azure` (only `Source` differs), plus the hardened **79/B** ceiling and empty-set fail-closed.
- **docs** — crawlable `#scan-bicep` coverage-hub card under Infrastructure-as-Code + 'Every mode, one engine' table row + `scan.md` deep-dive section.

## Grade
A fully hardened compiled-Bicep ACI container tops out at **79/100 (grade B)** — identical to `--azure`, one dimension (read-only rootfs, unexpressible on ACI) below Cloud Run's 89/B.

## Verification
- `CGO_ENABLED=1 go build ./cmd/ironctl` + `go vet` clean
- 299 scan/cli tests pass (parity, hardened-grade, fail-closed)
- CLI smoke with a stub compiler grades a hardened group at 79/B, `source=bicep`; fail-open verified when no compiler on PATH

## Lenses
Build-matrix fidelity (CGO build green); reproducibility (offline local compile, no Azure login); fail-closed (unset dims + surviving ARM expressions graded insecure, empty set errors); fail-open only on tooling absence so an opt-in CI step never crashes.

Closes IRO-543.