### PR TITLE
feat(scan): ironctl scan --app-runner grades AWS App Runner service configs [IRO-542]

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -52,6 +52,7 @@ func cmdScan(args []string) error {
 	cloudformation := fs.String("cloudformation", "", "grade AWS::ECS::TaskDefinition resources in a CloudFormation template (YAML or JSON), or a directory of them")
 	pulumi := fs.String("pulumi", "", "grade container workloads in a Pulumi `pulumi stack export` / `pulumi preview --json` file (or a directory of them): kubernetes:* workloads and aws ECS task definitions")
 	azure := fs.String("azure", "", "grade Microsoft.ContainerInstance/containerGroups in an Azure ARM template / `az container show` JSON, or a directory of them")
+	appRunner := fs.String("app-runner", "", "grade an AWS App Runner service: `aws apprunner describe-service` JSON, a raw Service object, or a directory of them")
 	kustomize := fs.String("kustomize", "", "render a kustomization directory with `kustomize build` (or `kubectl kustomize`) and grade the isolation posture of its workloads")
 	kustomizeBin := fs.String("kustomize-bin", envOrDefault("KUSTOMIZE", "kustomize"), "kustomize binary used to render the directory (falls back to `kubectl kustomize` if absent)")
 	kubectlBin := fs.String("kubectl-bin", envOrDefault("KUBECTL", "kubectl"), "kubectl binary used for `kubectl kustomize` when the kustomize binary is absent")
@@ -259,6 +260,27 @@ func cmdScan(args []string) error {
 	if *azure != "" {
 		return runAzureScan(azureScanArgs{
 			path:      *azure,
+			asJSON:    *asJSON,
+			md:        *md,
+			badge:     *badge,
+			badgeJSON: *badgeJSON,
+			sarif:     *sarif,
+			minScore:  *minScore,
+		})
+	}
+
+	// --app-runner: consume an AWS App Runner service (an `aws apprunner
+	// describe-service` JSON, a raw Service object, or a directory of them) and grade
+	// it, reusing the SAME pod-spec scorer as --k8s/--cloudrun/--azure plus App
+	// Runner's managed-runtime floors. App Runner exposes no securityContext, so the
+	// user-hardenable dimensions grade fail-closed and a service tops out at 48/100
+	// (D) on the managed floors alone. It reads the JSON here (no external binary)
+	// then defers to the pure SpecsFromAppRunner + AggregateAppRunner scorer.
+	// Fail-OPEN on a load/parse failure; --min-score still gates once a service is
+	// graded.
+	if *appRunner != "" {
+		return runAppRunnerScan(appRunnerScanArgs{
+			path:      *appRunner,
 			asJSON:    *asJSON,
 			md:        *md,
 			badge:     *badge,
@@ -1641,6 +1663,126 @@ func loadAzureSpecs(path string) ([]scan.Spec, bool, error) {
 	return specs, usedExpressions, nil
 }
 
+// appRunnerScanArgs carries the resolved inputs for a `scan --app-runner` run.
+type appRunnerScanArgs struct {
+	path      string
+	asJSON    bool
+	md        bool
+	badge     string
+	badgeJSON string
+	sarif     string
+	minScore  int
+}
+
+// runAppRunnerScan grades an AWS App Runner service, reusing the SAME pod-spec scorer
+// as --cloudrun/--azure plus App Runner's managed-runtime floors. App Runner output
+// is plain JSON, so there is no external binary to shell out to. It accepts an
+// `aws apprunner describe-service` JSON, a raw Service object, or a directory of them
+// (weakest-service rollup). It fails OPEN on a load/parse failure (unreadable path,
+// malformed JSON): it prints a clear diagnostic to stderr and returns nil so an
+// opt-in CI/Action step never crashes the build. Once a service is graded, scoring
+// and the --min-score CI gate apply exactly like --cloudrun/--azure/--ecs.
+func runAppRunnerScan(a appRunnerScanArgs) error {
+	specs, err := loadAppRunnerSpecs(a.path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --app-runner could not load %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregateAppRunner(specs, filepath.Base(strings.TrimRight(a.path, "/")))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --app-runner found nothing to grade in %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (a service was graded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// loadAppRunnerSpecs resolves a --app-runner argument to graded Specs. A single file
+// is parsed directly. A directory is a weakest-service rollup: every *.json file in
+// it is parsed and its service specs are pooled, so AggregateAppRunner grades the
+// single most-exposed service across the whole set. It is daemon-free and offline:
+// App Runner output is read from disk (the user runs the aws CLI, if at all).
+func loadAppRunnerSpecs(path string) ([]scan.Spec, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil, rerr
+		}
+		return scan.SpecsFromAppRunner(raw)
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	var specs []scan.Spec
+	for _, e := range entries {
+		if e.IsDir() || !strings.EqualFold(filepath.Ext(e.Name()), ".json") {
+			continue
+		}
+		raw, rerr := os.ReadFile(filepath.Join(path, e.Name()))
+		if rerr != nil {
+			return nil, rerr
+		}
+		fileSpecs, perr := scan.SpecsFromAppRunner(raw)
+		if perr != nil {
+			// A single malformed file in a directory should not sink the rollup:
+			// skip it with a diagnostic and grade the rest (fail-open per file).
+			fmt.Fprintf(os.Stderr, "  warning: scan --app-runner skipping %s (parse error): %v\n", e.Name(), perr)
+			continue
+		}
+		specs = append(specs, fileSpecs...)
+	}
+	return specs, nil
+}
+
 func writeDockerfileSARIF(path string, r scan.Report, opts scan.SARIFOptions) error {
 	f, err := os.Create(path)
 	if err != nil {
@@ -1777,6 +1919,7 @@ USAGE:
   ironctl scan --cloudformation PATH            grade AWS::ECS::TaskDefinition in a CloudFormation template (YAML/JSON or dir)
   ironctl scan --pulumi PATH                     grade container workloads in Pulumi stack-export / preview --json output (or dir)
   ironctl scan --azure PATH                     grade Azure Container Instances (ARM template / az container show JSON or dir)
+  ironctl scan --app-runner PATH                grade an AWS App Runner service (apprunner describe-service JSON / dir)
   ironctl scan --kustomize DIR                  render a kustomization (kustomize build) and grade its workloads
   ironctl scan --dockerfile FILE...           grade Dockerfile(s) statically (no daemon, no pull)
   ironctl scan --compare A B                   diff two containers' isolation posture

--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -209,6 +209,20 @@ no API call.
 
     [:octicons-arrow-right-24: Grade an Azure container group](scan.md#grade-an-azure-container-group)
 
+-   #### :fontawesome-brands-aws:{ .lg .middle } AWS App Runner { #scan-app-runner }
+
+    ---
+
+    Grades an App Runner service from its `aws apprunner describe-service` JSON with the
+    managed-runtime model. App Runner exposes no `securityContext`, so it grades honestly
+    on its Fargate/Firecracker floors.
+
+    ```bash
+    ironctl scan --app-runner service.json
+    ```
+
+    [:octicons-arrow-right-24: Grade an App Runner service](scan.md#grade-an-aws-app-runner-service)
+
 </div>
 
 ### Infrastructure-as-Code { #modes-iac }
@@ -279,6 +293,7 @@ the container they eventually produce are all measured on one comparable scale.
 | Cloud runtimes | [Cloud Run](#scan-cloudrun) | `--cloudrun` | a Knative Service's container config | [Grade a Cloud Run service](scan.md#grade-a-google-cloud-run-service) |
 | Cloud runtimes | [Amazon ECS](#scan-ecs) | `--ecs` | a task definition's container contract | [Grade an ECS task definition](scan.md#grade-an-aws-ecs-task-definition) |
 | Cloud runtimes | [Azure Container Instances](#scan-azure) | `--azure` | weakest container in an ARM `containerGroups` | [Grade an Azure container group](scan.md#grade-an-azure-container-group) |
+| Cloud runtimes | [AWS App Runner](#scan-app-runner) | `--app-runner` | a service's managed-runtime posture | [Grade an App Runner service](scan.md#grade-an-aws-app-runner-service) |
 | Infrastructure-as-Code | [Terraform plan](#scan-terraform) | `--terraform` | container workloads in a plan/state | [Grade a Terraform plan](scan.md#grade-a-terraform-plan) |
 | Infrastructure-as-Code | [CloudFormation](#scan-cloudformation) | `--cloudformation` | ECS task defs in a CFN template | [Grade a CloudFormation template](scan.md#grade-a-cloudformation-template) |
 | Infrastructure-as-Code | [Pulumi program](#scan-pulumi) | `--pulumi` | K8s &amp; ECS workloads in stack-export / preview JSON | [Grade a Pulumi program](scan.md#grade-a-pulumi-program) |

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -358,6 +358,47 @@ container's score in the notes. Load or parse failures fail **open** (a clear
 diagnostic and exit 0) so an opt-in CI step never crashes the build; once containers
 are graded, `--min-score` still trips on a low posture.
 
+## Grade an AWS App Runner service
+
+`--app-runner PATH` grades an [AWS App Runner](https://docs.aws.amazon.com/apprunner/)
+service straight from its `aws apprunner describe-service` JSON, a raw `Service`
+object, or a directory of them. It rounds out the AWS coverage alongside `--ecs`
+(task definitions) and joins the managed-runtime family with `--cloudrun` (GCP) and
+`--azure` (ACI). App Runner output is plain JSON, so it is structured and
+daemon-free, with no AWS call and no external binary:
+
+```bash
+aws apprunner describe-service --service-arn "$ARN" > service.json
+ironctl scan --app-runner service.json
+ironctl scan --app-runner service.json --min-score 40   # CI gate
+ironctl scan --app-runner ./services                    # a directory of *.json
+```
+
+App Runner runs every service on **AWS Fargate (a Firecracker microVM)**, graded
+through the **same managed-runtime model** as `--cloudrun` / `--azure`:
+
+| Dimension | How App Runner is graded |
+|---|---|
+| Non-root user | **not expressible** — App Runner's service config has no user field; it respects the image `USER`, which the config cannot override. Graded fail-closed. |
+| Dropped capabilities | Fargate **retains Docker's default capability set** and App Runner gives no knob to drop it — unlike Cloud Run, capabilities are NOT credited as dropped. |
+| Seccomp | Fargate applies Docker's default profile — credited as confined. |
+| Network isolation | App Runner egress is **managed** (public by default, or via a VPC connector), never `network=none`. Graded as egress-capable. |
+| Read-only rootfs | **not expressible** — App Runner has no read-only-rootfs field (like ACI). Graded fail-closed. |
+| docker.sock | impossible on App Runner (no host bind mounts) — passes by construction. |
+| Host namespaces | each service runs in a dedicated **Firecracker microVM**; host PID/IPC/network are unreachable and privileged mode is not permitted — passes by construction. |
+
+App Runner's service configuration exposes **no container `securityContext` at all**,
+so three dimensions (non-root, capabilities, read-only rootfs) cannot be hardened and
+are graded fail-closed. A fully hardened App Runner service therefore tops out at
+**48/100 (grade D)** on the managed-runtime floors alone — honestly lower than Cloud
+Run's 89/B and ACI's 79/B, because App Runner buys you strong microVM isolation but
+almost no config-expressible hardening surface. The Firecracker boundary is surfaced
+as an informational note but awards no points (scoring is runtime-agnostic). The
+deployment grade is the **weakest** service, with every service's score in the notes.
+Load or parse failures fail **open** (a clear diagnostic and exit 0) so an opt-in CI
+step never crashes the build; once a service is graded, `--min-score` still trips on a
+low posture.
+
 ## Grade a kustomization
 
 `--kustomize DIR` renders a [Kustomize](https://kustomize.io/) directory with

--- a/internal/host/scan/apprunner.go
+++ b/internal/host/scan/apprunner.go
@@ -1,0 +1,253 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SpecsFromAppRunner parses an AWS App Runner service definition — the JSON emitted
+// by `aws apprunner describe-service`, a raw Service object, or a directory of them
+// (via the CLI wrapper) — and returns one graded Spec per service. It is the App
+// Runner counterpart to the --cloudrun (GCP) and --azure (ACI) managed-runtime
+// paths.
+//
+// The mapping reuses the SAME specFromPodSpec scorer as --k8s/--cloudrun/--azure and
+// then folds in App Runner's managed-runtime floors. App Runner runs your container
+// on AWS Fargate (a Firecracker microVM), so host PID/IPC/network namespaces and a
+// host docker.sock are unreachable, privileged mode is not permitted, and a default
+// seccomp profile is applied — those dimensions pass by construction. Egress is
+// managed (allowed by default, never network=none), so the network dimension caps at
+// the WARN tier.
+//
+// App Runner is HONEST-graded lower than Cloud Run (89/B) and ACI (79/B) because its
+// service configuration exposes NO container securityContext at all — there is no
+// field to set a non-root user, drop capabilities, or enable a read-only root
+// filesystem (unlike Cloud Run's pod spec or ACI's securityContext). Those
+// user-hardenable dimensions are therefore always graded fail-closed:
+//   - non-root user: unexpressible (App Runner respects the image USER, which the
+//     service config cannot override) → fail-closed (−15).
+//   - read-only rootfs: no field (like ACI) → fail-closed (−10).
+//   - capabilities: App Runner runs on Fargate, which retains Docker's default
+//     capability set and gives no knob to drop it, so caps are NOT credited as
+//     dropped (unlike Cloud Run, whose runtime strips capabilities).
+//
+// A fully hardened App Runner service therefore tops out at 48/100 (grade D) on the
+// managed-runtime floors alone (seccomp 15 + network 4 + docker.sock 15 + host-ns 10
+// + default-caps-retained 4). The strong Firecracker microVM boundary is surfaced as
+// an informational HardenedRuntime note but awards no points (scoring stays
+// runtime-agnostic per IRO-429). The honest takeaway the scan documents: App Runner
+// buys you microVM isolation but almost no config-expressible hardening surface.
+//
+// It is pure and unit-testable: the caller reads the file / runs the aws CLI (I/O)
+// and passes the JSON here. It fails OPEN on a malformed top-level document (returns
+// the parse error); the CLI wrapper turns that into a skip so an opt-in CI step never
+// crashes the build. A document with no App Runner service returns no specs.
+func SpecsFromAppRunner(raw []byte) ([]Spec, error) {
+	var doc appRunnerDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parse app runner service JSON: %w", err)
+	}
+	// describe-service wraps the service under {"Service": {...}}; a raw Service
+	// object carries the fields at the document root. Prefer the wrapper.
+	svc := doc.appRunnerService
+	if doc.Service != nil {
+		svc = *doc.Service
+	}
+	if !svc.isAppRunnerService() {
+		return nil, nil
+	}
+	return []Spec{specFromAppRunnerService(svc)}, nil
+}
+
+// AggregateAppRunner folds one or more App Runner service specs into a single Report.
+// Like AggregateCloudRun/AggregateAzure, the aggregate is the WEAKEST service
+// (minimum score): a deployment is only as isolated as its most-exposed service, so
+// grading the weakest link is the honest, fail-closed summary. target names the
+// source (file/dir). It returns the aggregate Report and the Spec that produced it
+// (for SARIF anchoring). It is pure; the caller injects Version/GeneratedAt.
+// Fail-closed: an empty service set is an error (a document that declares no App
+// Runner service is not a pass).
+func AggregateAppRunner(specs []Spec, target string) (Report, Spec, error) {
+	if len(specs) == 0 {
+		return Report{}, Spec{}, fmt.Errorf("no gradeable App Runner services found (looked for a describe-service document or a raw Service object with SourceConfiguration)")
+	}
+
+	all := make([]scoredWorkload, len(specs))
+	worst := 0
+	for i, s := range specs {
+		all[i] = scoredWorkload{spec: s, report: Score(s)}
+		if all[i].report.Score < all[worst].report.Score {
+			worst = i
+		}
+	}
+
+	agg := all[worst].report
+	worstSpec := all[worst].spec
+	if strings.TrimSpace(target) != "" {
+		agg.Target = target
+	}
+	agg.Source = "app-runner"
+	agg.Notes = append(appRunnerSummaryNotes(all[worst], all), agg.Notes...)
+
+	return agg, worstSpec, nil
+}
+
+// appRunnerSummaryNotes builds the deployment-level roll-up notes for an aggregate
+// App Runner report: a headline naming the weakest service and a per-service score
+// list.
+func appRunnerSummaryNotes(worst scoredWorkload, all []scoredWorkload) []string {
+	notes := []string{
+		fmt.Sprintf("graded %d App Runner service(s); the grade is the WEAKEST (a deployment is only as isolated as its most-exposed service). Weakest: %s at %d/100 (grade %s).",
+			len(all), nz(worst.spec.Target, "service"), worst.report.Score, worst.report.Grade),
+	}
+	sorted := make([]scoredWorkload, len(all))
+	copy(sorted, all)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].report.Score < sorted[j].report.Score })
+	rows := make([]string, len(sorted))
+	for i, w := range sorted {
+		rows[i] = fmt.Sprintf("%s = %d/100 (%s)", nz(w.spec.Target, "service"), w.report.Score, w.report.Grade)
+	}
+	notes = append(notes, "per-service: "+strings.Join(rows, "; "))
+	return notes
+}
+
+// --------------------------------------------------------------------------- //
+// AWS App Runner service document model.
+//
+// `aws apprunner describe-service` wraps the service under a top-level "Service"
+// key; a raw Service object (from the API/SDK) carries the fields at the root. Both
+// share the same PascalCase shape. App Runner exposes NO container securityContext,
+// so the security-relevant fields are limited to the network egress mode and the
+// (informational) source image / instance sizing.
+// --------------------------------------------------------------------------- //
+
+// appRunnerDoc accepts both input shapes at once: the describe-service wrapper
+// (Service) and a raw Service object (the embedded appRunnerService fields at the
+// document root).
+type appRunnerDoc struct {
+	Service *appRunnerService `json:"Service"`
+	appRunnerService
+}
+
+type appRunnerService struct {
+	ServiceName         string `json:"ServiceName"`
+	ServiceArn          string `json:"ServiceArn"`
+	SourceConfiguration struct {
+		ImageRepository *struct {
+			ImageIdentifier     string `json:"ImageIdentifier"`
+			ImageRepositoryType string `json:"ImageRepositoryType"`
+			ImageConfiguration  *struct {
+				Port string `json:"Port"`
+			} `json:"ImageConfiguration"`
+		} `json:"ImageRepository"`
+		CodeRepository *struct {
+			RepositoryUrl string `json:"RepositoryUrl"`
+		} `json:"CodeRepository"`
+	} `json:"SourceConfiguration"`
+	InstanceConfiguration struct {
+		Cpu             string `json:"Cpu"`
+		Memory          string `json:"Memory"`
+		InstanceRoleArn string `json:"InstanceRoleArn"`
+	} `json:"InstanceConfiguration"`
+	NetworkConfiguration struct {
+		EgressConfiguration *struct {
+			EgressType      string `json:"EgressType"`
+			VpcConnectorArn string `json:"VpcConnectorArn"`
+		} `json:"EgressConfiguration"`
+		IngressConfiguration *struct {
+			IsPubliclyAccessible *bool `json:"IsPubliclyAccessible"`
+		} `json:"IngressConfiguration"`
+	} `json:"NetworkConfiguration"`
+}
+
+// isAppRunnerService reports whether a decoded document is an App Runner service
+// worth grading. It matches on an App Runner service ARN or the presence of a
+// SourceConfiguration image/code repository, so an unrelated JSON object is not
+// mistaken for a service.
+func (svc appRunnerService) isAppRunnerService() bool {
+	if strings.Contains(strings.ToLower(svc.ServiceArn), ":apprunner:") {
+		return true
+	}
+	return svc.SourceConfiguration.ImageRepository != nil || svc.SourceConfiguration.CodeRepository != nil
+}
+
+// specFromAppRunnerService maps one App Runner service to a graded Spec. It grades an
+// EMPTY container securityContext through specFromPodSpec (App Runner exposes no
+// securityContext, so non-root / read-only rootfs / capabilities all grade
+// fail-closed exactly as an unset k8s container would), then folds in App Runner's
+// managed-runtime floors.
+func specFromAppRunnerService(svc appRunnerService) Spec {
+	name := strings.TrimSpace(svc.ServiceName)
+	target := "app-runner/" + nz(name, "service")
+
+	// App Runner has NO container securityContext: grade an empty pod spec so the
+	// user-hardenable dimensions (non-root, read-only rootfs, capabilities) fall to
+	// their fail-closed defaults, exactly like an unset k8s container.
+	ps := podSpec{Containers: []k8sContainer{{Name: name}}}
+	s := specFromPodSpec("app-runner", target, ps)
+
+	// The k8s pod-spec grader appends conservative notes that are WRONG for App
+	// Runner's managed runtime (it assumes an invisible NetworkPolicy governs egress,
+	// that seccomp is unconfined by default, and phrases non-root in k8s terms). Drop
+	// them; the managed floors below give concrete, honest answers.
+	s.Notes = dropNotesContaining(s.Notes,
+		"NetworkPolicy", "egress depends on", "no seccompProfile set", "no runAsNonRoot/runAsUser set")
+
+	// --- managed-runtime floors (platform-enforced, not spec-visible) ----------
+	// App Runner runs every service on AWS Fargate (a Firecracker microVM): there is
+	// no tenant host to share, so host PID/IPC/network namespaces and a host docker
+	// socket are unreachable, and privileged mode is not permitted. Credit them
+	// explicitly (the raw pod-spec grader scores them fail-closed / Unknown).
+	s.Privileged = No
+	s.HostPID = No
+	s.HostIPC = No
+	s.HostNetwork = No
+	s.DockerSock = No
+
+	// Capabilities: unlike Cloud Run (whose runtime strips all Linux capabilities),
+	// App Runner runs on Fargate, which RETAINS Docker's default capability set and
+	// exposes no knob to drop it. Grade it honestly as the default set retained (a
+	// FAIL earning partial credit), NOT as drop-all.
+	s.CapDropAll = No
+
+	// Fargate applies Docker's default seccomp profile: an unset profile is confined
+	// here, not unconfined (mirrors the docker/ecs default-profile mapping).
+	if strings.TrimSpace(s.Seccomp) == "" {
+		s.Seccomp = "confined"
+	}
+
+	// --- network (managed egress → honest WARN tier) --------------------------
+	// App Runner egress is managed (public by default, or routed through a VPC
+	// connector) and can never be network=none, so grade egress-capable (WARN).
+	egress := "app-runner (managed egress)"
+	if ec := svc.NetworkConfiguration.EgressConfiguration; ec != nil && strings.EqualFold(strings.TrimSpace(ec.EgressType), "VPC") {
+		egress = "app-runner (VPC egress)"
+	}
+	s.NetworkMode = egress
+
+	// Firecracker microVM isolation: surface it informationally (scoring stays
+	// runtime-agnostic per IRO-429, so no points are awarded for the runtime name).
+	s.Runtime = "firecracker"
+
+	// --- managed-runtime + honest-ceiling notes -------------------------------
+	s.Notes = append(s.Notes,
+		"AWS App Runner runs every service on AWS Fargate (a Firecracker microVM); host PID/IPC/network namespaces and a host docker.sock are not reachable, and privileged mode is not permitted — those dimensions pass by construction",
+		"App Runner's service configuration exposes NO container securityContext: you cannot set a non-root user, drop capabilities, or enable a read-only root filesystem, so those dimensions are graded fail-closed",
+		"managed runtime: Fargate applies Docker's default seccomp profile but RETAINS Docker's default capability set (App Runner gives no knob to drop it) — unlike Cloud Run, capabilities are not credited as dropped",
+		"a fully hardened App Runner service tops out at 48/100 (grade D): the managed-runtime floors (seccomp, network, no docker.sock, no host namespaces) are the only expressible wins — App Runner buys microVM isolation but almost no config-expressible hardening surface")
+
+	// Source image / instance sizing are informational evidence — not containment
+	// dimensions in the 7-dim scorer.
+	if img := svc.SourceConfiguration.ImageRepository; img != nil && strings.TrimSpace(img.ImageIdentifier) != "" {
+		s.Notes = append(s.Notes, "source image: "+strings.TrimSpace(img.ImageIdentifier)+" (informational — the image USER determines the runtime uid, which App Runner cannot override)")
+	} else if code := svc.SourceConfiguration.CodeRepository; code != nil {
+		s.Notes = append(s.Notes, "source: code repository build (App Runner builds and runs the image; the runtime uid is set by the managed builder)")
+	}
+	if cpu, mem := strings.TrimSpace(svc.InstanceConfiguration.Cpu), strings.TrimSpace(svc.InstanceConfiguration.Memory); cpu != "" || mem != "" {
+		s.Notes = append(s.Notes, fmt.Sprintf("instance sizing: cpu=%s memory=%s (informational — not a containment dimension)", nz(cpu, "default"), nz(mem, "default")))
+	}
+
+	return s
+}

--- a/internal/host/scan/apprunner_test.go
+++ b/internal/host/scan/apprunner_test.go
@@ -1,0 +1,200 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+// appRunnerDescribeService mirrors `aws apprunner describe-service` output: the
+// service wrapped under a top-level "Service" key, sourced from an ECR image with a
+// default (public) egress config.
+const appRunnerDescribeService = `{
+  "Service": {
+    "ServiceName": "web",
+    "ServiceArn": "arn:aws:apprunner:us-east-1:123456789012:service/web/abc123",
+    "SourceConfiguration": {
+      "ImageRepository": {
+        "ImageIdentifier": "public.ecr.aws/nginx/nginx:latest",
+        "ImageRepositoryType": "ECR_PUBLIC",
+        "ImageConfiguration": { "Port": "8080" }
+      }
+    },
+    "InstanceConfiguration": { "Cpu": "1024", "Memory": "2048" },
+    "NetworkConfiguration": {
+      "EgressConfiguration": { "EgressType": "DEFAULT" },
+      "IngressConfiguration": { "IsPubliclyAccessible": true }
+    }
+  }
+}`
+
+// appRunnerRawService is a raw Service object (no describe-service wrapper), routed
+// through a VPC connector for egress.
+const appRunnerRawService = `{
+  "ServiceName": "api",
+  "ServiceArn": "arn:aws:apprunner:eu-west-1:123456789012:service/api/def456",
+  "SourceConfiguration": {
+    "CodeRepository": { "RepositoryUrl": "https://github.com/acme/api" }
+  },
+  "InstanceConfiguration": { "Cpu": "2048", "Memory": "4096" },
+  "NetworkConfiguration": {
+    "EgressConfiguration": { "EgressType": "VPC", "VpcConnectorArn": "arn:aws:apprunner:eu-west-1:123456789012:vpcconnector/c/1/x" }
+  }
+}`
+
+func gradeAppRunner(t *testing.T, raw string) (Report, Spec) {
+	t.Helper()
+	specs, err := SpecsFromAppRunner([]byte(raw))
+	if err != nil {
+		t.Fatalf("SpecsFromAppRunner: %v", err)
+	}
+	report, worst, err := AggregateAppRunner(specs, "service.json")
+	if err != nil {
+		t.Fatalf("AggregateAppRunner: %v", err)
+	}
+	return report, worst
+}
+
+func TestAppRunnerHonestCeiling(t *testing.T) {
+	// App Runner exposes no securityContext, so non-root / read-only rootfs / caps
+	// all grade fail-closed. The managed floors (seccomp 15 + net 4 + sock 15 +
+	// host-ns 10 + default-caps-retained 4) sum to the honest 48/100 ceiling.
+	report, worst := gradeAppRunner(t, appRunnerDescribeService)
+	if report.Score != 48 || report.Grade != "D" {
+		t.Fatalf("App Runner service: got %d/100 (grade %s), want 48 (D) — the honest managed-runtime ceiling; notes: %v", report.Score, report.Grade, report.Notes)
+	}
+	if report.Source != "app-runner" {
+		t.Errorf("source = %q, want app-runner", report.Source)
+	}
+	// Managed-runtime floors must be credited, not fail-closed.
+	if worst.Privileged != No || worst.HostPID != No || worst.HostIPC != No || worst.HostNetwork != No {
+		t.Errorf("managed floors not applied: priv=%v hostPID=%v hostIPC=%v hostNet=%v", worst.Privileged, worst.HostPID, worst.HostIPC, worst.HostNetwork)
+	}
+	if worst.DockerSock != No {
+		t.Errorf("docker.sock should be impossible on App Runner: %v", worst.DockerSock)
+	}
+	if worst.Seccomp != "confined" {
+		t.Errorf("managed sandbox seccomp = %q, want confined", worst.Seccomp)
+	}
+	// Unexpressible dimensions: fail-closed.
+	if worst.RunAsNonRoot != Unknown {
+		t.Errorf("non-root = %v, want Unknown (App Runner cannot express a user)", worst.RunAsNonRoot)
+	}
+	if worst.ReadonlyRoot != Unknown {
+		t.Errorf("read-only rootfs = %v, want Unknown (App Runner has no such field)", worst.ReadonlyRoot)
+	}
+	// Capabilities are NOT credited as dropped (Fargate retains the default set).
+	if worst.CapDropAll != No {
+		t.Errorf("caps must NOT be credited as dropped on App Runner (Fargate retains defaults): CapDropAll=%v", worst.CapDropAll)
+	}
+}
+
+func TestAppRunnerSurfacesFirecracker(t *testing.T) {
+	report, worst := gradeAppRunner(t, appRunnerDescribeService)
+	if worst.Runtime != "firecracker" {
+		t.Errorf("runtime = %q, want firecracker (Fargate microVM)", worst.Runtime)
+	}
+	if !strings.Contains(strings.ToLower(report.HardenedRuntime), "firecracker") {
+		t.Errorf("App Runner should surface Firecracker as a hardened runtime; got %q", report.HardenedRuntime)
+	}
+}
+
+func TestAppRunnerRawServiceGraded(t *testing.T) {
+	// A raw Service object (no describe-service wrapper) with VPC egress must grade
+	// identically (App Runner has no config surface to vary the score).
+	report, worst := gradeAppRunner(t, appRunnerRawService)
+	if report.Score != 48 || report.Grade != "D" {
+		t.Fatalf("raw App Runner service: got %d/100 (grade %s), want 48 (D)", report.Score, report.Grade)
+	}
+	if !strings.Contains(worst.NetworkMode, "VPC") {
+		t.Errorf("VPC egress mode not surfaced: %q", worst.NetworkMode)
+	}
+	if !strings.Contains(worst.Target, "api") {
+		t.Errorf("service name not in target: %q", worst.Target)
+	}
+}
+
+func TestAppRunnerCeilingDocumented(t *testing.T) {
+	report, _ := gradeAppRunner(t, appRunnerDescribeService)
+	joined := strings.Join(report.Notes, " ")
+	if !strings.Contains(joined, "48/100") {
+		t.Errorf("the honest ceiling (48/100) should be documented in the notes: %v", report.Notes)
+	}
+	// The misleading k8s conservative notes must be gone.
+	if strings.Contains(joined, "NetworkPolicy") {
+		t.Errorf("k8s NetworkPolicy note must be dropped for App Runner: %v", report.Notes)
+	}
+}
+
+func TestAppRunnerWeakestServiceWins(t *testing.T) {
+	// Two services graded together: the aggregate is the weakest (both are 48 here,
+	// but the rollup note must reflect a 2-service grade).
+	specs, err := SpecsFromAppRunner([]byte(appRunnerDescribeService))
+	if err != nil {
+		t.Fatalf("SpecsFromAppRunner: %v", err)
+	}
+	more, err := SpecsFromAppRunner([]byte(appRunnerRawService))
+	if err != nil {
+		t.Fatalf("SpecsFromAppRunner: %v", err)
+	}
+	specs = append(specs, more...)
+	report, _, err := AggregateAppRunner(specs, "services")
+	if err != nil {
+		t.Fatalf("AggregateAppRunner: %v", err)
+	}
+	if !strings.Contains(strings.Join(report.Notes, " "), "graded 2 App Runner service") {
+		t.Errorf("expected 2 services graded; notes: %v", report.Notes)
+	}
+}
+
+func TestAppRunnerNonServiceSkipped(t *testing.T) {
+	// A JSON object that is not an App Runner service must not be graded.
+	specs, err := SpecsFromAppRunner([]byte(`{"foo": "bar", "Cluster": {"status": "ACTIVE"}}`))
+	if err != nil {
+		t.Fatalf("SpecsFromAppRunner: %v", err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("non-App-Runner JSON should be skipped; got %d specs", len(specs))
+	}
+	if _, _, err := AggregateAppRunner(specs, "x"); err == nil {
+		t.Error("AggregateAppRunner on an empty service set must error (fail-closed)")
+	}
+}
+
+func TestAppRunnerMalformedJSONErrors(t *testing.T) {
+	if _, err := SpecsFromAppRunner([]byte(`{"Service": {`)); err == nil {
+		t.Error("malformed JSON must return a parse error")
+	}
+}
+
+// TestAppRunnerCloudRunManagedFloorParity asserts that App Runner reuses the SAME
+// managed-runtime model as the sibling --cloudrun mode: on every dimension the two
+// managed runtimes both enforce by construction (no privileged, no host namespaces,
+// no docker.sock, a default seccomp profile, managed egress at the WARN tier), an App
+// Runner service and a Cloud Run service grade IDENTICALLY. The two intentionally
+// diverge only on the dimensions App Runner cannot express (non-root, read-only
+// rootfs, capabilities), which is what makes App Runner's honest ceiling lower.
+func TestAppRunnerCloudRunManagedFloorParity(t *testing.T) {
+	_, ar := gradeAppRunner(t, appRunnerDescribeService)
+	_, cr := gradeCloudRun(t, cloudRunBaselineService)
+
+	if ar.Privileged != cr.Privileged {
+		t.Errorf("privileged floor diverges: app-runner=%v cloudrun=%v", ar.Privileged, cr.Privileged)
+	}
+	if ar.HostPID != cr.HostPID || ar.HostIPC != cr.HostIPC || ar.HostNetwork != cr.HostNetwork {
+		t.Errorf("host-namespace floor diverges: app-runner(%v/%v/%v) cloudrun(%v/%v/%v)",
+			ar.HostPID, ar.HostIPC, ar.HostNetwork, cr.HostPID, cr.HostIPC, cr.HostNetwork)
+	}
+	if ar.DockerSock != cr.DockerSock {
+		t.Errorf("docker.sock floor diverges: app-runner=%v cloudrun=%v", ar.DockerSock, cr.DockerSock)
+	}
+	if ar.Seccomp != cr.Seccomp {
+		t.Errorf("seccomp floor diverges: app-runner=%q cloudrun=%q", ar.Seccomp, cr.Seccomp)
+	}
+	// Both are egress-capable managed runtimes → the network dimension scores the
+	// same WARN-tier points, even though the mode label differs.
+	arNet, _, _ := gradeNetwork(ar)
+	crNet, _, _ := gradeNetwork(cr)
+	if arNet != crNet {
+		t.Errorf("managed-egress network score diverges: app-runner=%d cloudrun=%d", arNet, crNet)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `ironctl scan --app-runner`, grading an **AWS App Runner** service from its `aws apprunner describe-service` JSON, a raw `Service` object, or a directory of them. Rounds out AWS coverage alongside `--ecs` and completes the managed-runtime family with `--cloudrun` (GCP) and `--azure` (ACI).

## Grading model — honest 48/100 (D)

App Runner runs every service on **AWS Fargate (a Firecracker microVM)**, so it reuses the `--cloudrun`/`--azure` managed-runtime model: host PID/IPC/network namespaces, a host `docker.sock`, and privileged mode are unreachable and pass by construction; Fargate's default seccomp profile is credited.

It grades **honestly lower** than Cloud Run (89/B) and ACI (79/B) — App Runner's service config exposes **no container `securityContext` at all**:

| Dimension | App Runner |
|---|---|
| Non-root user | not expressible (respects image `USER`) → fail-closed |
| Dropped capabilities | Fargate retains Docker defaults, no knob to drop → not credited |
| Seccomp | Fargate default profile → confined ✓ |
| Network | managed egress (public/VPC), never `network=none` → WARN |
| Read-only rootfs | no field (like ACI) → fail-closed |
| docker.sock | impossible → pass ✓ |
| Host namespaces | Firecracker microVM → pass ✓ |

A fully hardened service tops out at **48/100 (D)**: managed floors are the only expressible wins. The Firecracker boundary is surfaced informationally (no points, per IRO-429). This mirrors the IRO-532 (Azure) precedent of shipping the *honest* grade over the ticket's optimistic guess.

## Changes
- `internal/host/scan/apprunner.go` — `SpecsFromAppRunner` + `AggregateAppRunner` (weakest-service rollup), reusing `specFromPodSpec` + managed floors.
- `cmd/ironctl/scan.go` — `--app-runner` flag, run/load handlers (file + dir, fail-open per file), usage text.
- `apprunner_test.go` — honest 48/D ceiling, describe-service wrapper + raw shapes, VPC egress, fail-closed dims, Firecracker surfacing, and a **cloudrun managed-floor parity test**.
- `docs/scan.md` + `docs/scan-coverage.md` — how-to section + crawlable `#scan-app-runner` hub card and summary-table row under Cloud runtimes.

## Verification
- `CGO_ENABLED=1 go build ./...` green; `go vet` clean.
- `go test ./internal/host/scan/ ./cmd/ironctl/` → 302 passed.
- CLI smoke: table renders 48/D + Firecracker; `--min-score 75` gates (exit 1); malformed JSON fails open (exit 0).

## Security lenses
Read-only scan feature (host-side, daemon-free, no network). No trust-boundary, gateway, key-custody, or egress changes. Fail-open on parse errors (opt-in CI never crashes); fail-closed grading of unexpressible dimensions.

Closes IRO-542.