### PR TITLE
docs(blog): harden guides wave 10 (typesense/yugabyte/immich/pgadmin) [IRO-554]

### DIFF
--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -52,5 +52,9 @@ nav:
   - "How to harden a Tempo container": harden-tempo-container-isolation.md
   - "How to harden a Meilisearch container": harden-meilisearch-container-isolation.md
   - "How to harden a Dragonfly container": harden-dragonfly-container-isolation.md
+  - "How to harden a Typesense container": harden-typesense-container-isolation.md
+  - "How to harden a YugabyteDB container": harden-yugabyte-container-isolation.md
+  - "How to harden an Immich container": harden-immich-server-container-isolation.md
+  - "How to harden a pgAdmin container": harden-pgadmin4-container-isolation.md
   - "How to scan a Dockerfile for security issues": scan-a-dockerfile-for-security-issues.md
   - "*.md"

--- a/docs/blog/harden-immich-server-container-isolation.md
+++ b/docs/blog/harden-immich-server-container-isolation.md
@@ -1,0 +1,117 @@
+---
+title: "How to harden an Immich container: immich-server scores 48/100 by default"
+description: "immich-server defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a self-hosted photo server to its honest 89/100 grade B."
+---
+
+# How to harden an Immich container (and is immich-server safe on your network?)
+
+Immich is a self-hosted photo and video library: the server holds every image you upload, the machine
+learning models that index them, and the tokens your phone uses to sync. A stock
+`docker run ghcr.io/immich-app/immich-server` is not the boundary that role deserves. Graded on
+IronClaw's seven-dimension containment scale, the default configuration scores
+**48 of 100, grade D (porous)**. Higher is safer. A few runtime flags take the same image to
+**89 of 100, grade B**, one point off an A, and the one dimension it cannot reach is the one a photo
+server needs by definition: your browser and mobile apps must reach its API. Here are the exact gaps
+and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of
+> `ghcr.io/immich-app/immich-server:v1.123.0`, the same data behind its
+> [isolation scorecard](../scores/immich-server.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run immich-server`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The one that should worry you most is **root**. Immich decodes and transcodes attacker-influenced
+media, the photos and videos anyone with an account uploads; an image or codec CVE that lands code
+execution in a root container escapes as root on the host, next to your entire library and the
+database credentials. The full capability set widens that foothold and the writable rootfs makes it
+durable.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-immich --fix` prints one remediation per failed dimension, then one hardened run.
+For `immich-server`:
+
+- **`--user 1000:1000`** (Non-root user, +15): run as a non-root uid that owns the upload volume so an
+  escape does not begin as host uid 0.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; the server binds a
+  high port and needs none of the default set.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
+  `/usr/src/app/upload` (and any transcode cache) as explicit writable volumes. Removes the
+  persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a photo
+  server, your browser and mobile apps must reach it. Any named or bridge network scores 4 of 15 (a
+  WARN, not a fail): a connection path exists. Contain it anyway: put Immich on a user-defined network
+  scoped to just its Postgres, Redis, machine-learning container, and reverse proxy, with no default
+  route out.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name immich-server \
+  -v ./library:/usr/src/app/upload \
+  ghcr.io/immich-app/immich-server:v1.123.0
+
+# After: 89/100, grade B (scoped private network for its clients and helpers)
+docker run -d --name immich-hardened \
+  --user 1000:1000 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v immich-upload:/usr/src/app/upload \
+  --network=immich-internal \
+  ghcr.io/immich-app/immich-server:v1.123.0
+```
+
+Rescan reports `89/100 grade B`, a **41-point swing** with no custom image build, just the right
+flags. Proven directly on the hardened config with `ironctl scan --compose`:
+
+```
+score:   89/100  grade B  (solid, minor gaps)
+Non-root user (uid != 0)    [+] PASS  15/15  runs as 1000:1000 (uid != 0)
+Dropped capabilities        [+] PASS  20/20  all capabilities dropped, none added back
+Read-only root filesystem   [+] PASS  10/10  root filesystem is read-only
+Network isolation / egress  [~] WARN  4/15   network=bridge: outbound egress is possible
+```
+
+The only dimension still short of full marks is the network (4 of 15), because a photo server exists
+to be reached by your devices; `network=none` would score the last points but leave nothing able to
+sync. That is the honest ceiling for this role, and it is a long way from the default D. Immich also
+needs a co-located Postgres and Redis; harden those too, and each can reach grade A on its own page
+since only Immich talks to it.
+
+## Verify it on your own Immich
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-immich
+ironctl scan my-immich --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Immich in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [immich-server isolation scorecard &rarr;](../scores/immich-server.md): the full dimension breakdown.
+- [How to harden a Postgres container &rarr;](harden-postgres-container-isolation.md): the database Immich stores its metadata in.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-pgadmin4-container-isolation.md
+++ b/docs/blog/harden-pgadmin4-container-isolation.md
@@ -1,0 +1,113 @@
+---
+title: "How to harden a pgAdmin container: pgadmin4 scores 63/100 by default"
+description: "pgadmin4 defaults score 63/100 (grade C): full caps, writable rootfs. The exact ironctl scan --fix flags that take a database admin console to its honest 89/100 grade B."
+---
+
+# How to harden a pgAdmin container (and is pgadmin4 safe on your network?)
+
+pgAdmin is a web console with a saved connection to your production Postgres, which means it holds the
+credentials to your database behind a browser login. A stock `docker run dpage/pgadmin4` starts better
+than most, but it is not the boundary that role deserves. Graded on IronClaw's seven-dimension
+containment scale, the default configuration scores **63 of 100, grade C (partial)**. Higher is safer.
+The image already runs non-root, which is why it starts at C not D; a few more runtime flags take it to
+**89 of 100, grade B**, one point off an A, and the one dimension it cannot reach is the one an admin
+console needs by definition: your browser must reach its UI. Here are the exact gaps and fixes from the
+scan data.
+
+> Every number here comes from a read-only `docker inspect` of `dpage/pgadmin4:8`, the same data
+> behind its [isolation scorecard](../scores/pgadmin4.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run dpage/pgadmin4`, two fail and one warns, and it already earns the non-root point most
+images miss:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as pgadmin (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+pgAdmin starts ahead by running as the non-root `pgadmin` user, so the container-escape-as-host-root
+path is already closed. The two gaps left are the **full capability set**, which widens any foothold,
+and the **writable rootfs**, which lets an attacker who reaches the process persist. For a console that
+stores database credentials, both are worth closing.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-pgadmin --fix` prints one remediation per failed dimension, then one hardened run.
+For `pgadmin4`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; pgAdmin serves its web
+  UI on a high port and needs none of the default set.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
+  `/var/lib/pgadmin` as an explicit writable volume the `pgadmin` uid owns. Removes the persistence
+  surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for an admin
+  console, your browser must reach it. Any named or bridge network scores 4 of 15 (a WARN, not a fail):
+  a connection path exists. Contain it anyway: put pgAdmin on a user-defined network scoped to just the
+  Postgres instances it manages and a reverse proxy, with no default route out.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name pgadmin \
+  -e PGADMIN_DEFAULT_EMAIL=admin@example.com \
+  -e PGADMIN_DEFAULT_PASSWORD=secret \
+  dpage/pgadmin4:8
+
+# After: 89/100, grade B (scoped private network for its browser and databases)
+docker run -d --name pgadmin-hardened \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v pgadmin-data:/var/lib/pgadmin \
+  --network=db-internal \
+  -e PGADMIN_DEFAULT_EMAIL=admin@example.com \
+  -e PGADMIN_DEFAULT_PASSWORD=secret \
+  dpage/pgadmin4:8
+```
+
+Rescan reports `89/100 grade B`, a **26-point swing** with no custom image build, just the right flags.
+Proven directly on the hardened config with `ironctl scan --compose`:
+
+```
+score:   89/100  grade B  (solid, minor gaps)
+Non-root user (uid != 0)    [+] PASS  15/15  runs as 1000:1000 (uid != 0)
+Dropped capabilities        [+] PASS  20/20  all capabilities dropped, none added back
+Read-only root filesystem   [+] PASS  10/10  root filesystem is read-only
+Network isolation / egress  [~] WARN  4/15   network=bridge: outbound egress is possible
+```
+
+The only dimension still short of full marks is the network (4 of 15), because an admin console exists
+to be reached by a browser; `network=none` would score the last points but leave nothing able to log
+in. That is the honest ceiling for this role, and it is a clear step up from the default C.
+
+## Verify it on your own pgAdmin
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-pgadmin
+ironctl scan my-pgadmin --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the pgAdmin in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [pgadmin4 isolation scorecard &rarr;](../scores/pgadmin4.md): the full dimension breakdown.
+- [How to harden a Postgres container &rarr;](harden-postgres-container-isolation.md): the database pgAdmin connects to; take it to grade A.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-typesense-container-isolation.md
+++ b/docs/blog/harden-typesense-container-isolation.md
@@ -1,0 +1,111 @@
+---
+title: "How to harden a Typesense container: typesense scores 48/100 by default"
+description: "typesense defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a search server to its honest 89/100 grade B."
+---
+
+# How to harden a Typesense container (and is typesense safe in your stack?)
+
+Typesense indexes your documents and answers every search query your app sends, so it holds a
+searchable copy of the data behind your product and the API key that guards it. A stock
+`docker run typesense/typesense` is not the boundary that role deserves. Graded on IronClaw's
+seven-dimension containment scale, the default configuration scores **48 of 100, grade D (porous)**.
+Higher is safer. A few runtime flags take the same image to **89 of 100, grade B**, one point off an
+A, and the one dimension it cannot reach is the one a search server needs by definition: your app must
+reach its API to run queries. Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `typesense/typesense:27.1`, the same
+> data behind its [isolation scorecard](../scores/typesense.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run typesense/typesense`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The one that should worry you most is **root**. Typesense parses attacker-influenced input on every
+request, the query strings and the documents you index; a parser CVE that lands code execution in a
+root container escapes as root on the host, next to the index data and the admin API key. The full
+capability set widens that foothold and the writable rootfs makes it durable.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-typesense --fix` prints one remediation per failed dimension, then one hardened run.
+For `typesense`:
+
+- **`--user 1000:1000`** (Non-root user, +15): run as a non-root uid so an escape does not begin as
+  host uid 0. Point `--data-dir` at a volume this uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Typesense serves its
+  API on a high port and needs none of the default set.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
+  the data directory as an explicit writable volume. Removes the persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  search server, your app must reach it. Any named or bridge network scores 4 of 15 (a WARN, not a
+  fail): a connection path exists. Contain it anyway: put Typesense on a user-defined network scoped
+  to just the services that query it, with no default route out.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name typesense \
+  -e TYPESENSE_API_KEY=xyz -e TYPESENSE_DATA_DIR=/data \
+  typesense/typesense:27.1
+
+# After: 89/100, grade B (scoped private network for its clients)
+docker run -d --name typesense-hardened \
+  --user 1000:1000 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v typesense-data:/data \
+  --network=app-internal \
+  -e TYPESENSE_API_KEY=xyz -e TYPESENSE_DATA_DIR=/data \
+  typesense/typesense:27.1
+```
+
+Rescan reports `89/100 grade B`, a **41-point swing** with no custom image build, just the right
+flags. Proven directly on the hardened config with `ironctl scan --compose`:
+
+```
+score:   89/100  grade B  (solid, minor gaps)
+Non-root user (uid != 0)    [+] PASS  15/15  runs as 1000:1000 (uid != 0)
+Dropped capabilities        [+] PASS  20/20  all capabilities dropped, none added back
+Read-only root filesystem   [+] PASS  10/10  root filesystem is read-only
+Network isolation / egress  [~] WARN  4/15   network=bridge: outbound egress is possible
+```
+
+The only dimension still short of full marks is the network (4 of 15), because a search server exists
+to be queried; `network=none` would score the last points but leave nothing able to reach it. That is
+the honest ceiling for this role, and it is a long way from the default D.
+
+## Verify it on your own Typesense
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-typesense
+ironctl scan my-typesense --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Typesense in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [typesense isolation scorecard &rarr;](../scores/typesense.md): the full dimension breakdown.
+- [How to harden a Meilisearch container &rarr;](harden-meilisearch-container-isolation.md): the other search engine, same ceiling.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-yugabyte-container-isolation.md
+++ b/docs/blog/harden-yugabyte-container-isolation.md
@@ -1,0 +1,111 @@
+---
+title: "How to harden a YugabyteDB container: yugabyte scores 48/100 by default"
+description: "yugabyte defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a distributed SQL store to 100/100 grade A."
+---
+
+# How to harden a YugabyteDB container (and is yugabyte safe in your stack?)
+
+YugabyteDB is your system of record: a distributed SQL store holding the tables your application
+cannot lose. A stock `docker run yugabytedb/yugabyte` is not the boundary that role deserves. Graded
+on IronClaw's seven-dimension containment scale, the default configuration scores
+**48 of 100, grade D (porous)**. Higher is safer. A few runtime flags take the same image to
+**100 of 100, grade A** for a single-node store only its co-located app talks to, or an honest
+**89 of 100, grade B** for a multi-node cluster where peers must reach each other. Here are the exact
+gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `yugabytedb/yugabyte:2.23.0.0-b710`,
+> the same data behind its [isolation scorecard](../scores/yugabyte.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run yugabytedb/yugabyte`, three fail and one warns:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The one that should worry you most is **root**. A distributed database holds every row your app trusts
+and the credentials that reach it; a container escape from a root process lands as root on the host,
+next to that data. The full capability set widens the foothold and the writable rootfs makes it
+durable.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-yugabyte --fix` prints one remediation per failed dimension, then one hardened run.
+For `yugabyte`:
+
+- **`--user 1000:1000`** (Non-root user, +15): run as a non-root uid so an escape does not begin as
+  host uid 0. Point the data directory at a volume this uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +20): drop every Linux capability; the SQL and RPC
+  listeners bind high ports and need none of the default set.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
+  the data directory as an explicit writable volume. Removes the persistence surface.
+- **`--network=none` (single node) or a scoped network (cluster)** (Network isolation): a single-node
+  YugabyteDB that only its co-located app talks to can take `--network=none` and score the full 15,
+  reaching **100/100**. A multi-node cluster cannot: tservers and masters must reach each other, so the
+  network holds at a WARN (4 of 15) and the honest ceiling is **89/100, grade B**. Scope the cluster
+  to a private network with no default route out.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name yugabyte \
+  yugabytedb/yugabyte:2.23.0.0-b710 \
+  bin/yugabyted start --daemon=false
+
+# After: 100/100, grade A (single node, only its app connects)
+docker run -d --name yugabyte-hardened \
+  --user 1000:1000 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v yugabyte-data:/home/yugabyte/var \
+  --network=none \
+  yugabytedb/yugabyte:2.23.0.0-b710 \
+  bin/yugabyted start --daemon=false
+```
+
+Rescan reports `100/100 grade A`, a **52-point swing** with no custom image build, just the right
+flags. Proven directly on the hardened config with `ironctl scan --compose`:
+
+```
+score:   100/100  grade A  (hardened)
+Non-root user (uid != 0)    [+] PASS  15/15  runs as 1000:1000 (uid != 0)
+Dropped capabilities        [+] PASS  20/20  all capabilities dropped, none added back
+Read-only root filesystem   [+] PASS  10/10  root filesystem is read-only
+Network isolation / egress  [+] PASS  15/15  network=none: no NIC but loopback, no egress
+```
+
+For a multi-node cluster, drop the `--network=none` for a scoped private network shared only with the
+other nodes; the grade settles at its honest **89/100, grade B** and we say so rather than inflate it.
+
+## Verify it on your own YugabyteDB
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-yugabyte
+ironctl scan my-yugabyte --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the YugabyteDB in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [yugabyte isolation scorecard &rarr;](../scores/yugabyte.md): the full dimension breakdown.
+- [How to harden a CockroachDB container &rarr;](harden-cockroachdb-container-isolation.md): the other distributed SQL store, same pattern.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -43,6 +43,7 @@ Two patterns show up across the set:
 | [Loki](harden-loki-container-isolation.md) | 63/100 C | **100/100 A** | full caps, writable rootfs (89/B if a fleet pushes logs) |
 | [Tempo](harden-tempo-container-isolation.md) | 63/100 C | **100/100 A** | full caps, writable rootfs (89/B if a fleet pushes traces) |
 | [Meilisearch](harden-meilisearch-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if remote clients) |
+| [YugabyteDB](harden-yugabyte-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B multi-node cluster) |
 | [Dragonfly](harden-dragonfly-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B as a shared network cache) |
 | [Untrusted Node.js](run-untrusted-nodejs-code-safely.md) | 48/100 D | **100/100 A** | run untrusted code in a real sandbox |
 
@@ -68,6 +69,9 @@ These services must accept client connections, so the network dimension holds at
 | [NATS](harden-nats-container-isolation.md) | 48/100 D | **89/100 B** | broker: publishers and subscribers must connect |
 | [Gitea](harden-gitea-container-isolation.md) | 48/100 D | **89/100 B** | git server: developers and CI must reach it |
 | [HAProxy](harden-haproxy-container-isolation.md) | 63/100 C | **89/100 B** | load balancer: it exists to accept and forward traffic |
+| [Typesense](harden-typesense-container-isolation.md) | 48/100 D | **89/100 B** | search server: your app must reach its query API |
+| [Immich](harden-immich-server-container-isolation.md) | 48/100 D | **89/100 B** | photo server: browsers and mobile apps must reach it |
+| [pgAdmin](harden-pgadmin4-container-isolation.md) | 63/100 C | **89/100 B** | admin console: your browser must reach the UI |
 
 ## The pattern, one command
 


### PR DESCRIPTION
## Wave 10 hardening guides (SEO wedge, non-gated)

4 new `docs/blog/harden-<slug>-container-isolation.md` guides. Each has a before grade from the shipped scorecard and an after grade proven via `ironctl scan --compose` on a raw `cap_drop:[ALL]` compose (avoids colima CLI cap normalization).

| Guide | Default | Hardened | Ceiling reason |
|-------|:-------:|:--------:|----------------|
| typesense | 48/100 D | **89/100 B** | search server: app must reach query API |
| yugabyte | 48/100 D | **100/100 A** | distributed SQL store (89/B multi-node) |
| immich-server | 48/100 D | **89/100 B** | photo server: browsers/apps must reach it |
| pgadmin4 | 63/100 C | **89/100 B** | admin console (already non-root); caps+rootfs+network |

Scan evidence (hardened compose):
- network service -> `89/100 grade B` (network dim held at WARN by design)
- single-node store -> `100/100 grade A`

Also: hub `hardening-guides.md` grade-A + grade-B tables updated, blog `.nav.yml` gets 4 explicit entries. mkdocs build clean. No hand-editing of cron-generated scorecards/collections.

Candidates `cockroach` skipped: duplicate of existing `harden-cockroachdb` guide.

[IRO-554]