### PR TITLE
feat(scan): add --openshift to grade DeploymentConfig / OpenShift manifests [IRO-553]

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -59,6 +59,7 @@ func cmdScan(args []string) error {
 	kustomize := fs.String("kustomize", "", "render a kustomization directory with `kustomize build` (or `kubectl kustomize`) and grade the isolation posture of its workloads")
 	kustomizeBin := fs.String("kustomize-bin", envOrDefault("KUSTOMIZE", "kustomize"), "kustomize binary used to render the directory (falls back to `kubectl kustomize` if absent)")
 	kubectlBin := fs.String("kubectl-bin", envOrDefault("KUBECTL", "kubectl"), "kubectl binary used for `kubectl kustomize` when the kustomize binary is absent")
+	openshift := fs.String("openshift", "", "grade OpenShift workloads (DeploymentConfig, Deployment, Pod) in a manifest file (`oc get -o yaml`) or a directory of them")
 	dockerfile := fs.Bool("dockerfile", false, "statically grade the positional Dockerfile(s) authoring-time posture (daemon-free)")
 	runtime := fs.String("runtime", envOrDefault("IRONCTL_SCAN_RUNTIME", "auto"), "container runtime: auto|docker|podman|nerdctl")
 	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker inspect`")
@@ -335,6 +336,28 @@ func cmdScan(args []string) error {
 			badgeJSON:    *badgeJSON,
 			sarif:        *sarif,
 			minScore:     *minScore,
+		})
+	}
+
+	// --openshift: consume an OpenShift manifest set (an `oc get -o yaml` export, a
+	// raw manifest file, or a directory of them) and grade its workloads. An
+	// OpenShift DeploymentConfig embeds a standard k8s PodSpec at spec.template.spec,
+	// so this reuses the SAME pod-spec scorer as --k8s/--kustomize with the same
+	// weakest-link aggregate; plain Deployment/Pod docs in the same stream grade too
+	// and OpenShift-only kinds (Route, ImageStream, …) are skipped. Manifests are
+	// plain YAML, so there is no external binary to shell out to. It reads the
+	// file(s) here then defers to the pure SpecsFromOpenShift + AggregateOpenShift
+	// scorer. Fail-OPEN on a load/parse failure so an opt-in CI/Action step never
+	// crashes the build; --min-score still gates once workloads are graded.
+	if *openshift != "" {
+		return runOpenShiftScan(openShiftScanArgs{
+			path:      *openshift,
+			asJSON:    *asJSON,
+			md:        *md,
+			badge:     *badge,
+			badgeJSON: *badgeJSON,
+			sarif:     *sarif,
+			minScore:  *minScore,
 		})
 	}
 
@@ -1303,6 +1326,129 @@ func loadCloudRunYAML(path string) ([]byte, error) {
 	return bytes.Join(docs, []byte("\n---\n")), nil
 }
 
+// openShiftScanArgs carries the resolved inputs for a `scan --openshift` run.
+type openShiftScanArgs struct {
+	path      string
+	asJSON    bool
+	md        bool
+	badge     string
+	badgeJSON string
+	sarif     string
+	minScore  int
+}
+
+// runOpenShiftScan grades the OpenShift workloads declared in a manifest set (a
+// DeploymentConfig, a plain Deployment/Pod, or a directory of them), reusing the
+// same pod-spec dimension mapping and weakest-link aggregate as --k8s/--kustomize.
+// OpenShift manifests are plain YAML, so there is no external binary to shell out
+// to. It fails OPEN on a load/parse failure (unreadable path, malformed YAML): it
+// prints a clear diagnostic to stderr and returns nil so an opt-in CI/Action step
+// never crashes the build. Once workloads are graded, scoring and the --min-score
+// CI gate apply exactly like --k8s/--kustomize (a genuinely low posture still
+// fails the gate).
+func runOpenShiftScan(a openShiftScanArgs) error {
+	raw, err := loadOpenShiftYAML(a.path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --openshift could not load %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	specs, err := scan.SpecsFromOpenShift(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --openshift could not parse %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregateOpenShift(specs, filepath.Base(strings.TrimRight(a.path, "/")))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --openshift found nothing to grade in %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (workloads graded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// loadOpenShiftYAML resolves a --openshift argument to an OpenShift manifest
+// stream. A file is read verbatim (it may itself be a multi-document
+// `---`-separated stream, e.g. `oc get all -o yaml`). A directory is walked for
+// *.yaml/*.yml/*.json files, concatenated into one document stream (weakest-
+// workload rollup across the set). It is offline and daemon-free: OpenShift
+// manifests are plain YAML/JSON, so there is nothing to shell out to.
+func loadOpenShiftYAML(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return os.ReadFile(path)
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	var docs [][]byte
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(e.Name()))
+		if ext != ".yaml" && ext != ".yml" && ext != ".json" {
+			continue
+		}
+		raw, rerr := os.ReadFile(filepath.Join(path, e.Name()))
+		if rerr != nil {
+			return nil, rerr
+		}
+		docs = append(docs, raw)
+	}
+	if len(docs) == 0 {
+		return nil, fmt.Errorf("no .yaml/.yml/.json files found in directory %q", path)
+	}
+	return bytes.Join(docs, []byte("\n---\n")), nil
+}
+
 // cloudFormationScanArgs carries the resolved inputs for a `scan --cloudformation` run.
 type cloudFormationScanArgs struct {
 	path      string
@@ -2103,6 +2249,7 @@ USAGE:
   ironctl scan --azure PATH                     grade Azure Container Instances (ARM template / az container show JSON or dir)
   ironctl scan --app-runner PATH                grade an AWS App Runner service (apprunner describe-service JSON / dir)
   ironctl scan --kustomize DIR                  render a kustomization (kustomize build) and grade its workloads
+  ironctl scan --openshift PATH                 grade OpenShift workloads (DeploymentConfig/Deployment/Pod) in a manifest file or dir
   ironctl scan --dockerfile FILE...           grade Dockerfile(s) statically (no daemon, no pull)
   ironctl scan --compare A B                   diff two containers' isolation posture
 
@@ -2225,6 +2372,18 @@ as its most-exposed pod); every workload's score is listed in the notes. As with
 is graded conservatively (the honest static ceiling). Render failures (neither
 kustomize nor kubectl on PATH / build error) fail OPEN (diagnostic + exit 0); a
 successful render still trips --min-score.
+
+--openshift grades the workloads in an OpenShift manifest set — an `+"`oc get -o yaml`"+`
+export, a raw manifest file, or a directory of them. An OpenShift DeploymentConfig
+(apps.openshift.io/v1) embeds a standard Kubernetes PodSpec at spec.template.spec,
+so it reuses the SAME pod-spec scorer as --k8s/--kustomize with no new dimensions;
+plain Deployment/Pod docs in the same stream grade too and OpenShift-only kinds
+(Route, ImageStream, BuildConfig, …) are skipped. The set grade is the WEAKEST
+workload (a manifest set is only as isolated as its most-exposed pod); every
+workload's score is listed in the notes. As with --k8s, network egress depends on a
+NetworkPolicy a pod spec does not carry, so it is graded conservatively. Manifests
+are plain YAML/JSON (no external binary); a load/parse failure fails OPEN
+(diagnostic + exit 0) and a successful parse still trips --min-score.
 
 --pulumi grades the container workloads declared in Pulumi program output — a
 `+"`pulumi stack export`"+` checkpoint or `+"`pulumi preview --json`"+` (or a directory of

--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -160,6 +160,20 @@ roll up to the **weakest** workload they produce.
 
     [:octicons-arrow-right-24: Scan reference](scan.md)
 
+-   #### :simple-redhatopenshift:{ .lg .middle } OpenShift manifest { #scan-openshift }
+
+    ---
+
+    Grades an OpenShift manifest set (**DeploymentConfig**, Deployment, Pod). A
+    DeploymentConfig embeds a standard pod spec, so it reuses the k8s scorer and rolls up
+    to the **weakest** workload.
+
+    ```bash
+    ironctl scan --openshift ./manifests
+    ```
+
+    [:octicons-arrow-right-24: Scan reference](scan.md)
+
 </div>
 
 ### Cloud runtimes { #modes-cloud }
@@ -304,6 +318,7 @@ the container they eventually produce are all measured on one comparable scale.
 | Compose &amp; orchestrators | [Helm chart](#scan-helm) | `--helm` | weakest workload from `helm template` | [Scan reference](scan.md) |
 | Compose &amp; orchestrators | [Kustomize overlay](#scan-kustomize) | `--kustomize` | weakest workload from `kustomize build` | [Grade a kustomization](scan.md#grade-a-kustomization) |
 | Compose &amp; orchestrators | [Nomad job](#scan-nomad) | `--nomad` | docker-driver tasks in a job spec | [Scan reference](scan.md) |
+| Compose &amp; orchestrators | [OpenShift manifest](#scan-openshift) | `--openshift` | weakest workload (DeploymentConfig/Deployment/Pod) | [Scan reference](scan.md) |
 | Cloud runtimes | [Cloud Run](#scan-cloudrun) | `--cloudrun` | a Knative Service's container config | [Grade a Cloud Run service](scan.md#grade-a-google-cloud-run-service) |
 | Cloud runtimes | [Amazon ECS](#scan-ecs) | `--ecs` | a task definition's container contract | [Grade an ECS task definition](scan.md#grade-an-aws-ecs-task-definition) |
 | Cloud runtimes | [Azure Container Instances](#scan-azure) | `--azure` | weakest container in an ARM `containerGroups` | [Grade an Azure container group](scan.md#grade-an-azure-container-group) |

--- a/internal/host/scan/helm.go
+++ b/internal/host/scan/helm.go
@@ -23,6 +23,12 @@ var workloadKinds = map[string]bool{
 	"ReplicationController": true,
 	"Job":                   true,
 	"CronJob":               true,
+	// OpenShift DeploymentConfig (apps.openshift.io/v1) embeds a standard k8s
+	// PodSpec at spec.template.spec, identical to a Deployment, so the shared
+	// pod-spec extraction grades it with no new scorer. Recognized here so an
+	// OpenShift manifest set (--openshift) and any helm/kustomize/pulumi stream
+	// that emits one grades the workload rather than silently skipping it.
+	"DeploymentConfig": true,
 }
 
 // SpecsFromK8sStream parses a multi-document Kubernetes YAML stream (the output

--- a/internal/host/scan/openshift.go
+++ b/internal/host/scan/openshift.go
@@ -1,0 +1,31 @@
+package scan
+
+// SpecsFromOpenShift parses a multi-document OpenShift manifest stream (an
+// `oc get -o yaml` export, a raw manifest file, or a directory of them
+// concatenated) and returns one Spec per gradeable workload, in document order.
+// It is the OpenShift-sourced twin of SpecsFromK8sStream/SpecsFromKustomize:
+// identical multi-doc parsing and workload selection, only the Spec.Source label
+// differs ("openshift") so reports name the input mode. An OpenShift
+// DeploymentConfig (apiVersion apps.openshift.io/v1) embeds a standard Kubernetes
+// PodSpec at spec.template.spec — the exact shape a plain Deployment uses — so
+// the shared k8s pod-spec extraction grades it with no new scorer. Plain
+// Deployment/StatefulSet/DaemonSet/Job/CronJob/Pod docs in the same stream are
+// graded too; OpenShift-only kinds (Route, ImageStream, BuildConfig, …) and the
+// DeploymentConfig's own non-pod fields (triggers, strategy, replicas) carry no
+// pod spec and are skipped. It is pure and unit-testable: the caller reads the
+// manifest(s) (I/O) and passes the stream here.
+func SpecsFromOpenShift(rendered []byte) ([]Spec, error) {
+	return specsFromK8sStreamSource(rendered, "openshift")
+}
+
+// AggregateOpenShift folds the per-workload specs of an OpenShift manifest set
+// into a single Report representing its isolation posture. Like AggregateHelm and
+// AggregateKustomize it is the WEAKEST workload (minimum score): a manifest set
+// is only as isolated as its most-exposed pod, so grading the weakest link is the
+// honest, fail-closed summary. target names the source file/directory for the
+// report. It is pure; the caller injects Version/GeneratedAt. Fail-closed: an
+// empty workload set is an error (a manifest set with no gradeable workload is not
+// a pass).
+func AggregateOpenShift(specs []Spec, target string) (Report, Spec, error) {
+	return aggregateWeakestWorkload(specs, target, "openshift", "manifest set")
+}

--- a/internal/host/scan/openshift_test.go
+++ b/internal/host/scan/openshift_test.go
@@ -1,0 +1,220 @@
+package scan
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// openShiftManifests mimics an `oc get -o yaml` export: a hardened OpenShift
+// DeploymentConfig (which embeds a standard k8s PodSpec at spec.template.spec and
+// carries OpenShift-only triggers/strategy fields that must be ignored), a
+// non-workload Route that must be skipped, and a porous plain Pod that sets the
+// set grade. The DeploymentConfig's pod spec is byte-for-byte a k8s pod template,
+// so the openshift path must agree with the raw --k8s stream path on the same YAML.
+const openShiftManifests = `
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: web
+spec:
+  to:
+    kind: Service
+    name: web
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: web
+spec:
+  replicas: 3
+  triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames: [web]
+  strategy:
+    type: Rolling
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: web
+          image: web:1
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: porous
+spec:
+  hostPID: true
+  hostNetwork: true
+  containers:
+    - name: app
+      image: nginx
+      securityContext:
+        privileged: true
+`
+
+func TestSpecsFromOpenShift_LabelsSourceGradesDCSkipsNonWorkloads(t *testing.T) {
+	specs, err := SpecsFromOpenShift([]byte(openShiftManifests))
+	if err != nil {
+		t.Fatalf("SpecsFromOpenShift: %v", err)
+	}
+	// DeploymentConfig + Pod graded; Route skipped.
+	if len(specs) != 2 {
+		t.Fatalf("want 2 workloads (DeploymentConfig+Pod), got %d: %+v", len(specs), specs)
+	}
+	if specs[0].Target != "DeploymentConfig/web" {
+		t.Errorf("first workload target: want DeploymentConfig/web, got %q", specs[0].Target)
+	}
+	for _, s := range specs {
+		if s.Source != "openshift" {
+			t.Errorf("source: want openshift, got %q", s.Source)
+		}
+	}
+}
+
+// TestOpenShift_ParityWithK8sStream is the acceptance parity test: the workloads
+// SpecsFromOpenShift extracts must score identically to the same manifests parsed
+// by the shared k8s stream path (a DeploymentConfig's embedded pod spec grades
+// exactly like the equivalent Deployment). Only the Source label differs.
+func TestOpenShift_ParityWithK8sStream(t *testing.T) {
+	oSpecs, err := SpecsFromOpenShift([]byte(openShiftManifests))
+	if err != nil {
+		t.Fatalf("SpecsFromOpenShift: %v", err)
+	}
+	kSpecs, err := SpecsFromK8sStream([]byte(openShiftManifests))
+	if err != nil {
+		t.Fatalf("SpecsFromK8sStream: %v", err)
+	}
+	if len(oSpecs) != len(kSpecs) {
+		t.Fatalf("workload count mismatch: openshift=%d k8s-stream=%d", len(oSpecs), len(kSpecs))
+	}
+	for i := range oSpecs {
+		o, k := oSpecs[i], kSpecs[i]
+		if o.Target != k.Target {
+			t.Errorf("workload %d target mismatch: %q vs %q", i, o.Target, k.Target)
+		}
+		or, kr := Score(o), Score(k)
+		if or.Score != kr.Score || or.Grade != kr.Grade {
+			t.Errorf("workload %d score mismatch: openshift=%d/%s k8s=%d/%s",
+				i, or.Score, or.Grade, kr.Score, kr.Grade)
+		}
+		o.Source, k.Source = "", ""
+		if !reflect.DeepEqual(o, k) {
+			t.Errorf("workload %d spec mismatch (ignoring Source):\n openshift=%+v\n k8s      =%+v", i, o, k)
+		}
+	}
+}
+
+func TestAggregateOpenShift_WeakestWorkloadGovernsAndIdentity(t *testing.T) {
+	specs, err := SpecsFromOpenShift([]byte(openShiftManifests))
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, worst, err := AggregateOpenShift(specs, "app-manifests")
+	if err != nil {
+		t.Fatalf("AggregateOpenShift: %v", err)
+	}
+	if report.Source != "openshift" || report.Target != "app-manifests" {
+		t.Errorf("aggregate identity: source=%q target=%q", report.Source, report.Target)
+	}
+	// The privileged, host-namespace pod must set the set grade, not the hardened DC.
+	if worst.Target != "Pod/porous" {
+		t.Errorf("weakest workload: want Pod/porous, got %q", worst.Target)
+	}
+	if report.Grade != "F" {
+		t.Errorf("set grade: want F (privileged pod), got %s (score %d)", report.Grade, report.Score)
+	}
+	joined := strings.Join(report.Notes, "\n")
+	if !strings.Contains(joined, "graded 2 rendered workload(s)") {
+		t.Errorf("missing workload-count note: %q", joined)
+	}
+	if !strings.Contains(joined, "manifest set") {
+		t.Errorf("roll-up note should name the manifest-set unit: %q", joined)
+	}
+	if !strings.Contains(joined, "per-workload:") {
+		t.Errorf("missing per-workload roll-up: %q", joined)
+	}
+}
+
+// TestOpenShift_DeploymentConfigParityWithDeployment proves a DeploymentConfig
+// grades identically to the equivalent plain Deployment: same embedded pod spec,
+// same score, and the OpenShift-only triggers/strategy/replicas fields are ignored.
+func TestOpenShift_DeploymentConfigParityWithDeployment(t *testing.T) {
+	const dc = `
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: web
+spec:
+  triggers: [{type: ConfigChange}]
+  strategy: {type: Rolling}
+  template:
+    spec:
+      containers:
+        - name: web
+          image: web:1
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities: {drop: [ALL]}
+`
+	const deploy = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  template:
+    spec:
+      containers:
+        - name: web
+          image: web:1
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities: {drop: [ALL]}
+`
+	dcSpecs, err := SpecsFromOpenShift([]byte(dc))
+	if err != nil {
+		t.Fatalf("SpecsFromOpenShift(dc): %v", err)
+	}
+	depSpecs, err := SpecsFromK8sStream([]byte(deploy))
+	if err != nil {
+		t.Fatalf("SpecsFromK8sStream(deploy): %v", err)
+	}
+	if len(dcSpecs) != 1 || len(depSpecs) != 1 {
+		t.Fatalf("want 1 workload each, got dc=%d deploy=%d", len(dcSpecs), len(depSpecs))
+	}
+	if Score(dcSpecs[0]).Score != Score(depSpecs[0]).Score {
+		t.Errorf("DeploymentConfig and Deployment must score identically: dc=%d deploy=%d",
+			Score(dcSpecs[0]).Score, Score(depSpecs[0]).Score)
+	}
+	// Ignoring Source and Target, the graded pod spec must be identical.
+	d, p := dcSpecs[0], depSpecs[0]
+	d.Source, p.Source = "", ""
+	d.Target, p.Target = "", ""
+	if !reflect.DeepEqual(d, p) {
+		t.Errorf("DeploymentConfig pod spec != Deployment pod spec:\n dc    =%+v\n deploy=%+v", d, p)
+	}
+}
+
+func TestAggregateOpenShift_NoWorkloadsIsError(t *testing.T) {
+	if _, _, err := AggregateOpenShift(nil, "empty"); err == nil {
+		t.Fatal("want error for empty workload set (fail-closed), got nil")
+	}
+}


### PR DESCRIPTION
## What

Adds `ironctl scan --openshift <path>` to grade OpenShift workloads (DeploymentConfig, Deployment, Pod) in a manifest file or a directory of them.

An OpenShift **DeploymentConfig** (`apps.openshift.io/v1`) embeds a standard Kubernetes PodSpec at `spec.template.spec` — identical shape to a plain Deployment — so this reuses the **shared k8s pod-spec extraction** (`specsFromK8sStreamSource`) and **weakest-workload rollup** (`aggregateWeakestWorkload`), the same seam `--helm`/`--kustomize` use. **No new scorer.**

## How

- `SpecsFromOpenShift` + `AggregateOpenShift` thin seam in `openshift.go` (source `openshift`, noun `manifest set`).
- `DeploymentConfig` added to the shared `workloadKinds` set; its embedded pod spec grades identically to a Deployment. OpenShift-only kinds (Route/ImageStream/BuildConfig) and DC `triggers`/`strategy`/`replicas` carry no pod spec → skipped/ignored gracefully.
- `runOpenShiftScan` + `loadOpenShiftYAML`: file or dir of `.yaml/.yml/.json`, offline & daemon-free, **fail-OPEN** on load/parse, `--min-score` CI gate once workloads graded.
- `#scan-openshift` card in `docs/scan-coverage.md` (Orchestrators category) + summary-table row; `:simple-redhatopenshift:` icon (bundled).

## Acceptance criteria

- [x] Parses DeploymentConfig (`apps.openshift.io/v1`) + plain Deployment/Pod in one stream.
- [x] Reuses shared k8s spec extraction; no new scorer.
- [x] Parity test: `reflect.DeepEqual` vs equivalent `--k8s` input (same podSpec grades identically) + DeploymentConfig-vs-Deployment parity proof.
- [x] OpenShift-specific triggers/params ignored (non-pod fields).
- [x] `#scan-openshift` card in hub + Orchestrators category.

## Verify

- `CGO_ENABLED=1 go build ./...` ✓, `go vet` ✓, `gofmt -l` clean.
- `go test ./internal/host/scan/ ./cmd/ironctl/` → **312 passed** (incl. new parity + DC tests).
- Dogfood: `scan --openshift` on a DeploymentConfig+Route manifest → DeploymentConfig graded 64/C, Route skipped, weakest-workload rollup shown.
- `mkdocs build` ✓ — card renders, icon resolves to inline SVG.

## Lenses

- **Build matrix fidelity / reproducibility**: pure-Go additions, CGO build green; no external binary in the scan path (static YAML).
- No signing/attestation/required-checks/installer surface touched.