### PR TITLE
feat(scan): ironctl scan --cdk grades AWS CDK synth output [IRO-552]

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -56,6 +56,8 @@ func cmdScan(args []string) error {
 	bicep := fs.String("bicep", "", "compile an Azure Bicep template (.bicep file or a directory of them) to ARM and grade the Microsoft.ContainerInstance/containerGroups it declares")
 	bicepBin := fs.String("bicep-bin", envOrDefault("BICEP", "bicep"), "standalone bicep binary used to compile a .bicep to ARM (`bicep build --stdout`); falls back to `az bicep build` if absent")
 	azBin := fs.String("az-bin", envOrDefault("AZ", "az"), "azure-cli binary used for the `az bicep build` fallback when the standalone bicep binary is absent")
+	cdk := fs.String("cdk", "", "grade an AWS CDK app: a CDK app dir (synthesized with `cdk synth`) OR a pre-synthesized CloudFormation template file/dir; grades the AWS::ECS::TaskDefinition resources it emits")
+	cdkBin := fs.String("cdk-bin", envOrDefault("CDK", "cdk"), "aws-cdk binary used to run `cdk synth` on a CDK app directory (falls back to `cdk.out` templates if the app is already synthesized)")
 	kustomize := fs.String("kustomize", "", "render a kustomization directory with `kustomize build` (or `kubectl kustomize`) and grade the isolation posture of its workloads")
 	kustomizeBin := fs.String("kustomize-bin", envOrDefault("KUSTOMIZE", "kustomize"), "kustomize binary used to render the directory (falls back to `kubectl kustomize` if absent)")
 	kubectlBin := fs.String("kubectl-bin", envOrDefault("KUBECTL", "kubectl"), "kubectl binary used for `kubectl kustomize` when the kustomize binary is absent")
@@ -307,6 +309,28 @@ func cmdScan(args []string) error {
 			path:      *bicep,
 			bicepBin:  *bicepBin,
 			azBin:     *azBin,
+			asJSON:    *asJSON,
+			md:        *md,
+			badge:     *badge,
+			badgeJSON: *badgeJSON,
+			sarif:     *sarif,
+			minScore:  *minScore,
+		})
+	}
+
+	// --cdk: grade an AWS CDK app. The CDK is a program that SYNTHESIZES a standard
+	// CloudFormation template, so this is a thin front-door over --cloudformation: if
+	// the path is a CDK app dir it is synthesized with `cdk synth` (I/O here), and a
+	// pre-synthesized template file/dir (or a synthesized `cdk.out`) is graded directly.
+	// Either way the emitted CloudFormation is decoded by the SAME shared ECS scorer as
+	// --cloudformation/--ecs/--terraform (SpecsFromCDK -> SpecsFromCloudFormation). It
+	// fails OPEN on a synth/parse failure (cdk absent or a bad app) so an opt-in CI step
+	// never crashes the build; --min-score still gates once containers are graded.
+	// Unresolvable CDK tokens / CFN intrinsics are graded fail-closed and noted.
+	if *cdk != "" {
+		return runCDKScan(cdkScanArgs{
+			path:      *cdk,
+			cdkBin:    *cdkBin,
 			asJSON:    *asJSON,
 			md:        *md,
 			badge:     *badge,
@@ -1965,6 +1989,240 @@ func isBicepFileExt(name string) bool {
 	return strings.ToLower(filepath.Ext(name)) == ".bicep"
 }
 
+// cdkScanArgs carries the resolved inputs for a `scan --cdk` run.
+type cdkScanArgs struct {
+	path      string
+	cdkBin    string
+	asJSON    bool
+	md        bool
+	badge     string
+	badgeJSON string
+	sarif     string
+	minScore  int
+}
+
+// runCDKScan grades an AWS CDK app by way of the CloudFormation template its
+// `cdk synth` step emits, reusing the SAME shared ECS scorer as
+// --cloudformation/--ecs/--terraform (the CDK synthesizes standard CFN). It accepts a
+// CDK app dir (synthesized here), a pre-synthesized template file, or a synthesized
+// cdk.out / template directory. It fails OPEN on a synth/parse failure (aws-cdk absent,
+// a bad app, unreadable path): it prints a clear diagnostic to stderr and returns nil
+// so an opt-in CI/Action step never crashes the build over tooling. Once containers are
+// graded, scoring and the --min-score CI gate apply exactly like --cloudformation.
+// Unresolvable CDK tokens / CFN intrinsics are graded fail-closed and noted.
+func runCDKScan(a cdkScanArgs) error {
+	specs, usedIntrinsics, err := loadCDKSpecs(a.cdkBin, a.path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --cdk could not synth/load %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregateCDK(specs, filepath.Base(strings.TrimRight(a.path, "/")))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --cdk found nothing to grade in %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+	if usedIntrinsics {
+		report.Notes = append(report.Notes, "synthesized template uses CloudFormation intrinsics / unresolved CDK tokens (!Ref/!Sub/Fn::.../${Token[...]}): unresolved values are graded as unset (fail-closed) — verify the deployed stack matches.")
+	}
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (containers graded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// cdkTemplate is one synthesized CloudFormation template blob plus its source name
+// (for per-file diagnostics in a directory rollup).
+type cdkTemplate struct {
+	name string
+	raw  []byte
+}
+
+// loadCDKSpecs resolves a --cdk argument to graded Specs. A single file is treated as
+// an already-synthesized CloudFormation template and parsed directly. A directory is a
+// weakest-container rollup: a CDK app dir (one containing cdk.json) is synthesized with
+// `cdk synth`, and any other directory is read as a set of pre-synthesized templates
+// (e.g. a checked-in cdk.out cloud assembly, or a plain template dir). Every template's
+// container specs are pooled, so AggregateCDK grades the single most-exposed container
+// across the whole app. The bool reports whether any template used intrinsics/tokens
+// that were skipped (graded fail-closed).
+func loadCDKSpecs(cdkBin, path string) ([]scan.Spec, bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, false, err
+	}
+	if !info.IsDir() {
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil, false, rerr
+		}
+		return scan.SpecsFromCDK(raw)
+	}
+
+	templates, err := cdkTemplateBytes(cdkBin, path)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(templates) == 0 {
+		return nil, false, fmt.Errorf("no synthesized CloudFormation templates found for CDK path %q (synthesize with `cdk synth`, or point --cdk at a template file / cdk.out dir)", path)
+	}
+
+	var specs []scan.Spec
+	usedIntrinsics := false
+	for _, t := range templates {
+		fileSpecs, intr, perr := scan.SpecsFromCDK(t.raw)
+		if perr != nil {
+			// A single malformed template in the assembly should not sink the rollup:
+			// skip it with a diagnostic and grade the rest (fail-open per file).
+			fmt.Fprintf(os.Stderr, "  warning: scan --cdk skipping %s (parse error): %v\n", t.name, perr)
+			continue
+		}
+		specs = append(specs, fileSpecs...)
+		usedIntrinsics = usedIntrinsics || intr
+	}
+	return specs, usedIntrinsics, nil
+}
+
+// cdkTemplateBytes resolves a --cdk directory to the synthesized CloudFormation
+// template blobs to grade. A directory containing cdk.json is a CDK app: it is
+// synthesized with `cdk synth`, falling back to an already-synthesized cdk.out inside
+// it when the aws-cdk binary is absent (so a CI that checks in its assembly still
+// grades). Any other directory is read as a set of pre-synthesized templates (a
+// cdk.out cloud assembly, or a plain CloudFormation template dir).
+func cdkTemplateBytes(cdkBin, dir string) ([]cdkTemplate, error) {
+	if fileExists(filepath.Join(dir, "cdk.json")) {
+		synthed, serr := synthCDKApp(cdkBin, dir)
+		if serr != nil {
+			// Fall back to a checked-in cloud assembly so a synth-less environment
+			// (no aws-cdk installed) still grades an already-synthesized app.
+			if fb, ferr := readTemplateDir(filepath.Join(dir, "cdk.out"), isCDKAssemblyTemplate); ferr == nil && len(fb) > 0 {
+				return fb, nil
+			}
+			return nil, serr
+		}
+		return synthed, nil
+	}
+	// Not a CDK app dir: grade the pre-synthesized templates already present. A
+	// synthesized cdk.out contains *.template.json (plus manifest/tree/assets JSON that
+	// carry no ECS resource and grade to nothing); a plain dir may hold *.yaml/*.json.
+	if fileExists(filepath.Join(dir, "manifest.json")) || dirHasAssemblyTemplate(dir) {
+		return readTemplateDir(dir, isCDKAssemblyTemplate)
+	}
+	return readTemplateDir(dir, isCFNTemplateExt)
+}
+
+// synthCDKApp runs `cdk synth` on a CDK app directory into a throwaway output dir and
+// returns the synthesized CloudFormation templates. It is daemon-free and local: `cdk
+// synth` transpiles the app to CloudFormation without deploying. The app dir is the
+// working directory so relative cdk.json/context resolves.
+func synthCDKApp(cdkBin, appDir string) ([]cdkTemplate, error) {
+	if _, err := exec.LookPath(cdkBin); err != nil {
+		return nil, fmt.Errorf("aws-cdk binary %q not found on PATH (install aws-cdk, pass --cdk-bin, or point --cdk at a pre-synthesized template / cdk.out dir)", cdkBin)
+	}
+	outDir, err := os.MkdirTemp("", "ironctl-cdk-synth-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(outDir)
+
+	cmd := exec.Command(cdkBin, "synth", "--output", outDir)
+	cmd.Dir = appDir
+	// `cdk synth --output` writes the cloud assembly to outDir; stdout carries the
+	// human-readable template we do not need (we read the *.template.json files).
+	if _, err := runKustomizeRenderer(cmd, "cdk synth"); err != nil {
+		return nil, err
+	}
+	return readTemplateDir(outDir, isCDKAssemblyTemplate)
+}
+
+// readTemplateDir reads every file in dir whose name matches and returns its bytes.
+func readTemplateDir(dir string, match func(string) bool) ([]cdkTemplate, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []cdkTemplate
+	for _, e := range entries {
+		if e.IsDir() || !match(e.Name()) {
+			continue
+		}
+		raw, rerr := os.ReadFile(filepath.Join(dir, e.Name()))
+		if rerr != nil {
+			return nil, rerr
+		}
+		out = append(out, cdkTemplate{name: e.Name(), raw: raw})
+	}
+	return out, nil
+}
+
+// dirHasAssemblyTemplate reports whether dir contains a CDK cloud-assembly template
+// (*.template.json), i.e. it is (or looks like) a synthesized cdk.out.
+func dirHasAssemblyTemplate(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && isCDKAssemblyTemplate(e.Name()) {
+			return true
+		}
+	}
+	return false
+}
+
+// isCDKAssemblyTemplate reports whether a filename is a CDK cloud-assembly
+// CloudFormation template (`<Stack>.template.json`). Restricting to this suffix skips
+// the assembly's manifest.json / tree.json / *.assets.json sidecars.
+func isCDKAssemblyTemplate(name string) bool {
+	return strings.HasSuffix(strings.ToLower(name), ".template.json")
+}
+
+// fileExists reports whether path names an existing (non-directory) file.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
 func writeDockerfileSARIF(path string, r scan.Report, opts scan.SARIFOptions) error {
 	f, err := os.Create(path)
 	if err != nil {
@@ -2102,6 +2360,7 @@ USAGE:
   ironctl scan --pulumi PATH                     grade container workloads in Pulumi stack-export / preview --json output (or dir)
   ironctl scan --azure PATH                     grade Azure Container Instances (ARM template / az container show JSON or dir)
   ironctl scan --app-runner PATH                grade an AWS App Runner service (apprunner describe-service JSON / dir)
+  ironctl scan --cdk PATH                        synth an AWS CDK app (cdk synth) or grade a pre-synthesized template/cdk.out
   ironctl scan --kustomize DIR                  render a kustomization (kustomize build) and grade its workloads
   ironctl scan --dockerfile FILE...           grade Dockerfile(s) statically (no daemon, no pull)
   ironctl scan --compare A B                   diff two containers' isolation posture

--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -286,6 +286,20 @@ roll up to the **weakest** one the code defines.
 
     [:octicons-arrow-right-24: Grade an Azure Bicep template](scan.md#grade-an-azure-bicep-template)
 
+-   #### :material-aws:{ .lg .middle } AWS CDK app { #scan-cdk }
+
+    ---
+
+    Synthesizes a CDK app with `cdk synth` (or grades a pre-synthesized template / `cdk.out`)
+    and grades every `AWS::ECS::TaskDefinition` it emits, reusing the `--cloudformation` scorer
+    and rolling up to the **weakest** container, so an app is graded before `cdk deploy`.
+
+    ```bash
+    ironctl scan --cdk ./my-cdk-app
+    ```
+
+    [:octicons-arrow-right-24: Grade an AWS CDK app](scan.md#grade-an-aws-cdk-app)
+
 </div>
 
 ## Every mode, one engine
@@ -312,6 +326,7 @@ the container they eventually produce are all measured on one comparable scale.
 | Infrastructure-as-Code | [CloudFormation](#scan-cloudformation) | `--cloudformation` | ECS task defs in a CFN template | [Grade a CloudFormation template](scan.md#grade-a-cloudformation-template) |
 | Infrastructure-as-Code | [Pulumi program](#scan-pulumi) | `--pulumi` | K8s &amp; ECS workloads in stack-export / preview JSON | [Grade a Pulumi program](scan.md#grade-a-pulumi-program) |
 | Infrastructure-as-Code | [Azure Bicep template](#scan-bicep) | `--bicep` | weakest `containerGroups` container, compiled to ARM | [Grade an Azure Bicep template](scan.md#grade-an-azure-bicep-template) |
+| Infrastructure-as-Code | [AWS CDK app](#scan-cdk) | `--cdk` | weakest ECS container, synthesized to CloudFormation | [Grade an AWS CDK app](scan.md#grade-an-aws-cdk-app) |
 
 Every mode also emits the machine-readable outputs: a [SARIF log](scan.md#github-code-scanning-security-tab)
 for GitHub code scanning, a [shields.io badge](scan.md#sandbox-isolation-score-badge), and

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -429,6 +429,38 @@ malformed) fails **open** — a clear diagnostic and exit 0 — so an opt-in CI 
 crashes the build; once containers are graded, `--min-score` still trips on a low
 posture.
 
+## Grade an AWS CDK app
+
+`--cdk PATH` grades an [AWS CDK](https://docs.aws.amazon.com/cdk/) app by way of the
+CloudFormation template its `cdk synth` step emits. The CDK is a program
+(TypeScript/Python/Go/...) that **synthesizes** standard CloudFormation, so once
+synthesized it is graded through the **exact same** shared ECS scorer as
+`--cloudformation`. Point it at a CDK app directory (one containing `cdk.json`), a
+pre-synthesized template file, or a synthesized `cdk.out` cloud assembly:
+
+```bash
+ironctl scan --cdk ./my-cdk-app                  # synthesize the app, then grade
+ironctl scan --cdk ./my-cdk-app --min-score 75   # CI gate
+ironctl scan --cdk cdk.out/MyStack.template.json # a pre-synthesized template
+ironctl scan --cdk ./cdk.out                     # a synthesized cloud assembly
+```
+
+A CDK app directory is synthesized with `cdk synth` (pass `--cdk-bin` to override the
+binary); when the `aws-cdk` binary is absent it falls back to an already-synthesized
+`cdk.out` inside the app, so a CI that checks in its cloud assembly still grades with no
+Node install. It is offline and daemon-free: synthesis is local, no AWS login. Because
+the synthesized output is the same `AWS::ECS::TaskDefinition` CloudFormation
+`--cloudformation` grades, the scoring is identical: each container definition runs
+through the shared ECS scorer, and a fully hardened task definition tops out at
+**89/100 (grade B)** — see [Grade a CloudFormation
+template](#grade-a-cloudformation-template) for the per-dimension breakdown. The app
+grade is the **weakest** container across every synthesized template. Unresolved CDK
+tokens / CloudFormation intrinsics (`!Ref`/`Fn::...`/`${Token[...]}`) are graded
+fail-closed and noted. A synth or parse failure (the `cdk` binary is absent with no
+`cdk.out`, or the app is malformed) fails **open** — a clear diagnostic and exit 0 — so
+an opt-in CI step never crashes the build; once containers are graded, `--min-score`
+still trips on a low posture.
+
 ## Grade a kustomization
 
 `--kustomize DIR` renders a [Kustomize](https://kustomize.io/) directory with

--- a/internal/host/scan/cdk.go
+++ b/internal/host/scan/cdk.go
@@ -1,0 +1,42 @@
+package scan
+
+// SpecsFromCDK grades an AWS CDK application by way of the CloudFormation template
+// its `cdk synth` step emits. The AWS CDK is a program (TypeScript/Python/Go/...) that
+// SYNTHESIZES a standard CloudFormation template — `cdk synth` writes exactly the
+// AWS::ECS::TaskDefinition (and every other) resource the CloudFormation deployer
+// consumes, in ordinary CFN JSON/YAML. A CDK app that declares an ECS task definition
+// therefore compiles to the SAME CloudFormation document the --cloudformation path
+// already grades. This is a deliberately thin seam over SpecsFromCloudFormation: the
+// CLI wrapper runs `cdk synth` (the I/O) and passes the synthesized template bytes
+// here, which decode through the identical shared ecsSpec mapper, PascalCase
+// case-insensitive handling, and intrinsic/token fail-closed nullification.
+//
+// Keeping it a named entry point (rather than calling SpecsFromCloudFormation directly
+// from the CLI) gives the --cdk mode a stable seam a parity test can pin against the
+// sibling --cloudformation mode: the same synthesized template must grade identically
+// through both. It mirrors the --bicep -> --azure seam (compile a higher-level IaC
+// input down to the native template, then reuse the native scorer unchanged).
+//
+// The second return value reports whether any CloudFormation intrinsic / unresolved
+// CDK token was nullified (graded fail-closed) so the caller can note it.
+func SpecsFromCDK(synthesizedTemplate []byte) ([]Spec, bool, error) {
+	return SpecsFromCloudFormation(synthesizedTemplate)
+}
+
+// AggregateCDK folds the per-container specs from one or more synthesized-CDK
+// CloudFormation templates into a single Report. It is the AggregateCloudFormation
+// WEAKEST-container rollup (a template is only as isolated as its most-exposed
+// container) with the Source re-labelled "cdk" so the report names the input mode the
+// user actually ran, plus a note recording that the grade is over synthesized CFN. It
+// is pure; the caller injects Version/GeneratedAt.
+func AggregateCDK(specs []Spec, target string) (Report, Spec, error) {
+	report, worst, err := AggregateCloudFormation(specs, target)
+	if err != nil {
+		return Report{}, Spec{}, err
+	}
+	report.Source = "cdk"
+	report.Notes = append([]string{
+		"input synthesized from an AWS CDK app to a CloudFormation template (cdk synth); grading is identical to the --cloudformation ECS path once synthesized",
+	}, report.Notes...)
+	return report, worst, nil
+}

--- a/internal/host/scan/cdk_test.go
+++ b/internal/host/scan/cdk_test.go
@@ -1,0 +1,84 @@
+package scan
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestCDKParityWithCloudFormation locks the core contract of the --cdk mode: because
+// `cdk synth` emits a standard CloudFormation template, the SAME synthesized template
+// must grade IDENTICALLY through the --cdk entry point (SpecsFromCDK / AggregateCDK)
+// and the sibling --cloudformation entry point (SpecsFromCloudFormation /
+// AggregateCloudFormation) — the only allowed difference is the reported Source label
+// (and the extra "synthesized from CDK" note). If the two ever diverge, the cdk path
+// has grown its own scoring behaviour and the parity guarantee is broken.
+func TestCDKParityWithCloudFormation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tmpl string
+	}{
+		{"hardened_yaml", cfnYAMLHardened},
+		{"porous_json", cfnJSONPorous},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cdkSpecs, cdkIntr, cdkErr := SpecsFromCDK([]byte(tc.tmpl))
+			cfnSpecs, cfnIntr, cfnErr := SpecsFromCloudFormation([]byte(tc.tmpl))
+			if cdkErr != nil || cfnErr != nil {
+				t.Fatalf("parse errors: cdk=%v cfn=%v", cdkErr, cfnErr)
+			}
+			if cdkIntr != cfnIntr {
+				t.Fatalf("intrinsic-skipped flag differs: cdk=%v cfn=%v", cdkIntr, cfnIntr)
+			}
+			if !reflect.DeepEqual(cdkSpecs, cfnSpecs) {
+				t.Fatalf("specs diverge between cdk and cloudformation entry points:\ncdk=%+v\ncfn=%+v", cdkSpecs, cfnSpecs)
+			}
+
+			cdkReport, cdkWorst, cdkErr := AggregateCDK(cdkSpecs, "example")
+			cfnReport, cfnWorst, cfnErr := AggregateCloudFormation(cfnSpecs, "example")
+			if cdkErr != nil || cfnErr != nil {
+				t.Fatalf("aggregate errors: cdk=%v cfn=%v", cdkErr, cfnErr)
+			}
+			if cdkReport.Score != cfnReport.Score || cdkReport.Grade != cfnReport.Grade {
+				t.Fatalf("grade diverges: cdk=%d/%s cfn=%d/%s", cdkReport.Score, cdkReport.Grade, cfnReport.Score, cfnReport.Grade)
+			}
+			if !reflect.DeepEqual(cdkWorst, cfnWorst) {
+				t.Fatalf("worst spec diverges between cdk and cloudformation")
+			}
+			// The one intentional difference: the Source label names the input mode.
+			if cdkReport.Source != "cdk" {
+				t.Fatalf("cdk report Source = %q, want %q", cdkReport.Source, "cdk")
+			}
+			if cfnReport.Source != "cloudformation" {
+				t.Fatalf("cloudformation report Source = %q, want %q", cfnReport.Source, "cloudformation")
+			}
+		})
+	}
+}
+
+// TestCDKAggregateEmptyFailsClosed confirms a synthesized template with no gradeable
+// ECS container is an error (fail-closed), not a silent pass.
+func TestCDKAggregateEmptyFailsClosed(t *testing.T) {
+	if _, _, err := AggregateCDK(nil, "empty"); err == nil {
+		t.Fatal("expected an error for zero gradeable containers, got nil")
+	}
+}
+
+// TestCDKPorousFailClosed pins that a synthesized porous task def (root, privileged,
+// host namespaces, docker.sock) grades identically to the same CloudFormation input
+// and lands at the fail-closed floor.
+func TestCDKPorousGrade(t *testing.T) {
+	specs, _, err := SpecsFromCDK([]byte(cfnJSONPorous))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	report, _, err := AggregateCDK(specs, "cdk.out")
+	if err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+	if report.Source != "cdk" {
+		t.Fatalf("Source = %q, want cdk", report.Source)
+	}
+	if report.Grade != "F" {
+		t.Fatalf("porous synthesized CDK task def = %d/%s, want grade F", report.Score, report.Grade)
+	}
+}


### PR DESCRIPTION
## What

Adds `ironctl scan --cdk <path>` to grade AWS CDK apps. The CDK synthesizes standard CloudFormation, so this is a **thin front-door seam** over the existing `--cloudformation` scorer — the same pattern as `--bicep` → `--azure`. No new scoring logic; the shared `ecsSpec` / `AWS::ECS::TaskDefinition` mapper and weakest-container rollup are reused unchanged.

## How

- `SpecsFromCDK` → `SpecsFromCloudFormation`; `AggregateCDK` relabels `Source` to `cdk` and prepends a synth note.
- `--cdk` accepts:
  - a **CDK app dir** (has `cdk.json`) → synthesized with `cdk synth --output <tmp>`, falling back to a checked-in `cdk.out` when the `aws-cdk` binary is absent;
  - a **pre-synthesized template file**;
  - a **synthesized `cdk.out`** cloud assembly (`*.template.json`; `manifest.json`/`tree.json`/`*.assets.json` sidecars ignored);
  - a **plain template dir** (`*.yaml`/`*.json`).
- Fail-**OPEN** on synth/parse failure (diagnostic + exit 0) so an opt-in CI step never crashes the build; `--min-score` still gates once containers are graded.
- Unresolvable CDK tokens / CFN intrinsics graded **fail-closed** (inherited from the CFN sanitizer) and noted.

## Security lenses

- **Egress least-privilege / isolation**: `cdk synth` is local and offline (no AWS login, no deploy). No new network path.
- Grading is host-side static analysis of synthesized templates; no sandbox trust boundary touched. Fail-closed on unknown posture preserved.

## Tests

- `cdk_test.go`: parity (`reflect.DeepEqual` specs + identical grade vs equivalent `--cloudformation` input, only `Source` differs), empty-fails-closed, porous grade.
- Dogfooded the built CLI: file mode (hardened **89/B**, byte-identical grade to `--cloudformation`), `cdk.out` dir mode (porous **F**, sidecars ignored), app-dir synth-fallback, fail-open on unsynthesizable app, `--min-score` gate exits non-zero, intrinsic fail-closed note.
- `go build`/`go vet`/`go test ./internal/host/scan/` all green (`CGO_ENABLED=1`).

## Docs

- `#scan-cdk` hub card in `docs/scan-coverage.md` (IaC category) + "Every mode, one engine" table row.
- `Grade an AWS CDK app` reference section in `docs/scan.md`.

Closes IRO-552.