### PR TITLE
docs(blog): harden guides wave 11 (opensearch/redpanda/qdrant/scylla) [IRO-563]

### DIFF
--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -56,5 +56,9 @@ nav:
   - "How to harden a YugabyteDB container": harden-yugabyte-container-isolation.md
   - "How to harden an Immich container": harden-immich-server-container-isolation.md
   - "How to harden a pgAdmin container": harden-pgadmin4-container-isolation.md
+  - "How to harden an OpenSearch container": harden-opensearch-container-isolation.md
+  - "How to harden a Redpanda container": harden-redpanda-container-isolation.md
+  - "How to harden a Qdrant container": harden-qdrant-container-isolation.md
+  - "How to harden a ScyllaDB container": harden-scylla-container-isolation.md
   - "How to scan a Dockerfile for security issues": scan-a-dockerfile-for-security-issues.md
   - "*.md"

--- a/docs/blog/harden-opensearch-container-isolation.md
+++ b/docs/blog/harden-opensearch-container-isolation.md
@@ -1,0 +1,111 @@
+---
+title: "How to harden an OpenSearch container: opensearch:2 scores 63/100 by default"
+description: "opensearch:2 defaults score 63/100 (grade C): full caps, writable rootfs, open egress. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden an OpenSearch container (and is opensearch:2 safe for untrusted workloads?)
+
+Short answer: a stock `docker run opensearchproject/opensearch:2` starts ahead of most images (it
+runs non-root out of the box) but is still **not** a boundary to trust around an untrusted network.
+Graded on IronClaw's seven-dimension containment scale, the default configuration scores
+**63 of 100, grade C (partial)**. Higher is safer. Three runtime flags take the same image to
+**100 of 100, grade A**. This guide shows the exact gaps and the exact fixes, straight from the
+scan data.
+
+> Every number here comes from a read-only `docker inspect` of `opensearchproject/opensearch:2`,
+> the same data behind its [isolation scorecard](../scores/opensearch.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run opensearchproject/opensearch:2`, three fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as 1000 (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+OpenSearch already runs as a non-root uid, which is why it clears the default 48/100 that
+databases like MySQL and Postgres sit at. The remaining leaks are the **retained capabilities**
+and **open egress**. An OpenSearch that can reach the network is one that can exfiltrate every
+document it indexes the moment a query DSL or plugin CVE lands code execution, and the full
+capability set hands that code `CAP_NET_RAW` and friends to work with.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-opensearch --fix` prints one remediation per failed dimension, then one hardened
+run. For `opensearchproject/opensearch:2`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only
+  what the workload provably needs. OpenSearch needs none of the defaults.
+- **`--network=none`** (Network isolation, +11): for a single-node index reached only by
+  co-located services on a private user-defined network, cut host egress entirely; otherwise
+  attach a single internal network with no default route, not `bridge`. (A multi-node cluster
+  needs inter-node transport on a scoped private network, which is a WARN, not a clean pass,
+  see the ceiling note below.)
+- **`--user 65532:65532`** (Non-root user, already passing at +0): non-root already passes at
+  uid 1000. Pinning an explicit fixed uid is the auditable choice and keeps volume ownership
+  unambiguous; it does not change the score.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/usr/share/opensearch/data` as an explicit writable volume. Removes the persistence
+  surface.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name opensearch \
+  -e discovery.type=single-node \
+  opensearchproject/opensearch:2
+
+# After: 100/100, grade A (single-node)
+docker run -d --name opensearch-hardened \
+  -e discovery.type=single-node \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v opensearch-data:/usr/share/opensearch/data \
+  --network=none \
+  opensearchproject/opensearch:2
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan opensearch-hardened` reports
+`100/100 grade A`. That is a **37-point swing from three one-line flags**, no image rebuild.
+
+## The honest ceiling for a multi-node cluster
+
+The 100/100 above is a **single-node** index with `network=none`. A multi-node OpenSearch cluster
+cannot use `network=none`: nodes must reach each other over the transport port. Attach a private
+user-defined network scoped to just the cluster with no default route out, and the network
+dimension scores 4 of 15 (a WARN, not a fail) instead of the full 15. That puts a hardened
+multi-node cluster at **89 of 100, grade B**, one point off an A. The other six dimensions still
+max out. That is the honest ceiling when nodes must talk, and it is a long way from the default C.
+
+## Verify it on your own cluster
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-opensearch
+ironctl scan my-opensearch --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can
+grade the OpenSearch in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [opensearch:2 isolation scorecard &rarr;](../scores/opensearch.md): the full dimension breakdown.
+- [Search engines, ranked by isolation &rarr;](../scores/collections/search-engines.md): how OpenSearch compares to Elasticsearch, Solr, Meilisearch, and the rest.
+- [How to harden an Elasticsearch container &rarr;](harden-elasticsearch-container-isolation.md): the same walkthrough for the upstream OpenSearch forked from.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-qdrant-container-isolation.md
+++ b/docs/blog/harden-qdrant-container-isolation.md
@@ -1,0 +1,95 @@
+---
+title: "How to harden a Qdrant container: qdrant:v1.12.4 scores 48/100 by default"
+description: "qdrant:v1.12.4 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden a Qdrant container (and is qdrant:v1.12.4 safe for untrusted workloads?)
+
+Short answer: a stock `docker run qdrant/qdrant:v1.12.4` is **not** a boundary you should trust
+around untrusted code or an untrusted network. Graded on IronClaw's seven-dimension containment
+scale, the default configuration scores **48 of 100, grade D (porous)**. Higher is safer. Four
+runtime flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and
+the exact fixes, straight from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `qdrant/qdrant:v1.12.4`, the same
+> data behind its [isolation scorecard](../scores/qdrant.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run qdrant/qdrant:v1.12.4`, four of them fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a vector database, the two that should worry you most are **egress** and **root**. A Qdrant
+process that can reach the network is a Qdrant process that can exfiltrate every embedding and its
+payload the moment it is compromised (a poisoned collection, a REST or gRPC CVE). And a root
+process that escapes the container escapes as root on the host.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-qdrant --fix` prints one remediation per failed dimension, then a single
+copy-pasteable hardened run. For `qdrant/qdrant:v1.12.4`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only
+  what the workload provably needs. Qdrant needs none of the defaults.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the storage directory at a volume this uid owns.
+- **`--network=none`** (Network isolation, +11): if the vector store is only reached by services
+  on a private user-defined network, cut host egress entirely; otherwise attach a single internal
+  network with no default route, not `bridge`.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/qdrant/storage` as an explicit writable volume. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name qdrant qdrant/qdrant:v1.12.4
+
+# After: 100/100, grade A
+docker run -d --name qdrant-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v qdrant-data:/qdrant/storage \
+  --network=none \
+  qdrant/qdrant:v1.12.4
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan qdrant-hardened` reports
+`100/100 grade A`. That is a **52-point swing from four one-line flags**, no image rebuild.
+
+## Verify it on your own vector store
+
+The grade above is the default image. Your deployment is what matters. Scan it in ten seconds:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-qdrant
+ironctl scan my-qdrant --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can
+grade the Qdrant in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [qdrant:v1.12.4 isolation scorecard &rarr;](../scores/qdrant.md): the full dimension breakdown.
+- [Vector databases, ranked by isolation &rarr;](../scores/collections/vector-databases.md): how Qdrant compares to Weaviate, Milvus, Chroma, and the rest.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-redpanda-container-isolation.md
+++ b/docs/blog/harden-redpanda-container-isolation.md
@@ -1,0 +1,106 @@
+---
+title: "How to harden a Redpanda container: redpanda:v24.2.11 scores 63/100 by default"
+description: "redpanda:v24.2.11 defaults score 63/100 (grade C): full caps, writable rootfs, open egress. The exact ironctl scan --fix flags that take a broker to its honest 89/100 grade B."
+---
+
+# How to harden a Redpanda container (and is redpanda:v24.2.11 safe for untrusted workloads?)
+
+A streaming broker sits between every producer and consumer you run, which is exactly why its
+container should be one of the tightest. A stock `docker run redpandadata/redpanda:v24.2.11` is
+not that. Graded on IronClaw's seven-dimension containment scale, the default configuration scores
+**63 of 100, grade C (partial)**. Higher is safer. A couple of runtime flags take the same image
+to **89 of 100, grade B**, one point off an A, and the one dimension it cannot reach is the one a
+broker needs by definition (clients must connect to it). Here are the exact gaps and fixes from
+the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `redpandadata/redpanda:v24.2.11`,
+> the same data behind its [isolation scorecard](../scores/redpanda.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run redpandadata/redpanda:v24.2.11`, three fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as redpanda (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+Redpanda already runs as a non-root uid, which is why it clears the default 48/100 that root
+images sit at. The sharpest remaining edges are the **retained capabilities** and **open egress**:
+a Kafka-protocol or admin-API CVE that lands code execution lands it with `CAP_NET_RAW` and
+friends, on a process every service in your stack already trusts and connects to, and it can reach
+the network to exfiltrate every message on the log.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-redpanda --fix` prints one remediation per failed dimension, then one hardened
+run. For `redpandadata/redpanda:v24.2.11`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only
+  what the workload provably needs. Redpanda needs none of the defaults.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  broker, producers and consumers must be able to connect to it. Any named or bridge network
+  scores 4 of 15 (a WARN, not a fail): a connection path exists. This is the one dimension a
+  broker cannot max out. Contain it anyway: attach a user-defined network scoped to just its
+  producers and consumers, with no default route out, so a compromised broker cannot call
+  arbitrary internet addresses.
+- **`--user 65532:65532`** (Non-root user, already passing at +0): non-root already passes as the
+  redpanda uid. Pinning an explicit fixed uid is the auditable choice and keeps volume ownership
+  unambiguous; it does not change the score.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/var/lib/redpanda/data` as an explicit writable volume. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name redpanda \
+  redpandadata/redpanda:v24.2.11 \
+  redpanda start --mode dev-container
+
+# After: 89/100, grade B (scoped private network for producers and consumers)
+docker run -d --name redpanda-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v redpanda-data:/var/lib/redpanda/data \
+  --network=redpanda-internal \
+  redpandadata/redpanda:v24.2.11 \
+  redpanda start --mode dev-container
+```
+
+Rescan: `ironctl scan redpanda-hardened` reports `89/100 grade B`. A **26-point swing** with no
+custom image build, just the right flags. The only dimension still short of full marks is the
+network (4 of 15), because a broker exists to be connected to; `network=none` would score the
+last points but leave nothing able to reach the log. That is the honest ceiling for a broker, and
+it is a long way from the default C.
+
+## Verify it on your own broker
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-redpanda
+ironctl scan my-redpanda --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can
+grade the Redpanda in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [redpanda:v24.2.11 isolation scorecard &rarr;](../scores/redpanda.md): the full dimension breakdown.
+- [Message queues, ranked by isolation &rarr;](../scores/collections/message-queues.md): how Redpanda compares to Kafka, RabbitMQ, NATS, and the rest.
+- [How to harden a Kafka container &rarr;](harden-kafka-container-isolation.md): the same honest-ceiling walkthrough for the broker Redpanda speaks the protocol of.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-scylla-container-isolation.md
+++ b/docs/blog/harden-scylla-container-isolation.md
@@ -1,0 +1,107 @@
+---
+title: "How to harden a ScyllaDB container: scylla:6.2 scores 48/100 by default"
+description: "scylla:6.2 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden a ScyllaDB container (and is scylla:6.2 safe for untrusted workloads?)
+
+Short answer: a stock `docker run scylladb/scylla:6.2` is **not** a boundary you should trust
+around untrusted code or an untrusted network. Graded on IronClaw's seven-dimension containment
+scale, the default configuration scores **48 of 100, grade D (porous)**. Higher is safer. Four
+runtime flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and
+the exact fixes, straight from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `scylladb/scylla:6.2`, the same
+> data behind its [isolation scorecard](../scores/scylla.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run scylladb/scylla:6.2`, four of them fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a wide-column database, the two that should worry you most are **egress** and **root**. A
+Scylla process that can reach the network is a Scylla process that can exfiltrate every row it
+stores the moment it is compromised (a poisoned UDF, a CQL or driver CVE). And a root process that
+escapes the container escapes as root on the host.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-scylla --fix` prints one remediation per failed dimension, then a single
+copy-pasteable hardened run. For `scylladb/scylla:6.2`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only
+  what the workload provably needs. Scylla itself needs none of the defaults.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the data directory at a volume this uid owns.
+- **`--network=none`** (Network isolation, +11): for a single-node store reached only by
+  co-located services on a private user-defined network, cut host egress entirely; otherwise
+  attach a single internal network with no default route, not `bridge`. (A multi-node cluster
+  needs inter-node gossip on a scoped private network, which is a WARN, not a clean pass, see the
+  ceiling note below.)
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/var/lib/scylla` as an explicit writable volume. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name scylla scylladb/scylla:6.2
+
+# After: 100/100, grade A (single-node)
+docker run -d --name scylla-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v scylla-data:/var/lib/scylla \
+  --network=none \
+  scylladb/scylla:6.2
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan scylla-hardened` reports
+`100/100 grade A`. That is a **52-point swing from four one-line flags**, no image rebuild.
+
+## The honest ceiling for a multi-node cluster
+
+The 100/100 above is a **single-node** store with `network=none`. A multi-node Scylla cluster
+cannot use `network=none`: nodes gossip and stream data to each other. Attach a private
+user-defined network scoped to just the cluster with no default route out, and the network
+dimension scores 4 of 15 (a WARN, not a fail) instead of the full 15. That puts a hardened
+multi-node cluster at **89 of 100, grade B**, one point off an A. The other six dimensions still
+max out. That is the honest ceiling when nodes must talk, and it is a long way from the default D.
+
+## Verify it on your own database
+
+The grade above is the default image. Your deployment is what matters. Scan it in ten seconds:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-scylla
+ironctl scan my-scylla --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can
+grade the Scylla in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [scylla:6.2 isolation scorecard &rarr;](../scores/scylla.md): the full dimension breakdown.
+- [Databases, ranked by isolation &rarr;](../scores/collections/databases.md): how Scylla compares to Cassandra, MongoDB, Postgres, and the rest.
+- [How to harden a Cassandra container &rarr;](harden-cassandra-container-isolation.md): the same walkthrough for the wide-column database Scylla is compatible with.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -45,6 +45,9 @@ Two patterns show up across the set:
 | [Meilisearch](harden-meilisearch-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if remote clients) |
 | [YugabyteDB](harden-yugabyte-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B multi-node cluster) |
 | [Dragonfly](harden-dragonfly-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B as a shared network cache) |
+| [OpenSearch](harden-opensearch-container-isolation.md) | 63/100 C | **100/100 A** | full caps, writable rootfs (89/B multi-node cluster) |
+| [Qdrant](harden-qdrant-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
+| [ScyllaDB](harden-scylla-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B multi-node cluster) |
 | [Untrusted Node.js](run-untrusted-nodejs-code-safely.md) | 48/100 D | **100/100 A** | run untrusted code in a real sandbox |
 
 ## Honest ceiling: grade B (89/100)
@@ -72,6 +75,7 @@ These services must accept client connections, so the network dimension holds at
 | [Typesense](harden-typesense-container-isolation.md) | 48/100 D | **89/100 B** | search server: your app must reach its query API |
 | [Immich](harden-immich-server-container-isolation.md) | 48/100 D | **89/100 B** | photo server: browsers and mobile apps must reach it |
 | [pgAdmin](harden-pgadmin4-container-isolation.md) | 63/100 C | **89/100 B** | admin console: your browser must reach the UI |
+| [Redpanda](harden-redpanda-container-isolation.md) | 63/100 C | **89/100 B** | broker: producers and consumers must connect |
 
 ## The pattern, one command
 


### PR DESCRIPTION
## Harden-guide SEO wave 11 — IRO-563

4 new organic-SEO harden guides, each backed by an existing `docs/scores/<slug>.md` scorecard. Non-gated growth funnel.

| Guide | Default | Hardened | Class |
|-------|:-------:|:--------:|-------|
| OpenSearch | 63/C | **100/A** | search datastore (89/B multi-node) |
| Redpanda | 63/C | **89/B** | kafka-compatible broker (honest ceiling) |
| Qdrant | 48/D | **100/A** | vector store |
| ScyllaDB | 48/D | **100/A** | wide-column store (89/B multi-node) |

Every number comes from the image's read-only scorecard; grade bands follow the standing rules (co-located store -> 100/A, broker -> 89/B ceiling with network held at WARN). No em/en-dashes in copy.

- Hub `hardening-guides.md` updated (grade-A + grade-B tables), no literal count.
- Blog `.nav.yml` registers all 4.
- All cross-links (scorecards, collections, sibling guides) verified to resolve.

Branch cut from `origin/main` (working-tree hub was stale).