### PR TITLE
feat(scan): grade ECS task defs in AWS SAM templates via --sam [IRO-562]

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -50,6 +50,7 @@ func cmdScan(args []string) error {
 	ecs := fs.String("ecs", "", "grade an AWS ECS task definition: `aws ecs describe-task-definition` JSON, a raw registered task-def JSON, or a directory of task-def JSON files")
 	cloudrun := fs.String("cloudrun", "", "grade Google Cloud Run service specs: a Knative Service YAML (`gcloud run services describe SVC --format=export`), or a directory of them")
 	cloudformation := fs.String("cloudformation", "", "grade AWS::ECS::TaskDefinition resources in a CloudFormation template (YAML or JSON), or a directory of them")
+	sam := fs.String("sam", "", "grade the AWS::ECS::TaskDefinition resources declared in an AWS SAM template (Transform: AWS::Serverless-*, YAML or JSON), or a directory of them")
 	pulumi := fs.String("pulumi", "", "grade container workloads in a Pulumi `pulumi stack export` / `pulumi preview --json` file (or a directory of them): kubernetes:* workloads and aws ECS task definitions")
 	azure := fs.String("azure", "", "grade Microsoft.ContainerInstance/containerGroups in an Azure ARM template / `az container show` JSON, or a directory of them")
 	appRunner := fs.String("app-runner", "", "grade an AWS App Runner service: `aws apprunner describe-service` JSON, a raw Service object, or a directory of them")
@@ -332,6 +333,27 @@ func cmdScan(args []string) error {
 		return runCDKScan(cdkScanArgs{
 			path:      *cdk,
 			cdkBin:    *cdkBin,
+			asJSON:    *asJSON,
+			md:        *md,
+			badge:     *badge,
+			badgeJSON: *badgeJSON,
+			sarif:     *sarif,
+			minScore:  *minScore,
+		})
+	}
+
+	// --sam: consume an AWS SAM template (Transform: AWS::Serverless-*) and grade the
+	// AWS::ECS::TaskDefinition resources it declares. SAM is a CloudFormation superset:
+	// raw (non-AWS::Serverless::*) resources are already native CFN, so this is a thin
+	// front-door over --cloudformation with no `sam` transform step required to reach
+	// the ECS task defs. The template is decoded by the SAME shared ECS scorer as
+	// --cloudformation/--cdk/--ecs/--terraform (SpecsFromSAM -> SpecsFromCloudFormation).
+	// It fails OPEN on a load/parse failure so an opt-in CI step never crashes the build;
+	// --min-score still gates once containers are graded. Unresolvable CFN intrinsics are
+	// graded fail-closed and noted.
+	if *sam != "" {
+		return runSAMScan(samScanArgs{
+			path:      *sam,
 			asJSON:    *asJSON,
 			md:        *md,
 			badge:     *badge,
@@ -1600,6 +1622,134 @@ func loadCFNSpecs(path string) ([]scan.Spec, bool, error) {
 	return specs, usedIntrinsics, nil
 }
 
+// samScanArgs carries the resolved inputs for a `scan --sam` run.
+type samScanArgs struct {
+	path      string
+	asJSON    bool
+	md        bool
+	badge     string
+	badgeJSON string
+	sarif     string
+	minScore  int
+}
+
+// runSAMScan grades the AWS::ECS::TaskDefinition resources declared in an AWS SAM
+// template (Transform: AWS::Serverless-*, YAML or JSON, or a directory of them),
+// reusing the SHARED ECS scorer the --cloudformation/--ecs/--terraform paths also use.
+// SAM is a CloudFormation superset — raw ECS task defs are already native CFN — so
+// there is no `sam` transform step or external binary to shell out to. It fails OPEN on
+// a load/parse failure: it prints a clear diagnostic to stderr and returns nil so an
+// opt-in CI/Action step never crashes the build. Once containers are graded, scoring and
+// the --min-score CI gate apply exactly like --cloudformation. Unresolvable CFN
+// intrinsics (!Ref/!Sub/Fn::...) are graded fail-closed and noted on the report.
+func runSAMScan(a samScanArgs) error {
+	specs, usedIntrinsics, err := loadSAMSpecs(a.path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --sam could not load %q (scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+
+	report, worstSpec, err := scan.AggregateSAM(specs, filepath.Base(strings.TrimRight(a.path, "/")))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: scan --sam found nothing to grade in %q (no AWS::ECS::TaskDefinition; scan skipped, exit 0): %v\n", a.path, err)
+		return nil
+	}
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+	if usedIntrinsics {
+		report.Notes = append(report.Notes, "template uses CloudFormation intrinsics (!Ref/!Sub/Fn::...): unresolved values are graded as unset (fail-closed) — verify the deployed stack matches.")
+	}
+
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		if err := writeSARIF(a.sarif, report, worstSpec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (containers graded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// loadSAMSpecs resolves a --sam argument to graded Specs. A SAM template is a
+// CloudFormation superset, so it is parsed exactly like a CloudFormation input: a single
+// file is parsed directly, and a directory is a weakest-container rollup over every
+// *.yaml/*.yml/*.json/*.template file in it (their container specs are pooled so
+// AggregateSAM grades the single most-exposed container across the whole set). It is
+// daemon-free and offline. The bool reports whether any file used CFN intrinsics that
+// were skipped (graded fail-closed).
+func loadSAMSpecs(path string) ([]scan.Spec, bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, false, err
+	}
+	if !info.IsDir() {
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil, false, rerr
+		}
+		return scan.SpecsFromSAM(raw)
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, false, err
+	}
+	var specs []scan.Spec
+	usedIntrinsics := false
+	for _, e := range entries {
+		if e.IsDir() || !isCFNTemplateExt(e.Name()) {
+			continue
+		}
+		raw, rerr := os.ReadFile(filepath.Join(path, e.Name()))
+		if rerr != nil {
+			return nil, false, rerr
+		}
+		fileSpecs, intr, perr := scan.SpecsFromSAM(raw)
+		if perr != nil {
+			// A single malformed template in a directory should not sink the rollup:
+			// skip it with a diagnostic and grade the rest (fail-open per file).
+			fmt.Fprintf(os.Stderr, "  warning: scan --sam skipping %s (parse error): %v\n", e.Name(), perr)
+			continue
+		}
+		specs = append(specs, fileSpecs...)
+		usedIntrinsics = usedIntrinsics || intr
+	}
+	return specs, usedIntrinsics, nil
+}
+
 // isCFNTemplateExt reports whether a filename has a CloudFormation template
 // extension (.yaml/.yml/.json/.template).
 func isCFNTemplateExt(name string) bool {
@@ -2503,6 +2653,7 @@ USAGE:
   ironctl scan --ecs PATH                       grade an AWS ECS task definition (describe-task-definition JSON / dir)
   ironctl scan --cloudrun PATH                  grade Google Cloud Run service specs (Knative Service YAML or dir)
   ironctl scan --cloudformation PATH            grade AWS::ECS::TaskDefinition in a CloudFormation template (YAML/JSON or dir)
+  ironctl scan --sam PATH                        grade AWS::ECS::TaskDefinition in an AWS SAM template (Transform: AWS::Serverless-*, YAML/JSON or dir)
   ironctl scan --pulumi PATH                     grade container workloads in Pulumi stack-export / preview --json output (or dir)
   ironctl scan --azure PATH                     grade Azure Container Instances (ARM template / az container show JSON or dir)
   ironctl scan --app-runner PATH                grade an AWS App Runner service (apprunner describe-service JSON / dir)

--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -314,6 +314,21 @@ roll up to the **weakest** one the code defines.
 
     [:octicons-arrow-right-24: Grade an AWS CDK app](scan.md#grade-an-aws-cdk-app)
 
+-   #### :material-aws:{ .lg .middle } AWS SAM template { #scan-sam }
+
+    ---
+
+    Grades the `AWS::ECS::TaskDefinition` resources declared in an AWS SAM template
+    (`Transform: AWS::Serverless-*`), reusing the `--cloudformation` scorer and rolling up to
+    the **weakest** container. SAM is a CloudFormation superset, so no `sam` build step is
+    needed to grade a serverless app's ECS/Fargate task definitions.
+
+    ```bash
+    ironctl scan --sam ./template.yaml
+    ```
+
+    [:octicons-arrow-right-24: Grade an AWS SAM template](scan.md#grade-an-aws-sam-template)
+
 </div>
 
 ## Every mode, one engine
@@ -342,6 +357,7 @@ the container they eventually produce are all measured on one comparable scale.
 | Infrastructure-as-Code | [Pulumi program](#scan-pulumi) | `--pulumi` | K8s &amp; ECS workloads in stack-export / preview JSON | [Grade a Pulumi program](scan.md#grade-a-pulumi-program) |
 | Infrastructure-as-Code | [Azure Bicep template](#scan-bicep) | `--bicep` | weakest `containerGroups` container, compiled to ARM | [Grade an Azure Bicep template](scan.md#grade-an-azure-bicep-template) |
 | Infrastructure-as-Code | [AWS CDK app](#scan-cdk) | `--cdk` | weakest ECS container, synthesized to CloudFormation | [Grade an AWS CDK app](scan.md#grade-an-aws-cdk-app) |
+| Infrastructure-as-Code | [AWS SAM template](#scan-sam) | `--sam` | ECS task defs in a SAM (Serverless) template | [Grade an AWS SAM template](scan.md#grade-an-aws-sam-template) |
 
 Every mode also emits the machine-readable outputs: a [SARIF log](scan.md#github-code-scanning-security-tab)
 for GitHub code scanning, a [shields.io badge](scan.md#sandbox-isolation-score-badge), and

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -461,6 +461,43 @@ fail-closed and noted. A synth or parse failure (the `cdk` binary is absent with
 an opt-in CI step never crashes the build; once containers are graded, `--min-score`
 still trips on a low posture.
 
+## Grade an AWS SAM template
+
+`--sam PATH` grades the container workloads declared in an [AWS SAM](https://aws.amazon.com/serverless/sam/)
+(Serverless Application Model) template. A SAM template carries a
+`Transform: AWS::Serverless-*` header and, when deployed, is expanded to
+CloudFormation — but SAM is a strict **superset** of CloudFormation: any resource that
+is not an `AWS::Serverless::*` type (an `AWS::ECS::TaskDefinition`, for instance) passes
+through the transform **unchanged**, in ordinary CloudFormation form. So an ECS/Fargate
+task definition in a SAM app is graded through the **exact same** shared ECS scorer as
+`--cloudformation`, with no `sam build`/transform step required. Point it at a SAM
+template file or a directory of them:
+
+```bash
+ironctl scan --sam ./template.yaml                 # grade the SAM template's ECS task defs
+ironctl scan --sam ./template.yaml --min-score 75  # CI gate
+ironctl scan --sam ./sam                            # a directory of SAM templates (weakest wins)
+ironctl scan --sam ./template.yaml --sarif scan.sarif  # upload to code-scanning
+```
+
+It is offline and daemon-free: the template is parsed on disk, with no AWS login and no
+deploy. Because a SAM template's ECS task definitions are already native
+CloudFormation, the scoring is identical to `--cloudformation`: each container
+definition runs through the shared ECS scorer, and a fully hardened task definition
+tops out at **89/100 (grade B)** — see [Grade a CloudFormation
+template](#grade-a-cloudformation-template) for the per-dimension breakdown. The
+template grade is the **weakest** container across every task definition. Unresolved
+CloudFormation intrinsics (`!Ref`/`!Sub`/`Fn::...`) are graded fail-closed and noted.
+
+`AWS::Serverless::Function` resources — including `PackageType: Image`
+Lambda-container functions — run on the managed Lambda runtime, which exposes none of
+the ECS task-definition isolation fields (privileged, user, read-only rootfs, host
+namespaces) this scorer grades, so they are not scored; the real, user-controllable
+container-isolation surface in a SAM app is its ECS/Fargate task definitions. A load or
+parse failure (an unreadable path or a malformed template) fails **open** — a clear
+diagnostic and exit 0 — so an opt-in CI step never crashes the build; once containers
+are graded, `--min-score` still trips on a low posture.
+
 ## Grade a kustomization
 
 `--kustomize DIR` renders a [Kustomize](https://kustomize.io/) directory with

--- a/internal/host/scan/sam.go
+++ b/internal/host/scan/sam.go
@@ -1,0 +1,52 @@
+package scan
+
+// SpecsFromSAM grades the container workloads declared in an AWS SAM (Serverless
+// Application Model) template. A SAM template carries `Transform: AWS::Serverless-*`
+// and, when deployed, is expanded to CloudFormation by the transform macro — but SAM
+// is a strict SUPERSET of CloudFormation: any resource that is not an
+// AWS::Serverless::* type (an AWS::ECS::TaskDefinition, for instance) passes through
+// the transform UNCHANGED, in ordinary CloudFormation form. An ECS/Fargate task
+// definition declared in a SAM template is therefore the SAME document node the
+// --cloudformation path already grades, so this is a deliberately thin seam over
+// SpecsFromCloudFormation: the SAM template bytes decode through the identical shared
+// ecsSpec mapper, PascalCase case-insensitive handling, and intrinsic fail-closed
+// nullification. No `sam build`/transform step is required to reach the ECS task
+// defs — they are already native CloudFormation in the source template.
+//
+// Keeping it a named entry point (rather than calling SpecsFromCloudFormation directly
+// from the CLI) gives the --sam mode a stable seam a parity test can pin against the
+// sibling --cloudformation mode: the same template must grade identically through both.
+// It mirrors the --cdk -> --cloudformation and --bicep -> --azure seams (route a
+// higher-level IaC input through the native template scorer unchanged).
+//
+// Scope note: the container-isolation scorer grades AWS::ECS::TaskDefinition resources.
+// AWS::Serverless::Function resources (including PackageType: Image Lambda-container
+// functions) run on the managed Lambda runtime, which exposes none of the ECS
+// task-definition isolation fields (privileged, user, readonlyRootFilesystem, host
+// namespaces) this scorer grades, so they are not graded here — the real,
+// user-controllable container-isolation surface in a SAM app is its ECS/Fargate task
+// definitions.
+//
+// The second return value reports whether any CloudFormation intrinsic was nullified
+// (graded fail-closed) so the caller can note it.
+func SpecsFromSAM(raw []byte) ([]Spec, bool, error) {
+	return SpecsFromCloudFormation(raw)
+}
+
+// AggregateSAM folds the per-container specs from one or more SAM templates into a
+// single Report. It is the AggregateCloudFormation WEAKEST-container rollup (a template
+// is only as isolated as its most-exposed container) with the Source re-labelled "sam"
+// so the report names the input mode the user actually ran, plus a note recording that
+// the grade is over the SAM template's ECS/Fargate task definitions. It is pure; the
+// caller injects Version/GeneratedAt.
+func AggregateSAM(specs []Spec, target string) (Report, Spec, error) {
+	report, worst, err := AggregateCloudFormation(specs, target)
+	if err != nil {
+		return Report{}, Spec{}, err
+	}
+	report.Source = "sam"
+	report.Notes = append([]string{
+		"input is an AWS SAM template (Transform: AWS::Serverless-*); grading covers its AWS::ECS::TaskDefinition resources through the identical --cloudformation ECS path (SAM is a CloudFormation superset)",
+	}, report.Notes...)
+	return report, worst, nil
+}

--- a/internal/host/scan/sam_test.go
+++ b/internal/host/scan/sam_test.go
@@ -1,0 +1,118 @@
+package scan
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestSAMParityWithCloudFormation locks the core contract of the --sam mode: because a
+// SAM template is a CloudFormation superset (its AWS::ECS::TaskDefinition resources are
+// already native CFN), the SAME template must grade IDENTICALLY through the --sam entry
+// point (SpecsFromSAM / AggregateSAM) and the sibling --cloudformation entry point
+// (SpecsFromCloudFormation / AggregateCloudFormation) — the only allowed difference is
+// the reported Source label (and the extra "SAM template" note). If the two ever
+// diverge, the sam path has grown its own scoring behaviour and the parity guarantee is
+// broken.
+func TestSAMParityWithCloudFormation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tmpl string
+	}{
+		{"hardened_yaml", cfnYAMLHardened},
+		{"porous_json", cfnJSONPorous},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			samSpecs, samIntr, samErr := SpecsFromSAM([]byte(tc.tmpl))
+			cfnSpecs, cfnIntr, cfnErr := SpecsFromCloudFormation([]byte(tc.tmpl))
+			if samErr != nil || cfnErr != nil {
+				t.Fatalf("parse errors: sam=%v cfn=%v", samErr, cfnErr)
+			}
+			if samIntr != cfnIntr {
+				t.Fatalf("intrinsic-skipped flag differs: sam=%v cfn=%v", samIntr, cfnIntr)
+			}
+			if !reflect.DeepEqual(samSpecs, cfnSpecs) {
+				t.Fatalf("specs diverge between sam and cloudformation entry points:\nsam=%+v\ncfn=%+v", samSpecs, cfnSpecs)
+			}
+
+			samReport, samWorst, samErr := AggregateSAM(samSpecs, "example")
+			cfnReport, cfnWorst, cfnErr := AggregateCloudFormation(cfnSpecs, "example")
+			if samErr != nil || cfnErr != nil {
+				t.Fatalf("aggregate errors: sam=%v cfn=%v", samErr, cfnErr)
+			}
+			if samReport.Score != cfnReport.Score || samReport.Grade != cfnReport.Grade {
+				t.Fatalf("grade diverges: sam=%d/%s cfn=%d/%s", samReport.Score, samReport.Grade, cfnReport.Score, cfnReport.Grade)
+			}
+			if !reflect.DeepEqual(samWorst, cfnWorst) {
+				t.Fatalf("worst spec diverges between sam and cloudformation")
+			}
+			// The one intentional difference: the Source label names the input mode.
+			if samReport.Source != "sam" {
+				t.Fatalf("sam report Source = %q, want %q", samReport.Source, "sam")
+			}
+			if cfnReport.Source != "cloudformation" {
+				t.Fatalf("cloudformation report Source = %q, want %q", cfnReport.Source, "cloudformation")
+			}
+		})
+	}
+}
+
+// TestSAMAggregateEmptyFailsClosed confirms a SAM template with no gradeable ECS
+// container is an error (fail-closed), not a silent pass.
+func TestSAMAggregateEmptyFailsClosed(t *testing.T) {
+	if _, _, err := AggregateSAM(nil, "empty"); err == nil {
+		t.Fatal("expected an error for zero gradeable containers, got nil")
+	}
+}
+
+// TestSAMTransformTemplateGrades pins that a SAM template (Transform header +
+// AWS::Serverless::Function alongside a raw AWS::ECS::TaskDefinition) grades its ECS
+// task definition through the seam: the serverless function is ignored and the porous
+// task def lands at the fail-closed floor.
+func TestSAMTransformTemplateGrades(t *testing.T) {
+	specs, _, err := SpecsFromSAM([]byte(samPorousTemplate))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	report, _, err := AggregateSAM(specs, "template.yaml")
+	if err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+	if report.Source != "sam" {
+		t.Fatalf("Source = %q, want sam", report.Source)
+	}
+	if report.Grade != "F" {
+		t.Fatalf("porous SAM ECS task def = %d/%s, want grade F", report.Score, report.Grade)
+	}
+}
+
+// samPorousTemplate is a SAM template with the AWS::Serverless-2016-10-31 transform, a
+// Lambda-container serverless function (which the ECS scorer does not grade), and a
+// porous raw AWS::ECS::TaskDefinition (root, privileged, host namespaces, docker.sock)
+// that must be graded through the CloudFormation seam and land at the fail-closed floor.
+const samPorousTemplate = `AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  ImageFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      ImageUri: 111122223333.dkr.ecr.us-east-1.amazonaws.com/app:latest
+  PorousTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      NetworkMode: host
+      PidMode: host
+      IpcMode: host
+      ContainerDefinitions:
+        - Name: app
+          Image: app:latest
+          Privileged: true
+          User: "0"
+          MountPoints:
+            - SourceVolume: docker-sock
+              ContainerPath: /var/run/docker.sock
+      Volumes:
+        - Name: docker-sock
+          Host:
+            SourcePath: /var/run/docker.sock
+`


### PR DESCRIPTION
## What

Adds `ironctl scan --sam` — grades the `AWS::ECS::TaskDefinition` resources declared in an AWS SAM template (`Transform: AWS::Serverless-*`, YAML or JSON, file or directory).

## Why a thin CFN seam

SAM is a strict **superset** of CloudFormation. Any resource that is not `AWS::Serverless::*` (an `AWS::ECS::TaskDefinition`, for instance) passes through the SAM transform **unchanged**, in ordinary CloudFormation form. So the ECS/Fargate task defs in a SAM app are already native CFN and grade through the **exact same** shared ECS scorer as `--cloudformation` — no `sam build`/transform step required. Same pattern as `--cdk -> --cloudformation` and `--bicep -> --azure`.

- `SpecsFromSAM` -> `SpecsFromCloudFormation`
- `AggregateSAM` -> `AggregateCloudFormation` (Source relabelled `sam` + seam note)

## Changes

- `internal/host/scan/sam.go` — `SpecsFromSAM` + `AggregateSAM`
- `internal/host/scan/sam_test.go` — parity vs `--cloudformation` (specs + grade + worst identical, only Source differs), fail-closed on empty, and a real SAM transform template (serverless fn + porous raw ECS task def -> grade F)
- `cmd/ironctl/scan.go` — `--sam` flag, `runSAMScan`/`loadSAMSpecs` (file or dir, mirrors `--cloudformation`), usage line
- `docs/scan-coverage.md` — IaC card + `#scan-sam` anchor + coverage-table row
- `docs/scan.md` — "Grade an AWS SAM template" section

## Scope / honesty

`AWS::Serverless::Function` (incl. `PackageType: Image` Lambda-container functions) run on the managed Lambda runtime, which exposes none of the ECS isolation fields (privileged, user, read-only rootfs, host namespaces) the scorer grades — out of scope, documented as such. The real user-controllable container-isolation surface in a SAM app is its ECS/Fargate task definitions.

## Supply-chain lenses

- **Fail-closed** — unresolved CFN intrinsics (`!Ref`/`!Sub`/`Fn::...`) grade as unset (insecure).
- **Fail-open** on load/parse error — an opt-in CI step never crashes the build; `--min-score` still gates once containers are graded.

## Verification

- `CGO_ENABLED=1 go build ./cmd/ironctl/` ✓
- `CGO_ENABLED=1 go vet ./internal/host/scan/ ./cmd/ironctl/` ✓
- `CGO_ENABLED=1 go test ./internal/host/scan/` — 217 pass ✓
- e2e: `ironctl scan --sam template.yaml` on a SAM template (serverless fn + host-network privileged root ECS task) -> **15/100 grade F**, serverless fn ignored, Source `sam`, seam note present ✓

Closes IRO-562.