### PR TITLE
feat(scan): --k8s-admission gate + AdmissionReview webhook backend [IRO-561]

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -41,6 +42,8 @@ func cmdScan(args []string) error {
 	compose := fs.String("compose", "", "grade a service in this docker-compose file")
 	service := fs.String("service", "", "compose service name (required if the file has >1 service)")
 	k8s := fs.String("k8s", "", "grade the first container in this Kubernetes pod/workload manifest")
+	k8sAdmission := fs.String("k8s-admission", "", "grade the workload carried in a Kubernetes admission.k8s.io/v1 AdmissionReview JSON (webhook backend); '-' reads stdin")
+	admissionResponse := fs.Bool("admission-response", false, "with --k8s-admission, emit an admission.k8s.io/v1 AdmissionReview response JSON (allow/deny) to stdout instead of the scorecard")
 	helm := fs.String("helm", "", "render a Helm chart (dir or .tgz) with `helm template` and grade the isolation posture of its workloads")
 	helmBin := fs.String("helm-bin", envOrDefault("HELM", "helm"), "helm binary used to render the chart")
 	terraform := fs.String("terraform", "", "grade container workloads in a `terraform show -json` file (plan.json/state.json) or a Terraform dir")
@@ -382,6 +385,26 @@ func cmdScan(args []string) error {
 			badgeJSON: *badgeJSON,
 			sarif:     *sarif,
 			minScore:  *minScore,
+		})
+	}
+
+	// --k8s-admission: grade the workload carried in a Kubernetes AdmissionReview
+	// request and gate admission on --min-score, reusing the SAME pod-spec scorer as
+	// --k8s. This turns `ironctl scan` from a static report into an in-cluster
+	// ENFORCEMENT gate: a thin ValidatingWebhook wrapper pipes the API server's
+	// request body to `scan --k8s-admission - --admission-response --min-score N`
+	// and returns stdout verbatim. Unlike the fail-OPEN batch modes, it is
+	// fail-CLOSED (unparseable input DENIES, never silently allows).
+	if *k8sAdmission != "" {
+		return runK8sAdmissionScan(k8sAdmissionArgs{
+			path:         *k8sAdmission,
+			emitResponse: *admissionResponse,
+			asJSON:       *asJSON,
+			md:           *md,
+			badge:        *badge,
+			badgeJSON:    *badgeJSON,
+			sarif:        *sarif,
+			minScore:     *minScore,
 		})
 	}
 
@@ -2369,6 +2392,143 @@ func fileExists(path string) bool {
 	return err == nil && !info.IsDir()
 }
 
+// k8sAdmissionArgs carries the resolved inputs for a `scan --k8s-admission` run.
+type k8sAdmissionArgs struct {
+	path         string
+	emitResponse bool
+	asJSON       bool
+	md           bool
+	badge        string
+	badgeJSON    string
+	sarif        string
+	minScore     int
+}
+
+// runK8sAdmissionScan grades the workload carried in a Kubernetes AdmissionReview
+// request and gates admission on --min-score, reusing the SAME pod-spec scorer as
+// --k8s. Two output modes:
+//
+//   - default (scorecard): print the table/JSON/md/badge/SARIF for the admitted
+//     workload, exactly like --k8s, and trip a non-zero exit below --min-score.
+//     This is the local/CI shape (inspect what a webhook WOULD decide).
+//   - --admission-response: emit an admission.k8s.io/v1 AdmissionReview response
+//     JSON (allow/deny, echoing the request uid) to stdout. This is the webhook
+//     backend shape: a thin HTTP wrapper serves stdout as the response body.
+//
+// It is fail-CLOSED, unlike the fail-OPEN batch modes (--helm/--terraform): an
+// admission webhook is an enforcement gate, so unreadable/unparseable input, a
+// missing request, or an object with nothing to grade DENIES admission (emits a
+// deny response in --admission-response mode) and exits non-zero. A denied gate
+// always exits non-zero; in --admission-response mode the deny JSON is still
+// written to stdout first so the webhook wrapper returns a valid response body.
+func runK8sAdmissionScan(a k8sAdmissionArgs) error {
+	raw, err := readFileOrStdin(a.path)
+	if err != nil {
+		return admissionFailClosed(a, "", fmt.Errorf("read AdmissionReview: %w", err))
+	}
+	spec, uid, err := scan.SpecFromAdmissionReview(raw)
+	if err != nil {
+		return admissionFailClosed(a, uid, err)
+	}
+
+	report := scan.Score(spec)
+	report.Version = version.String()
+	report.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+
+	target := spec.Target
+	if target == "" {
+		target = "workload"
+	}
+	allowed := a.minScore <= 0 || report.Score >= a.minScore
+
+	// --admission-response: emit the AdmissionReview response the API server expects
+	// and return. The exit code still reflects the decision (non-zero on deny) for
+	// CI callers; the JSON is written first so a webhook wrapper always has a body.
+	if a.emitResponse {
+		var msg string
+		if allowed {
+			msg = fmt.Sprintf("IronClaw containment gate: %s scored %d/100 (grade %s)", target, report.Score, report.Grade)
+		} else {
+			msg = fmt.Sprintf("IronClaw containment gate: %s scored %d/100 (grade %s), below the required %d", target, report.Score, report.Grade, a.minScore)
+		}
+		out, merr := scan.AdmissionReviewResponse(uid, allowed, msg, nil)
+		if merr != nil {
+			return merr
+		}
+		fmt.Fprintln(os.Stdout, string(out))
+		if !allowed {
+			return fmt.Errorf("k8s-admission denied: %s", msg)
+		}
+		return nil
+	}
+
+	// Scorecard mode: same representations as the other file modes.
+	if a.asJSON {
+		if err := scan.RenderJSON(os.Stdout, report); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderTable(os.Stdout, report)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderMarkdown(report))
+	}
+	if a.badge != "" {
+		if err := os.WriteFile(a.badge, []byte(scan.RenderBadgeSVG(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote badge: %s\n", a.badge)
+		}
+	}
+	if a.badgeJSON != "" {
+		if err := os.WriteFile(a.badgeJSON, []byte(scan.RenderBadgeEndpointJSON(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-json: %w", err)
+		}
+		if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", a.badgeJSON)
+		}
+	}
+	if a.sarif != "" {
+		// SARIF is a best-effort side artifact: fail-open, never blocks the scan.
+		if err := writeSARIF(a.sarif, report, spec, scan.SARIFOptions{}); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (scan result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	// CI gate: fail-closed below the requested threshold (workload graded).
+	if a.minScore > 0 && report.Score < a.minScore {
+		return fmt.Errorf("containment score %d/100 is below the required %d", report.Score, a.minScore)
+	}
+	return nil
+}
+
+// admissionFailClosed handles an input that could not be graded. As an ENFORCEMENT
+// gate this DENIES: in --admission-response mode it writes a deny AdmissionReview
+// (echoing the uid when one was recovered) to stdout so the webhook wrapper returns
+// a valid body, then returns a non-zero error in every mode.
+func admissionFailClosed(a k8sAdmissionArgs, uid string, cause error) error {
+	if a.emitResponse {
+		msg := "IronClaw containment gate denied (fail-closed): " + cause.Error()
+		if out, merr := scan.AdmissionReviewResponse(uid, false, msg, nil); merr == nil {
+			fmt.Fprintln(os.Stdout, string(out))
+		}
+	}
+	return fmt.Errorf("k8s-admission fail-closed (denied): %w", cause)
+}
+
+// readFileOrStdin reads path, or stdin when path is "-" (the webhook-backend shape,
+// where the request body is piped in).
+func readFileOrStdin(path string) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(os.Stdin)
+	}
+	return os.ReadFile(path)
+}
+
 func writeDockerfileSARIF(path string, r scan.Report, opts scan.SARIFOptions) error {
 	f, err := os.Create(path)
 	if err != nil {
@@ -2497,6 +2657,7 @@ USAGE:
   ironctl scan <container>                    grade a running container (docker|podman|nerdctl)
   ironctl scan --compose FILE [--service N]   grade a docker-compose service
   ironctl scan --k8s FILE                     grade a Kubernetes pod/workload manifest
+  ironctl scan --k8s-admission FILE            grade the workload in a Kubernetes AdmissionReview JSON (webhook backend; '-' = stdin)
   ironctl scan --helm CHART                    render a Helm chart (dir or .tgz) and grade its workloads
   ironctl scan --terraform PATH                grade container workloads in a terraform show -json file/dir
   ironctl scan --nomad PATH                     grade docker-driver tasks in a Nomad job spec (JSON or HCL)
@@ -2522,7 +2683,8 @@ FLAGS:
   --badge-json PATH   write a shields.io endpoint JSON badge to PATH (live README badge)
   --sarif PATH        write a SARIF 2.1.0 log to PATH (GitHub code-scanning upload)
   --md                print a shareable markdown block
-  --min-score N       exit non-zero if the score is below N (CI gate)
+  --min-score N       exit non-zero if the score is below N (CI gate; the admission threshold for --k8s-admission)
+  --admission-response  with --k8s-admission, emit an AdmissionReview response JSON (allow/deny) to stdout
   --service NAME      compose service to grade (if the file has >1)
   --helm-bin BIN      helm binary for `+"`helm template`"+` (default: helm)
   --terraform-bin BIN terraform binary for `+"`terraform show -json`"+` (default: terraform)
@@ -2660,5 +2822,15 @@ pinned base image, no secrets in ENV/ARG, COPY over remote/opaque ADD, no
 world-writable files, HEALTHCHECK, layer hygiene). Runtime hardening (caps,
 seccomp, network, rootfs, docker.sock) is set at run time and is NOT expressible
 in a Dockerfile, so a high static grade still needs a runtime scan.
+
+--k8s-admission turns scan into an in-cluster ENFORCEMENT gate. It reads a
+Kubernetes admission.k8s.io/v1 AdmissionReview request ('-' = stdin), grades the
+admitted workload through the SAME pod-spec scorer as --k8s, and gates admission
+on --min-score. By default it prints the scorecard (what a webhook WOULD decide);
+with --admission-response it emits an AdmissionReview response JSON (allow/deny,
+echoing the request uid) so a thin ValidatingWebhook wrapper can serve stdout as
+the response body. Unlike the fail-OPEN batch modes, it is fail-CLOSED: an
+unparseable review or an object with nothing to grade DENIES admission and exits
+non-zero (the deny JSON is still written in --admission-response mode).
 `)
 }

--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -174,6 +174,20 @@ roll up to the **weakest** workload they produce.
 
     [:octicons-arrow-right-24: Scan reference](scan.md)
 
+-   #### :simple-kubernetes:{ .lg .middle } Admission gate { #scan-k8s-admission }
+
+    ---
+
+    Turns scan into an in-cluster **enforcement gate**. Grades the workload in a Kubernetes
+    **AdmissionReview** through the same pod-spec scorer and gates admission on `--min-score`;
+    `--admission-response` emits the allow/deny JSON a **ValidatingWebhook** returns. Fail-closed.
+
+    ```bash
+    ironctl scan --k8s-admission - --admission-response --min-score 80
+    ```
+
+    [:octicons-arrow-right-24: Scan reference](scan.md#grade-a-kubernetes-admission-review)
+
 </div>
 
 ### Cloud runtimes { #modes-cloud }
@@ -333,6 +347,7 @@ the container they eventually produce are all measured on one comparable scale.
 | Compose &amp; orchestrators | [Kustomize overlay](#scan-kustomize) | `--kustomize` | weakest workload from `kustomize build` | [Grade a kustomization](scan.md#grade-a-kustomization) |
 | Compose &amp; orchestrators | [Nomad job](#scan-nomad) | `--nomad` | docker-driver tasks in a job spec | [Scan reference](scan.md) |
 | Compose &amp; orchestrators | [OpenShift manifest](#scan-openshift) | `--openshift` | weakest workload (DeploymentConfig/Deployment/Pod) | [Scan reference](scan.md) |
+| Compose &amp; orchestrators | [Admission gate](#scan-k8s-admission) | `--k8s-admission` `--admission-response` | the workload in an AdmissionReview (webhook backend) | [Grade a Kubernetes AdmissionReview](scan.md#grade-a-kubernetes-admission-review) |
 | Cloud runtimes | [Cloud Run](#scan-cloudrun) | `--cloudrun` | a Knative Service's container config | [Grade a Cloud Run service](scan.md#grade-a-google-cloud-run-service) |
 | Cloud runtimes | [Amazon ECS](#scan-ecs) | `--ecs` | a task definition's container contract | [Grade an ECS task definition](scan.md#grade-an-aws-ecs-task-definition) |
 | Cloud runtimes | [Azure Container Instances](#scan-azure) | `--azure` | weakest container in an ARM `containerGroups` | [Grade an Azure container group](scan.md#grade-an-azure-container-group) |

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -492,6 +492,43 @@ build; once the kustomization renders, `--min-score` still trips on a low postur
 Point at a non-default renderer with `--kustomize-bin` / `--kubectl-bin` (or the
 `KUSTOMIZE` / `KUBECTL` environment variables).
 
+## Grade a Kubernetes Admission Review
+
+`--k8s-admission FILE` moves scan from a static report to an **in-cluster
+enforcement gate**. It reads a Kubernetes [`admission.k8s.io/v1`
+AdmissionReview](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
+request &mdash; the exact JSON body the API server POSTs to a validating webhook
+&mdash; grades the admitted workload through the **same pod-spec scorer as
+`--k8s`**, and gates admission on `--min-score`. Pass `-` to read the request from
+stdin (the webhook shape):
+
+```bash
+# Local / CI: inspect what a webhook WOULD decide (scorecard + exit gate)
+ironctl scan --k8s-admission review.json --min-score 80
+
+# Webhook backend: emit the AdmissionReview response the API server expects
+ironctl scan --k8s-admission - --admission-response --min-score 80 < review.json
+```
+
+By default it prints the familiar scorecard (table, or `--json`/`--md`/`--sarif`)
+and exits non-zero below `--min-score`. With `--admission-response` it instead
+emits an `admission.k8s.io/v1` AdmissionReview **response** to stdout &mdash;
+`response.allowed` set from the grade, the request `uid` echoed (the API server
+rejects a mismatch), and a `403` status message on deny &mdash; so a thin
+`ValidatingWebhookConfiguration` backend can serve stdout verbatim as its HTTP
+response body. Because the object under admission is fed straight to the `--k8s`
+scorer, the admission decision is **identical** to what `ironctl scan --k8s` would
+report for the same manifest (parity is unit-tested).
+
+Unlike the fail-**open** batch modes (`--helm`, `--terraform`, `--kustomize`), an
+admission gate is fail-**closed**: an unreadable or unparseable review, a missing
+request, or an object with nothing to grade **denies** admission and exits
+non-zero (the deny JSON is still written first in `--admission-response` mode, so
+the webhook always returns a valid body). A gate must never silently admit what it
+could not inspect. As with `--k8s`, network egress depends on a `NetworkPolicy`
+not visible in the pod spec, so the honest static ceiling applies &mdash; size
+`--min-score` accordingly (a fully hardened pod tops out around a strong **B**).
+
 ## Grade a Dockerfile statically
 
 `--dockerfile FILE` grades a Dockerfile with no daemon and no image pull, so it

--- a/internal/host/scan/k8s_admission.go
+++ b/internal/host/scan/k8s_admission.go
@@ -1,0 +1,144 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// admissionReview is the minimal shape of a Kubernetes admission.k8s.io/v1
+// AdmissionReview REQUEST: enough to pull the admitted object and echo the uid.
+// It is decoded with encoding/json (the API server always sends JSON); the
+// carried object is then handed to the SAME pod-spec scorer as `--k8s`.
+type admissionReview struct {
+	APIVersion string             `json:"apiVersion"`
+	Kind       string             `json:"kind"`
+	Request    *admissionRequest  `json:"request,omitempty"`
+	Response   *admissionResponse `json:"response,omitempty"`
+}
+
+// admissionRequest mirrors the request half of an AdmissionReview. Object is the
+// resource being admitted (the CREATE/UPDATE target); OldObject is the prior
+// state (populated on UPDATE/DELETE). Both are kept raw so the graded object is
+// fed verbatim to SpecFromK8s.
+type admissionRequest struct {
+	UID       string          `json:"uid"`
+	Kind      groupVersionK   `json:"kind"`
+	Name      string          `json:"name"`
+	Namespace string          `json:"namespace"`
+	Operation string          `json:"operation"`
+	Object    json.RawMessage `json:"object"`
+	OldObject json.RawMessage `json:"oldObject"`
+}
+
+// groupVersionK is the request.kind GroupVersionKind (used only for diagnostics).
+type groupVersionK struct {
+	Group   string `json:"group"`
+	Version string `json:"version"`
+	Kind    string `json:"kind"`
+}
+
+// admissionResponse is the response half IronClaw emits when acting as a webhook
+// backend. status carries a human-readable deny reason (surfaced by kubectl when
+// the API server rejects the object).
+type admissionResponse struct {
+	UID      string           `json:"uid"`
+	Allowed  bool             `json:"allowed"`
+	Status   *admissionStatus `json:"status,omitempty"`
+	Warnings []string         `json:"warnings,omitempty"`
+	// PatchType/Patch are intentionally omitted: this is a VALIDATING gate, never
+	// mutating. It only ever allows or denies; it never rewrites the object.
+}
+
+type admissionStatus struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message"`
+}
+
+// SpecFromAdmissionReview parses a Kubernetes admission.k8s.io/v1 AdmissionReview
+// request payload (the JSON body a ValidatingWebhookConfiguration POSTs to its
+// backend) and grades the admitted workload with the SAME pod-spec scorer as
+// `--k8s`. It returns the graded Spec and the request uid (which a webhook
+// response MUST echo). The source is labeled "k8s-admission" so the scorecard
+// names the origin.
+//
+// Fail-CLOSED, and deliberately unlike the fail-OPEN batch modes (--helm /
+// --terraform): an admission webhook is an ENFORCEMENT gate, so an unparseable
+// review, a missing request, or an object with nothing to grade is an ERROR the
+// caller must translate into a DENY — never a silent allow. The one tolerated
+// no-object case is a sub-resource/connect request the caller handles explicitly.
+func SpecFromAdmissionReview(raw []byte) (Spec, string, error) {
+	var ar admissionReview
+	if err := json.Unmarshal(raw, &ar); err != nil {
+		return Spec{}, "", fmt.Errorf("parse AdmissionReview: %w", err)
+	}
+	if k := strings.TrimSpace(ar.Kind); k != "" && k != "AdmissionReview" {
+		return Spec{}, "", fmt.Errorf("payload kind is %q, not AdmissionReview", k)
+	}
+	if ar.Request == nil {
+		return Spec{}, "", fmt.Errorf("AdmissionReview carries no request")
+	}
+	uid := ar.Request.UID
+
+	// Grade the object under admission. On DELETE the object is empty and only
+	// oldObject is present; grade whichever is available so a delete review is
+	// still gradeable rather than a hard error.
+	obj := ar.Request.Object
+	if len(obj) == 0 {
+		obj = ar.Request.OldObject
+	}
+	if len(obj) == 0 {
+		return Spec{}, uid, fmt.Errorf("admission request for %s carries no object to grade", nz(admissionKindLabel(ar.Request), "workload"))
+	}
+
+	spec, err := SpecFromK8s(obj)
+	if err != nil {
+		return Spec{}, uid, err
+	}
+	spec.Source = "k8s-admission"
+	return spec, uid, nil
+}
+
+// admissionKindLabel renders a request's GroupVersionKind + name for diagnostics
+// (e.g. "apps/v1 Deployment web").
+func admissionKindLabel(req *admissionRequest) string {
+	if req == nil {
+		return ""
+	}
+	gv := strings.TrimPrefix(req.Kind.Group+"/"+req.Kind.Version, "/")
+	kind := strings.TrimSpace(req.Kind.Kind)
+	label := strings.TrimSpace(gv + " " + kind)
+	if n := strings.TrimSpace(req.Name); n != "" {
+		label = strings.TrimSpace(label + " " + n)
+	}
+	return strings.TrimSpace(label)
+}
+
+// AdmissionReviewResponse builds the admission.k8s.io/v1 AdmissionReview RESPONSE
+// a webhook backend returns to the API server. uid MUST match the request uid
+// (the API server rejects a mismatch). allowed decides admission; when denied,
+// message is surfaced to the user by kubectl (HTTP 403). warnings are non-fatal
+// notes shown regardless of the decision. The bytes are ready to write to the
+// webhook's HTTP response body.
+func AdmissionReviewResponse(uid string, allowed bool, message string, warnings []string) ([]byte, error) {
+	resp := admissionReview{
+		APIVersion: "admission.k8s.io/v1",
+		Kind:       "AdmissionReview",
+		Response: &admissionResponse{
+			UID:      uid,
+			Allowed:  allowed,
+			Warnings: warnings,
+		},
+	}
+	if !allowed {
+		resp.Response.Status = &admissionStatus{Code: 403, Message: nz(message, "denied by IronClaw containment gate")}
+	} else if strings.TrimSpace(message) != "" {
+		// An allowed response may still carry an informational status message.
+		resp.Response.Status = &admissionStatus{Code: 200, Message: message}
+	}
+	out, err := json.Marshal(resp)
+	if err != nil {
+		return nil, fmt.Errorf("marshal AdmissionReview response: %w", err)
+	}
+	return out, nil
+}

--- a/internal/host/scan/k8s_admission_test.go
+++ b/internal/host/scan/k8s_admission_test.go
@@ -1,0 +1,177 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// admObjWeak / admObjHardened are the SAME workloads as k8s_test.go's fixtures,
+// expressed as JSON objects so they can be embedded verbatim inside an
+// AdmissionReview request.object (the API server always sends JSON).
+const admObjHardened = `{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {"name": "hardened-pod"},
+  "spec": {
+    "containers": [{
+      "name": "app",
+      "image": "ironclaw",
+      "securityContext": {
+        "runAsNonRoot": true,
+        "runAsUser": 65532,
+        "readOnlyRootFilesystem": true,
+        "allowPrivilegeEscalation": false,
+        "capabilities": {"drop": ["ALL"]},
+        "seccompProfile": {"type": "RuntimeDefault"}
+      }
+    }]
+  }
+}`
+
+const admObjWeak = `{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {"name": "weak-pod"},
+  "spec": {
+    "hostPID": true,
+    "hostNetwork": true,
+    "containers": [{
+      "name": "app",
+      "image": "nginx",
+      "securityContext": {"privileged": true}
+    }]
+  }
+}`
+
+const admObjDeployment = `{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {"name": "dep"},
+  "spec": {"template": {"spec": {"containers": [{
+    "name": "app",
+    "securityContext": {
+      "runAsUser": 1000,
+      "readOnlyRootFilesystem": true,
+      "capabilities": {"drop": ["ALL"]},
+      "seccompProfile": {"type": "RuntimeDefault"}
+    }
+  }]}}}
+}`
+
+// review wraps a k8s object JSON in an AdmissionReview request with the given uid.
+func review(uid, obj string) string {
+	return fmt.Sprintf(`{"apiVersion":"admission.k8s.io/v1","kind":"AdmissionReview","request":{"uid":%q,"operation":"CREATE","kind":{"group":"","version":"v1","kind":"Pod"},"name":"x","namespace":"default","object":%s}}`, uid, obj)
+}
+
+// TestAdmission_ParityWithK8s is the core acceptance: an admitted object grades
+// IDENTICALLY to the same object fed through --k8s. The admission path is a thin
+// wrapper over the SAME scorer, so every posture field and the final score must
+// match; only the Source label differs.
+func TestAdmission_ParityWithK8s(t *testing.T) {
+	for _, obj := range []struct {
+		name string
+		json string
+	}{
+		{"hardened", admObjHardened},
+		{"weak", admObjWeak},
+		{"deployment", admObjDeployment},
+	} {
+		t.Run(obj.name, func(t *testing.T) {
+			direct, err := SpecFromK8s([]byte(obj.json))
+			if err != nil {
+				t.Fatalf("SpecFromK8s: %v", err)
+			}
+			adm, uid, err := SpecFromAdmissionReview([]byte(review("uid-1", obj.json)))
+			if err != nil {
+				t.Fatalf("SpecFromAdmissionReview: %v", err)
+			}
+			if uid != "uid-1" {
+				t.Errorf("uid=%q, want uid-1", uid)
+			}
+			if adm.Source != "k8s-admission" {
+				t.Errorf("source=%q, want k8s-admission", adm.Source)
+			}
+			// Normalize Source so the rest of the Spec must match byte-for-byte.
+			direct.Source, adm.Source = "", ""
+			dj, _ := json.Marshal(direct)
+			aj, _ := json.Marshal(adm)
+			if string(dj) != string(aj) {
+				t.Errorf("admission spec diverged from --k8s scorer:\n direct=%s\n admit =%s", dj, aj)
+			}
+			if Score(direct).Score != Score(adm).Score {
+				t.Errorf("score parity broken: k8s=%d admission=%d", Score(direct).Score, Score(adm).Score)
+			}
+		})
+	}
+}
+
+// TestAdmission_GradesDeleteOldObject: a DELETE review carries oldObject, not
+// object; it must still be gradeable rather than a hard error.
+func TestAdmission_GradesDeleteOldObject(t *testing.T) {
+	raw := fmt.Sprintf(`{"apiVersion":"admission.k8s.io/v1","kind":"AdmissionReview","request":{"uid":"del-1","operation":"DELETE","oldObject":%s}}`, admObjWeak)
+	s, uid, err := SpecFromAdmissionReview([]byte(raw))
+	if err != nil {
+		t.Fatalf("delete review should grade oldObject: %v", err)
+	}
+	if uid != "del-1" || s.Privileged != Yes {
+		t.Errorf("oldObject not graded: uid=%q spec=%+v", uid, s)
+	}
+}
+
+// TestAdmission_FailClosed: an enforcement gate must ERROR (deny) on any input it
+// cannot grade, never silently allow.
+func TestAdmission_FailClosed(t *testing.T) {
+	cases := map[string]string{
+		"garbage":        `not json at all`,
+		"wrong kind":     `{"kind":"Pod"}`,
+		"no request":     `{"apiVersion":"admission.k8s.io/v1","kind":"AdmissionReview"}`,
+		"no object":      `{"kind":"AdmissionReview","request":{"uid":"u"}}`,
+		"empty object":   `{"kind":"AdmissionReview","request":{"uid":"u","object":{}}}`,
+		"object no ctrs": `{"kind":"AdmissionReview","request":{"uid":"u","object":{"kind":"Pod","spec":{}}}}`,
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := SpecFromAdmissionReview([]byte(raw)); err == nil {
+				t.Errorf("expected fail-closed error for %q input", name)
+			}
+		})
+	}
+}
+
+// TestAdmissionReviewResponse checks the webhook response contract: uid echoed,
+// allow carries no 403, deny carries a 403 status message.
+func TestAdmissionReviewResponse(t *testing.T) {
+	allow, err := AdmissionReviewResponse("uid-9", true, "ok", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var av admissionReview
+	if err := json.Unmarshal(allow, &av); err != nil {
+		t.Fatal(err)
+	}
+	if av.APIVersion != "admission.k8s.io/v1" || av.Kind != "AdmissionReview" {
+		t.Errorf("bad envelope: %+v", av)
+	}
+	if av.Response == nil || av.Response.UID != "uid-9" || !av.Response.Allowed {
+		t.Errorf("allow response wrong: %+v", av.Response)
+	}
+
+	deny, err := AdmissionReviewResponse("uid-9", false, "score 10/100 below 80", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dv admissionReview
+	if err := json.Unmarshal(deny, &dv); err != nil {
+		t.Fatal(err)
+	}
+	if dv.Response == nil || dv.Response.Allowed {
+		t.Fatalf("deny response should not be allowed: %+v", dv.Response)
+	}
+	if dv.Response.UID != "uid-9" {
+		t.Errorf("uid not echoed on deny: %q", dv.Response.UID)
+	}
+	if dv.Response.Status == nil || dv.Response.Status.Code != 403 {
+		t.Errorf("deny should carry a 403 status: %+v", dv.Response.Status)
+	}
+}


### PR DESCRIPTION
## What

New ENFORCEMENT wedge for `ironctl scan` (IRO-561): grade the workload in a Kubernetes **AdmissionReview** and gate admission. Moves scan from a static report to an in-cluster gate — new adoption surface (production clusters) + SEO/integration landing.

Ships **slice (a)** from the issue's design-first choice (recommended): thin, testable, no running service. It reuses the `--k8s` pod-spec scorer, so the admission decision is identical to `scan --k8s` for the same manifest.

## How

`ironctl scan --k8s-admission FILE` reads an `admission.k8s.io/v1` AdmissionReview request (`-` = stdin), extracts `request.object` (or `oldObject` on DELETE), grades it via the existing `SpecFromK8s` scorer, and gates on `--min-score`.

- **default (scorecard):** table/`--json`/`--md`/`--sarif` + non-zero exit below `--min-score` — inspect what a webhook *would* decide (local/CI).
- **`--admission-response`:** emit an `admission.k8s.io/v1` AdmissionReview **response** JSON (allow/deny, request `uid` echoed, `403` status on deny) so a thin `ValidatingWebhookConfiguration` backend serves stdout verbatim as its HTTP body.

## Security posture

Fail-**CLOSED**, deliberately unlike the fail-**open** batch modes (`--helm`/`--terraform`): an unparseable review, missing request, or object with nothing to grade **denies** admission and exits non-zero (the deny JSON is still written first in `--admission-response` mode). A gate must never silently admit what it could not inspect. Validating only — never mutates the object. Reuses the frozen k8s scorer; no contract change, no trust-boundary widening.

## Tests / verification

- `k8s_admission_test.go`: `--k8s` parity (hardened/weak/deployment), DELETE `oldObject`, fail-closed matrix (garbage/wrong-kind/no-request/no-object/empty/no-containers), response contract (uid echo, 403 on deny).
- `CGO_ENABLED=1 go test ./internal/host/scan/ ./cmd/ironctl/` → **330 pass**.
- E2E: weak pod → deny (exit 1); hardened → allow at `--min 75`, deny at `--min 80` (79/B static ceiling, same as `--k8s`); garbage stdin → deny JSON + exit 1.

## Docs

- Coverage-hub Orchestrators card `#scan-k8s-admission` + table row.
- `docs/scan.md` → "Grade a Kubernetes Admission Review" section.

Lens touched: **isolation / mandatory gateway** (enforcement gate is deterministic + fail-closed). Routing to CEO review — enforcement-surface change. Merge via request_confirmation → reviewer-approve.yml.