### PR TITLE
docs(blog): harden guides wave 12 (arangodb/solr/victoria-metrics/emqx) [IRO-572]

### DIFF
--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -60,5 +60,9 @@ nav:
   - "How to harden a Redpanda container": harden-redpanda-container-isolation.md
   - "How to harden a Qdrant container": harden-qdrant-container-isolation.md
   - "How to harden a ScyllaDB container": harden-scylla-container-isolation.md
+  - "How to harden an ArangoDB container": harden-arangodb-container-isolation.md
+  - "How to harden a Solr container": harden-solr-container-isolation.md
+  - "How to harden a VictoriaMetrics container": harden-victoria-metrics-container-isolation.md
+  - "How to harden an EMQX container": harden-emqx-container-isolation.md
   - "How to scan a Dockerfile for security issues": scan-a-dockerfile-for-security-issues.md
   - "*.md"

--- a/docs/blog/harden-arangodb-container-isolation.md
+++ b/docs/blog/harden-arangodb-container-isolation.md
@@ -1,0 +1,102 @@
+---
+title: "How to harden an ArangoDB container: arangodb:3.12 scores 48/100 by default"
+description: "arangodb:3.12 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden an ArangoDB container (and is arangodb:3.12 safe for untrusted workloads?)
+
+Short answer: a stock `docker run arangodb:3.12` is **not** a boundary you should trust around
+untrusted code or an untrusted network. Graded on IronClaw's seven-dimension containment scale, the
+default configuration scores **48 of 100, grade D (porous)**. Higher is safer. Four runtime flags
+take the same image to **100 of 100, grade A**. This guide shows the exact gaps and the exact fixes,
+straight from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `arangodb:3.12`, the same data behind
+> its [isolation scorecard](../scores/arangodb.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run arangodb:3.12`, four of them fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a multi-model database that holds your graphs, documents, and key-value data in one place, the
+two that should worry you most are **egress** and **root**. An ArangoDB process that can reach the
+network is a process that can exfiltrate every collection the moment it is compromised (a poisoned
+AQL query, a Foxx service CVE). And a root process that escapes the container escapes as root on the
+host.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-arangodb --fix` prints one remediation per failed dimension, then a single
+copy-pasteable hardened run. For `arangodb:3.12`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. ArangoDB needs none of the defaults.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the data directory at a volume this uid owns.
+- **`--network=none`** (Network isolation, +11): if the database is only reached by services on a
+  private user-defined network, cut host egress entirely; otherwise attach a single internal network
+  with no default route, not `bridge`.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/var/lib/arangodb3` as an explicit writable volume. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name arangodb -e ARANGO_ROOT_PASSWORD=changeme arangodb:3.12
+
+# After: 100/100, grade A
+docker run -d --name arangodb-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v arangodb-data:/var/lib/arangodb3 \
+  --network=none \
+  -e ARANGO_ROOT_PASSWORD=changeme \
+  arangodb:3.12
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan arangodb-hardened` reports
+`100/100 grade A`. That is a **52-point swing from four one-line flags**, no image rebuild.
+
+If ArangoDB is clustered (Coordinators and DB-Servers talk to Agents over the network) or serves
+remote clients, keep the data node hardened but hold the network dimension at a WARN with a scoped
+internal network instead of `--network=none`. That is an honest **89/100, grade B** ceiling: the
+last 11 points pay for cutting a connection the cluster needs.
+
+## Verify it on your own database
+
+The grade above is the default image. Your deployment is what matters. Scan it in ten seconds:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-arangodb
+ironctl scan my-arangodb --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the ArangoDB in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [arangodb:3.12 isolation scorecard &rarr;](../scores/arangodb.md): the full dimension breakdown.
+- [Databases, ranked by isolation &rarr;](../scores/collections/databases.md): how ArangoDB compares to Postgres, MongoDB, Neo4j, and the rest.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-emqx-container-isolation.md
+++ b/docs/blog/harden-emqx-container-isolation.md
@@ -1,0 +1,105 @@
+---
+title: "How to harden an EMQX container: emqx:5 scores 63/100 by default"
+description: "emqx:5 defaults score 63/100 (grade C): full caps and a writable rootfs. The exact ironctl scan --fix flags that take it to an honest 89/100 grade B ceiling."
+---
+
+# How to harden an EMQX container (and is emqx:5 safe for untrusted workloads?)
+
+Short answer: a stock `docker run emqx:5` already runs as a non-root uid, but it is **not** a boundary
+you should trust around untrusted code or an untrusted network. Graded on IronClaw's seven-dimension
+containment scale, the default configuration scores **63 of 100, grade C (partial)**. Higher is safer.
+A few runtime flags take the same image to an honest **89 of 100, grade B** ceiling, the most a broker
+can reach without breaking the thing it exists to do: accept connections. This guide shows the exact
+gaps, the exact fixes, and why 89 is the honest number.
+
+> Every number here comes from a read-only `docker inspect` of `emqx:5`, the same data behind its
+> [isolation scorecard](../scores/emqx.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run emqx:5`,
+three of them fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as uid emqx (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+EMQX already ships the hardest win, a non-root uid. What is left is a full Linux capability set and a
+writable root filesystem. An MQTT broker that keeps all its default capabilities is a broker where a
+compromise (a malicious payload, a protocol CVE) starts with more Linux privilege than it will ever
+need, and a writable rootfs is a persistence surface an attacker keeps across a restart.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-emqx --fix` prints one remediation per failed dimension, then a single
+copy-pasteable hardened run. For `emqx:5`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. EMQX needs none of the defaults.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/opt/emqx/data` as an explicit writable volume. Removes the persistence surface.
+- **Scope the network, do not cut it** (Network isolation, held at WARN): a broker exists to be
+  connected to, so `--network=none` would break it. Put EMQX on a dedicated internal Docker network
+  that only its publishers and subscribers join, with no default route to the host or internet.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name emqx -p 1883:1883 emqx:5
+
+# After: 89/100, grade B (the honest broker ceiling)
+docker network create --internal mqtt-net
+docker run -d --name emqx-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v emqx-data:/opt/emqx/data \
+  --network=mqtt-net \
+  emqx:5
+```
+
+Rescan and six of seven dimensions pass; the network dimension holds at a WARN by design:
+`ironctl scan emqx-hardened` reports `89/100 grade B`. That is a **26-point swing from a few
+one-line flags**, no image rebuild.
+
+## Why 89 is the ceiling, not a failure
+
+The last 11 points live in the network dimension, and a broker cannot claim them without ceasing to
+be a broker. Publishers and subscribers have to reach the listener, so the honest posture is a
+**scoped** network, not **no** network. We hold the dimension at a WARN and say so, rather than mount
+a fake `--network=none` that would score 100 and drop every MQTT client. The mitigation that matters
+is blast radius: an internal network with no default route means a compromised EMQX can talk to its
+clients and nothing else, not the host, not the internet.
+
+## Verify it on your own broker
+
+The grade above is the default image. Your deployment is what matters. Scan it in ten seconds:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-emqx
+ironctl scan my-emqx --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the EMQX in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [emqx:5 isolation scorecard &rarr;](../scores/emqx.md): the full dimension breakdown.
+- [Message queues, ranked by isolation &rarr;](../scores/collections/message-queues.md): how EMQX compares to Kafka, RabbitMQ, NATS, and the rest.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-solr-container-isolation.md
+++ b/docs/blog/harden-solr-container-isolation.md
@@ -1,0 +1,98 @@
+---
+title: "How to harden a Solr container: solr:9 scores 63/100 by default"
+description: "solr:9 defaults score 63/100 (grade C): full caps and a writable rootfs. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden an Apache Solr container (and is solr:9 safe for untrusted workloads?)
+
+Short answer: a stock `docker run solr:9` already runs as a non-root uid, but it is **not** a boundary
+you should trust around untrusted code or an untrusted network. Graded on IronClaw's seven-dimension
+containment scale, the default configuration scores **63 of 100, grade C (partial)**. Higher is
+safer. Three runtime flags take the same image to **100 of 100, grade A**. This guide shows the exact
+gaps and the exact fixes, straight from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `solr:9`, the same data behind its
+> [isolation scorecard](../scores/solr.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run solr:9`,
+three of them fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as uid 8983 (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+Solr already ships the hardest win, a non-root uid. What is left is a full Linux capability set and a
+writable root filesystem. A Solr instance that can reach the network is one that can exfiltrate every
+indexed document the moment it is compromised (a malicious `stream.body` request, a data-import CVE),
+and a writable rootfs is a persistence surface an attacker keeps after a restart.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-solr --fix` prints one remediation per failed dimension, then a single
+copy-pasteable hardened run. For `solr:9`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. Solr needs none of the defaults.
+- **`--network=none`** (Network isolation, +11): if the search node is only reached by services on a
+  private user-defined network, cut host egress entirely; otherwise attach a single internal network
+  with no default route, not `bridge`.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/var/solr` as an explicit writable volume. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name solr -p 8983:8983 solr:9
+
+# After: 100/100, grade A
+docker run -d --name solr-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v solr-data:/var/solr \
+  --network=none \
+  solr:9
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan solr-hardened` reports
+`100/100 grade A`. That is a **37-point swing from three one-line flags**, no image rebuild.
+
+If Solr is queried by application servers over the network or runs as a SolrCloud cluster with peers
+talking to ZooKeeper, keep the node hardened but hold the network dimension at a WARN with a scoped
+internal network instead of `--network=none`. That is an honest **89/100, grade B** ceiling: the last
+11 points pay for cutting the query connection your app needs.
+
+## Verify it on your own search node
+
+The grade above is the default image. Your deployment is what matters. Scan it in ten seconds:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-solr
+ironctl scan my-solr --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Solr in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [solr:9 isolation scorecard &rarr;](../scores/solr.md): the full dimension breakdown.
+- [Search engines, ranked by isolation &rarr;](../scores/collections/search-engines.md): how Solr compares to Elasticsearch, OpenSearch, Meilisearch, and the rest.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-victoria-metrics-container-isolation.md
+++ b/docs/blog/harden-victoria-metrics-container-isolation.md
@@ -1,0 +1,102 @@
+---
+title: "How to harden a VictoriaMetrics container: victoria-metrics:v1.107.0 scores 48/100 by default"
+description: "victoria-metrics:v1.107.0 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take it to 100/100 grade A."
+---
+
+# How to harden a VictoriaMetrics container (and is victoria-metrics:v1.107.0 safe for untrusted workloads?)
+
+Short answer: a stock `docker run victoriametrics/victoria-metrics:v1.107.0` is **not** a boundary you
+should trust around untrusted code or an untrusted network. Graded on IronClaw's seven-dimension
+containment scale, the default configuration scores **48 of 100, grade D (porous)**. Higher is safer.
+Four runtime flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and
+the exact fixes, straight from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of
+> `victoriametrics/victoria-metrics:v1.107.0`, the same data behind its
+> [isolation scorecard](../scores/victoria-metrics.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default
+`docker run victoriametrics/victoria-metrics:v1.107.0`, four of them fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+For a time-series database that holds every metric your fleet emits, the two that should worry you
+most are **egress** and **root**. A VictoriaMetrics process that can reach the network is one that can
+exfiltrate your entire metrics history the moment it is compromised (a poisoned remote-write payload,
+a MetricsQL CVE). And a root process that escapes the container escapes as root on the host.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-victoria-metrics --fix` prints one remediation per failed dimension, then a single
+copy-pasteable hardened run. For `victoriametrics/victoria-metrics:v1.107.0`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. VictoriaMetrics needs none of the defaults.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. Point the storage directory at a volume this uid owns.
+- **`--network=none`** (Network isolation, +11): if the TSDB is only reached by services on a private
+  user-defined network, cut host egress entirely; otherwise attach a single internal network with no
+  default route, not `bridge`.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/victoria-metrics-data` as an explicit writable volume. Removes the persistence surface.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name victoria-metrics \
+  victoriametrics/victoria-metrics:v1.107.0
+
+# After: 100/100, grade A
+docker run -d --name victoria-metrics-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v vmdata:/victoria-metrics-data \
+  --network=none \
+  victoriametrics/victoria-metrics:v1.107.0
+```
+
+Rescan and the same seven dimensions all pass: `ironctl scan victoria-metrics-hardened` reports
+`100/100 grade A`. That is a **52-point swing from four one-line flags**, no image rebuild.
+
+`--network=none` fits a store that is queried only by co-located services. If a fleet of agents or
+`vmagent` instances pushes metrics in over the network, keep the node hardened but hold the network
+dimension at a WARN with a scoped internal network instead. That is an honest **89/100, grade B**
+ceiling: the last 11 points pay for cutting the remote-write connection the fleet needs.
+
+## Verify it on your own database
+
+The grade above is the default image. Your deployment is what matters. Scan it in ten seconds:
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-victoria-metrics
+ironctl scan my-victoria-metrics --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the VictoriaMetrics in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [victoria-metrics:v1.107.0 isolation scorecard &rarr;](../scores/victoria-metrics.md): the full dimension breakdown.
+- [Observability tools, ranked by isolation &rarr;](../scores/collections/observability.md): how VictoriaMetrics compares to Prometheus, InfluxDB, Loki, and the rest.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -47,6 +47,9 @@ Two patterns show up across the set:
 | [Dragonfly](harden-dragonfly-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B as a shared network cache) |
 | [OpenSearch](harden-opensearch-container-isolation.md) | 63/100 C | **100/100 A** | full caps, writable rootfs (89/B multi-node cluster) |
 | [Qdrant](harden-qdrant-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs |
+| [ArangoDB](harden-arangodb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if clustered or remote clients) |
+| [Solr](harden-solr-container-isolation.md) | 63/100 C | **100/100 A** | full caps, writable rootfs (89/B multi-node cluster or remote clients) |
+| [VictoriaMetrics](harden-victoria-metrics-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if a fleet pushes metrics) |
 | [ScyllaDB](harden-scylla-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B multi-node cluster) |
 | [Untrusted Node.js](run-untrusted-nodejs-code-safely.md) | 48/100 D | **100/100 A** | run untrusted code in a real sandbox |
 
@@ -76,6 +79,7 @@ These services must accept client connections, so the network dimension holds at
 | [Immich](harden-immich-server-container-isolation.md) | 48/100 D | **89/100 B** | photo server: browsers and mobile apps must reach it |
 | [pgAdmin](harden-pgadmin4-container-isolation.md) | 63/100 C | **89/100 B** | admin console: your browser must reach the UI |
 | [Redpanda](harden-redpanda-container-isolation.md) | 63/100 C | **89/100 B** | broker: producers and consumers must connect |
+| [EMQX](harden-emqx-container-isolation.md) | 63/100 C | **89/100 B** | MQTT broker: publishers and subscribers must connect |
 
 ## The pattern, one command
 


### PR DESCRIPTION
Wave 12 of the SEO harden-guide funnel (non-gated growth lever). Four NEW scorecard-backed components, all verified to have a `docs/scores/<slug>.md` before selection.

## Guides
| Component | Default | Hardened | Class |
|---|---|---|---|
| ArangoDB (arangodb:3.12) | 48/D | **100/A** | multi-model store; 89/B if clustered/remote clients |
| Solr (solr:9) | 63/C | **100/A** | search node; 89/B multi-node/remote clients |
| VictoriaMetrics (victoriametrics/victoria-metrics:v1.107.0) | 48/D | **100/A** | TSDB; 89/B if a fleet pushes metrics |
| EMQX (emqx:5) | 63/C | **89/B** | MQTT broker honest ceiling (must accept connections) |

## Proof
Grades verified with `ironctl scan --compose` on hardened compose files (fresh build off this branch). Broker held at network WARN by design -> 89/B; co-located stores take `--network=none` -> 100/A. Colima cap-drop normalization avoided by proving via raw `cap_drop: [ALL]` in compose, not CLI.

## Wiring
- Hub `hardening-guides.md`: ArangoDB/Solr/VictoriaMetrics in the grade-A table, EMQX in the 89/B ceiling table.
- Blog `.nav.yml`: 4 explicit ordering lines added before the Dockerfile guide.
- `mkdocs build --strict` passes (all 4 pages emit, no broken links).

Scorecards are CRON-gen and untouched. No literal count in the hub.