### PR TITLE
docs(blog): harden guides wave 13 (dgraph/weaviate/kong/envoy) [IRO-580]

### DIFF
--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -64,5 +64,9 @@ nav:
   - "How to harden a Solr container": harden-solr-container-isolation.md
   - "How to harden a VictoriaMetrics container": harden-victoria-metrics-container-isolation.md
   - "How to harden an EMQX container": harden-emqx-container-isolation.md
+  - "How to harden a Dgraph container": harden-dgraph-container-isolation.md
+  - "How to harden a Weaviate container": harden-weaviate-container-isolation.md
+  - "How to harden a Kong container": harden-kong-container-isolation.md
+  - "How to harden an Envoy container": harden-envoy-container-isolation.md
   - "How to scan a Dockerfile for security issues": scan-a-dockerfile-for-security-issues.md
   - "*.md"

--- a/docs/blog/harden-dgraph-container-isolation.md
+++ b/docs/blog/harden-dgraph-container-isolation.md
@@ -1,0 +1,99 @@
+---
+title: "How to harden a Dgraph container: dgraph/dgraph:v24.0.5 scores 48/100 by default"
+description: "dgraph/dgraph:v24.0.5 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a graph database to 100/100 grade A."
+---
+
+# How to harden a Dgraph container (and is dgraph/dgraph:v24.0.5 safe for untrusted workloads?)
+
+A graph database holds the relationships at the center of your data, so its container should be one
+of the tightest things you run. A stock `docker run dgraph/dgraph:v24.0.5` is not: graded on
+IronClaw's seven-dimension containment scale it scores **48 of 100, grade D (porous)**. Higher is
+safer. A short list of runtime flags takes the same image to **100 of 100, grade A**, because a
+graph database that only its co-located services query can drop its network entirely. Here are the
+exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `dgraph/dgraph:v24.0.5`, the same data
+> behind its [isolation scorecard](../scores/dgraph.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+dgraph/dgraph:v24.0.5`, four fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The sharpest edges are **root**, the **retained capabilities**, and the **writable rootfs**: a
+query-parser or plugin CVE that lands code execution lands it as uid 0, with `CAP_NET_RAW` and
+friends, on a filesystem it can rewrite to persist.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-dgraph --fix` prints one remediation per failed dimension, then one hardened run.
+For `dgraph/dgraph:v24.0.5`:
+
+- **`--user 1000:1000`** (Non-root, +15): run the process as an unprivileged uid. Point the data
+  directory at a volume that uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. Dgraph needs none of the defaults.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount the data path as an explicit writable volume. Removes the persistence surface.
+- **`--network=none`** (Network isolation, +11): a single-node graph database that only its
+  co-located app queries needs no external network at all. Attach it to app services over a private
+  compose network and cut the default route out. This is the dimension that takes it to a full A.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name dgraph dgraph/dgraph:v24.0.5
+
+# After: 100/100, grade A
+docker run -d --name dgraph-hardened \
+  --user 1000:1000 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v dgraph-data:/dgraph \
+  --network=none \
+  dgraph/dgraph:v24.0.5
+```
+
+Rescan: `ironctl scan dgraph-hardened` reports `100/100 grade A`. A **52-point swing** with no custom
+image build, just the right flags.
+
+> **Running a cluster?** A multi-node Dgraph (alpha and zero nodes, or remote clients) needs the
+> nodes to reach each other, so `--network=none` is wrong there. Keep the other four fixes and attach
+> a scoped private network; the honest ceiling is then **89/100, grade B**, with the network
+> dimension held at a WARN. Single-node with a co-located app reaches the full A.
+
+## Verify it on your own database
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-dgraph
+ironctl scan my-dgraph --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Dgraph in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [dgraph:v24.0.5 isolation scorecard &rarr;](../scores/dgraph.md): the full dimension breakdown.
+- [Databases, ranked by isolation &rarr;](../scores/collections/databases.md): how Dgraph compares to Postgres, Neo4j, and the rest.
+- [How to harden a Neo4j container &rarr;](harden-neo4j-container-isolation.md): another graph database with the same single-node A and clustered-B story.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-envoy-container-isolation.md
+++ b/docs/blog/harden-envoy-container-isolation.md
@@ -1,0 +1,100 @@
+---
+title: "How to harden an Envoy container: envoy:v1.32-latest scores 48/100 by default"
+description: "envoyproxy/envoy:v1.32-latest defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a service proxy to its honest 89/100 grade B."
+---
+
+# How to harden an Envoy container (and is envoy:v1.32-latest safe for untrusted workloads?)
+
+A service proxy carries every request between your services, which is exactly why its container
+should be one of the tightest. A stock `docker run envoyproxy/envoy:v1.32-latest` is not: graded on
+IronClaw's seven-dimension containment scale it scores **48 of 100, grade D (porous)**. Higher is
+safer. A short list of runtime flags takes the same image to **89 of 100, grade B**, one point off an
+A, and the one dimension it cannot reach is the one a proxy needs by definition (it exists to accept
+and forward traffic). Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `envoyproxy/envoy:v1.32-latest`, the
+> same data behind its [isolation scorecard](../scores/envoy.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+envoyproxy/envoy:v1.32-latest`, four fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The sharpest edges are **root**, the **retained capabilities**, and the **writable rootfs**: a
+config-parser or filter CVE that lands code execution lands it as uid 0, with `CAP_NET_RAW` and
+friends, on the process every request in your mesh passes through, and with a filesystem it can
+rewrite to persist.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-envoy --fix` prints one remediation per failed dimension, then one hardened run.
+For `envoyproxy/envoy:v1.32-latest`:
+
+- **`--user 1000:1000`** (Non-root, +15): run the process as an unprivileged uid. Envoy binds
+  unprivileged ports fine as a non-root user.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. Envoy needs none of the defaults for a standard listen on an
+  unprivileged port.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only; Envoy
+  reads a static config and writes nothing to root. Removes the persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  proxy, it exists to accept and forward traffic. Any named or bridge network scores 4 of 15 (a WARN,
+  not a fail): a connection path exists. This is the one dimension a proxy cannot max out. Contain it
+  anyway: attach a user-defined network scoped to just its upstreams, with no default route out, so a
+  compromised proxy cannot call arbitrary internet addresses.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name envoy envoyproxy/envoy:v1.32-latest
+
+# After: 89/100, grade B (scoped private mesh network)
+docker run -d --name envoy-hardened \
+  --user 1000:1000 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=mesh-internal \
+  envoyproxy/envoy:v1.32-latest
+```
+
+Rescan: `ironctl scan envoy-hardened` reports `89/100 grade B`. A **41-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a proxy exists to forward traffic; `network=none` would score the last points but leave
+nothing able to reach it. That is the honest ceiling for a proxy, and it is a clear step up from the
+default D.
+
+## Verify it on your own proxy
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-envoy
+ironctl scan my-envoy --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Envoy in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [envoy:v1.32-latest isolation scorecard &rarr;](../scores/envoy.md): the full dimension breakdown.
+- [Web servers and proxies, ranked by isolation &rarr;](../scores/collections/web-servers.md): how Envoy compares to nginx, Traefik, Kong, and the rest.
+- [How to harden an nginx container &rarr;](harden-nginx-container-isolation.md): another proxy with the same honest network ceiling, explained the same way.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-kong-container-isolation.md
+++ b/docs/blog/harden-kong-container-isolation.md
@@ -1,0 +1,102 @@
+---
+title: "How to harden a Kong container: kong:3.8 scores 63/100 by default"
+description: "kong:3.8 defaults score 63/100 (grade C): full caps, writable rootfs. The exact ironctl scan --fix flags that take an API gateway to its honest 89/100 grade B."
+---
+
+# How to harden a Kong container (and is kong:3.8 safe for untrusted workloads?)
+
+An API gateway sits at the edge, in front of everything, which is exactly why its container should be
+one of the tightest. A stock `docker run kong:3.8` is closer than most, it already runs as a non-root
+user, but graded on IronClaw's seven-dimension containment scale it still scores only **63 of 100,
+grade C (partial)**. Higher is safer. A couple of runtime flags take the same image to **89 of 100,
+grade B**, one point off an A, and the one dimension it cannot reach is the one a gateway needs by
+definition (clients and upstreams must connect through it). Here are the exact gaps and fixes from
+the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `kong:3.8`, the same data behind its
+> [isolation scorecard](../scores/kong.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run kong:3.8`,
+three fail or warn (and, notably, non-root already passes):
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as kong (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+Kong's image already did the hardest part, it drops root. The sharpest edges that remain are the
+**retained capabilities** and the **writable rootfs**: a plugin or Lua-runtime CVE that lands code
+execution lands it with `CAP_NET_RAW` and friends, on the process every request in your stack passes
+through, and with a filesystem it can rewrite to persist.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-kong --fix` prints one remediation per failed dimension, then one hardened run.
+For `kong:3.8`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. Kong needs none of the defaults for a standard listen on an
+  unprivileged port.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount Kong's prefix path (`/usr/local/kong`) as an explicit writable volume. Removes the
+  persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  gateway, clients and upstreams must reach it. Any named or bridge network scores 4 of 15 (a WARN,
+  not a fail): a connection path exists. This is the one dimension a gateway cannot max out. Contain
+  it anyway: attach a user-defined network scoped to just its upstreams, with no default route out,
+  so a compromised gateway cannot call arbitrary internet addresses.
+
+No `--user` flag is needed: the image already runs as `kong`.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name kong kong:3.8
+
+# After: 89/100, grade B (scoped private network for clients and upstreams)
+docker run -d --name kong-hardened \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v kong-prefix:/usr/local/kong \
+  --network=kong-internal \
+  kong:3.8
+```
+
+Rescan: `ironctl scan kong-hardened` reports `89/100 grade B`. A **26-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a gateway exists to be connected through; `network=none` would score the last points but
+leave nothing able to reach the upstreams. That is the honest ceiling for a gateway, and it is a
+clear step up from the default C.
+
+## Verify it on your own gateway
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-kong
+ironctl scan my-kong --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Kong in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [kong:3.8 isolation scorecard &rarr;](../scores/kong.md): the full dimension breakdown.
+- [Web servers and proxies, ranked by isolation &rarr;](../scores/collections/web-servers.md): how Kong compares to nginx, Traefik, Envoy, and the rest.
+- [How to harden a Traefik container &rarr;](harden-traefik-container-isolation.md): another edge proxy with the same honest network ceiling, explained the same way.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-weaviate-container-isolation.md
+++ b/docs/blog/harden-weaviate-container-isolation.md
@@ -1,0 +1,98 @@
+---
+title: "How to harden a Weaviate container: weaviate:1.28.1 scores 48/100 by default"
+description: "semitechnologies/weaviate:1.28.1 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a vector database to 100/100 grade A."
+---
+
+# How to harden a Weaviate container (and is weaviate:1.28.1 safe for untrusted workloads?)
+
+A vector database backs your retrieval and RAG pipelines, so it sees a lot of untrusted input and
+its container should be tight. A stock `docker run semitechnologies/weaviate:1.28.1` is not: graded
+on IronClaw's seven-dimension containment scale it scores **48 of 100, grade D (porous)**. Higher is
+safer. A short list of runtime flags takes the same image to **100 of 100, grade A**, because a
+vector store that only its co-located app queries can drop its network entirely. Here are the exact
+gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of
+> `semitechnologies/weaviate:1.28.1`, the same data behind its [isolation
+> scorecard](../scores/weaviate.md). No workload is executed. [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+semitechnologies/weaviate:1.28.1`, four fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The sharpest edges are **root**, the **retained capabilities**, and the **writable rootfs**: a module
+or import-path CVE that lands code execution lands it as uid 0, with `CAP_NET_RAW` and friends, on a
+filesystem it can rewrite to persist its embeddings-poisoning payload.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-weaviate --fix` prints one remediation per failed dimension, then one hardened run.
+For `semitechnologies/weaviate:1.28.1`:
+
+- **`--user 1000:1000`** (Non-root, +15): run the process as an unprivileged uid. Point the
+  persistence path at a volume that uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. Weaviate needs none of the defaults.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount the data path as an explicit writable volume. Removes the persistence surface.
+- **`--network=none`** (Network isolation, +11): a Weaviate that only its co-located app queries
+  needs no external network at all. Attach it to the app over a private compose network and cut the
+  default route out. This is the dimension that takes it to a full A.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name weaviate semitechnologies/weaviate:1.28.1
+
+# After: 100/100, grade A
+docker run -d --name weaviate-hardened \
+  --user 1000:1000 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v weaviate-data:/var/lib/weaviate \
+  --network=none \
+  semitechnologies/weaviate:1.28.1
+```
+
+Rescan: `ironctl scan weaviate-hardened` reports `100/100 grade A`. A **52-point swing** with no
+custom image build, just the right flags.
+
+> **Serving remote clients?** If apps outside the compose network hit Weaviate's REST or gRPC API,
+> `--network=none` is wrong. Keep the other four fixes and attach a scoped private network; the honest
+> ceiling is then **89/100, grade B**, with the network dimension held at a WARN. A single-node store
+> with a co-located app reaches the full A.
+
+## Verify it on your own database
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-weaviate
+ironctl scan my-weaviate --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Weaviate in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [weaviate:1.28.1 isolation scorecard &rarr;](../scores/weaviate.md): the full dimension breakdown.
+- [Vector databases, ranked by isolation &rarr;](../scores/collections/vector-databases.md): how Weaviate compares to Qdrant, Milvus, and the rest.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -51,6 +51,8 @@ Two patterns show up across the set:
 | [Solr](harden-solr-container-isolation.md) | 63/100 C | **100/100 A** | full caps, writable rootfs (89/B multi-node cluster or remote clients) |
 | [VictoriaMetrics](harden-victoria-metrics-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if a fleet pushes metrics) |
 | [ScyllaDB](harden-scylla-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B multi-node cluster) |
+| [Dgraph](harden-dgraph-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if clustered or remote clients) |
+| [Weaviate](harden-weaviate-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if remote clients) |
 | [Untrusted Node.js](run-untrusted-nodejs-code-safely.md) | 48/100 D | **100/100 A** | run untrusted code in a real sandbox |
 
 ## Honest ceiling: grade B (89/100)
@@ -80,6 +82,8 @@ These services must accept client connections, so the network dimension holds at
 | [pgAdmin](harden-pgadmin4-container-isolation.md) | 63/100 C | **89/100 B** | admin console: your browser must reach the UI |
 | [Redpanda](harden-redpanda-container-isolation.md) | 63/100 C | **89/100 B** | broker: producers and consumers must connect |
 | [EMQX](harden-emqx-container-isolation.md) | 63/100 C | **89/100 B** | MQTT broker: publishers and subscribers must connect |
+| [Kong](harden-kong-container-isolation.md) | 63/100 C | **89/100 B** | API gateway: clients and upstreams connect through it |
+| [Envoy](harden-envoy-container-isolation.md) | 48/100 D | **89/100 B** | proxy: it exists to accept and forward traffic |
 
 ## The pattern, one command
 


### PR DESCRIPTION
## Wave 13 hardening guides

Four scorecard-backed hardening guides. All grades proven via \`ironctl scan --compose\` off a fresh build off origin/main (static YAML parse, no image pull).

| Component | Type | Default | Hardened |
|---|---|---|---|
| dgraph/dgraph:v24.0.5 | graph DB (store) | 48/D | **100/A** (89/B clustered/remote) |
| semitechnologies/weaviate:1.28.1 | vector DB (store) | 48/D | **100/A** (89/B remote clients) |
| kong:3.8 | API gateway | 63/C | **89/B** (gateway ceiling; non-root already) |
| envoyproxy/envoy:v1.32-latest | service proxy | 48/D | **89/B** (proxy ceiling) |

Graded honestly: co-located stores reach A via \`network=none\`; gateway/proxy hit the honest 89/B network-WARN ceiling.

Wired into hub (\`hardening-guides.md\` grade-A + grade-B tables) and explicit \`.nav.yml\` lines. Cross-links verified (neo4j/traefik/nginx guides + databases/vector-databases/web-servers collections all exist).

Parent IRO-577.