### PR TITLE
docs(blog): harden guides wave 14 (rethinkdb/tidb/pulsar/nsq) [IRO-591]

### DIFF
--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -68,5 +68,9 @@ nav:
   - "How to harden a Weaviate container": harden-weaviate-container-isolation.md
   - "How to harden a Kong container": harden-kong-container-isolation.md
   - "How to harden an Envoy container": harden-envoy-container-isolation.md
+  - "How to harden a RethinkDB container": harden-rethinkdb-container-isolation.md
+  - "How to harden a TiDB container": harden-tidb-container-isolation.md
+  - "How to harden a Pulsar container": harden-pulsar-container-isolation.md
+  - "How to harden an NSQ container": harden-nsq-container-isolation.md
   - "How to scan a Dockerfile for security issues": scan-a-dockerfile-for-security-issues.md
   - "*.md"

--- a/docs/blog/harden-nsq-container-isolation.md
+++ b/docs/blog/harden-nsq-container-isolation.md
@@ -1,0 +1,102 @@
+---
+title: "How to harden an NSQ container: nsqio/nsq:v1.3.0 scores 48/100 by default"
+description: "nsqio/nsq:v1.3.0 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a message broker to its honest 89/100 grade B."
+---
+
+# How to harden an NSQ container (and is nsqio/nsq:v1.3.0 safe for untrusted workloads?)
+
+NSQ is a realtime distributed message queue that every producer and consumer in your system connects
+to, which is exactly why its container should be one of the tightest. A stock `docker run
+nsqio/nsq:v1.3.0` is not: graded on IronClaw's seven-dimension containment scale it scores **48 of
+100, grade D (porous)**. Higher is safer. A short list of runtime flags takes the same image to **89
+of 100, grade B**, one point off an A, and the one dimension it cannot reach is the one a broker needs
+by definition (publishers and subscribers must connect to it). Here are the exact gaps and fixes from
+the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `nsqio/nsq:v1.3.0`, the same data
+> behind its [isolation scorecard](../scores/nsq.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+nsqio/nsq:v1.3.0`, four fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The sharpest edges are **root**, the **retained capabilities**, and the **writable rootfs**: a
+protocol or client CVE that lands code execution lands it as uid 0, with `CAP_NET_RAW` and friends,
+on the process every message in your stack passes through, and with a filesystem it can rewrite to
+persist.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-nsq --fix` prints one remediation per failed dimension, then one hardened run.
+For `nsqio/nsq:v1.3.0`:
+
+- **`--user 65532:65532`** (Non-root, +15): run `nsqd` as an unprivileged uid. Point the data
+  directory (`--data-path`) at a volume that uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. NSQ needs none of the defaults for a standard listen on its TCP and
+  HTTP ports.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount the queue data path as an explicit writable volume. Removes the persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  broker, publishers and subscribers must reach it. Any named or bridge network scores 4 of 15 (a
+  WARN, not a fail): a connection path exists. This is the one dimension a broker cannot max out.
+  Contain it anyway: attach a user-defined network scoped to just its clients, with no default route
+  out, so a compromised broker cannot call arbitrary internet addresses.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name nsq nsqio/nsq:v1.3.0 /nsqd
+
+# After: 89/100, grade B (scoped private network for publishers and subscribers)
+docker run -d --name nsq-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v nsq-data:/data \
+  --network=nsq-internal \
+  nsqio/nsq:v1.3.0 /nsqd --data-path=/data
+```
+
+Rescan: `ironctl scan nsq-hardened` reports `89/100 grade B`. A **41-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a broker exists to be connected through; `network=none` would score the last points but
+leave nothing able to publish or subscribe. That is the honest ceiling for a broker, and it is a
+clear step up from the default D.
+
+## Verify it on your own broker
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-nsq
+ironctl scan my-nsq --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the NSQ in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [nsq:v1.3.0 isolation scorecard &rarr;](../scores/nsq.md): the full dimension breakdown.
+- [Message queues, ranked by isolation &rarr;](../scores/collections/message-queues.md): how NSQ compares to Kafka, RabbitMQ, NATS, and the rest.
+- [How to harden a NATS container &rarr;](harden-nats-container-isolation.md): another lightweight broker with the same honest network ceiling, explained the same way.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-pulsar-container-isolation.md
+++ b/docs/blog/harden-pulsar-container-isolation.md
@@ -1,0 +1,102 @@
+---
+title: "How to harden a Pulsar container: apachepulsar/pulsar:3.3.2 scores 63/100 by default"
+description: "apachepulsar/pulsar:3.3.2 defaults score 63/100 (grade C): full caps, writable rootfs. The exact ironctl scan --fix flags that take a message broker to its honest 89/100 grade B."
+---
+
+# How to harden a Pulsar container (and is apachepulsar/pulsar:3.3.2 safe for untrusted workloads?)
+
+A message broker sits between every producer and consumer in your system, which is exactly why its
+container should be one of the tightest. A stock `docker run apachepulsar/pulsar:3.3.2` is closer
+than most, it already runs as a non-root user, but graded on IronClaw's seven-dimension containment
+scale it still scores only **63 of 100, grade C (partial)**. Higher is safer. A couple of runtime
+flags take the same image to **89 of 100, grade B**, one point off an A, and the one dimension it
+cannot reach is the one a broker needs by definition (producers and consumers must connect to it).
+Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `apachepulsar/pulsar:3.3.2`, the same
+> data behind its [isolation scorecard](../scores/pulsar.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+apachepulsar/pulsar:3.3.2`, three fail or warn (and, notably, non-root already passes):
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as 10000 (uid != 0) |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+Pulsar's image already did the hardest part, it drops root. The sharpest edges that remain are the
+**retained capabilities** and the **writable rootfs**: a broker or function-runtime CVE that lands
+code execution lands it with `CAP_NET_RAW` and friends, on the process every message in your stack
+passes through, and with a filesystem it can rewrite to persist.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-pulsar --fix` prints one remediation per failed dimension, then one hardened run.
+For `apachepulsar/pulsar:3.3.2`:
+
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. Pulsar needs none of the defaults for a standard listen on its
+  broker port.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount Pulsar's data and ledger paths (`/pulsar/data`) as explicit writable volumes. Removes the
+  persistence surface.
+- **Scoped network** (Network isolation): `--network=none` scores the full 15 but is wrong for a
+  broker, producers and consumers must reach it. Any named or bridge network scores 4 of 15 (a WARN,
+  not a fail): a connection path exists. This is the one dimension a broker cannot max out. Contain
+  it anyway: attach a user-defined network scoped to just its clients, with no default route out, so
+  a compromised broker cannot call arbitrary internet addresses.
+
+No `--user` flag is needed: the image already runs as uid 10000.
+
+## Before and after
+
+```bash
+# Before: 63/100, grade C
+docker run -d --name pulsar apachepulsar/pulsar:3.3.2
+
+# After: 89/100, grade B (scoped private network for producers and consumers)
+docker run -d --name pulsar-hardened \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v pulsar-data:/pulsar/data \
+  --network=pulsar-internal \
+  apachepulsar/pulsar:3.3.2
+```
+
+Rescan: `ironctl scan pulsar-hardened` reports `89/100 grade B`. A **26-point swing** with no custom
+image build, just the right flags. The only dimension still short of full marks is the network (4 of
+15), because a broker exists to be connected through; `network=none` would score the last points but
+leave nothing able to publish or subscribe. That is the honest ceiling for a broker, and it is a
+clear step up from the default C.
+
+## Verify it on your own broker
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-pulsar
+ironctl scan my-pulsar --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the Pulsar in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [pulsar:3.3.2 isolation scorecard &rarr;](../scores/pulsar.md): the full dimension breakdown.
+- [Message queues, ranked by isolation &rarr;](../scores/collections/message-queues.md): how Pulsar compares to Kafka, RabbitMQ, NATS, and the rest.
+- [How to harden a Kafka container &rarr;](harden-kafka-container-isolation.md): another broker with the same honest network ceiling, explained the same way.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-rethinkdb-container-isolation.md
+++ b/docs/blog/harden-rethinkdb-container-isolation.md
@@ -1,0 +1,99 @@
+---
+title: "How to harden a RethinkDB container: rethinkdb:2.4 scores 48/100 by default"
+description: "rethinkdb:2.4 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a realtime document database to 100/100 grade A."
+---
+
+# How to harden a RethinkDB container (and is rethinkdb:2.4 safe for untrusted workloads?)
+
+A realtime document database pushes query results straight to connected clients, so the process sits
+close to your application data and deserves a tight container. A stock `docker run rethinkdb:2.4` is
+not: graded on IronClaw's seven-dimension containment scale it scores **48 of 100, grade D
+(porous)**. Higher is safer. A short list of runtime flags takes the same image to **100 of 100,
+grade A**, because a single-node RethinkDB that only its co-located app queries can drop its network
+entirely. Here are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `rethinkdb:2.4`, the same data behind
+> its [isolation scorecard](../scores/rethinkdb.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+rethinkdb:2.4`, four fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The sharpest edges are **root**, the **retained capabilities**, and the **writable rootfs**: a
+ReQL-parser or driver CVE that lands code execution lands it as uid 0, with `CAP_NET_RAW` and
+friends, on a filesystem it can rewrite to persist.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-rethinkdb --fix` prints one remediation per failed dimension, then one hardened run.
+For `rethinkdb:2.4`:
+
+- **`--user 65532:65532`** (Non-root, +15): run the process as an unprivileged uid. Point the data
+  directory (`/data`) at a volume that uid owns.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. RethinkDB needs none of the defaults.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
+  mount `/data` as an explicit writable volume. Removes the persistence surface.
+- **`--network=none`** (Network isolation, +11): a single-node document database that only its
+  co-located app queries needs no external network at all. Attach it to app services over a private
+  compose network and cut the default route out. This is the dimension that takes it to a full A.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name rethinkdb rethinkdb:2.4
+
+# After: 100/100, grade A
+docker run -d --name rethinkdb-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  -v rethinkdb-data:/data \
+  --network=none \
+  rethinkdb:2.4
+```
+
+Rescan: `ironctl scan rethinkdb-hardened` reports `100/100 grade A`. A **52-point swing** with no
+custom image build, just the right flags.
+
+> **Running a cluster?** A multi-node RethinkDB (peers joined over the cluster port, or remote
+> drivers) needs the nodes to reach each other, so `--network=none` is wrong there. Keep the other
+> four fixes and attach a scoped private network; the honest ceiling is then **89/100, grade B**, with
+> the network dimension held at a WARN. Single-node with a co-located app reaches the full A.
+
+## Verify it on your own database
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-rethinkdb
+ironctl scan my-rethinkdb --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the RethinkDB in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [rethinkdb:2.4 isolation scorecard &rarr;](../scores/rethinkdb.md): the full dimension breakdown.
+- [Databases, ranked by isolation &rarr;](../scores/collections/databases.md): how RethinkDB compares to MongoDB, CouchDB, and the rest.
+- [How to harden a MongoDB container &rarr;](harden-mongodb-container-isolation.md): another document store with the same single-node A and clustered-B story.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/harden-tidb-container-isolation.md
+++ b/docs/blog/harden-tidb-container-isolation.md
@@ -1,0 +1,98 @@
+---
+title: "How to harden a TiDB container: pingcap/tidb:v8.5.0 scores 48/100 by default"
+description: "pingcap/tidb:v8.5.0 defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a distributed SQL database to 100/100 grade A."
+---
+
+# How to harden a TiDB container (and is pingcap/tidb:v8.5.0 safe for untrusted workloads?)
+
+TiDB is a distributed SQL database that speaks the MySQL protocol, so its container fronts your
+application's queries and belongs among the tightest things you run. A stock `docker run
+pingcap/tidb:v8.5.0` is not: graded on IronClaw's seven-dimension containment scale it scores **48 of
+100, grade D (porous)**. Higher is safer. A short list of runtime flags takes the same image to **100
+of 100, grade A** on a single-instance deployment whose components share one private network. Here
+are the exact gaps and fixes from the scan data.
+
+> Every number here comes from a read-only `docker inspect` of `pingcap/tidb:v8.5.0`, the same data
+> behind its [isolation scorecard](../scores/tidb.md). No workload is executed.
+> [How scoring works &rarr;](../scan.md)
+
+## Where the default configuration leaks
+
+`ironctl scan` grades seven independent containment boundaries. On a default `docker run
+pingcap/tidb:v8.5.0`, four fail or warn:
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
+| Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
+| Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
+| Read-only root filesystem | ❌ FAIL | 0/10 | root filesystem is writable |
+| No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
+| No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
+
+The sharpest edges are **root**, the **retained capabilities**, and the **writable rootfs**: a
+SQL-parser or plugin CVE that lands code execution lands it as uid 0, with `CAP_NET_RAW` and friends,
+on a filesystem it can rewrite to persist.
+
+## Harden it: the exact `--fix` remediation
+
+`ironctl scan my-tidb --fix` prints one remediation per failed dimension, then one hardened run.
+For `pingcap/tidb:v8.5.0`:
+
+- **`--user 65532:65532`** (Non-root, +15): run the tidb-server process as an unprivileged uid.
+- **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
+  the workload provably needs. The SQL layer needs none of the defaults.
+- **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): the tidb-server is stateless (storage lives
+  in TiKV), so a read-only rootfs with a `/tmp` scratch mount removes the persistence surface cleanly.
+- **`--network=none`** (Network isolation, +11): when the whole stack (PD, TiKV, tidb-server) sits on
+  one private compose network with no default route out, the tidb-server needs no host egress. Cutting
+  it is the dimension that takes a single-machine deployment to a full A.
+
+## Before and after
+
+```bash
+# Before: 48/100, grade D
+docker run -d --name tidb pingcap/tidb:v8.5.0
+
+# After: 100/100, grade A
+docker run -d --name tidb-hardened \
+  --user 65532:65532 \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --read-only --tmpfs /tmp \
+  --network=none \
+  pingcap/tidb:v8.5.0
+```
+
+Rescan: `ironctl scan tidb-hardened` reports `100/100 grade A`. A **52-point swing** with no custom
+image build, just the right flags.
+
+> **Running a production cluster?** A multi-node TiDB where tidb-server reaches PD and TiKV across
+> hosts, or where remote MySQL clients connect, needs a real network, so `--network=none` is wrong
+> there. Keep the other four fixes and attach a scoped private network; the honest ceiling is then
+> **89/100, grade B**, with the network dimension held at a WARN. A single-machine stack behind one
+> private network reaches the full A.
+
+## Verify it on your own database
+
+```bash
+# install (Homebrew)
+brew install ironsecco/ironclaw/ironclaw
+
+# grade your running container, then print the fixes
+ironctl scan my-tidb
+ironctl scan my-tidb --fix
+```
+
+`ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, so you can grade
+the TiDB in your stack, not just a bare `docker run`.
+
+## Keep going
+
+- [All hardening guides &rarr;](hardening-guides.md): every harden-a-container walkthrough, with grade deltas.
+- [tidb:v8.5.0 isolation scorecard &rarr;](../scores/tidb.md): the full dimension breakdown.
+- [Databases, ranked by isolation &rarr;](../scores/collections/databases.md): how TiDB compares to CockroachDB, MySQL, and the rest.
+- [How to harden a CockroachDB container &rarr;](harden-cockroachdb-container-isolation.md): another distributed SQL database with the same single-node A and clustered-B story.
+- [Scan any container in 10 seconds &rarr;](../scan.md): the full `ironctl scan` reference.
+- [Run untrusted code in a real sandbox &rarr;](../index.md): IronClaw wraps every AI-agent session in a gVisor/Kata boundary with `network=none` by default.

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -53,6 +53,8 @@ Two patterns show up across the set:
 | [ScyllaDB](harden-scylla-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B multi-node cluster) |
 | [Dgraph](harden-dgraph-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if clustered or remote clients) |
 | [Weaviate](harden-weaviate-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if remote clients) |
+| [RethinkDB](harden-rethinkdb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B if clustered or remote clients) |
+| [TiDB](harden-tidb-container-isolation.md) | 48/100 D | **100/100 A** | root, full caps, writable rootfs (89/B production cluster or remote clients) |
 | [Untrusted Node.js](run-untrusted-nodejs-code-safely.md) | 48/100 D | **100/100 A** | run untrusted code in a real sandbox |
 
 ## Honest ceiling: grade B (89/100)
@@ -84,6 +86,8 @@ These services must accept client connections, so the network dimension holds at
 | [EMQX](harden-emqx-container-isolation.md) | 63/100 C | **89/100 B** | MQTT broker: publishers and subscribers must connect |
 | [Kong](harden-kong-container-isolation.md) | 63/100 C | **89/100 B** | API gateway: clients and upstreams connect through it |
 | [Envoy](harden-envoy-container-isolation.md) | 48/100 D | **89/100 B** | proxy: it exists to accept and forward traffic |
+| [Pulsar](harden-pulsar-container-isolation.md) | 63/100 C | **89/100 B** | broker: producers and consumers must connect |
+| [NSQ](harden-nsq-container-isolation.md) | 48/100 D | **89/100 B** | broker: publishers and subscribers must connect |
 
 ## The pattern, one command
 


### PR DESCRIPTION
## Wave 14 hardening guides

Four new container-hardening walkthroughs for the SEO content flywheel (parent CEO-thinking IRO-588).

| Image | Default | Hardened | Class |
|-------|:-------:|:--------:|-------|
| rethinkdb:2.4 | 48/D | **100/A** | realtime document store |
| pingcap/tidb:v8.5.0 | 48/D | **100/A** | distributed SQL (89/B prod cluster) |
| apachepulsar/pulsar:3.3.2 | 63/C | **89/B** | broker |
| nsqio/nsq:v1.3.0 | 48/D | **89/B** | broker |

### Verification
Hardened grades reproduced via `ironctl scan --compose` off a **fresh-built** binary (local stale):
- rethinkdb / tidb hardened (network=none, cap_drop:[ALL]) -> **100/100 A**
- pulsar / nsq hardened (scoped network) -> **89/100 B** (network WARN 4/15 by design)

Stores reach A because a co-located single-node DB can drop its network; brokers hold at the honest 89/B ceiling because producers/consumers must connect. Every claim maps to a real scan result.

### Wiring
- Each guide added to `hardening-guides.md` hub (grade-A + grade-B tables)
- Each guide added to blog `.nav.yml`
- `mkdocs build --strict` clean (all 4 pages render; only EOL banner warning)
- Cross-links verified (nats/cockroachdb/mongodb/kafka guides + collections exist)

No cron-generated scorecards edited.