### PR TITLE
feat(scan): badge-in-README nudge in scan-Action PR comment [IRO-590]

### DIFF
--- a/.github/actions/scan/README.md
+++ b/.github/actions/scan/README.md
@@ -100,6 +100,10 @@ grade bands.
 
 - The sticky comment updates in place (keyed by mode+target), so re-runs never
   spam the PR. Multiple targets in one PR each get their own comment.
+- The comment ends with a copy-paste **README badge** snippet and an "Add this to
+  your README" nudge. Paste it once and your repo carries a live containment-grade
+  badge that links back to the scan receipt. The snippet is part of the same sticky
+  comment, so the marker keeps it idempotent (it is never double-posted).
 - On non-PR events (push, dispatch) the scorecard is written to the job summary
   instead of a comment.
 - Grant `pull-requests: write` if you want the comment; without it the action

--- a/.github/actions/scan/scan.sh
+++ b/.github/actions/scan/scan.sh
@@ -82,6 +82,7 @@ grade_file() {
 # ---------------------------------------------------------------------------
 scorecard="${WORK}/scorecard.md"
 receipt="${WORK}/receipt.md"
+badge_md="${WORK}/badge-snippet.md"
 badge_path=""
 sarif_path=""
 scan_args=()
@@ -104,6 +105,12 @@ scan_args+=(--md)
 # branded, verifiable receipt — a compounding, account-free viral loop. Rendered
 # offline by ironctl (no network at scan time), so it is credential- and egress-safe.
 scan_args+=(--share)
+# --badge-md writes a copy-paste README badge snippet (IRO-590): the same live
+# shields grade badge as the receipt, wrapped in a link to the hosted /receipt
+# card, plus an "Add this to your README" CTA. Appended to the sticky PR comment
+# so every scanned repo gets a low-friction path from receipt -> a persistent
+# README badge -> inbound reach (compounds IRO-441). Rendered offline by ironctl.
+scan_args+=(--badge-md "$badge_md")
 if [ "$BADGE" = "true" ]; then
   badge_path="${WORK}/scan-badge.svg"
   scan_args+=(--badge "$badge_path")
@@ -136,7 +143,11 @@ fi
 # badge so the scorecard never bleeds into the receipt block (both carry the same
 # "### IronClaw containment scan:" header).
 awk '/^\[!\[IronClaw containment score\]/{exit} /^### IronClaw containment scan:/{f=1} f' "$raw" >"$scorecard"
-sed -n '/^\[!\[IronClaw containment score\]/,$p' "$raw" >"$receipt"
+# The receipt runs from the badge line to EOF, but the side-artifact writers
+# (--badge-md/--badge/--sarif) print "  wrote ...: PATH" status lines to stdout
+# AFTER the receipt block. Drop those so the runner-local paths never bleed into
+# the PR comment. grep -v may filter to empty on an odd run, so guard set -e.
+sed -n '/^\[!\[IronClaw containment score\]/,$p' "$raw" | grep -v '^  wrote ' >"$receipt" || true
 [ -s "$scorecard" ] || die "could not extract the markdown scorecard from scan output"
 
 # Parse the score/grade from the header: "... scored **NN/100 (grade X)**".
@@ -202,7 +213,15 @@ if [ "$COMMENT" = "true" ] && [ -n "$pr" ] && [ -n "${GH_TOKEN:-}" ]; then
   # plain scorecard if the receipt block failed to render, so a comment always posts.
   comment_body="$receipt"
   [ -s "$comment_body" ] || comment_body="$scorecard"
-  { echo "$marker"; cat "$comment_body"; [ -n "$delta_line" ] && { echo; echo "$delta_line"; }; } >"$body"
+  {
+    echo "$marker"
+    cat "$comment_body"
+    [ -n "$delta_line" ] && { echo; echo "$delta_line"; }
+    # Badge-adoption nudge (IRO-590): append the copy-paste README badge snippet
+    # so the receipt funnels into a persistent README badge -> inbound reach. Part
+    # of the same sticky comment, so the marker keeps it idempotent (no double-post).
+    [ -s "$badge_md" ] && { echo; echo "---"; echo; cat "$badge_md"; }
+  } >"$body"
 
   # Find an existing comment carrying our marker and update it; else create one.
   existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" --paginate \

--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -34,6 +34,7 @@ func cmdScan(args []string) error {
 	asJSON := fs.Bool("json", false, "emit the scorecard as JSON")
 	badge := fs.String("badge", "", "write a shareable SVG badge to this path")
 	badgeJSON := fs.String("badge-json", "", "write a shields.io endpoint JSON badge to this path (embed a live README badge)")
+	badgeMd := fs.String("badge-md", "", "write a copy-paste README badge Markdown snippet to this path (grade badge linked to the receipt card)")
 	sarif := fs.String("sarif", "", "write a SARIF 2.1.0 log to this path (GitHub code-scanning upload)")
 	md := fs.Bool("md", false, "print a shareable markdown block (README/blog section)")
 	share := fs.Bool("share", false, "print a shareable scan receipt: grade badge + per-dim breakdown + a link to a hosted receipt page and install CTA (offline; no network)")
@@ -541,6 +542,14 @@ func cmdScan(args []string) error {
 		}
 		if !*asJSON {
 			fmt.Fprintf(os.Stdout, "  wrote shields endpoint badge: %s\n", *badgeJSON)
+		}
+	}
+	if *badgeMd != "" {
+		if err := os.WriteFile(*badgeMd, []byte(scan.RenderBadgeSnippet(report)), 0o644); err != nil {
+			return fmt.Errorf("write badge-md: %w", err)
+		}
+		if !*asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote README badge snippet: %s\n", *badgeMd)
 		}
 	}
 

--- a/docs/scan-action.md
+++ b/docs/scan-action.md
@@ -142,6 +142,13 @@ if the base cannot be fetched or graded, the scorecard is still posted without a
 delta line. `container` mode has no git base to compare against, so it shows no
 delta.
 
+Every comment also ends with a copy-paste **README badge** snippet and an "Add
+this to your README" nudge, rendered offline by `ironctl scan --badge-md`. Paste
+it once and your repo carries a live containment-grade badge that links back to
+the scan receipt, turning a one-off PR check into a persistent, self-promoting
+signal. The snippet lives inside the same sticky comment, so it is idempotent and
+never double-posted.
+
 Everything the [scan](scan.md) command guarantees still holds: it is local and
 read-only, it never talks to a control-plane, it needs no credentials, and it is
 fail-closed. See [`.github/actions/scan`](https://github.com/IronSecCo/ironclaw/tree/main/.github/actions/scan)

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -709,6 +709,7 @@ which gates the three container images it ships at `--min-score=80`.
 | `--fix` | print the concrete remediation for every failed dimension, plus a copy-pasteable hardened config (`--remediate` is an alias) |
 | `--badge scan.svg` | a self-contained SVG badge you can drop into a README |
 | `--badge-json badge.json` | a [shields.io endpoint](https://shields.io/badges/endpoint-badge) JSON file for a live, self-updating README badge |
+| `--badge-md snippet.md` | a copy-paste Markdown README badge snippet (the live grade badge linked to the scan receipt) plus an "Add this to your README" nudge (offline; no network) |
 | `--sarif scan.sarif` | a SARIF 2.1.0 log you can upload to GitHub code scanning (findings land in the repo Security tab) |
 | `--md` | a shareable markdown block for a README or blog post |
 | `--share` | a shareable scan receipt: a grade badge, the per-dimension breakdown, a link to a hosted receipt page, and an install CTA (offline; no network) |

--- a/internal/host/scan/render_share.go
+++ b/internal/host/scan/render_share.go
@@ -129,3 +129,25 @@ func RenderShareReceipt(r Report) string {
 	fmt.Fprintf(&b, "```sh\n%s\nironctl scan <container> --share\n```\n", installOneLiner)
 	return b.String()
 }
+
+// BadgeSnippetMarkdown returns the raw one-line Markdown a user copy-pastes into
+// their README to embed the live shields grade badge, wrapped in a link to the
+// dynamic-OG receipt card. It reuses ShareBadgeURL and ShareCardURL, so the
+// persistent README badge is byte-identical to the badge in the scan receipt and
+// can never drift. Pure/offline/deterministic.
+func BadgeSnippetMarkdown(r Report) string {
+	return fmt.Sprintf("[![IronClaw containment score](%s)](%s)", ShareBadgeURL(r), ShareCardURL(r))
+}
+
+// RenderBadgeSnippet returns a copy-paste README-badge nudge block for r: a
+// one-line "Add this to your README" CTA followed by a fenced Markdown snippet
+// embedding the live grade badge (BadgeSnippetMarkdown). It turns a one-off scan
+// receipt into a low-friction path to a persistent README badge -> inbound reach
+// (compounds IRO-441 badge adoption). Pure/offline/deterministic; makes no
+// network call, so it renders with no connectivity.
+func RenderBadgeSnippet(r Report) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "**Add this to your README** so every visitor sees your containment grade:\n\n")
+	fmt.Fprintf(&b, "```md\n%s\n```\n", BadgeSnippetMarkdown(r))
+	return b.String()
+}

--- a/internal/host/scan/render_share_test.go
+++ b/internal/host/scan/render_share_test.go
@@ -121,6 +121,55 @@ func TestShareBadgeURL(t *testing.T) {
 	}
 }
 
+func TestBadgeSnippetMarkdown(t *testing.T) {
+	r := sampleReport()
+	snip := BadgeSnippetMarkdown(r)
+
+	// The snippet is a Markdown image (the live badge) wrapped in a link to the
+	// receipt card, so a README render shows the badge and clicking it opens the
+	// dynamic-OG receipt.
+	if !strings.HasPrefix(snip, "[![IronClaw containment score](") {
+		t.Errorf("snippet must be a linked badge image, got %q", snip)
+	}
+	// Reuses the exact receipt badge + card URLs (no drift): both must appear.
+	if !strings.Contains(snip, ShareBadgeURL(r)) {
+		t.Errorf("snippet badge URL drifted from ShareBadgeURL: %q", snip)
+	}
+	if !strings.Contains(snip, ShareCardURL(r)) {
+		t.Errorf("snippet link target drifted from ShareCardURL: %q", snip)
+	}
+	// One self-contained line (copy-paste into a README): no newline.
+	if strings.Contains(snip, "\n") {
+		t.Errorf("badge snippet must be a single line, got %q", snip)
+	}
+	if BadgeSnippetMarkdown(r) != snip {
+		t.Error("BadgeSnippetMarkdown is not deterministic")
+	}
+}
+
+func TestRenderBadgeSnippet(t *testing.T) {
+	r := sampleReport()
+	md := RenderBadgeSnippet(r)
+	for _, want := range []string{
+		"Add this to your README", // one-line CTA
+		"```md",                   // fenced copy-paste snippet
+		BadgeSnippetMarkdown(r),   // the exact snippet line
+		"img.shields.io",          // live badge preview
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("badge nudge missing %q\n%s", want, md)
+		}
+	}
+	// Public-copy house style: no em/en-dashes (IRO-254).
+	if strings.ContainsAny(md, "—–") {
+		t.Error("badge nudge contains an em/en-dash")
+	}
+	// Offline + deterministic (pure string building, no network).
+	if RenderBadgeSnippet(r) != md {
+		t.Error("RenderBadgeSnippet is not deterministic")
+	}
+}
+
 func TestRenderShareReceipt(t *testing.T) {
 	md := RenderShareReceipt(sampleReport())
 	for _, want := range []string{


### PR DESCRIPTION
## What

Extend the sticky **scan-Action PR comment** with a copy-paste **README badge** snippet plus an "Add this to your README" CTA. Every scanned repo now has a low-friction path from a one-off scan receipt to a persistent README badge, which drives inbound reach and compounds the badge-adoption loop (IRO-441). Prereqs (viral PR-comment loop #543, `--share` receipt #539/#541) are merged.

## Changes

- **`render_share.go`** — new pure/offline `RenderBadgeSnippet` + `BadgeSnippetMarkdown` renderers. They reuse `ShareBadgeURL`/`ShareCardURL`, so the persistent README badge is byte-identical to the receipt badge and can never drift. Deterministic; no network call at render time.
- **`ironctl scan --badge-md <path>`** — new flag, mirrors `--badge-json`; writes the snippet file. Wired into the common container/compose/k8s emit path (the Action's modes).
- **`.github/actions/scan/scan.sh`** — always renders `--badge-md` and appends the nudge to the **same sticky comment**. Marker unchanged, so it stays idempotent (no double-post). Receipt slice now strips trailing `  wrote ...` status lines so runner-local artifact paths never bleed into the comment.
- **Docs** — `scan.md` flag row, `scan-action.md` + action `README.md` nudge notes.

## Verification

- `go test ./internal/host/scan/` → **246 passed** (incl. new `TestBadgeSnippetMarkdown`, `TestRenderBadgeSnippet`: drift, single-line, no em/en-dash, determinism).
- `go vet ./internal/host/scan/ ./cmd/ironctl/` clean; `bash -n scan.sh` OK.
- End-to-end simulation of the scan output → slice → comment assembly: nudge appended after the receipt, no `wrote` lines leaked.

## Lenses

Offline pure renderer (no build-time network / nondeterminism). No signing, attestation, checksum, required-check, token-scope, or installer-verification surface touched — read-only, credential-free Action path. Idempotent sticky comment preserved.

Closes IRO-590.