### PR TITLE
feat(scan): --check policy-as-code CI gate (enforce --emit-policy rules in place) [IRO-589]

### DIFF
--- a/.github/actions/scan/scan.sh
+++ b/.github/actions/scan/scan.sh
@@ -11,6 +11,7 @@ MODE="${IC_MODE:-container}"
 TARGET="${IC_TARGET:-}"
 SERVICE="${IC_SERVICE:-}"
 MIN_SCORE="${IC_MIN_SCORE:-0}"
+POLICY_CHECK="${IC_POLICY_CHECK:-false}"
 COMMENT="${IC_COMMENT:-true}"
 BADGE="${IC_BADGE:-false}"
 UPLOAD_SARIF="${IC_UPLOAD_SARIF:-false}"
@@ -224,6 +225,37 @@ fi
 
 # Job summary is always useful, PR or not.
 { echo "## IronClaw sandbox scan"; echo; cat "$scorecard"; } >>"${GITHUB_STEP_SUMMARY:-/dev/null}" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# 4.5 Policy-as-code gate (mode=k8s only). Evaluate the manifest AGAINST the rules
+#     --emit-policy would generate and fail the check on any violation — a
+#     self-contained gate needing no cluster or admission controller. Runs AFTER
+#     the sticky comment so a violating manifest still posts its scorecard, and is
+#     independent of min-score (a manifest can score high yet still break a rule).
+#     Skipped for container/compose mode (the rules target Kubernetes pod specs).
+# ---------------------------------------------------------------------------
+if [ "$POLICY_CHECK" = "true" ]; then
+  if [ "$MODE" != "k8s" ]; then
+    echo "::warning::policy-check applies to mode=k8s only; skipping for mode=${MODE}"
+    out policy-passed "true"
+  else
+    check_out="${WORK}/policy-check.md"
+    set +e
+    "$IRONCTL" scan --k8s "$TARGET" --check --md >"$check_out" 2>&1
+    check_rc=$?
+    set -e
+    cat "$check_out"
+    { echo; echo "## IronClaw policy check"; echo; cat "$check_out"; } >>"${GITHUB_STEP_SUMMARY:-/dev/null}" 2>/dev/null || true
+    if [ "$check_rc" -ne 0 ]; then
+      out policy-passed "false"
+      die "policy-as-code check failed: the manifest violates rules --emit-policy would enforce (see above)."
+    fi
+    out policy-passed "true"
+    echo "==> policy check passed (no guardrail rule violated)"
+  fi
+else
+  out policy-passed "true"
+fi
 
 # ---------------------------------------------------------------------------
 # 5. Gate: fail the check when below min-score (0 = report-only).

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,10 @@ inputs:
     description: 'Fail the check when the containment score is below this (0-100). 0 = report-only (default).'
     required: false
     default: '0'
+  policy-check:
+    description: 'Policy-as-code gate (mode=k8s only): evaluate the manifest against the rules --emit-policy would generate and fail the check on any violation. Independent of min-score; needs no cluster or admission controller. Default false.'
+    required: false
+    default: 'false'
   comment:
     description: 'Post the scorecard as a sticky comment on the pull request (true/false).'
     required: false
@@ -90,6 +94,9 @@ outputs:
   passed:
     description: 'true when the score met min-score (or min-score was 0).'
     value: ${{ steps.scan.outputs.passed }}
+  policy-passed:
+    description: 'true when the policy-as-code check passed (or policy-check was off). Only meaningful when policy-check=true.'
+    value: ${{ steps.scan.outputs.policy-passed }}
 
 runs:
   using: 'composite'
@@ -104,6 +111,7 @@ runs:
         IC_MODE: ${{ inputs.mode }}
         IC_SERVICE: ${{ inputs.service }}
         IC_MIN_SCORE: ${{ inputs.min-score }}
+        IC_POLICY_CHECK: ${{ inputs.policy-check }}
         IC_COMMENT: ${{ inputs.comment }}
         IC_BADGE: ${{ inputs.badge }}
         IC_UPLOAD_SARIF: ${{ inputs.upload-sarif }}

--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -46,6 +46,7 @@ func cmdScan(args []string) error {
 	k8sAdmission := fs.String("k8s-admission", "", "grade the workload carried in a Kubernetes admission.k8s.io/v1 AdmissionReview JSON (webhook backend); '-' reads stdin")
 	admissionResponse := fs.Bool("admission-response", false, "with --k8s-admission, emit an admission.k8s.io/v1 AdmissionReview response JSON (allow/deny) to stdout instead of the scorecard")
 	emitPolicy := fs.String("emit-policy", "", "instead of a scorecard, emit admission-policy YAML (engine: kyverno|gatekeeper|vap) that BLOCKS the controls the scanned --k8s manifest failed (the delta to 100/A); vap is a controller-free native ValidatingAdmissionPolicy")
+	check := fs.Bool("check", false, "policy-as-code CI gate: evaluate the --k8s manifest AGAINST the rules --emit-policy would generate and exit non-zero on any violation (no cluster, no controller). Pairs with --md/--json/--sarif for diagnostics")
 	helm := fs.String("helm", "", "render a Helm chart (dir or .tgz) with `helm template` and grade the isolation posture of its workloads")
 	helmBin := fs.String("helm-bin", envOrDefault("HELM", "helm"), "helm binary used to render the chart")
 	terraform := fs.String("terraform", "", "grade container workloads in a `terraform show -json` file (plan.json/state.json) or a Terraform dir")
@@ -446,6 +447,16 @@ func cmdScan(args []string) error {
 			sarif:        *sarif,
 			minScore:     *minScore,
 		})
+	}
+
+	// --check: the enforce-in-place dual of --emit-policy. Instead of EMITTING
+	// guardrail YAML, evaluate the scanned Kubernetes manifest AGAINST the rules
+	// --emit-policy would generate and exit non-zero on any violation — a
+	// self-contained policy-as-code CI gate that needs no cluster and no admission
+	// controller. It reuses the SAME dim->rule map as --emit-policy (checkRules /
+	// policyRules share keys), so generate and enforce never diverge.
+	if *check {
+		return runCheck(checkArgs{k8s: *k8s, positional: positional, asJSON: *asJSON, md: *md, sarif: *sarif})
 	}
 
 	// --emit-policy: turn scan findings into a guardrail. Instead of a scorecard,
@@ -2646,6 +2657,102 @@ func isCDKAssemblyTemplate(name string) bool {
 func fileExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
+}
+
+// checkArgs carries the resolved inputs for a `scan --check` run.
+type checkArgs struct {
+	k8s        string   // manifest path from --k8s (takes precedence)
+	positional []string // fallback manifest path(s)
+	asJSON     bool
+	md         bool
+	sarif      string
+}
+
+// runCheck is the enforce-in-place half of the generate/enforce loop: it grades a
+// Kubernetes manifest and evaluates each workload against the SAME guardrail rules
+// --emit-policy would generate (scan.CheckPolicy), then exits non-zero if any
+// workload breaks one. This turns the scanner into a self-contained policy-as-code
+// CI gate — no cluster, no Kyverno/Gatekeeper/VAP controller needed.
+//
+// It reuses the SAME pod-spec parser as --k8s / --emit-policy
+// (SpecsFromK8sStream); a rule is enforced per-workload, so a multi-doc manifest
+// reports every workload's violations. It fails CLOSED: an unreadable/unparseable
+// manifest errors (non-zero), exactly like an admission gate would DENY it.
+// --md/--json select the diagnostic format; --sarif writes a code-scanning log of
+// the worst-scoring workload as a side artifact (best-effort, never masks the gate
+// result).
+func runCheck(a checkArgs) error {
+	path := a.k8s
+	if path == "" {
+		switch len(a.positional) {
+		case 0:
+			return fmt.Errorf("scan --check needs a Kubernetes manifest: pass --k8s FILE or a positional path")
+		case 1:
+			path = a.positional[0]
+		default:
+			return fmt.Errorf("scan --check grades one manifest at a time; got %d", len(a.positional))
+		}
+	}
+	raw, rerr := os.ReadFile(path)
+	if rerr != nil {
+		return fmt.Errorf("read manifest: %w", rerr)
+	}
+	specs, serr := scan.SpecsFromK8sStream(raw)
+	if serr != nil {
+		return serr
+	}
+	res := scan.CheckPolicy(specs)
+
+	// Diagnostics. Default is the human table; --json swaps it. --md appends a
+	// PR-comment/job-summary block.
+	if a.asJSON {
+		if err := scan.RenderCheckJSON(os.Stdout, res); err != nil {
+			return err
+		}
+	} else {
+		scan.RenderCheckText(os.Stdout, res)
+	}
+	if a.md {
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprint(os.Stdout, scan.RenderCheckMarkdown(res))
+	}
+
+	// SARIF is a best-effort side artifact anchored on the worst-scoring workload,
+	// so GitHub code-scanning surfaces the violation at the manifest. An emit error
+	// never masks the gate result below (fail-open on the artifact only).
+	if a.sarif != "" {
+		worstReport, worstSpec := worstK8sWorkload(specs)
+		opts := scan.SARIFOptions{ConfigFile: path, AnchorLine: scan.AnchorLine(raw, worstSpec.Target)}
+		if err := writeSARIF(a.sarif, worstReport, worstSpec, opts); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: SARIF emit failed (check result unaffected): %v\n", err)
+		} else if !a.asJSON {
+			fmt.Fprintf(os.Stdout, "  wrote SARIF: %s\n", a.sarif)
+		}
+	}
+
+	if !res.OK() {
+		return fmt.Errorf("policy check failed: %d violation(s) across %d workload(s)", len(res.Violations), res.Workloads)
+	}
+	return nil
+}
+
+// worstK8sWorkload scores every pod spec and returns the lowest-scoring report and
+// its spec (the most porous workload), for anchoring the SARIF side artifact. Empty
+// input yields zero values; the SARIF renderer tolerates an empty report.
+func worstK8sWorkload(specs []scan.Spec) (scan.Report, scan.Spec) {
+	var (
+		worstReport scan.Report
+		worstSpec   scan.Spec
+		found       bool
+	)
+	for _, s := range specs {
+		r := scan.Score(s)
+		r.Version = version.String()
+		if !found || r.Score < worstReport.Score {
+			worstReport, worstSpec, found = r, s, true
+		}
+	}
+	return worstReport, worstSpec
 }
 
 // emitPolicyArgs carries the resolved inputs for a `scan --emit-policy` run.

--- a/docs/scan-action.md
+++ b/docs/scan-action.md
@@ -76,13 +76,14 @@ The file modes need no Docker daemon — the action reads the file directly:
 | `mode` | `container` | `container`, `compose`, or `k8s`. |
 | `service` | `""` | Compose service name (when the file has more than one). |
 | `min-score` | `0` | Fail the check below this score. `0` = report-only. |
+| `policy-check` | `false` | Policy-as-code gate (`mode=k8s` only): fail the check if the manifest violates the rules `--emit-policy` would generate. Needs no cluster or controller. Independent of `min-score`. |
 | `comment` | `true` | Post the scorecard as a sticky PR comment. |
 | `badge` | `false` | Write and upload the SVG badge as a build artifact. |
 | `upload-sarif` | `false` | Emit SARIF and upload it to GitHub code scanning (Security tab). Requires `security-events: write`. |
 | `version` | `latest` | ironctl release (`latest` or a tag like `v0.1.252`). |
 | `github-token` | `${{ github.token }}` | Token for the comment + release lookup. |
 
-Outputs: `score`, `grade`, `scorecard` (path), `badge-path`, `sarif-path`, and `passed`.
+Outputs: `score`, `grade`, `scorecard` (path), `badge-path`, `sarif-path`, `passed`, and `policy-passed`.
 
 ## Surface findings in the Security tab (SARIF)
 

--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -368,6 +368,21 @@ into admission control instead of a scorecard.
 
     [:octicons-arrow-right-24: Generate an admission policy](scan.md#generate-an-admission-policy-from-the-findings)
 
+-   #### :material-check-decagram-outline:{ .lg .middle } Policy-as-code gate { #scan-check }
+
+    ---
+
+    Closes the loop: `--check` evaluates the manifest **against the rules `--emit-policy` would
+    generate** and exits non-zero on any violation &mdash; a self-contained CI gate with **no
+    cluster and no controller**. Same dim&rarr;rule map as the generator, enforced in place.
+    Pair with `--md`/`--sarif` for PR diagnostics.
+
+    ```bash
+    ironctl scan --k8s pod.yaml --check --sarif check.sarif
+    ```
+
+    [:octicons-arrow-right-24: Gate a manifest in CI](scan.md#gate-a-manifest-as-policy-as-code)
+
 </div>
 
 ## Every mode, one engine

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -619,6 +619,36 @@ One scope difference: Kyverno auto-generates matching rules for pod controllers
 directly. Bind it to the workload resources you care about, or pair it with a Pod
 Security admission label, so controller-created pods are also caught at creation.
 
+## Gate a manifest as policy-as-code
+
+`--check` closes the generate&rarr;enforce loop. Where `--emit-policy` *writes* the
+guardrail YAML, `--check` **evaluates the manifest against the same rules in place**
+and exits non-zero on any violation. That turns scan into a self-contained
+**policy-as-code CI gate**: no cluster, no Kyverno/Gatekeeper/VAP controller, just
+the binary. It reuses the **same dim&rarr;rule map** as `--emit-policy`, so the gate
+enforces exactly what the generator would emit &mdash; generate and enforce never
+diverge.
+
+```bash
+# Fail the build if the manifest breaks any guardrail rule
+ironctl scan --k8s pod.yaml --check
+
+# PR diagnostics: a markdown table and a code-scanning SARIF log
+ironctl scan --k8s pod.yaml --check --md
+ironctl scan --k8s pod.yaml --check --sarif check.sarif
+```
+
+It applies each rule with the **same deny-the-bad semantics as the emitted
+policy**, not the stricter scorer verdict. Require-present controls (non-root,
+drop-caps, seccomp, read-only rootfs) fail closed when the field is absent, exactly
+as the generated `validate` pattern rejects them. Deny-present controls
+(`hostNetwork`, host namespaces, runtime-socket mounts) only fail on an
+explicitly-bad value, so a manifest that never sets them **passes** &mdash; the same
+verdict the API server would reach with the emitted rule applied. A multi-document
+manifest is checked workload by workload; the gate fails if any workload breaks any
+rule. It fails closed: an unreadable or unparseable manifest errors rather than
+passing silently.
+
 ## Grade a Dockerfile statically
 
 `--dockerfile FILE` grades a Dockerfile with no daemon and no image pull, so it

--- a/internal/host/scan/check.go
+++ b/internal/host/scan/check.go
@@ -1,0 +1,237 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// PolicyViolation is one enforceable containment control a checked workload
+// breaks — the exact guardrail rule `--emit-policy` would generate for the SAME
+// dimension, evaluated in place against the manifest instead of emitted as YAML.
+type PolicyViolation struct {
+	Target      string  `json:"target"`      // workload the violation was found on
+	Key         string  `json:"key"`         // scorer dimension key (score.go `scorers`)
+	Title       string  `json:"title"`       // human control name
+	Requirement string  `json:"requirement"` // what a compliant manifest must set
+	Evidence    string  `json:"evidence"`    // why it violates the rule
+	Verdict     Verdict `json:"verdict"`     // always FAIL for a rule breach
+}
+
+// CheckResult is the outcome of `scan --check`: a Kubernetes manifest evaluated,
+// workload by workload, against the SAME guardrail rules `--emit-policy` would
+// generate. It is the enforce-in-place half of the generate/enforce loop — a
+// self-contained policy-as-code gate that needs no cluster and no admission
+// controller. When Violations is empty the manifest satisfies every rule the
+// generated policy would enforce and the gate passes.
+type CheckResult struct {
+	Workloads  int               `json:"workloads"`  // number of pod specs evaluated
+	Violations []PolicyViolation `json:"violations"` // broken rules, in canonical order
+}
+
+// OK reports whether the manifest passed the gate (no guardrail rule was broken).
+func (c CheckResult) OK() bool { return len(c.Violations) == 0 }
+
+// checkRule mirrors, in Go, the admission rule `--emit-policy` emits for one
+// dimension (policyRules). `violated` returns true (with evidence) when the pod
+// spec BREAKS that rule, using the SAME deny-the-bad semantics as the emitted
+// Kyverno/Gatekeeper/VAP rule — NOT the stricter scorer verdict.
+//
+// The polarity therefore matches the generated policy exactly:
+//   - "require-present" controls (non-root, drop-caps, seccomp, read-only rootfs)
+//     demand a field be set to a safe value, so an ABSENT field is a violation
+//     (fail-closed) — just as the emitted validate: pattern / CEL rejects it.
+//   - "deny-present" controls (hostNetwork, host namespaces, runtime socket)
+//     only block an explicitly-bad value, so an ABSENT field ADMITS — just as the
+//     emitted rule admits a pod that never sets hostNetwork. This is why a clean
+//     manifest can pass the gate even though the scorer cannot certify
+//     network=none from a bare pod spec.
+type checkRule struct {
+	title       string
+	requirement string
+	violated    func(Spec) (bool, string)
+}
+
+// checkRules is keyed by the SAME scorer dimension keys as policyRules, so the
+// gate enforces exactly the set `--emit-policy` would generate — one map, two
+// views (generate vs enforce). Evaluated in canonical scorer order for stable
+// output.
+var checkRules = map[string]checkRule{
+	"user.nonroot": {
+		title:       "runs as non-root",
+		requirement: "set securityContext.runAsNonRoot: true (at the pod or container level)",
+		violated: func(s Spec) (bool, string) {
+			if s.RunAsNonRoot == Yes || s.Rootless == Yes {
+				return false, ""
+			}
+			return true, fmt.Sprintf("runAsNonRoot not set to true (user %q)", nz(s.User, "unset"))
+		},
+	},
+	"caps.dropped": {
+		title:       "capabilities dropped",
+		requirement: "drop ALL Linux capabilities (securityContext.capabilities.drop: [ALL]) and do not run privileged",
+		violated: func(s Spec) (bool, string) {
+			if s.Privileged == Yes {
+				return true, "runs privileged (grants the full capability set)"
+			}
+			if s.CapDropAll != Yes {
+				return true, "does not drop ALL capabilities (securityContext.capabilities.drop: [ALL] absent)"
+			}
+			return false, ""
+		},
+	},
+	"seccomp": {
+		title:       "seccomp confined",
+		requirement: "set spec.securityContext.seccompProfile.type to RuntimeDefault or Localhost",
+		violated: func(s Spec) (bool, string) {
+			if s.Privileged == Yes {
+				return true, "privileged: seccomp is disabled"
+			}
+			if s.Seccomp != "confined" {
+				return true, "seccompProfile type is not RuntimeDefault or Localhost"
+			}
+			return false, ""
+		},
+	},
+	"rootfs.readonly": {
+		title:       "read-only root filesystem",
+		requirement: "set securityContext.readOnlyRootFilesystem: true on every container",
+		violated: func(s Spec) (bool, string) {
+			if s.ReadonlyRoot == Yes {
+				return false, ""
+			}
+			return true, "readOnlyRootFilesystem not set to true"
+		},
+	},
+	"network.isolated": {
+		title:       "no host network",
+		requirement: "do not set hostNetwork: true",
+		violated: func(s Spec) (bool, string) {
+			if s.HostNetwork == Yes {
+				return true, "hostNetwork: true (full host network reachability)"
+			}
+			return false, ""
+		},
+	},
+	"namespaces.host": {
+		title:       "no host namespaces",
+		requirement: "do not share the host PID or IPC namespace (hostPID/hostIPC: false)",
+		violated: func(s Spec) (bool, string) {
+			var shared []string
+			if s.HostPID == Yes {
+				shared = append(shared, "hostPID")
+			}
+			if s.HostIPC == Yes {
+				shared = append(shared, "hostIPC")
+			}
+			if len(shared) == 0 {
+				return false, ""
+			}
+			return true, "shares host namespace(s): " + strings.Join(shared, ", ")
+		},
+	},
+	"docker.sock": {
+		title:       "no runtime socket mount",
+		requirement: "do not mount the container runtime socket (docker.sock / containerd.sock / crio.sock)",
+		violated: func(s Spec) (bool, string) {
+			if s.DockerSock == Yes {
+				return true, "mounts the container runtime socket (trivial host-root escape)"
+			}
+			return false, ""
+		},
+	},
+}
+
+// CheckPolicy evaluates each pod spec against every guardrail rule and returns the
+// violations, in canonical scorer order per workload so the output is
+// deterministic regardless of input order. It is the enforce-in-place dual of
+// EmitPolicy: same dim->rule map (policyRules / checkRules share keys), but the
+// rule is applied to the scanned manifest itself rather than baked into YAML.
+//
+// It is pure: no I/O, deterministic for a given spec set.
+func CheckPolicy(specs []Spec) CheckResult {
+	res := CheckResult{Workloads: len(specs)}
+	for _, s := range specs {
+		target := s.Target
+		if target == "" {
+			target = "workload"
+		}
+		for _, sc := range scorers {
+			rule, ok := checkRules[sc.key]
+			if !ok {
+				continue
+			}
+			broken, evidence := rule.violated(s)
+			if !broken {
+				continue
+			}
+			res.Violations = append(res.Violations, PolicyViolation{
+				Target:      target,
+				Key:         sc.key,
+				Title:       rule.title,
+				Requirement: rule.requirement,
+				Evidence:    evidence,
+				Verdict:     VerdictFail,
+			})
+		}
+	}
+	return res
+}
+
+// RenderCheckText writes a human-readable gate report to w: a PASS banner when the
+// manifest satisfies every rule, otherwise one line per broken rule with the
+// workload, the requirement, and the evidence. This is the default CLI/CI output.
+func RenderCheckText(w io.Writer, res CheckResult) {
+	if res.OK() {
+		fmt.Fprintf(w, "PASS  policy check: %d workload(s), 0 violations\n", res.Workloads)
+		fmt.Fprintln(w, "  every guardrail rule --emit-policy would generate is satisfied in place.")
+		return
+	}
+	fmt.Fprintf(w, "FAIL  policy check: %d violation(s) across %d workload(s)\n\n", len(res.Violations), res.Workloads)
+	for _, v := range res.Violations {
+		fmt.Fprintf(w, "  %s [%s]\n", v.Title, v.Target)
+		fmt.Fprintf(w, "          require: %s\n", v.Requirement)
+		if v.Evidence != "" {
+			fmt.Fprintf(w, "          found:   %s\n", v.Evidence)
+		}
+	}
+	fmt.Fprintln(w, "\nRun `ironctl scan --k8s <file> --emit-policy=kyverno` to generate the guardrail these rules enforce.")
+}
+
+// RenderCheckMarkdown renders the gate result as a Markdown block for a PR comment
+// or CI job summary. A clean manifest yields a one-line pass; violations become a
+// table so a reviewer sees exactly which rule each workload broke.
+func RenderCheckMarkdown(res CheckResult) string {
+	var b strings.Builder
+	b.WriteString("### IronClaw policy check\n\n")
+	if res.OK() {
+		fmt.Fprintf(&b, "**PASS** — %d workload(s), 0 violations. Every guardrail rule --emit-policy would generate is satisfied.\n", res.Workloads)
+		return b.String()
+	}
+	fmt.Fprintf(&b, "**FAIL** — %d violation(s) across %d workload(s).\n\n", len(res.Violations), res.Workloads)
+	b.WriteString("| Workload | Control | Requirement | Found |\n")
+	b.WriteString("| --- | --- | --- | --- |\n")
+	for _, v := range res.Violations {
+		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n",
+			mdCell(v.Target), mdCell(v.Title), mdCell(v.Requirement), mdCell(v.Evidence))
+	}
+	return b.String()
+}
+
+// RenderCheckJSON writes the machine-readable gate result to w (for --json).
+func RenderCheckJSON(w io.Writer, res CheckResult) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(res)
+}
+
+// mdCell escapes a value for a single Markdown table cell (pipes and newlines).
+func mdCell(s string) string {
+	s = strings.ReplaceAll(s, "|", "\\|")
+	s = strings.ReplaceAll(s, "\n", " ")
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/internal/host/scan/check_test.go
+++ b/internal/host/scan/check_test.go
@@ -1,0 +1,159 @@
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// specsFromFixture parses a k8s manifest fixture into pod specs.
+func specsFromFixture(t *testing.T, name string) []Spec {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	specs, err := SpecsFromK8sStream(raw)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	return specs
+}
+
+// TestCheckPolicyInsecure: the fully-insecure fixture breaks EVERY guardrail rule
+// — one violation per checkRules key, so the gate rejects it.
+func TestCheckPolicyInsecure(t *testing.T) {
+	res := CheckPolicy(specsFromFixture(t, "emitpolicy_insecure.yaml"))
+	if res.OK() {
+		t.Fatal("insecure manifest passed the gate; want failure")
+	}
+	if res.Workloads != 1 {
+		t.Errorf("workloads = %d, want 1", res.Workloads)
+	}
+	if len(res.Violations) != len(checkRules) {
+		t.Errorf("violations = %d, want %d (one per enforceable rule)", len(res.Violations), len(checkRules))
+	}
+	for _, v := range res.Violations {
+		if _, ok := policyRules[v.Key]; !ok {
+			t.Errorf("violation key %q has no guardrail rule", v.Key)
+		}
+		if v.Requirement == "" {
+			t.Errorf("violation %q has empty requirement", v.Key)
+		}
+		if v.Verdict != VerdictFail {
+			t.Errorf("violation %q verdict = %q, want FAIL", v.Key, v.Verdict)
+		}
+	}
+}
+
+// TestCheckPolicyHardened: a hardened manifest satisfies every rule and passes the
+// gate. This exercises the deny-the-bad polarity: a pod that simply never sets
+// hostNetwork/hostPID/hostIPC/runtime-socket is admitted, matching the emitted
+// rule (even though the scorer cannot certify network=none from a bare pod spec).
+func TestCheckPolicyHardened(t *testing.T) {
+	res := CheckPolicy(specsFromFixture(t, "check_hardened.yaml"))
+	if !res.OK() {
+		t.Fatalf("hardened manifest failed the gate: %+v", res.Violations)
+	}
+	if len(res.Violations) != 0 {
+		t.Errorf("violations = %d, want 0", len(res.Violations))
+	}
+}
+
+// TestCheckRulesMatchPolicyRules: the gate enforces EXACTLY the dimensions
+// --emit-policy generates rules for — the two maps must share their key set so
+// generate and enforce never diverge.
+func TestCheckRulesMatchPolicyRules(t *testing.T) {
+	if len(checkRules) != len(policyRules) {
+		t.Fatalf("checkRules has %d keys, policyRules has %d", len(checkRules), len(policyRules))
+	}
+	for k := range policyRules {
+		if _, ok := checkRules[k]; !ok {
+			t.Errorf("policyRules has %q but checkRules does not enforce it", k)
+		}
+	}
+}
+
+// TestCheckPolicyParityOnInsecure: for a fully-insecure manifest the controls the
+// gate flags are exactly the ones --emit-policy would generate rules for
+// (failingDims), confirming the enforce view matches the generate view.
+func TestCheckPolicyParityOnInsecure(t *testing.T) {
+	specs := specsFromFixture(t, "emitpolicy_insecure.yaml")
+	reports := make([]Report, len(specs))
+	for i, s := range specs {
+		reports[i] = Score(s)
+	}
+	gotKeys := map[string]bool{}
+	for _, v := range CheckPolicy(specs).Violations {
+		gotKeys[v.Key] = true
+	}
+	for _, k := range failingDims(reports) {
+		if !gotKeys[k] {
+			t.Errorf("--emit-policy generates a rule for %q but the gate did not flag it", k)
+		}
+	}
+	if len(gotKeys) != len(failingDims(reports)) {
+		t.Errorf("gate flagged %d controls, --emit-policy would generate %d", len(gotKeys), len(failingDims(reports)))
+	}
+}
+
+// TestCheckPolicyFailClosedUnknown: for a require-present control (non-root), an
+// absent/unknown field is a violation — fail-closed, matching the emitted rule
+// that rejects a pod without runAsNonRoot: true.
+func TestCheckPolicyFailClosedUnknown(t *testing.T) {
+	res := CheckPolicy([]Spec{{Target: "empty"}}) // all fields Unknown/zero
+	if res.OK() {
+		t.Fatal("empty spec passed the gate; want fail-closed on require-present controls")
+	}
+	// Require-present controls (non-root, caps, seccomp, rootfs) must all fire;
+	// deny-present controls (network, namespaces, docker.sock) admit an absent field.
+	present := map[string]bool{}
+	for _, v := range res.Violations {
+		present[v.Key] = true
+	}
+	for _, k := range []string{"user.nonroot", "caps.dropped", "seccomp", "rootfs.readonly"} {
+		if !present[k] {
+			t.Errorf("require-present control %q did not fail closed on an empty spec", k)
+		}
+	}
+	for _, k := range []string{"network.isolated", "namespaces.host", "docker.sock"} {
+		if present[k] {
+			t.Errorf("deny-present control %q fired on an absent field; should admit", k)
+		}
+	}
+}
+
+func TestRenderCheckTextPass(t *testing.T) {
+	var b strings.Builder
+	RenderCheckText(&b, CheckResult{Workloads: 2})
+	if out := b.String(); !strings.HasPrefix(out, "PASS") {
+		t.Errorf("pass output does not start with PASS:\n%s", out)
+	}
+}
+
+func TestRenderCheckTextFail(t *testing.T) {
+	var b strings.Builder
+	RenderCheckText(&b, CheckPolicy(specsFromFixture(t, "emitpolicy_insecure.yaml")))
+	out := b.String()
+	if !strings.HasPrefix(out, "FAIL") {
+		t.Errorf("fail output does not start with FAIL:\n%s", out)
+	}
+	if !strings.Contains(out, "require:") {
+		t.Errorf("fail output missing requirement lines:\n%s", out)
+	}
+}
+
+func TestRenderCheckMarkdown(t *testing.T) {
+	md := RenderCheckMarkdown(CheckPolicy(specsFromFixture(t, "emitpolicy_insecure.yaml")))
+	if !strings.Contains(md, "**FAIL**") {
+		t.Errorf("markdown missing FAIL banner:\n%s", md)
+	}
+	if !strings.Contains(md, "| Workload | Control | Requirement | Found |") {
+		t.Errorf("markdown missing table header:\n%s", md)
+	}
+	ok := RenderCheckMarkdown(CheckResult{Workloads: 1})
+	if !strings.Contains(ok, "**PASS**") {
+		t.Errorf("clean markdown missing PASS banner:\n%s", ok)
+	}
+}

--- a/internal/host/scan/testdata/check_hardened.yaml
+++ b/internal/host/scan/testdata/check_hardened.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good
+spec:
+  hostNetwork: false
+  hostPID: false
+  hostIPC: false
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: app
+      image: nginx
+      securityContext:
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
+        privileged: false
+        capabilities:
+          drop:
+            - ALL


### PR DESCRIPTION
## What

Closes the generate->enforce loop from `--emit-policy` (#538/#545). Adds `scan --check`: instead of EMITTING guardrail YAML, it evaluates a Kubernetes manifest **against the rules `--emit-policy` would generate** and exits non-zero on any violation. The scanner becomes a self-contained **policy-as-code CI gate** — no cluster, no Kyverno/Gatekeeper/VAP controller.

## How

- **`internal/host/scan/check.go`** — `CheckPolicy(specs)` + text/markdown/JSON renderers. `checkRules` shares its key set with `policyRules` (one dim->rule map, two views: generate vs enforce). It applies the emitted rules' **deny-the-bad** semantics, not the stricter scorer verdict:
  - require-present controls (non-root, drop-caps, seccomp, read-only rootfs) fail **closed** when the field is absent, exactly as the emitted `validate` pattern / CEL rejects them.
  - deny-present controls (`hostNetwork`, host namespaces, runtime-socket) fail only on an explicitly-bad value, so a clean manifest **passes** — the same verdict the API server would reach with the emitted rule applied. (The scorer alone can't certify `network=none` from a bare pod spec; the *rule* admits it.)
- **`cmd/ironctl/scan.go`** — `--check` flag + `runCheck`; `--md`/`--json`/`--sarif` diagnostics; fails closed on unreadable/unparseable input. Multi-doc manifests checked workload by workload.
- **`action.yml` + `scan.sh`** — optional `policy-check` gate (mode=k8s) that fails the PR on violation, independent of `min-score`, run after the sticky comment posts so a violating manifest still gets its scorecard. New `policy-passed` output.
- **docs** — `scan.md` gate section, `scan-coverage.md` hub card, `scan-action.md` inputs/outputs.

## Verify

```
$ ironctl scan --k8s insecure.yaml --check   # 7 violations, exit 1
$ ironctl scan --k8s hardened.yaml --check    # PASS, exit 0
```

`go test -run Check ./internal/host/scan` (parity with `failingDims`, fail-closed, polarity, renderers). Full scan package: **252 tests green**. `CGO_ENABLED=1 go build ./cmd/ironctl` green. `bash -n scan.sh` clean.

## Security lenses

Mandatory-gateway / egress: none touched — `--check` is pure, local, read-only (parse + score), no network, no control-plane. The Action gate keeps the existing credential-free, egress-only-to-releases posture.

IRO-589. Parent CEO-thinking IRO-588.