### PR TITLE
fix(examples): pin pydantic-ai-slim>=1.0 to fix smoke-matrix (opentelemetry._events) [IRO-595]

### DIFF
--- a/examples/integrations/pydantic-ai/requirements.txt
+++ b/examples/integrations/pydantic-ai/requirements.txt
@@ -2,7 +2,15 @@
 # example adds is Pydantic AI itself. `pydantic-ai-slim` carries the core `Tool`
 # and `Agent` types with no model-provider extras, which is all the default,
 # credential-free path needs. Pinned for reproducible fresh-machine runs.
-pydantic-ai-slim>=0.0.15,<1.0
+#
+# Floor at the 1.0 GA line: the entire pre-1.0 line does
+# `from opentelemetry._events import Event`, a module opentelemetry-api removed in
+# 1.37, so any fresh install of a 0.x pin now fails to import with
+# `ModuleNotFoundError: No module named 'opentelemetry._events'` (IRO-595). The 1.x+
+# line dropped that import and works with current opentelemetry-api. Capped below the
+# next major so a future breaking release can't silently retrigger the same class of
+# transitive-dependency break.
+pydantic-ai-slim>=1.0,<3
 
 # Optional -- only needed for the real-LLM path (set OPENAI_API_KEY):
-# pydantic-ai-slim[openai]>=0.0.15,<1.0
+# pydantic-ai-slim[openai]>=1.0,<3


### PR DESCRIPTION
## What
The `example-smoke` **smoke-matrix** job went red on a fresh install of the Pydantic AI integration example.

## Root cause
`examples/integrations/pydantic-ai/requirements.txt` pinned `pydantic-ai-slim>=0.0.15,<1.0`. The entire pre-1.0 line does `from opentelemetry._events import Event`, and `opentelemetry-api` **removed the `_events` module in 1.37**. A fresh venv now resolves `pydantic-ai-slim 0.8.1` + `opentelemetry-api 1.44`, so importing `pydantic_ai` (via `ironclaw_tool`) fails:

```
ModuleNotFoundError: No module named 'opentelemetry._events'
```

Pinning *within* `<1.0` cannot fix it — every 0.x version has the broken import.

## Fix
Floor at the 1.0 GA line (which dropped the removed import and works with current `opentelemetry-api`) and cap below the next major for reproducibility: `pydantic-ai-slim>=1.0,<3`.

## Verification
Fresh venv, exactly what CI's `setup_venv` does:
- `pip install -r requirements.txt` → `pydantic-ai-slim 2.13.0` + `opentelemetry-api 1.44.0`
- `from pydantic_ai import Tool, Agent` → OK
- `import ironclaw_tool; make_sandbox_tool` → OK (the exact import chain the demo runs)

`Tool(func, name=..., description=...)` and `Agent(...)` — the only pydantic-ai APIs the example uses — are unchanged in 2.x.

## Scope / security
Docs/example dependency pin only. No Go, no `internal/contract`, no control-plane or sandbox code. No trust boundary, gateway, encryption, isolation, or egress path touched. Demo stays credential-free through the sandbox.

Closes IRO-595.