### PR TITLE
docs(scan): wire --check policy-as-code gate into coverage-hub summary table [IRO-596]

### DIFF
--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -414,6 +414,7 @@ the container they eventually produce are all measured on one comparable scale.
 | Infrastructure-as-Code | [AWS SAM template](#scan-sam) | `--sam` | ECS task defs in a SAM (Serverless) template | [Grade an AWS SAM template](scan.md#grade-an-aws-sam-template) |
 | Enforce &amp; generate | [Admission gate](#scan-k8s-admission) | `--k8s-admission` `--admission-response` | the workload in an AdmissionReview (webhook backend) | [Grade a Kubernetes AdmissionReview](scan.md#grade-a-kubernetes-admission-review) |
 | Enforce &amp; generate | [Policy generator](#scan-emit-policy) | `--k8s` `--emit-policy` | failed controls &rarr; Kyverno/Gatekeeper admission YAML | [Generate an admission policy](scan.md#generate-an-admission-policy-from-the-findings) |
+| Enforce &amp; generate | [Policy-as-code gate](#scan-check) | `--k8s` `--check` | the manifest against the rules `--emit-policy` would generate; non-zero on violation | [Gate a manifest in CI](scan.md#gate-a-manifest-as-policy-as-code) |
 
 Every mode also emits the machine-readable outputs: a [SARIF log](scan.md#github-code-scanning-security-tab)
 for GitHub code scanning, a [shields.io badge](scan.md#sandbox-isolation-score-badge), and


### PR DESCRIPTION
## What
IRO-589 (`scan --check` CI gate) merged today via #553, unblocking IRO-592/IRO-596.

The `--check` **Policy-as-code gate** card already landed with the feature PR (#553) under the `Enforce & generate` H3, alongside `--k8s-admission` and `--emit-policy`. But the *Every mode, one engine* summary table only carried two of the three Enforce rows — the `--check` row was missing, so the table and the card set were out of sync.

This adds the third summary-table row:

| Enforce & generate | Policy-as-code gate (#scan-check) | `--k8s` `--check` | the manifest against the rules `--emit-policy` would generate; non-zero on violation | Gate a manifest in CI |

Flag name and semantics match merged #553 (`--check` bool + `--sarif <path>` / `--md`).

## Verification (visual-truth gate)
- Built with mkdocs, no broken-link warnings.
- Rendered `docs/scan-coverage.md` at 1792x998 desktop viewport.
  - Card `#scan-check` present with `check-decagram-outline` icon + 'Gate a manifest in CI' deep-dive (anchor `scan.md#gate-a-manifest-as-policy-as-code` resolves).
  - Summary table shows all three Enforce rows: Admission gate, Policy generator, Policy-as-code gate.
  - TOC lists 'Policy-as-code gate' 3rd under Enforce & generate.

## Acceptance
- [x] coverage hub renders `--check` capability, flag name matches #553
- [x] PR against ironclaw main