### PR TITLE
feat(scan): compile containment scorer to WASM for the public web scanner [IRO-598]

### DIFF
--- a/cmd/scan-wasm/main.go
+++ b/cmd/scan-wasm/main.go
@@ -1,0 +1,233 @@
+// Command scan-wasm compiles IronClaw's pure containment scorer to WebAssembly
+// so the exact same 7-dimension grade the `ironctl scan` CLI produces can run
+// in-browser — no install, no auth, and the pasted content never leaves the
+// page (it is graded entirely client-side).
+//
+// It is a thin adapter over the pure internal/host/scan package: it registers a
+// single JS-callable function `ironclawScan(kind, text, service)` on globalThis
+// and returns a JSON string. NO grading logic is reimplemented here — the WASM
+// binary calls scan.Score / scan.ScoreDockerfile / scan.Remediate directly, so
+// the web result can never drift from the CLI.
+//
+// Build (from repo root):
+//
+//	GOOS=js GOARCH=wasm go build -o scan.wasm ./cmd/scan-wasm
+//
+// The build constraint keeps this file out of the normal host build (it imports
+// syscall/js, which only compiles under js/wasm).
+//
+//go:build js && wasm
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"syscall/js"
+
+	"github.com/IronSecCo/ironclaw/internal/host/scan"
+	"github.com/IronSecCo/ironclaw/internal/version"
+
+	"gopkg.in/yaml.v3"
+)
+
+// result is one graded workload plus everything the page needs to render it and
+// build a shareable receipt. Report carries the 0-100 score, A-F grade and the
+// per-dimension pass/fail table; Remediation holds the one-line fix hint per
+// non-PASS dimension; the Share* URLs reuse the CLI's own renderers so the web
+// share link and the CLI share link are byte-identical for the same posture.
+type result struct {
+	Service     string             `json:"service"`
+	Report      scan.Report        `json:"report"`
+	Remediation []scan.Remediation `json:"remediation"`
+	ShareCard   string             `json:"shareCardUrl"`
+	ShareBadge  string             `json:"shareBadgeUrl"`
+	ShareReceipt string            `json:"shareReceiptUrl"`
+}
+
+// response is the full JSON payload handed back to the page. results holds one
+// entry per graded workload (a Dockerfile or k8s manifest yields exactly one; a
+// multi-service compose file yields one per service). PrimaryIndex points at the
+// weakest — the headline grade, matching the CLI's weakest-rollup convention.
+type response struct {
+	OK           bool     `json:"ok"`
+	Error        string   `json:"error,omitempty"`
+	DetectedKind string   `json:"detectedKind"`
+	Results      []result `json:"results,omitempty"`
+	PrimaryIndex int      `json:"primaryIndex"`
+}
+
+// detectKind classifies pasted text as a Dockerfile, docker-compose file, or
+// Kubernetes manifest. It is best-effort and only used when the caller passes
+// kind "auto" (an explicit kind always wins). k8s and compose are both YAML, so
+// order matters: a `kind:`+`apiVersion:` pair is unambiguously k8s; a top-level
+// `services:` map is compose; a `FROM` instruction is a Dockerfile.
+func detectKind(text string) string {
+	lower := strings.ToLower(text)
+	hasAPIVersion := lineStartsWith(lower, "apiversion:")
+	hasKind := lineStartsWith(lower, "kind:")
+	if hasAPIVersion && hasKind {
+		return "k8s"
+	}
+	if lineStartsWith(lower, "services:") {
+		return "compose"
+	}
+	if lineStartsWith(lower, "from ") {
+		return "dockerfile"
+	}
+	// Fall back on remaining YAML signals before giving up.
+	if hasAPIVersion || hasKind {
+		return "k8s"
+	}
+	if strings.Contains(lower, "services:") {
+		return "compose"
+	}
+	return "dockerfile"
+}
+
+// lineStartsWith reports whether any line of s (after trimming leading spaces)
+// begins with prefix. Used for top-level YAML/Dockerfile key detection.
+func lineStartsWith(s, prefix string) bool {
+	for _, ln := range strings.Split(s, "\n") {
+		if strings.HasPrefix(strings.TrimLeft(ln, " \t"), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// gradeOne builds a full result from a graded Report + its source Spec. The Spec
+// is nil for the Dockerfile path (its scorer takes a DockerfileSpec, not a Spec,
+// and has no Spec-based remediation), so remediation is only attached when a Spec
+// is available (compose / k8s).
+func gradeOne(service string, r scan.Report, s *scan.Spec) result {
+	r.Version = version.String()
+	res := result{
+		Service:      service,
+		Report:       r,
+		ShareCard:    scan.ShareCardURL(r),
+		ShareBadge:   scan.ShareBadgeURL(r),
+		ShareReceipt: scan.ShareReceiptURL(r),
+	}
+	if s != nil {
+		res.Remediation = scan.Remediate(*s, r).Items
+	}
+	return res
+}
+
+// composeServiceNames returns the service keys declared in a compose file, in
+// stable sorted order, so a multi-service paste can be graded service-by-service.
+func composeServiceNames(raw []byte) ([]string, error) {
+	var cf struct {
+		Services map[string]yaml.Node `yaml:"services"`
+	}
+	if err := yaml.Unmarshal(raw, &cf); err != nil {
+		return nil, fmt.Errorf("parse compose file: %w", err)
+	}
+	names := make([]string, 0, len(cf.Services))
+	for n := range cf.Services {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// scanText is the core: it grades pasted text and returns the JSON response. kind
+// is "auto" | "dockerfile" | "compose" | "k8s"; service optionally selects a
+// single compose service (empty = grade every service).
+func scanText(kind, text, service string) response {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return response{OK: false, Error: "paste a Dockerfile, docker-compose.yml, or Kubernetes manifest to grade"}
+	}
+	if kind == "" || kind == "auto" {
+		kind = detectKind(text)
+	}
+	raw := []byte(text)
+
+	switch kind {
+	case "dockerfile":
+		spec, err := scan.SpecFromDockerfile(raw, "Dockerfile")
+		if err != nil {
+			return response{OK: false, DetectedKind: kind, Error: err.Error()}
+		}
+		return response{OK: true, DetectedKind: kind, PrimaryIndex: 0,
+			Results: []result{gradeOne("Dockerfile", scan.ScoreDockerfile(spec), nil)}}
+
+	case "k8s":
+		spec, err := scan.SpecFromK8s(raw)
+		if err != nil {
+			return response{OK: false, DetectedKind: kind, Error: err.Error()}
+		}
+		return response{OK: true, DetectedKind: kind, PrimaryIndex: 0,
+			Results: []result{gradeOne(spec.Target, scan.Score(spec), &spec)}}
+
+	case "compose":
+		names, err := composeServiceNames(raw)
+		if err != nil {
+			return response{OK: false, DetectedKind: kind, Error: err.Error()}
+		}
+		if len(names) == 0 {
+			return response{OK: false, DetectedKind: kind, Error: "compose file declares no services"}
+		}
+		if service != "" {
+			names = []string{service}
+		}
+		var results []result
+		for _, n := range names {
+			spec, err := scan.SpecFromCompose(raw, n)
+			if err != nil {
+				return response{OK: false, DetectedKind: kind, Error: err.Error()}
+			}
+			results = append(results, gradeOne(n, scan.Score(spec), &spec))
+		}
+		return response{OK: true, DetectedKind: kind, Results: results, PrimaryIndex: weakest(results)}
+
+	default:
+		return response{OK: false, Error: fmt.Sprintf("unknown kind %q (want auto|dockerfile|compose|k8s)", kind)}
+	}
+}
+
+// weakest returns the index of the lowest-scoring result — the headline grade a
+// multi-service compose file rolls up to (a stack is only as contained as its
+// weakest workload).
+func weakest(rs []result) int {
+	idx := 0
+	for i, r := range rs {
+		if r.Report.Score < rs[idx].Report.Score {
+			idx = i
+		}
+	}
+	return idx
+}
+
+// ironclawScan is the JS entry point: ironclawScan(kind, text, service) -> JSON
+// string. It never throws into JS; all errors are reported in the JSON payload.
+func ironclawScan(_ js.Value, args []js.Value) any {
+	kind, text, service := "auto", "", ""
+	if len(args) > 0 {
+		kind = args[0].String()
+	}
+	if len(args) > 1 {
+		text = args[1].String()
+	}
+	if len(args) > 2 && args[2].Type() == js.TypeString {
+		service = args[2].String()
+	}
+	out, err := json.Marshal(scanText(kind, text, service))
+	if err != nil {
+		b, _ := json.Marshal(response{OK: false, Error: "internal: " + err.Error()})
+		return string(b)
+	}
+	return string(out)
+}
+
+func main() {
+	js.Global().Set("ironclawScan", js.FuncOf(ironclawScan))
+	js.Global().Set("ironclawScanReady", js.ValueOf(true))
+	// Block forever: the exported function must stay callable for the page's
+	// lifetime (a returning main() would tear the instance down).
+	select {}
+}

--- a/scripts/build-scan-wasm.sh
+++ b/scripts/build-scan-wasm.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# build-scan-wasm.sh — compile the pure containment scorer to WebAssembly for the
+# public web scanner (IRO-598) and stage it next to the Go runtime's wasm_exec.js.
+#
+# The .wasm binary embeds internal/host/scan as-is, so the in-browser grade can
+# never drift from `ironctl scan`. Re-run this whenever the scorer changes and
+# copy the two artifacts into the landing repo's public/scan/ directory.
+#
+# Usage:
+#   scripts/build-scan-wasm.sh [OUT_DIR]
+#
+# OUT_DIR defaults to ./dist/scan-wasm. Pass the landing repo's public/scan path
+# to build straight into place, e.g.:
+#   scripts/build-scan-wasm.sh ../nivardsec-landing/public/scan
+set -euo pipefail
+
+OUT_DIR="${1:-dist/scan-wasm}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+mkdir -p "$OUT_DIR"
+
+echo "building scan.wasm -> $OUT_DIR/scan.wasm"
+GOOS=js GOARCH=wasm go build -trimpath -ldflags='-s -w' -o "$OUT_DIR/scan.wasm" ./cmd/scan-wasm
+
+# wasm_exec.js ships with the Go toolchain; it MUST match the toolchain that
+# built the binary. Go 1.24+ keeps it under lib/wasm; older releases under misc.
+GOROOT="$(go env GOROOT)"
+WASM_EXEC=""
+for cand in "$GOROOT/lib/wasm/wasm_exec.js" "$GOROOT/misc/wasm/wasm_exec.js"; do
+  if [ -f "$cand" ]; then WASM_EXEC="$cand"; break; fi
+done
+if [ -z "$WASM_EXEC" ]; then
+  echo "error: wasm_exec.js not found under $GOROOT" >&2
+  exit 1
+fi
+echo "copying wasm_exec.js ($WASM_EXEC) -> $OUT_DIR/wasm_exec.js"
+cp "$WASM_EXEC" "$OUT_DIR/wasm_exec.js"
+
+BYTES=$(wc -c < "$OUT_DIR/scan.wasm" | tr -d ' ')
+echo "done: scan.wasm = $BYTES bytes (~$(( BYTES / 1024 / 1024 ))MB; ~1.3MB gzipped over the wire)"


### PR DESCRIPTION
## What
Compile the pure `internal/host/scan` scorer to WebAssembly so the exact same 7-dimension containment grade `ironctl scan` produces can run **in-browser** — powering the public zero-install web scanner (IRO-598).

`cmd/scan-wasm/main.go` is a thin `syscall/js` adapter (build-tagged `js && wasm`, excluded from the host build) that registers `ironclawScan(kind, text, service)` on globalThis and returns JSON:
- Grades **Dockerfile** (`ScoreDockerfile`), **docker-compose** (every service, weakest = headline), and **k8s** (`Score`) — auto-detects type or takes an explicit kind.
- Reuses `ShareCardURL`/`ShareBadgeURL`/`Remediate` so the web receipt + fix hints can never drift from the CLI. **No grading reimplemented.**

`scripts/build-scan-wasm.sh` builds the 4.7MB binary (~1.3MB gzipped) and stages it next to the toolchain's `wasm_exec.js` for the landing repo's `public/scan/`.

## Security lenses
- **Trust boundary / isolation:** pure offline scorer; the WASM path makes zero network/daemon/file calls — pasted content stays client-side. No new sandbox capability.
- Host build unaffected (`go build ./...` green; build tag isolates the adapter).

## Verified
`GOOS=js GOARCH=wasm go build` clean; ran the binary in Node **and** in a real browser: insecure Dockerfile 32/D, hardened pod 89/B, privileged multi-service compose rolls up to db 19/F.

Landing counterpart PR (the /scan page): nivardsec-landing#iro-598-public-scan.