### PR TITLE
docs(scan): enforce section says three cards for --check gate [IRO-592]

### DIFF
--- a/docs/scan-coverage.md
+++ b/docs/scan-coverage.md
@@ -333,9 +333,9 @@ roll up to the **weakest** one the code defines.
 
 ### Enforce &amp; generate { #modes-enforce }
 
-The cards above answer *what can I point scan at*. These two answer *what scan does past the
-grade*: it becomes the gate, or it writes the guardrail. Same seven-dimension scorer, now wired
-into admission control instead of a scorecard.
+The cards above answer *what can I point scan at*. These three answer *what scan does past the
+grade*: it becomes the gate, writes the guardrail, or fails the build. Same seven-dimension
+scorer, now wired into admission control instead of a scorecard.
 
 <div class="grid cards" markdown>
 


### PR DESCRIPTION
IRO-592 closeout. The `--check` policy-as-code gate card (#553) and its summary-table row (#559, child IRO-596) are both live in the coverage hub. The only leftover was the **Enforce & generate** section intro still reading "These **two** answer" above what are now **three** cards (admission gate, policy generator, policy-as-code gate).

One-line copy fix: `two` → `three`, and the follow-on clause now names all three actions ("becomes the gate, writes the guardrail, or fails the build"). No structural/CSS change; anchors untouched.