### PR TITLE
Add .gitattributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
+* text=auto eol=lf
+
+*.sh text eol=lf
+*.go text eol=lf
+
+*.svg text eol=lf
+
+*.png binary
+*.gif binary
+*.mp4 binary
+*.ico binary
+*.cast text eol=lf


### PR DESCRIPTION
## Summary

This adds a root `.gitattributes` file to keep line endings consistent across platforms.

- Normalizes text files to LF using `text=auto eol=lf`
- Explicitly enforces LF for shell scripts and Go files
- Treats SVG and cast/JSON files as text
- Marks PNG, GIF, MP4, and ICO files as binary

## Test plan

- [x] Verified `README.md` uses `text: auto` and `eol: lf`
- [x] Verified `scripts/install.sh` uses `text: set` and `eol: lf`
- [x] Verified PNG assets are detected as binary
- [x] Verified SVG assets are detected as text
- [x] Confirmed that only `.gitattributes` was added and no unrelated files were reformatted

Closes #191