### PR TITLE
feat(ironctl): add --json output mode to tools command

### DIFF
--- a/cmd/ironctl/main.go
+++ b/cmd/ironctl/main.go
@@ -574,7 +574,7 @@ func printReference(w io.Writer) {
   ironctl help | usage | commands                                          (this reference; help is the short first-run banner)
   ironctl [--addr URL] [--token T] agent create [--name N] [--template T] [--tool X ...]   (guided in a terminal)
   ironctl [--addr URL] [--token T] agent list | show <id> | templates
-  ironctl [--addr URL] [--token T] tools [list]
+  ironctl [--addr URL] [--token T] tools [list] [--json]
   ironctl [--addr URL] [--token T] change submit --kind <k> --group <g> --by <user>
   ironctl [--addr URL] [--token T] change pending [--json]
   ironctl [--addr URL] [--token T] change history [--json]

--- a/cmd/ironctl/tools.go
+++ b/cmd/ironctl/tools.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"flag"
 	"fmt"
 
 	"github.com/IronSecCo/ironclaw/internal/host/catalog"
@@ -11,9 +13,25 @@ import (
 // names. It reads the catalog package directly, so it works offline and always
 // matches what the sandbox actually implements.
 func cmdTools(_ string, args []string) error {
-	if len(args) > 0 && args[0] != "list" && args[0] != "ls" {
+	fs := flag.NewFlagSet("tools", flag.ContinueOnError)
+	asJSON := fs.Bool("json", false, "emit the tool catalog as indented JSON")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	remaining := fs.Args()
+	if len(remaining) > 0 && remaining[0] != "list" && remaining[0] != "ls" {
 		return fmt.Errorf("usage: tools [list]")
 	}
+
+	if *asJSON {
+		b, err := json.MarshalIndent(catalog.Tools(), "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+		return nil
+	}
+
 	byCat := map[catalog.Category][]catalog.ToolInfo{}
 	for _, t := range catalog.Tools() {
 		byCat[t.Category] = append(byCat[t.Category], t)

--- a/cmd/ironctl/tools.go
+++ b/cmd/ironctl/tools.go
@@ -15,10 +15,22 @@ import (
 func cmdTools(_ string, args []string) error {
 	fs := flag.NewFlagSet("tools", flag.ContinueOnError)
 	asJSON := fs.Bool("json", false, "emit the tool catalog as indented JSON")
-	if err := fs.Parse(args); err != nil {
-		return err
+	// Go's flag package stops at the first positional, so `tools list --json`
+	// would silently drop the flag. Re-parse around each positional so flags may
+	// appear anywhere, matching ironctl scan.
+	var remaining []string
+	rest := args
+	for len(rest) > 0 {
+		if err := fs.Parse(rest); err != nil {
+			return err
+		}
+		rest = fs.Args()
+		if len(rest) == 0 {
+			break
+		}
+		remaining = append(remaining, rest[0])
+		rest = rest[1:]
 	}
-	remaining := fs.Args()
 	if len(remaining) > 0 && remaining[0] != "list" && remaining[0] != "ls" {
 		return fmt.Errorf("usage: tools [list]")
 	}

--- a/cmd/ironctl/tools_test.go
+++ b/cmd/ironctl/tools_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/host/catalog"
+)
+
+func TestCmdToolsJSON(t *testing.T) {
+	out, errOut := captureStdouterr(t, func() {
+		if err := cmdTools("", []string{"--json"}); err != nil {
+			t.Fatalf("cmdTools --json: %v", err)
+		}
+	})
+	if errOut != "" {
+		t.Fatalf("unexpected stderr: %q", errOut)
+	}
+
+	var tools []catalog.ToolInfo
+	if err := json.Unmarshal([]byte(out), &tools); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%q", err, out)
+	}
+	if len(tools) != len(catalog.Tools()) {
+		t.Fatalf("got %d tools in JSON, want %d", len(tools), len(catalog.Tools()))
+	}
+	var webSearch *catalog.ToolInfo
+	for i := range tools {
+		if tools[i].Name == "web_search" {
+			webSearch = &tools[i]
+			break
+		}
+	}
+	if webSearch == nil || !webSearch.Egress {
+		t.Fatal("expected web_search tool with egress=true in JSON output")
+	}
+}
+
+func TestCmdToolsDefaultTextOutput(t *testing.T) {
+	out, errOut := captureStdouterr(t, func() {
+		if err := cmdTools("", nil); err != nil {
+			t.Fatalf("cmdTools: %v", err)
+		}
+	})
+	if errOut != "" {
+		t.Fatalf("unexpected stderr: %q", errOut)
+	}
+	if !strings.Contains(out, "Built-in tools") {
+		t.Fatalf("expected human-readable header, got %q", out)
+	}
+	if strings.HasPrefix(strings.TrimSpace(out), "[") {
+		t.Fatalf("default output should be text, not JSON: %q", out)
+	}
+}

--- a/cmd/ironctl/tools_test.go
+++ b/cmd/ironctl/tools_test.go
@@ -37,6 +37,41 @@ func TestCmdToolsJSON(t *testing.T) {
 	}
 }
 
+func TestCmdToolsListJSON(t *testing.T) {
+	out, errOut := captureStdouterr(t, func() {
+		if err := cmdTools("", []string{"list", "--json"}); err != nil {
+			t.Fatalf("cmdTools list --json: %v", err)
+		}
+	})
+	if errOut != "" {
+		t.Fatalf("unexpected stderr: %q", errOut)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(out), "[") {
+		t.Fatalf("list --json should emit JSON array, got %q", out)
+	}
+	var tools []catalog.ToolInfo
+	if err := json.Unmarshal([]byte(out), &tools); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%q", err, out)
+	}
+	if len(tools) != len(catalog.Tools()) {
+		t.Fatalf("got %d tools in JSON, want %d", len(tools), len(catalog.Tools()))
+	}
+}
+
+func TestCmdToolsLsJSON(t *testing.T) {
+	out, errOut := captureStdouterr(t, func() {
+		if err := cmdTools("", []string{"ls", "--json"}); err != nil {
+			t.Fatalf("cmdTools ls --json: %v", err)
+		}
+	})
+	if errOut != "" {
+		t.Fatalf("unexpected stderr: %q", errOut)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(out), "[") {
+		t.Fatalf("ls --json should emit JSON array, got %q", out)
+	}
+}
+
 func TestCmdToolsDefaultTextOutput(t *testing.T) {
 	out, errOut := captureStdouterr(t, func() {
 		if err := cmdTools("", nil); err != nil {


### PR DESCRIPTION
## Summary

Add a `--json` flag to `ironctl tools` so scripts and CI can consume the built-in tool catalog as machine-readable JSON.

## Motivation

Fixes #399. The `tools` command only printed a human-readable table, which made it hard to use in automation. Other read commands in ironctl already support `--json`; this brings `tools` in line with that convention.

## Changes

- Parse a `--json` flag in `cmdTools` via `flag.FlagSet` (consistent with `onboard` / `status`).
- When set, emit `catalog.Tools()` as indented JSON; default text output is unchanged.
- Document the flag in the `ironctl` command reference (`main.go`).
- Add `tools_test.go` covering JSON validity, tool count, an egress field spot-check, and default text output.

## Tests

```bash
go test ./cmd/ironctl/... -run TestCmdTools -v
go test ./cmd/ironctl/...
```

Both pass locally (Go 1.23.6).

## Notes

- `ironctl tools --json` and `ironctl tools --json list` work; flags after the first positional are not parsed (same Go `flag` limitation as other subcommands).