### PR TITLE
docs(scan): link hardening guides hub from scan reference

### DIFF
--- a/docs/scan.md
+++ b/docs/scan.md
@@ -1007,9 +1007,17 @@ grade this page describes:
 - [gVisor vs runc](blog/gvisor-vs-runc-container-isolation-compared.md): why they
   score the same on a config scan yet block a different number of live escape attempts.
 
+## Harden a specific image
+
+`ironctl scan` grades where you stand; the hardening guides show how to close the
+gap for the image you actually run. Browse every walkthrough on the
+[container hardening guides hub](blog/hardening-guides.md), or start with three
+of the most common targets:
+
+- [Harden Postgres](blog/harden-postgres-container-isolation.md): `postgres:17-alpine`, 48 to 100.
+- [Harden Redis](blog/harden-redis-container-isolation.md): `redis:7-alpine`, 48 to 100.
+- [Harden nginx](blog/harden-nginx-container-isolation.md): `nginx:1.27-alpine`, 48 to 89 (the honest proxy ceiling).
+
 Per-image hardening walkthroughs, default grade to hardened, with the exact `--fix` flags:
 
-- [Harden a Postgres container](blog/harden-postgres-container-isolation.md): `postgres:17-alpine`, 48 to 100.
-- [Harden a Redis container](blog/harden-redis-container-isolation.md): `redis:7-alpine`, 48 to 100.
 - [Run untrusted Node.js code safely](blog/run-untrusted-nodejs-code-safely.md): `node:22-alpine`, 48 to 100.
-- [Harden an nginx container](blog/harden-nginx-container-isolation.md): `nginx:1.27-alpine`, 48 to 89 (the honest proxy ceiling).


### PR DESCRIPTION
## Summary

Add a short "Harden a specific image" section to the `ironctl scan` docs that links to the hardening guides hub and three common entry walkthroughs.

## Motivation

Fixes #500. `docs/scan.md` is the canonical scan reference but did not link to the per-image hardening catalog at `docs/blog/hardening-guides.md`, leaving a gap between grading a container and finding the exact fix for a specific image.

## Changes

- Add a "Harden a specific image" section with a link to `blog/hardening-guides.md`
- Highlight Postgres, Redis, and nginx as common starting points
- Keep the existing Node.js walkthrough link below the hub pointer

## Tests

```bash
mkdocs build --strict
```

Local build could not run here because the `render_swagger` plugin is not installed in this environment. The added links use the same relative `blog/...` paths already used elsewhere in `docs/scan.md`.

## Notes

- Docs-only change; no code behavior affected

Fixes #500