### PR TITLE
docs(ironctl): add package overview

### DIFF
--- a/cmd/ironctl/doc.go
+++ b/cmd/ironctl/doc.go
@@ -1,0 +1,12 @@
+// Package main implements ironctl, IronClaw's administrative and local
+// diagnostics command-line interface.
+//
+// The run function in main.go parses global options, handles version and help
+// requests, and dispatches the first positional argument to the matching
+// top-level command handler. The change command uses a second switch to route
+// its submit, pending, history, approve, and reject verbs.
+//
+// To add a top-level subcommand, implement a focused cmdX handler in the
+// appropriate file, connect it to run in main.go, and update the command
+// reference and dispatch tests.
+package main


### PR DESCRIPTION
## Summary

- describe what the `ironctl` package implements
- explain top-level and `change` subcommand dispatch in `main.go`
- point contributors to the handler, dispatcher, help, and test touchpoints

Closes #283

## Verification

- `go doc ./cmd/ironctl`
- `CGO_ENABLED=1 go build ./cmd/ironctl/...`
- `CGO_ENABLED=1 go vet ./cmd/ironctl/...`
- `CGO_ENABLED=1 make build vet test`
- `git diff --check`