### PR TITLE
test(scan): add hardened SARIF golden fixture

### DIFF
--- a/internal/host/scan/sarif_test.go
+++ b/internal/host/scan/sarif_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 )
 
-// updateGolden regenerates the committed golden SARIF fixture: `go test
+// updateGolden regenerates the committed golden SARIF fixtures: `go test
 // ./internal/host/scan/ -run Golden -update`.
-var updateGolden = flag.Bool("update", false, "update the golden SARIF fixture")
+var updateGolden = flag.Bool("update", false, "update the golden SARIF fixtures")
 
 // goldenSpec is a fixed weak compose service used for the golden fixture: root,
 // default caps, seccomp=unconfined, bridge egress, writable rootfs, docker.sock
@@ -29,30 +29,81 @@ func goldenSpec() Spec {
 	}
 }
 
-// TestRenderSARIF_Golden pins the exact SARIF byte output for a fixed spec so
-// any accidental shape/field change is caught in review. Regenerate with
-// -update after an intentional change.
+// hardenedGoldenSpec is a fixed 100/A compose service. It pins the successful
+// no-findings SARIF shape as well as the failing shape covered by goldenSpec.
+func hardenedGoldenSpec() Spec {
+	return Spec{
+		Source: "compose", Target: "agent", Image: "ironclaw",
+		RunAsNonRoot: Yes, User: "65532",
+		CapDropAll: Yes, Seccomp: "confined",
+		NetworkMode: "none", ReadonlyRoot: Yes,
+		DockerSock: No,
+		HostPID:    No, HostIPC: No, HostNetwork: No,
+	}
+}
+
+// TestRenderSARIF_Golden pins the exact SARIF byte output for fixed weak and
+// hardened specs so any accidental shape/field change is caught in review.
+// Regenerate with -update after an intentional change.
 func TestRenderSARIF_Golden(t *testing.T) {
-	s := goldenSpec()
-	r := Score(s)
-	r.Version = "v0.0.0-golden"
-	var b bytes.Buffer
-	if err := RenderSARIF(&b, r, s, SARIFOptions{ConfigFile: "docker-compose.yml", AnchorLine: 3}); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name        string
+		spec        Spec
+		goldenFile  string
+		wantScore   int
+		wantResults int
+	}{
+		{
+			name:        "weak compose",
+			spec:        goldenSpec(),
+			goldenFile:  "weak_compose.sarif.json",
+			wantScore:   8,
+			wantResults: len(scorers),
+		},
+		{
+			name:        "hardened compose",
+			spec:        hardenedGoldenSpec(),
+			goldenFile:  "hardened_compose.sarif.json",
+			wantScore:   100,
+			wantResults: 0,
+		},
 	}
-	golden := filepath.Join("testdata", "weak_compose.sarif.json")
-	if *updateGolden {
-		if err := os.WriteFile(golden, b.Bytes(), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		return
-	}
-	want, err := os.ReadFile(golden)
-	if err != nil {
-		t.Fatalf("read golden (run with -update to create): %v", err)
-	}
-	if !bytes.Equal(b.Bytes(), want) {
-		t.Errorf("SARIF output drifted from golden. Run: go test ./internal/host/scan/ -run Golden -update\n--- got ---\n%s", b.String())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := Score(tt.spec)
+			if r.Score != tt.wantScore {
+				t.Fatalf("score = %d, want %d", r.Score, tt.wantScore)
+			}
+			r.Version = "v0.0.0-golden"
+			var b bytes.Buffer
+			if err := RenderSARIF(&b, r, tt.spec, SARIFOptions{ConfigFile: "docker-compose.yml", AnchorLine: 3}); err != nil {
+				t.Fatal(err)
+			}
+
+			var log sarifLog
+			if err := json.Unmarshal(b.Bytes(), &log); err != nil {
+				t.Fatalf("decode generated SARIF: %v", err)
+			}
+			if got := len(log.Runs[0].Results); got != tt.wantResults {
+				t.Fatalf("results = %d, want %d", got, tt.wantResults)
+			}
+
+			golden := filepath.Join("testdata", tt.goldenFile)
+			if *updateGolden {
+				if err := os.WriteFile(golden, b.Bytes(), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			want, err := os.ReadFile(golden)
+			if err != nil {
+				t.Fatalf("read golden (run with -update to create): %v", err)
+			}
+			if !bytes.Equal(b.Bytes(), want) {
+				t.Errorf("SARIF output drifted from %s. Run: go test ./internal/host/scan/ -run Golden -update\n--- got ---\n%s", tt.goldenFile, b.String())
+			}
+		})
 	}
 }
 

--- a/internal/host/scan/testdata/hardened_compose.sarif.json
+++ b/internal/host/scan/testdata/hardened_compose.sarif.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "ironctl-scan",
+          "version": "v0.0.0-golden",
+          "informationUri": "https://ironsecco.github.io/ironclaw/scan/",
+          "rules": [
+            {
+              "id": "user.nonroot",
+              "name": "UserNonroot",
+              "shortDescription": {
+                "text": "Non-root user (uid != 0)"
+              },
+              "fullDescription": {
+                "text": "Pin a non-root uid so a container escape does not begin as host uid 0."
+              },
+              "help": {
+                "text": "Pin a non-root uid so a container escape does not begin as host uid 0.\n\nFix: user: \"65532:65532\"\nMore: https://ironsecco.github.io/ironclaw/scan/",
+                "markdown": "Pin a non-root uid so a container escape does not begin as host uid 0.\n\n**Fix:** `user: \"65532:65532\"`\n\n[Hardening guide](https://ironsecco.github.io/ironclaw/scan/)"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "containment",
+                  "ironclaw"
+                ]
+              }
+            },
+            {
+              "id": "caps.dropped",
+              "name": "CapsDropped",
+              "shortDescription": {
+                "text": "Dropped capabilities"
+              },
+              "fullDescription": {
+                "text": "Drop every Linux capability; add back only what the workload provably needs."
+              },
+              "help": {
+                "text": "Drop every Linux capability; add back only what the workload provably needs.\n\nFix: cap_drop: [ALL]\nMore: https://ironsecco.github.io/ironclaw/scan/",
+                "markdown": "Drop every Linux capability; add back only what the workload provably needs.\n\n**Fix:** `cap_drop: [ALL]`\n\n[Hardening guide](https://ironsecco.github.io/ironclaw/scan/)"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "containment",
+                  "ironclaw"
+                ]
+              }
+            },
+            {
+              "id": "seccomp",
+              "name": "Seccomp",
+              "shortDescription": {
+                "text": "Seccomp profile"
+              },
+              "fullDescription": {
+                "text": "Keep a seccomp profile active to shrink the reachable syscall surface."
+              },
+              "help": {
+                "text": "Keep a seccomp profile active to shrink the reachable syscall surface.\n\nFix: security_opt: [no-new-privileges:true]  (and remove any seccomp=unconfined)\nMore: https://ironsecco.github.io/ironclaw/scan/",
+                "markdown": "Keep a seccomp profile active to shrink the reachable syscall surface.\n\n**Fix:** `security_opt: [no-new-privileges:true]  (and remove any seccomp=unconfined)`\n\n[Hardening guide](https://ironsecco.github.io/ironclaw/scan/)"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "containment",
+                  "ironclaw"
+                ]
+              }
+            },
+            {
+              "id": "network.isolated",
+              "name": "NetworkIsolated",
+              "shortDescription": {
+                "text": "Network isolation / egress"
+              },
+              "fullDescription": {
+                "text": "Cut egress so a compromised workload cannot reach the network or exfiltrate."
+              },
+              "help": {
+                "text": "Cut egress so a compromised workload cannot reach the network or exfiltrate.\n\nFix: network_mode: none\nMore: https://ironsecco.github.io/ironclaw/scan/",
+                "markdown": "Cut egress so a compromised workload cannot reach the network or exfiltrate.\n\n**Fix:** `network_mode: none`\n\n[Hardening guide](https://ironsecco.github.io/ironclaw/scan/)"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "containment",
+                  "ironclaw"
+                ]
+              }
+            },
+            {
+              "id": "rootfs.readonly",
+              "name": "RootfsReadonly",
+              "shortDescription": {
+                "text": "Read-only root filesystem"
+              },
+              "fullDescription": {
+                "text": "Make the root filesystem read-only to remove the tamper/persistence surface."
+              },
+              "help": {
+                "text": "Make the root filesystem read-only to remove the tamper/persistence surface.\n\nFix: read_only: true\nMore: https://ironsecco.github.io/ironclaw/scan/",
+                "markdown": "Make the root filesystem read-only to remove the tamper/persistence surface.\n\n**Fix:** `read_only: true`\n\n[Hardening guide](https://ironsecco.github.io/ironclaw/scan/)"
+              },
+              "defaultConfiguration": {
+                "level": "warning"
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "containment",
+                  "ironclaw"
+                ]
+              }
+            },
+            {
+              "id": "docker.sock",
+              "name": "DockerSock",
+              "shortDescription": {
+                "text": "No docker.sock exposure"
+              },
+              "fullDescription": {
+                "text": "Mounting the container-runtime socket is a one-command host-root escape."
+              },
+              "help": {
+                "text": "Mounting the container-runtime socket is a one-command host-root escape.\n\nFix: remove the docker.sock entry from the service's volumes:\nMore: https://ironsecco.github.io/ironclaw/scan/",
+                "markdown": "Mounting the container-runtime socket is a one-command host-root escape.\n\n**Fix:** `remove the docker.sock entry from the service's volumes:`\n\n[Hardening guide](https://ironsecco.github.io/ironclaw/scan/)"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "containment",
+                  "ironclaw"
+                ]
+              }
+            },
+            {
+              "id": "namespaces.host",
+              "name": "NamespacesHost",
+              "shortDescription": {
+                "text": "No shared host namespaces"
+              },
+              "fullDescription": {
+                "text": "Do not share host namespaces; each shared namespace erases an isolation boundary."
+              },
+              "help": {
+                "text": "Do not share host namespaces; each shared namespace erases an isolation boundary.\n\nFix: remove any pid: host / ipc: host (and privileged: true)\nMore: https://ironsecco.github.io/ironclaw/scan/",
+                "markdown": "Do not share host namespaces; each shared namespace erases an isolation boundary.\n\n**Fix:** `remove any pid: host / ipc: host (and privileged: true)`\n\n[Hardening guide](https://ironsecco.github.io/ironclaw/scan/)"
+              },
+              "defaultConfiguration": {
+                "level": "warning"
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "containment",
+                  "ironclaw"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "results": []
+    }
+  ]
+}


### PR DESCRIPTION
## What & why

Add the missing 100/100 hardened golden case so the SARIF zero-findings output is pinned alongside the existing weak fixture.

Closes #499

## Changes

- add a deterministic hardened compose spec and committed SARIF fixture
- make the golden test table-driven across weak and hardened inputs
- assert the hardened report scores 100 and emits zero results

## Checklist

- [x] **Tests pass:** `CGO_ENABLED=1 go test ./...` is green.
- [x] **Formatted & vetted:** `gofmt` applied and `go vet ./...` passes.
- [x] **Frozen contract:** `internal/contract/**` is untouched.
- [x] **Threat model:** test-only change; runtime posture is unchanged.
- [x] **Docs updated:** no user-facing behavior changed.
- [x] **No secrets:** no tokens, keys, or credentials are included.

## Validation

```bash
CGO_ENABLED=1 go test ./internal/host/scan/...
CGO_ENABLED=1 make build vet test
```

Both pass locally.