### PR TITLE
test(scan): add named subtests for grade bands and isolation runtimes

### DIFF
--- a/internal/host/scan/nerdctl_test.go
+++ b/internal/host/scan/nerdctl_test.go
@@ -50,27 +50,34 @@ func TestSpecFromNerdctlInspect_Hardened(t *testing.T) {
 
 func TestStrongIsolationRuntime(t *testing.T) {
 	cases := []struct {
+		name     string
 		in       string
 		wantName string
 		wantOK   bool
 	}{
-		{"runsc", "gVisor (runsc)", true},
-		{"io.containerd.runsc.v1", "gVisor (runsc)", true},
-		{"gvisor", "gVisor (runsc)", true},
-		{"kata-runtime", "Kata Containers", true},
-		{"io.containerd.kata.v2", "Kata Containers", true},
-		{"kata-qemu", "Kata Containers", true},
-		{"firecracker", "Firecracker", true},
-		{"runc-fc", "Firecracker", true},
-		{"runc", "", false},
-		{"crun", "", false},
-		{"", "", false},
+		{"runsc", "runsc", "gVisor (runsc)", true},
+		{"containerd runsc shim", "io.containerd.runsc.v1", "gVisor (runsc)", true},
+		{"gvisor lowercase", "gvisor", "gVisor (runsc)", true},
+		{"gvisor mixed case", "gVisor", "gVisor (runsc)", true},
+		{"kata-runtime", "kata-runtime", "Kata Containers", true},
+		{"containerd kata shim", "io.containerd.kata.v2", "Kata Containers", true},
+		{"kata-qemu", "kata-qemu", "Kata Containers", true},
+		{"kata mixed case", "KATA-QEMU", "Kata Containers", true},
+		{"firecracker", "firecracker", "Firecracker", true},
+		{"fc-runtime alias", "fc-runtime", "Firecracker", true},
+		{"runc-fc alias", "runc-fc", "Firecracker", true},
+		{"unknown runc", "runc", "", false},
+		{"unknown crun", "crun", "", false},
+		{"empty string", "", "", false},
+		{"whitespace only", "   ", "", false},
 	}
 	for _, c := range cases {
-		name, ok := StrongIsolationRuntime(c.in)
-		if name != c.wantName || ok != c.wantOK {
-			t.Errorf("StrongIsolationRuntime(%q)=(%q,%v) want (%q,%v)", c.in, name, ok, c.wantName, c.wantOK)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			name, ok := StrongIsolationRuntime(c.in)
+			if name != c.wantName || ok != c.wantOK {
+				t.Fatalf("StrongIsolationRuntime(%q)=(%q,%v) want (%q,%v)", c.in, name, ok, c.wantName, c.wantOK)
+			}
+		})
 	}
 }
 

--- a/internal/host/scan/score_test.go
+++ b/internal/host/scan/score_test.go
@@ -218,11 +218,28 @@ func TestScoreFailClosedEmpty(t *testing.T) {
 }
 
 func TestGrades(t *testing.T) {
-	cases := map[int]string{100: "A", 90: "A", 89: "B", 75: "B", 74: "C", 50: "C", 49: "D", 25: "D", 24: "F", 0: "F"}
-	for score, want := range cases {
-		if g := grade(score); g != want {
-			t.Errorf("grade(%d)=%s want %s", score, g, want)
-		}
+	cases := []struct {
+		name  string
+		score int
+		want  string
+	}{
+		{"max score", 100, "A"},
+		{"A lower boundary", 90, "A"},
+		{"just below A", 89, "B"},
+		{"B lower boundary", 75, "B"},
+		{"just below B", 74, "C"},
+		{"C lower boundary", 50, "C"},
+		{"just below C", 49, "D"},
+		{"D lower boundary", 25, "D"},
+		{"just below D", 24, "F"},
+		{"min score", 0, "F"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := grade(c.score); got != c.want {
+				t.Fatalf("grade(%d)=%s want %s", c.score, got, c.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
Enhance existing `grade()` and `StrongIsolationRuntime()` tests with descriptive table-driven subtests and a few missing edge cases.

## Motivation
Fixes #448 — lock in score→letter band boundaries and hardened-runtime classification so future refactors cannot silently move thresholds.

## Changes
- Refactor `TestGrades` from a map loop to named subtests at every band boundary (100/90/89/75/74/50/49/25/24/0).
- Extend `TestStrongIsolationRuntime` with named subtests, mixed-case runtime strings (`gVisor`, `KATA-QEMU`), the `fc-runtime` Firecracker alias, and whitespace-only input.

## Tests
- `go test ./internal/host/scan/...` — pass
- `gofmt -l internal/host/scan/score_test.go internal/host/scan/nerdctl_test.go` — clean

## Notes
Test-only change; no production code modified. Some coverage already existed — this PR focuses on descriptive subtests and the remaining edge cases called out in the issue.

Fixes #448