### PR TITLE
feat(provider): add Groq OpenAI-wire-compatible shim

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -249,6 +249,13 @@ func main() {
 	if apiKey := os.Getenv("OPENAI_API_KEY"); apiKey != "" {
 		addProvider("api.openai.com", modelproxy.OpenAIInjector(apiKey), apiKey)
 	}
+	// Groq — an OpenAI-wire-compatible inference provider serving chat completions
+	// under /openai/v1. Like OpenRouter it is plain Bearer auth, so the injector and
+	// allowlist wiring mirror OpenRouter. The host is allowlisted only when
+	// GROQ_API_KEY is present; the injector self-guards on the api.groq.com host.
+	if apiKey := os.Getenv("GROQ_API_KEY"); apiKey != "" {
+		addProvider("api.groq.com", modelproxy.GroqInjector(apiKey), apiKey)
+	}
 	if apiKey := os.Getenv("OPENROUTER_API_KEY"); apiKey != "" {
 		addProvider("openrouter.ai", modelproxy.OpenRouterInjector(apiKey), apiKey)
 	}

--- a/docs/providers/groq.md
+++ b/docs/providers/groq.md
@@ -1,0 +1,101 @@
+---
+title: "Groq (fast OpenAI-compatible inference)"
+description: Run IronClaw against Groq's OpenAI-compatible chat-completions API — first-class groq provider, default host and model, per-group setup, and how the key stays host-side.
+---
+
+# Groq provider
+
+**`groq`** is IronClaw's fast-inference OpenAI-compatible backend: a single
+[Groq](https://groq.com) key unlocks Groq-hosted LLMs (Llama, Mixtral, and the
+open `gpt-oss` family) behind the **identical OpenAI Chat Completions wire
+format**. Because Groq serves that API under `/openai/v1`, IronClaw reuses the
+same request/streaming/tool-use path as the `openai` provider; the `groq` kind
+only changes the upstream host and the request path.
+
+!!! info "Where the credential lives"
+    As with every provider, the sandbox has `network=none` and holds **no**
+    credential. It reaches Groq only through the host **model-proxy** unix socket.
+    The proxy is the sole authenticator: it stamps each forwarded request with
+    your Groq key (`Authorization: Bearer`) on the way out. Your `GROQ_API_KEY`
+    never enters the sandbox image, its environment, or its filesystem.
+
+## How it differs from the OpenAI provider
+
+Same wire format, a different host and path — all handled for you:
+
+| | OpenAI (`openai`) | Groq (`groq`) |
+|---|---|---|
+| Host | `api.openai.com` | `api.groq.com` |
+| Path | `/v1/chat/completions` | `/openai/v1/chat/completions` |
+| Model id | `gpt-4o` | `openai/gpt-oss-120b` (default), or any Groq-hosted model |
+| Auth | `Authorization: Bearer` (host-side) | `Authorization: Bearer` (host-side) |
+| Reach | OpenAI models | Groq-hosted open models (Llama, Mixtral, gpt-oss) |
+
+Groq routes by the **model id** in the request body, exactly like the OpenAI
+API. The host is a single global endpoint, so — unlike Azure — no per-resource
+host is required.
+
+## 1. Enable Groq on the control-plane
+
+Set your Groq key in the **control-plane** environment (never the sandbox):
+
+```sh
+export GROQ_API_KEY=gsk_…
+```
+
+When `GROQ_API_KEY` is set, the control-plane:
+
+- allowlists `api.groq.com` on the model-proxy egress allowlist, and
+- installs the injector that stamps every forwarded Groq request with your key
+  as an `Authorization: Bearer` header.
+
+The injector self-guards on the `api.groq.com` host, so the key is stamped only
+on Groq requests and can never leak to another upstream.
+
+## 2. Point an agent group at Groq
+
+Pin a group to the `groq` provider and a Groq-hosted model id:
+
+```sh
+ironctl agent create --yes --id groq-helper --name "Groq Helper" \
+  --provider groq --model openai/gpt-oss-120b
+```
+
+Or make Groq the deployment default for provider-less groups:
+
+```sh
+export IRONCLAW_DEV_PROVIDER=groq
+export IRONCLAW_DEV_MODEL=openai/gpt-oss-120b
+```
+
+Browse available ids at [console.groq.com](https://console.groq.com/settings/models);
+any model Groq hosts works — `openai/gpt-oss-120b`, `openai/gpt-oss-20b`,
+`meta-llama/llama-3.3-70b-versatile` (when available), and so on.
+
+!!! note "Default model"
+    The shipped default is `openai/gpt-oss-120b`. The `llama-3.3-70b-versatile`
+    id suggested in earlier notes is **deprecated** on Groq's platform; prefer
+    the `gpt-oss` family or check the Groq console for the current catalog.
+
+## 3. Verify
+
+Send the group a message. On success you get a normal reply; the model-proxy
+audit log records a `200` to `api.groq.com`. Common failures:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `401 ... No auth credentials found` | missing/invalid `GROQ_API_KEY` | set a valid key in the control-plane environment |
+| `404 ... model not found` | the model id is wrong or not hosted on Groq | use an id listed at [console.groq.com](https://console.groq.com/settings/models) |
+| `destination not on allowlist` | `GROQ_API_KEY` was unset when the control-plane started | set the key and restart so `api.groq.com` is allowlisted |
+
+## Security notes
+
+- **Credential isolation.** The Groq key stays on the host. The sandbox is
+  treated as potentially compromised and never receives it; the proxy
+  self-guards on the `api.groq.com` host so the key is stamped only on Groq
+  requests.
+- **Least-privilege egress.** Only `api.groq.com` is allowlisted. The sandbox
+  cannot reach any other host or the public internet.
+- **No plaintext secrets in logs.** The injector never logs credential
+  material, and the model-proxy redacts the key from any response body it
+  forwards.

--- a/internal/host/modelproxy/modelproxy.go
+++ b/internal/host/modelproxy/modelproxy.go
@@ -169,6 +169,19 @@ func OpenRouterInjector(apiKey string) Injector {
 	}
 }
 
+// GroqInjector returns an Injector that authenticates requests to the Groq API —
+// an OpenAI-compatible inference provider — with a host-held API key via the
+// Bearer scheme (e.g. from GROQ_API_KEY). It self-guards on the upstream host so
+// it no-ops for any other provider — safe to compose through MultiInjector.
+func GroqInjector(apiKey string) Injector {
+	return func(upstreamHost string, req *http.Request) {
+		if !strings.Contains(strings.ToLower(upstreamHost), "api.groq.com") {
+			return
+		}
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+}
+
 // GeminiInjector returns an Injector that authenticates requests to the Google
 // Generative Language API (Google AI Studio / Gemini) with a host-held API key via
 // the x-goog-api-key header (e.g. from GOOGLE_API_KEY or GEMINI_API_KEY). Like the

--- a/internal/host/modelproxy/modelproxy_test.go
+++ b/internal/host/modelproxy/modelproxy_test.go
@@ -126,18 +126,20 @@ func TestMultiInjectorRoutesCredentialByHost(t *testing.T) {
 	cases := []struct {
 		host        string
 		wantAPIKey  string // x-api-key (Anthropic)
-		wantAuth    string // Authorization (OpenAI / OpenRouter)
+		wantAuth    string // Authorization (OpenAI / OpenRouter / Groq)
 		wantVersion string
 	}{
 		{"api.anthropic.com", "anthropic-secret", "", "2023-06-01"},
 		{"api.openai.com", "", "Bearer openai-secret", ""},
 		{"openrouter.ai", "", "Bearer openrouter-secret", ""},
+		{"api.groq.com", "", "Bearer groq-secret", ""},
 	}
 
 	inject := MultiInjector(
 		AnthropicInjector("anthropic-secret", "2023-06-01"),
 		OpenAIInjector("openai-secret"),
 		OpenRouterInjector("openrouter-secret"),
+		GroqInjector("groq-secret"),
 	)
 
 	for _, tc := range cases {
@@ -151,7 +153,7 @@ func TestMultiInjectorRoutesCredentialByHost(t *testing.T) {
 			}))
 			defer upstream.Close()
 
-			p := New([]string{"api.anthropic.com", "api.openai.com", "openrouter.ai"},
+			p := New([]string{"api.anthropic.com", "api.openai.com", "openrouter.ai", "api.groq.com"},
 				WithInjector(inject),
 				WithTransport(&redirectTransport{target: upstream.Listener.Addr().String()}),
 			)
@@ -189,6 +191,7 @@ func TestProviderInjectorsNoOpOffHost(t *testing.T) {
 	OpenAIInjector("k")("api.anthropic.com", req)
 	OpenRouterInjector("k")("api.openai.com", req)
 	AnthropicInjector("k", "v")("openrouter.ai", req)
+	GroqInjector("k")("api.openai.com", req)
 	if got := req.Header.Get("Authorization"); got != "" {
 		t.Errorf("Authorization set off-host: %q", got)
 	}

--- a/internal/sandbox/provider/groq.go
+++ b/internal/sandbox/provider/groq.go
@@ -1,0 +1,33 @@
+// This file wires Groq (https://groq.com) as a first-class provider
+// kind. Groq is an OpenAI-wire-compatible provider: it serves chat
+// completions under /openai/v1, so it reuses OpenAIProvider unchanged —
+// NewOpenAI detects the api.groq.com host and selects the /openai/v1 path.
+// The only thing this backend contributes over the raw OpenAI path is
+// Groq's distinct default upstream host and model, applied in the
+// registered factory below before delegating to NewOpenAI.
+//
+// It lives in its own file (kind constant + defaults + registration all here) so
+// Groq can be added or changed without touching a shared region of
+// provider.go — the whole point of the provider registry.
+
+package provider
+
+const (
+	KindGroq         = "groq"
+	groqUpstreamHost = "api.groq.com"
+	defaultGroqModel = "openai/gpt-oss-120b"
+)
+
+func init() {
+	Register(KindGroq, func(cfg Config) (Provider, error) {
+		if cfg.UpstreamHost == "" {
+			cfg.UpstreamHost = groqUpstreamHost
+		}
+
+		if cfg.Model == "" {
+			cfg.Model = defaultGroqModel
+		}
+
+		return NewOpenAI(cfg), nil
+	})
+}

--- a/internal/sandbox/provider/groq_test.go
+++ b/internal/sandbox/provider/groq_test.go
@@ -1,0 +1,109 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGroqFactoryDefaults(t *testing.T) {
+	pv, err := New(Config{Kind: KindGroq})
+	if err != nil {
+		t.Fatalf("groq with no host/model: want defaults, got error: %v", err)
+	}
+	if pv == nil {
+		t.Fatal("groq provider = nil, want non-nil")
+	}
+	op, ok := pv.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("groq kind = %T, want *OpenAIProvider", pv)
+	}
+	if op.cfg.UpstreamHost != groqUpstreamHost {
+		t.Fatalf("groq default upstream host = %q, want %q", op.cfg.UpstreamHost, groqUpstreamHost)
+	}
+	if op.cfg.Model != defaultGroqModel {
+		t.Fatalf("groq default model = %q, want %q", op.cfg.Model, defaultGroqModel)
+	}
+	// Groq uses /openai/v1 path
+	if !strings.Contains(op.url, groqUpstreamHost+"/openai/v1/chat/completions") {
+		t.Fatalf("groq url = %q, want the %s /openai/v1 path", op.url, groqUpstreamHost)
+	}
+}
+
+func TestGroqFactoryOverrides(t *testing.T) {
+	const host = "gateway.example.test"
+	const model = "meta-llama/llama-3.1-8b-instruct"
+
+	pv, err := New(Config{Kind: "Groq", UpstreamHost: host, Model: model})
+	if err != nil {
+		t.Fatalf("groq override: %v", err)
+	}
+	op, ok := pv.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("groq kind = %T, want *OpenAIProvider", pv)
+	}
+	if op.cfg.UpstreamHost != host {
+		t.Fatalf("groq upstream host = %q, want overridden %q", op.cfg.UpstreamHost, host)
+	}
+	if op.cfg.Model != model {
+		t.Fatalf("groq model = %q, want overridden %q", op.cfg.Model, model)
+	}
+	// When overridden, uses standard /v1 path (OpenAI default)
+	if !strings.Contains(op.url, host+"/v1/chat/completions") {
+		t.Fatalf("groq override url = %q, want the overridden host standard /v1 path", op.url)
+	}
+}
+
+func TestGroqFactoryHostOnlyOverride(t *testing.T) {
+	const host = "gateway.example.test"
+
+	pv, err := New(Config{Kind: KindGroq, UpstreamHost: host})
+	if err != nil {
+		t.Fatalf("groq host-only override: %v", err)
+	}
+	op, ok := pv.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("groq kind = %T, want *OpenAIProvider", pv)
+	}
+	if op.cfg.UpstreamHost != host {
+		t.Fatalf("groq upstream host = %q, want overridden %q", op.cfg.UpstreamHost, host)
+	}
+	if op.cfg.Model != defaultGroqModel {
+		t.Fatalf("groq model = %q, want default %q", op.cfg.Model, defaultGroqModel)
+	}
+	if !strings.Contains(op.url, host+"/v1/chat/completions") {
+		t.Fatalf("groq host-only override url = %q, want the overridden host standard /v1 path", op.url)
+	}
+}
+
+func TestGroqFactoryModelOnlyOverride(t *testing.T) {
+	const model = "meta-llama/llama-3.1-8b-instruct"
+
+	pv, err := New(Config{Kind: KindGroq, Model: model})
+	if err != nil {
+		t.Fatalf("groq model-only override: %v", err)
+	}
+	op, ok := pv.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("groq kind = %T, want *OpenAIProvider", pv)
+	}
+	if op.cfg.UpstreamHost != groqUpstreamHost {
+		t.Fatalf("groq upstream host = %q, want default %q", op.cfg.UpstreamHost, groqUpstreamHost)
+	}
+	if op.cfg.Model != model {
+		t.Fatalf("groq model = %q, want overridden %q", op.cfg.Model, model)
+	}
+	// Groq uses /openai/v1 path
+	if !strings.Contains(op.url, groqUpstreamHost+"/openai/v1/chat/completions") {
+		t.Fatalf("groq model-only override url = %q, want the %s /openai/v1 path", op.url, groqUpstreamHost)
+	}
+}
+
+func TestGroqFactoryRegistered(t *testing.T) {
+	pv, err := New(Config{Kind: KindGroq})
+	if err != nil {
+		t.Fatalf("groq registry discovery: %v", err)
+	}
+	if pv == nil {
+		t.Fatal("groq registry discovery = nil, want non-nil provider")
+	}
+}

--- a/internal/sandbox/provider/openai.go
+++ b/internal/sandbox/provider/openai.go
@@ -70,6 +70,9 @@ func NewOpenAI(cfg Config) *OpenAIProvider {
 	if strings.Contains(strings.ToLower(cfg.UpstreamHost), "openrouter.ai") {
 		path = "/api/v1/chat/completions"
 	}
+	if strings.Contains(strings.ToLower(cfg.UpstreamHost), "api.groq.com") {
+		path = "/openai/v1/chat/completions"
+	}
 	return &OpenAIProvider{
 		cfg:    cfg,
 		client: newSocketClient(cfg.SocketPath, cfg.HTTPTimeout),


### PR DESCRIPTION
## Summary

Adds Groq (api.groq.com) as a first-class provider end-to-end — sandbox shim **and** host-side egress wiring — by mirroring the existing OpenRouter path. No shared region of `provider.go` is touched.

### Sandbox side (commit 1f25a3b)
- `internal/sandbox/provider/groq.go`: `KindGroq = "groq"`, default host `api.groq.com`, default model `openai/gpt-oss-120b`; factory fills defaults then delegates to `NewOpenAI`.
- 3-line host-detection branch in `NewOpenAI` (`openai.go`) routes Groq to `/openai/v1/chat/completions`, paralleling the existing OpenRouter `/api/v1` case — approach sanctioned by @omerzamir in #396.
- `groq_test.go` mirrors `openrouter_test.go`: defaults applied, host/model overrides preserved, case-insensitive kind lookup, registry discovery, and correct `/openai/v1` path asserted.

### Host side (commit 5676495 — review follow-up)
The sandbox shim alone builds correct requests, but the host model-proxy is deny-by-default and held no allowlist entry or injector for `api.groq.com`, so `provider=groq` would 403 at the proxy. Mirrors the OpenRouter wiring:
- `modelproxy.GroqInjector`: Bearer, self-guarded on the `api.groq.com` host, composed safely through `MultiInjector`.
- `addProvider("api.groq.com", GroqInjector, key)` gated on `GROQ_API_KEY` in `cmd/controlplane/main.go`, alongside the OpenRouter block.
- Tests: `TestMultiInjectorRoutesCredentialByHost` and `TestProviderInjectorsNoOpOffHost` extended to cover Groq (sets Bearer on-host, no-op off-host); allowlist entry added.
- `docs/providers/groq.md` provider page (the short docs follow-up).

## Notes

- Default model is `openai/gpt-oss-120b`, not `llama-3.3-70b-versatile` from the issue example — the latter is deprecated on Groq's platform.
- Groq serves chat completions under `/openai/v1` (not the standard `/v1`), hence the small `openai.go` tweak alongside the new shim file.

## Verification

- `go test ./internal/sandbox/provider/... ./internal/host/modelproxy/...` ✅ (incl. all `TestGroqFactory*` and the extended injector tests)
- `go vet ./...` ✅
- `go build ./...` ✅
- `provider.New(Config{Kind: "groq"})` returns a working `*OpenAIProvider` targeting `http://api.groq.com/openai/v1/chat/completions` by default.
- With `GROQ_API_KEY` set, the control-plane allowlists `api.groq.com` and stamps `Authorization: Bearer` host-side; without the key the host stays off the allowlist (deny-by-default).

Closes #396