### PR TITLE
docs(community): index the parked content backlog after the IRO-606 board decision [IRO-608]

### DIFF
--- a/community/README.md
+++ b/community/README.md
@@ -13,6 +13,7 @@ version-controlled here but intentionally **not** published to the docs site
 | [amplification-submissions-queue.md](amplification-submissions-queue.md) | Staged newsletter / directory submissions, held for the IRO-40 launch gate. | Per launch wave |
 | [security-proof-writeup.md](security-proof-writeup.md) | "We tried to break our own sandbox" proof piece (blog + Show HN + social), built on the real red-team harness output. Gated draft, needs CEO/board sign-off. | Per launch |
 | [social-proof.md](social-proof.md) | Collection process, sourcing guardrails, and raw-capture ledger behind the public [social-proof wall](../docs/social-proof.md). | 24h / 72h / 1wk, then weekly |
+| [parked-content-backlog.md](parked-content-backlog.md) | **Start here.** Index of the written-but-unposted copy parked by the IRO-606 board decision (repo-only, no posting identity), and what unparks it. | On board-decision change |
 
 Refresh the metrics snapshot with:
 

--- a/community/parked-content-backlog.md
+++ b/community/parked-content-backlog.md
@@ -69,9 +69,15 @@ pages rather than unposted drafts. They need no rescue:
 
 ### MCP Registry listing
 
-The listing copy is the tracked [`server.json`](../server.json) at the repo root,
-plus the runbook at [`runbooks/mcp-registry.md`](../runbooks/mcp-registry.md).
-It is a build input, not a draft, so it stays where the workflow reads it.
+The machine-readable listing is the tracked [`server.json`](../server.json) at
+the repo root plus the runbook at
+[`runbooks/mcp-registry.md`](../runbooks/mcp-registry.md). It is a build input,
+not a draft, so it stays where the workflow reads it.
+
+The human-facing directory listing copy (the prose blurbs written for Smithery,
+mcp.so, and mcpservers.org) is parked at `content/drafts/mcp-directory-listing.md`
+via PR #579, filed when IRO-378 was cancelled. See also the correction below:
+the official registry listing itself is currently dark.
 
 ## Correction: the MCP Registry listing is not healthy
 
@@ -93,19 +99,29 @@ that is not the current state:
 - **Auto-publish is off.** The `publish-mcp-registry` job in
   `.github/workflows/image.yml` is hard-gated to a manual `workflow_dispatch`
   with `publish_mcp_registry=true` and never runs on the release path.
+- **The replacement image does not exist yet.** `container/mcp.Dockerfile`
+  defines the slim, socket-free `ironclaw-mcp` (option B, IRO-414), but it is
+  referenced by **no workflow**: `image.yml` builds only
+  `container/controlplane.Dockerfile`. `ghcr.io/ironsecco/ironclaw-mcp` is not
+  anonymously pullable, while `ironclaw-controlplane` is. So the Dockerfile is
+  in-tree but has never been built or published.
 
 This does not change the cancellation. The board's decision was about not
 creating accounts, and none of Smithery, mcp.so, or mcpservers.org becomes
 reachable because of this. But the premise that the listing "that matters" is
-already handled does not hold, and the fix is a **non-gated, no-account** lever:
-the registry authenticates the `io.github.IronSecCo` namespace with this repo's
-own GitHub Actions OIDC token, so no human account is involved. The dependency
-that parked it, the slim socket-free image from IRO-414, has since shipped
-(`container/mcp.Dockerfile`, `ghcr.io/ironsecco/ironclaw-mcp`). What remains is
-repointing `server.json` at that image and re-enabling the publish job.
+already handled does not hold, and repairing it is a **non-gated, no-account**
+lever: the registry authenticates the `io.github.IronSecCo` namespace with this
+repo's own GitHub Actions OIDC token, so no human account is involved.
 
-That is engineering work on the release pipeline, so it is filed to Forge rather
-than done here. Tracked as **IRO-612**.
+Note the sequencing, because it is easy to underestimate. This is not a
+one-line repoint. The socket-free image has to be **built and published first**,
+then `server.json` repointed at it, then the publish job re-enabled, then the
+listing flipped back to `active`.
+
+That is release-pipeline and image work, not Growth's. It is already owned:
+**IRO-611** (Relay), "Relight the official MCP Registry listing." The parked
+MCP directory listing copy is preserved separately at `content/drafts/`
+(PR #579).
 
 ## What is not parked
 

--- a/community/parked-content-backlog.md
+++ b/community/parked-content-backlog.md
@@ -1,0 +1,119 @@
+# Parked content backlog (board decision on IRO-606)
+
+Single index of the written-but-unposted go-to-market content. Everything listed
+here is finished copy that was never published because the channel needs an
+account or identity the board declined to create. **The work is parked, not
+lost.** This file is the durable pointer so a cancelled issue thread never
+becomes the only record of it.
+
+- **Owner:** Growth / DevRel (WS-E)
+- **Decision of record:** board answer on IRO-606, interaction `96a6b54d`,
+  answers `g3_cancel`, `g4_cancel`, `dir_nongated`.
+- **Parked on:** 2026-07-29 (IRO-608).
+
+## Why it is parked
+
+- **Gate 4, posting identity: `g4_cancel`. We stay repo-only.** No
+  project-branded Reddit, X, or AlternativeTo identity will be created, and
+  IRO-265 still forbids the owner's real name and personal GitHub, LinkedIn, or
+  Instagram accounts. With no company identity and no personal identity, there
+  is no legal channel for external posting. Every Reddit, Show HN, and
+  newsletter draft below is therefore unpublishable today, regardless of
+  quality.
+- **Gate 3, MCP directories: `g3_cancel`.** Smithery, mcp.so, and
+  mcpservers.org all require a registered account behind a web form. The board
+  declined to create them. See the correction below on what this does and does
+  not cover.
+- **Standing direction: `dir_nongated`.** Remaining capacity goes to non-gated
+  product and OSS-community levers (IRO-475), not to writing more copy for
+  channels we cannot post to.
+
+Do not write more copy for these channels. The backlog is already deeper than
+any future posting window will consume. If the board ever approves an identity,
+the unparking task is a review-and-refresh pass, not a writing task.
+
+## The parked assets
+
+### Launch and social copy (channel-gated on an identity)
+
+| Asset | Path | Channel | Unparks when |
+| --- | --- | --- | --- |
+| Show HN title + first comment | [`docs/launch/show-hn.md`](../docs/launch/show-hn.md) | Hacker News | An approved posting identity exists |
+| r/devops self-post | [`docs/launch/reddit-devops.md`](../docs/launch/reddit-devops.md) | Reddit | Same |
+| r/kubernetes self-post | [`docs/launch/reddit-kubernetes.md`](../docs/launch/reddit-kubernetes.md) | Reddit | Same |
+| r/LocalLLaMA self-post | [`docs/launch/reddit-localllama.md`](../docs/launch/reddit-localllama.md) | Reddit | Same |
+| r/programming link + comment | [`docs/launch/reddit-programming.md`](../docs/launch/reddit-programming.md) | Reddit | Same |
+| r/selfhosted self-post | [`docs/launch/reddit-selfhosted.md`](../docs/launch/reddit-selfhosted.md) | Reddit | Same |
+| Publishing guardrails + reusable hooks | [`docs/launch/README.md`](../docs/launch/README.md) | All | Read this first when unparking |
+| Newsletter and curated-list submissions | [`amplification-submissions-queue.md`](amplification-submissions-queue.md) | Newsletters | Same |
+| Framework-community posts (Discord, forums) | [`integration-framework-community-posts.md`](integration-framework-community-posts.md) | Framework communities | Same |
+| Integration-guide launch posts | [`integration-guides-launch-posts.md`](integration-guides-launch-posts.md) | Social | Same |
+| Launch-week engagement and response templates | [`launch-engagement-playbook.md`](launch-engagement-playbook.md) | All | Same |
+| Directory and OSS-tracker listing copy | [`directory-listings.md`](directory-listings.md) | AlternativeTo, LibHunt | An approved account path |
+
+`docs/launch/` is excluded from the published docs site
+(`exclude_docs` in `mkdocs.yml`), so these drafts are version-controlled but not
+served. `community/` is outside `docs/` entirely and is never built.
+
+### Long-form posts (already published, not parked)
+
+Two of the assets named in the IRO-608 brief turned out to be shipped docs-site
+pages rather than unposted drafts. They need no rescue:
+
+| Asset | Path | State |
+| --- | --- | --- |
+| gVisor deep-dive | [`docs/gvisor-deep-dive.md`](../docs/gvisor-deep-dive.md) | Live on the docs site |
+| Bring-your-own-model | [`docs/bring-your-own-model.md`](../docs/bring-your-own-model.md) | Live on the docs site |
+| Sandbox red-team proof piece | [`security-proof-writeup.md`](security-proof-writeup.md) | Drafted, needs sign-off, no channel |
+| Containment proof pack | [`containment-proof-pack.md`](containment-proof-pack.md) | Data asset, non-gated |
+
+### MCP Registry listing
+
+The listing copy is the tracked [`server.json`](../server.json) at the repo root,
+plus the runbook at [`runbooks/mcp-registry.md`](../runbooks/mcp-registry.md).
+It is a build input, not a draft, so it stays where the workflow reads it.
+
+## Correction: the MCP Registry listing is not healthy
+
+The `g3_cancel` rationale states that we are "already live on the official MCP
+Registry as `io.github.IronSecCo/ironclaw` with OIDC auto-publish on every
+release." Checked against `main` and against the live registry on 2026-07-29,
+that is not the current state:
+
+- **The listing is `deprecated`, not active.** The live registry record for
+  `io.github.IronSecCo/ironclaw` reports `status: deprecated` at version
+  `0.1.230`, published 2026-07-07.
+- **It is stale by roughly 150 releases.** Current shipping version is around
+  `0.1.383`.
+- **It points at the rejected image.** The published package is
+  `ghcr.io/ironsecco/ironclaw-controlplane:v0.1.230` with a
+  `/var/run/docker.sock` mount, which is exactly the option-A listing the CEO
+  rejected as host-root and against our hardening promise (IRO-391, IRO-414).
+  It was deprecated on purpose via `.github/workflows/mcp-registry-deprecate.yml`.
+- **Auto-publish is off.** The `publish-mcp-registry` job in
+  `.github/workflows/image.yml` is hard-gated to a manual `workflow_dispatch`
+  with `publish_mcp_registry=true` and never runs on the release path.
+
+This does not change the cancellation. The board's decision was about not
+creating accounts, and none of Smithery, mcp.so, or mcpservers.org becomes
+reachable because of this. But the premise that the listing "that matters" is
+already handled does not hold, and the fix is a **non-gated, no-account** lever:
+the registry authenticates the `io.github.IronSecCo` namespace with this repo's
+own GitHub Actions OIDC token, so no human account is involved. The dependency
+that parked it, the slim socket-free image from IRO-414, has since shipped
+(`container/mcp.Dockerfile`, `ghcr.io/ironsecco/ironclaw-mcp`). What remains is
+repointing `server.json` at that image and re-enabling the publish job.
+
+That is engineering work on the release pipeline, so it is filed to Forge rather
+than done here. Tracked as **IRO-612**.
+
+## What is not parked
+
+The non-gated levers stay open and are where capacity goes under `dir_nongated`:
+
+- `ironctl scan` and the public web scanner, the only wedge that needs no account.
+- Docs-site SEO and the hardening-guide waves.
+- OSS-community triage on our own repo, including the good-first-issue queue.
+  Note: the open GitHub issues on the repo are deliberate newcomer bait. Do not
+  mass-close them.
+- The MCP Registry repair above, which is account-free.

--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -26,6 +26,18 @@ docs. No hero numbers from machines you cannot inspect.
 | [`reddit-selfhosted.md`](reddit-selfhosted.md) | r/selfhosted | self-post |
 | [`show-hn.md`](show-hn.md) | Hacker News | Show HN title + first comment |
 
+## Status: parked, not lost (2026-07-29)
+
+None of these drafts can be posted today. The board answered IRO-606 with
+`g4_cancel`: we stay repo-only, no project-branded posting identity will be
+created, and IRO-265 still forbids the owner's personal accounts. With no company
+identity and no personal identity there is no legal channel for this copy.
+
+The drafts are kept because the writing is the expensive part and it is finished.
+See [`community/parked-content-backlog.md`](../../community/parked-content-backlog.md)
+for the full parked inventory, the decision of record, and what unparks it. Do
+not write more copy for these channels until an identity is approved.
+
 ## TL;DR (reusable hook)
 
 IronClaw runs every AI agent inside its own gVisor (`runsc`) sandbox: one


### PR DESCRIPTION
## Why

The board answered IRO-606 (interaction `96a6b54d`) with **`g4_cancel`** (stay repo-only, no project-branded posting identity) and **`g3_cancel`** (no MCP-directory accounts). That makes five reach issues unexecutable, and they are cancelled as bookkeeping under IRO-608.

The finished copy behind those issues is the expensive part. This PR makes sure it survives the cancelled threads.

## What

- **New: `community/parked-content-backlog.md`** — single durable index of every written-but-unposted asset, the decision of record, and the specific condition that unparks each one.
- Linked from `community/README.md`.
- `docs/launch/README.md` gets a "parked, not lost" status block so nobody writes more copy for channels we cannot post to.

Complements PR #579, which parks the MCP directory listing prose at `content/drafts/`. This index cross-links it.

Docs only. No code, no workflow, no site-served content: `docs/launch/` is in `exclude_docs` and `community/` is outside `docs/`.

## The MCP Registry correction

The `g3_cancel` rationale states we are "already live on the official MCP Registry with OIDC auto-publish on every release." Verified against the live registry and `main` on 2026-07-29, that is not the current state:

| Claim | Actual |
|---|---|
| Live listing | `status: deprecated` |
| Current | `v0.1.230` (2026-07-07), roughly 150 releases stale |
| Package | `ghcr.io/ironsecco/ironclaw-controlplane:v0.1.230` with a `/var/run/docker.sock` mount, the option-A listing the CEO **rejected** |
| Auto-publish | Off. `publish-mcp-registry` in `image.yml` is gated to manual `workflow_dispatch` |
| Replacement image | **Does not exist.** `container/mcp.Dockerfile` is referenced by no workflow; `image.yml` builds only `controlplane.Dockerfile`, and `ghcr.io/ironsecco/ironclaw-mcp` is not anonymously pullable |

Repairing the listing is **account-free** (the registry authenticates our namespace with this repo's own Actions OIDC token), which makes it a live lever under the board's `dir_nongated` direction. But it is a sequence, not a repoint: build and publish the socket-free image first, then update `server.json`, then re-enable the publish job, then flip the listing to `active`.

That work is already owned by **IRO-611** (Relay). This PR only records the finding next to the parked backlog.

> **Correction:** an earlier revision of this PR claimed the socket-free image "has since shipped." That was wrong, and the second commit fixes it. The Dockerfile exists in-tree but has never been built or published.

Refs IRO-608, IRO-606, IRO-611.