### PR TITLE
docs(marketplace): point every owned surface at the live scan Action listing [IRO-609]

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Each one runs sealed in a sandbox that provably cannot phone home, read your hos
 [![Signed releases (cosign)](https://img.shields.io/badge/releases-cosign%20signed-0a7bbb.svg)](#verifying-a-release)
 [![SBOM: SPDX + CycloneDX](https://img.shields.io/badge/SBOM-SPDX%20%2B%20CycloneDX-44883e.svg)](#verifying-a-release)
 [![SLSA provenance](https://img.shields.io/badge/SLSA-build%20provenance-44883e.svg)](#verifying-a-release)
+[![GitHub Marketplace: IronClaw sandbox scan](https://img.shields.io/badge/GitHub%20Marketplace-IronClaw%20sandbox%20scan-0a7bbb.svg?logo=github&logoColor=white)](https://github.com/marketplace/actions/ironclaw-sandbox-scan)
 [![Sandbox scan: PR scorecard](https://img.shields.io/badge/sandbox%20scan-PR%20scorecard-0a7bbb.svg)](https://ironsecco.github.io/ironclaw/scan-action/)
 [![Sandbox Isolation Score](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/IronSecCo/ironclaw/main/.ironclaw/sandbox-isolation.json)](https://ironsecco.github.io/ironclaw/scan/#sandbox-isolation-score-badge)
 
@@ -302,6 +303,27 @@ Per-image hardening walkthroughs, the default grade, the dimensions that fail, a
 [Valkey](https://ironsecco.github.io/ironclaw/blog/harden-valkey-container-isolation/),
 [HAProxy](https://ironsecco.github.io/ironclaw/blog/harden-haproxy-container-isolation/), and
 [untrusted Node.js](https://ironsecco.github.io/ironclaw/blog/run-untrusted-nodejs-code-safely/).
+
+### Grade every pull request
+
+The same grader is published on the GitHub Marketplace as
+[**IronClaw sandbox scan**](https://github.com/marketplace/actions/ironclaw-sandbox-scan). One
+line in a workflow and every pull request gets a containment scorecard as a sticky comment that
+updates in place:
+
+```yaml
+# .github/workflows/scan.yml
+- uses: IronSecCo/ironclaw@v1
+  with:
+    target: docker-compose.yml
+    mode: compose
+    min-score: 90        # omit / 0 = report-only, never blocks the check
+```
+
+It runs on a stock `ubuntu-latest` runner with no credentials and no control-plane. `mode: k8s`
+adds `policy-check: true` to fail the check on any rule `--emit-policy` would generate, and
+`upload-sarif: true` sends failed dimensions to the Security tab. Full inputs and outputs:
+[scan in CI](https://ironsecco.github.io/ironclaw/scan-action/).
 
 ### Show your score
 

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@
 # The subdir ref `IronSecCo/ironclaw/.github/actions/scan@v1` keeps working as a
 # fallback. See docs/scan-action.md for the full guide.
 name: 'IronClaw sandbox scan'
-description: 'Grade a container / compose / k8s sandbox isolation posture 0-100 and post a sticky PR scorecard.'
+description: 'Grade container, compose, or Kubernetes isolation posture 0-100, post a sticky PR scorecard, gate merges. No credentials.'
 author: 'IronSec Co.'
 branding:
   icon: 'shield'

--- a/docs/integrations/ci.md
+++ b/docs/integrations/ci.md
@@ -13,6 +13,15 @@ offline control-plane, sends the prompt through the **real** secured route
 reply plus a JSON run report. Ask for the containment report and it also freezes the
 signed-able isolation proof for the exact build under test.
 
+!!! tip "Looking for the scan scorecard action?"
+
+    This page covers the **agent** action, which runs a sandboxed agent task in CI.
+    If you want a containment scorecard on every pull request, that is a separate,
+    Marketplace-published action:
+    [**IronClaw sandbox scan**](https://github.com/marketplace/actions/ironclaw-sandbox-scan),
+    installed with `uses: IronSecCo/ironclaw@v1`. See
+    [scan in CI](../scan-action.md).
+
 It is a thin wrapper over the same zero-credential path
 [`hello-ironclaw`](https://github.com/IronSecCo/ironclaw/tree/main/examples/hello-ironclaw)
 and [`red-team-escape`](https://github.com/IronSecCo/ironclaw/tree/main/examples/red-team-escape)
@@ -117,7 +126,10 @@ round-trip, one job emits and uploads the containment report — so a regression
 action turns a build red before it reaches an adopter. The runnable example lives in
 [`examples/ci-action/`](https://github.com/IronSecCo/ironclaw/tree/main/examples/ci-action).
 
-!!! note "Not on the Marketplace yet"
-    The action carries Marketplace metadata but is not published there yet
-    (owner-manual, launch-gated). Reference it by repository path
-    (`IronSecCo/ironclaw/.github/actions/ironclaw@<ref>`) in the meantime.
+!!! note "This agent action is not a separate Marketplace listing"
+    A repository publishes one Marketplace listing, and ours is
+    [**IronClaw sandbox scan**](https://github.com/marketplace/actions/ironclaw-sandbox-scan)
+    (`uses: IronSecCo/ironclaw@v1`), the containment scorecard action documented in
+    [scan in CI](../scan-action.md). The agent action on this page is referenced by
+    repository path instead: `IronSecCo/ironclaw/.github/actions/ironclaw@<ref>`.
+    Pin `<ref>` to a release tag or commit SHA in production.

--- a/docs/scan-action.md
+++ b/docs/scan-action.md
@@ -1,12 +1,17 @@
 # Scan in CI: a sandbox scorecard on every pull request
 
-The [`ironctl scan`](scan.md) audit also ships as a **GitHub Action**, so every
-repository can render an IronClaw containment scorecard right in its pull
+The [`ironctl scan`](scan.md) audit also ships as a **GitHub Action**, published on
+the GitHub Marketplace as
+[**IronClaw sandbox scan**](https://github.com/marketplace/actions/ironclaw-sandbox-scan),
+so every repository can render an IronClaw containment scorecard right in its pull
 requests and gate merges on isolation posture. It is the same local, read-only,
 credential-free grader; the action just installs `ironctl`, runs it against your
 target, and posts the result as a sticky PR comment.
 
 ## Add it to your workflow
+
+The install path is the Marketplace ref `IronSecCo/ironclaw@v1`. Nothing to
+configure beyond `target`:
 
 ```yaml
 name: Sandbox scorecard
@@ -29,10 +34,19 @@ jobs:
           min-score: 90        # omit / 0 = report-only, never blocks the check
 ```
 
-`IronSecCo/ironclaw@v1` is the [Marketplace](https://github.com/marketplace/actions/ironclaw-sandbox-scan)
-listing (root `action.yml`). The subdir ref
-`IronSecCo/ironclaw/.github/actions/scan@v1` runs the exact same grader and stays
-supported as a fallback — both point at one `scan.sh`, so they never diverge.
+!!! tip "Which ref should I use?"
+
+    **`IronSecCo/ironclaw@v1`** is the
+    [Marketplace listing](https://github.com/marketplace/actions/ironclaw-sandbox-scan)
+    (root `action.yml`) and is the recommended path for everyone. `v1` is a moving
+    major tag, so you get fixes without editing your workflow.
+
+    **`IronSecCo/ironclaw/.github/actions/scan@v1`** is the advanced option: the
+    same action addressed by subdirectory. It predates the Marketplace listing and
+    stays supported, so existing workflows keep working unchanged. Either ref
+    accepts an immutable commit SHA instead of `v1`
+    (`IronSecCo/ironclaw@<sha>`) if your supply-chain policy requires pinning.
+    Both paths execute one `scan.sh`, so they never diverge in behavior.
 
 On the pull request you get a scorecard comment that updates in place on every
 push:


### PR DESCRIPTION
The Marketplace listing for the scan Action is live and nothing we own pointed at it. This wires the on-ramp.

Verified live before writing:

```
$ curl -sIL -o /dev/null -w '%{http_code}\n' https://github.com/marketplace/actions/ironclaw-sandbox-scan
200
$ <title>IronClaw sandbox scan · Actions · GitHub Marketplace · GitHub</title>
```

Rendered listing (text extract): About = `Grade a container / compose / k8s sandbox isolation posture 0-100 and post a sticky PR scorecard`, publisher `IronSecCo`, category `security`, latest `v0.1.399`, body = the repo README.

## Changes

- **README** - Marketplace badge in the trust cluster, plus a new `### Grade every pull request` subsection inside the scan pitch carrying the copy-paste `uses: IronSecCo/ironclaw@v1` snippet, the `policy-check` / `upload-sarif` pointers, and a link to the full input docs.
- **docs/scan-action.md** - leads with the Marketplace install path. The buried fallback sentence becomes a *Which ref should I use?* tip that keeps `IronSecCo/ironclaw/.github/actions/scan@v1` documented as the advanced option (and notes both refs accept a commit SHA).
- **docs/integrations/ci.md** - the `Not on the Marketplace yet` note was stale *and* ambiguous: that page documents the **agent** action, while the listing is the **scan** action. Replaced with an accurate note, plus a cross-link tip at the top so Marketplace traffic landing on the wrong CI page is routed to `scan-action.md`.
- **action.yml** - `description:` is the Marketplace card copy. Tightened to name the three targets, the merge gate, and the credential-free property, inside the ~125 char card budget (121). No behaviour change; `branding: shield/blue` kept.

## Verification

- `mkdocs build` clean; the new relative link resolves to `../../scan-action/`, and both edited pages render the Marketplace URL twice each.
- `actionlint` clean for this change (only pre-existing SC1010 warnings in unrelated workflows).
- `action.yml` parses; all 10 inputs carry a description.
- No em-dashes added to public copy.

The `description:` change reaches the live listing on the next published release, since the listing tracks the newest release (currently v0.1.399).

[IRO-609]