### PR TITLE
docs(seo): title/meta the scan and CI on-ramp pages, crosslink gVisor and BYO-model [IRO-610]

### DIFF
--- a/docs/blog/gvisor-vs-runc-container-isolation-compared.md
+++ b/docs/blog/gvisor-vs-runc-container-isolation-compared.md
@@ -80,6 +80,10 @@ The cost of gVisor is a syscall-performance overhead and some compatibility edge
 The benefit is that the last escape attempt has nowhere to go. For an autonomous
 agent running arbitrary code, that trade is the whole reason
 [IronClaw](https://github.com/IronSecCo/ironclaw) defaults its runtime to gVisor.
+The full design, what the sandbox gets and what it is denied, is written up in
+[Why we run AI agents in a gVisor sandbox](../gvisor-deep-dive.md); the measured
+cost of that choice, +13 ms warm and +39 ms cold per sandbox launch, is in
+[Performance and footprint](../benchmarks.md).
 
 ## Verify it yourself
 

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -21,6 +21,11 @@ Two patterns show up across the set:
   The honest ceiling is **89/100, grade B**, with the network dimension held at a WARN and contained
   with a scoped private network instead. We say so on every page rather than inflate the number.
 
+Hardening once is the easy half. To keep the grade you just earned, put the same
+grader on every pull request with the
+[GitHub Action](../scan-action.md): one `uses: IronSecCo/ironclaw@v1` line, about
+30 seconds, no account and no credentials.
+
 ## Reach grade A (100/100)
 
 | Service | Default | Hardened | The gap that closes |

--- a/docs/bring-your-own-model.md
+++ b/docs/bring-your-own-model.md
@@ -3,13 +3,15 @@ title: "Bring your own model: Ollama, Gemini, or Vertex in 5 minutes"
 description: "Run an IronClaw agent on the model you already have, local, private, or your own cloud account. The model key never enters the sandbox, and provider selection is configuration, not a fork."
 ---
 
+# Bring your own model: run an AI agent on Ollama, Gemini, or Vertex
+
 ## The job: run an agent on *your* model, not someone else's
 
 Plenty of agent runtimes assume one vendor and one cloud. The job a self-hoster is hiring for is the opposite:
 **"use the model I already have, whether local, private, or my own cloud account, without rebuilding anything."**
 IronClaw speaks the OpenAI-compatible API shape, so the model is a config choice, not a fork.
 
-> IronClaw ships more backends than the three below (Anthropic, OpenAI, OpenRouter, Codex, and a credential-free `mock` provider too). For the full list with an auth-and-streaming comparison and a short decision guide, see [Choose your model provider](providers/index.md).
+> IronClaw ships more backends than the three below. Eleven are registered today: Anthropic, OpenAI, OpenRouter, Codex, Gemini, Vertex AI, AWS Bedrock, Azure OpenAI, Ollama, a generic OpenAI-compatible `local` endpoint, and a credential-free `mock` provider. For the full list with an auth-and-streaming comparison and a short decision guide, see [Choose your model provider](providers/index.md).
 
 
 And because of how the runtime is built, **your model key never enters the agent sandbox**. Model calls are

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -47,15 +47,17 @@ enters a sandbox) and point an agent group at that provider. See the
 
 ## Which model providers are supported?
 
-**Anthropic, OpenAI, OpenRouter, Codex, Google Gemini, Google Vertex AI**, a
-**local / self-hosted** OpenAI-compatible server (Ollama, LM Studio, vLLM,
-llama.cpp), plus a generic gateway URL (`IRONCLAW_MODEL_GATEWAY_URL`) — all reached
-through the host model-proxy, so keys stay host-side and never enter a sandbox. AWS
-**Bedrock** is landing and Azure OpenAI is incoming. The zero-credential `mock`
-provider is built in for offline demos and tests.
+**Anthropic, OpenAI, OpenRouter, Codex, Google Gemini, Google Vertex AI, AWS
+Bedrock, Azure OpenAI**, a dedicated **Ollama** backend, and a generic
+**local / self-hosted** OpenAI-compatible server (LM Studio, vLLM, llama.cpp),
+plus a generic gateway URL (`IRONCLAW_MODEL_GATEWAY_URL`). All of them are
+reached through the host model-proxy, so keys stay host-side and never enter a
+sandbox. The zero-credential `mock` provider is built in for offline demos and
+tests.
 
-To pick one, see [Choose your model provider](providers/index.md) — a capability
-matrix and a short decision guide.
+To pick one, see [Choose your model provider](providers/index.md), a capability
+matrix and a short decision guide, or
+[Bring your own model](bring-your-own-model.md) for the 5-minute version.
 
 ## Which channels are supported?
 

--- a/docs/gvisor-deep-dive.md
+++ b/docs/gvisor-deep-dive.md
@@ -1,6 +1,6 @@
 ---
-title: "Why we run AI agents in gVisor"
-description: "The security model behind IronClaw: why a sandboxed agent gets no network, no host secrets, and no way to change its own configuration, and what gVisor actually buys you."
+title: "Why we run AI agents in a gVisor sandbox: the agent isolation model"
+description: "The security model behind IronClaw: why a sandboxed AI agent gets no network, no host secrets, and no way to change its own configuration, and what gVisor actually buys you over a plain container."
 ---
 # Why we run AI agents in gVisor
 
@@ -18,7 +18,7 @@ it:
 > walls that hold anyway.[^assume]
 
 That single asymmetry, *the host is trusted, the agent is not*, is the whole
-design. This post is about the most load-bearing wall it produces: running each
+design. This page documents the most load-bearing wall it produces: running each
 agent inside a **gVisor** sandbox with **no network**, and what that actually buys
 you.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -79,6 +79,10 @@ reply flowed back through the encrypted queues. Tear it down with
 (gVisor sandboxes + the host model-proxy) is the supported path — see [deployment](https://github.com/IronSecCo/ironclaw/blob/main/README.md#deployment).
 See the [environment variable reference](env-reference.md) for every supported
 host-side setting and its default.
+No key at all is also a supported path: [Bring your own model](bring-your-own-model.md)
+runs the same agent on a local Ollama, LM Studio, or vLLM endpoint, and
+[Why we run AI agents in gVisor](gvisor-deep-dive.md) explains the boundary the
+key stays outside of.
 Run `ironctl doctor` any time to diagnose a stuck setup, and `ironctl onboard` for a guided first-run check.
 
 ---

--- a/docs/scan-action.md
+++ b/docs/scan-action.md
@@ -1,3 +1,8 @@
+---
+title: "Add container isolation scanning to your CI in 30 seconds (GitHub Action)"
+description: "One line, uses: IronSecCo/ironclaw@v1, puts a 0 to 100 container isolation scorecard on every pull request and can fail the check below your threshold. No account, no credentials."
+---
+
 # Scan in CI: a sandbox scorecard on every pull request
 
 The [`ironctl scan`](scan.md) audit also ships as a **GitHub Action**, published on
@@ -7,6 +12,10 @@ so every repository can render an IronClaw containment scorecard right in its pu
 requests and gate merges on isolation posture. It is the same local, read-only,
 credential-free grader; the action just installs `ironctl`, runs it against your
 target, and posts the result as a sticky PR comment.
+
+Wiring it up takes about 30 seconds. There is nothing to sign up for and no token
+to mint: the action needs `contents: read`, plus `pull-requests: write` only if
+you want the scorecard comment.
 
 ## Add it to your workflow
 

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -1,3 +1,8 @@
+---
+title: "Scan any container for isolation gaps: Docker, Compose, and Kubernetes, in 10 seconds"
+description: "ironctl scan grades any running container, Compose service, or Kubernetes manifest from 0 to 100 across seven isolation dimensions. Local, read-only, credential-free, fail-closed."
+---
+
 # Scan: audit any container's containment in 10 seconds
 
 `ironctl scan` grades the isolation posture of any running container, any
@@ -8,6 +13,16 @@ containment you actually have before you trust a sandbox with untrusted code.
 It grades the same dimensions IronClaw's own containment benchmark checks, and
 it is fail-closed: any posture it cannot determine is scored as insecure, never
 silently passed.
+
+Two things the score deliberately does not cover, each with its own page:
+
+- **The runtime underneath.** The scan reads configuration, so a hardened
+  container grades identically under runc and under gVisor. Which kernel serves
+  your syscalls is a separate question, answered in
+  [Why we run AI agents in gVisor](gvisor-deep-dive.md).
+- **Keeping the grade.** A one-off score drifts on the next pull request. Put
+  the same grader on every pull request with the
+  [GitHub Action](scan-action.md), which takes about 30 seconds to wire up.
 
 Curious how the images you already pull score? Browse the public
 [Container Isolation Scores directory](scores/index.md): the default-config


### PR DESCRIPTION
## What this is

IRO-610 asked to publish the parked gVisor and BYO-model drafts to our own docs
site, plus a Marketplace-driven CI on-ramp page.

Audit first: all three pages already exist, are in nav, and return HTTP 200.

| Asked for | Already live | Inbound links before this PR |
|---|---|---|
| gVisor deep-dive | `/gvisor-deep-dive/` | 10 |
| BYO-model post | `/bring-your-own-model/` | 2 |
| CI on-ramp | `/scan-action/` | 3 |

So the publishing half was done. Scope item 4, SEO hygiene, was not. This PR is
that half.

## The finding

`docs/scan.md` and `docs/scan-action.md` were the **only two pages on the entire
site with no front-matter**. Both therefore served the site-wide fallback
description on our two highest commercial-intent URLs:

```
/scan/        <meta name="description" content="Security-first, self-hosted AI agents ...">
/scan-action/ <meta name="description" content="Security-first, self-hosted AI agents ...">
```

That is the SERP snippet for `/scan/`, our main organic entry point, and search
is the only ungated acquisition channel we have.

## Changes

**Titles and meta descriptions**
- `docs/scan.md`: keyword-accurate title plus a description naming the three
  input modes and the fail-closed property.
- `docs/scan-action.md`: title built on the "add it to CI in 30 seconds" intent,
  description built on the `uses: IronSecCo/ironclaw@v1` snippet.
- `docs/gvisor-deep-dive.md`: title widened to include "gVisor sandbox", and one
  "this post" changed to "this page" (the issue asked for docs voice, not
  thread-opener voice).
- `docs/bring-your-own-model.md`: added a real `<h1>`. The page had none, so
  Material was synthesising one from the nav label.

**Internal links, from high-traffic pages inward**
- `scan.md` now states the two things the score deliberately does not cover and
  links each: the runtime underneath goes to the gVisor deep-dive, keeping the
  grade goes to the CI on-ramp.
- `blog/hardening-guides.md` (the hub over ~70 guides) now links the CI on-ramp.
- `quickstart.md` now links bring-your-own-model and the gVisor deep-dive.
- `blog/gvisor-vs-runc-container-isolation-compared.md` now links the deep-dive
  and the benchmark page.

**Accuracy fixes found while writing**
- `docs/faq.md` said "AWS **Bedrock** is landing and Azure OpenAI is incoming".
  Both have shipped: `bedrock.go:48` and `azure.go:45` both call `Register`,
  both have host-side injectors under `internal/host/modelproxy/`. The FAQ also
  omitted `ollama` and `azure` from its list.
- `docs/bring-your-own-model.md` listed 5 backends. 11 are registered.

For a security product, understating what shipped is the same credibility
problem as overstating it, just cheaper. Fixed both.

## Verification

- `mkdocs build --strict`: clean, no broken links or anchors.
- Built HTML confirmed for all four pages: new `<title>`, new
  `<meta name="description">`, and the new `<h1>` on bring-your-own-model.
- Guardrails on the diff: no em-dashes or en-dashes in any added line, no owner
  name, no personal handles.

## Deliberately not in scope

- **Site-wide em-dash cleanup.** 699 em/en-dashes exist across `docs/`. Fixing
  them is a separate, high-churn PR. I removed only the 3 prose ones on the page
  I rewrote, and left the one on `scan-action.md:150` because it is a literal
  quote of the string `scan.sh` actually emits.
- **Nav wiring for the Marketplace link.** Relay owns README/docs/landing nav.
  This PR adds no nav lines, so there is nothing to collide on.