### PR TITLE
feat(mcp-registry): repoint the listing at the socket-free ironclaw-mcp image [IRO-612]

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -516,11 +516,28 @@ jobs:
           fi
 
           # GHCR anonymous pull flow: request a bearer token with NO credentials. For a
-          # PUBLIC package this token carries pull scope; for a PRIVATE one it does not and
-          # the manifest fetch below returns 401/403 — exactly the regression we guard.
-          token="$(curl -fsSL "https://ghcr.io/token?scope=repository:${repo}:pull" | jq -r '.token')"
-          if [ -z "${token}" ] || [ "${token}" = "null" ]; then
-            echo "::error::Could not obtain an anonymous GHCR pull token for ${repo}." >&2
+          # PUBLIC package that token carries pull scope. For a PRIVATE package — or one
+          # that does not exist yet — GHCR refuses to distinguish the two and denies the
+          # TOKEN REQUEST ITSELF with 403 DENIED; execution never reaches the manifest
+          # fetch. So this request must not use `curl -f`: under `set -e` that aborts the
+          # step with a bare `curl: (56)` and the remediation below never prints, which is
+          # the one failure this guard exists to explain. Retry first — GHCR is eventually
+          # consistent right after a push, so a brief denial is not proof of private.
+          tok_body="$(mktemp)"
+          tok_code=""
+          token=""
+          for attempt in 1 2 3 4 5; do
+            tok_code="$(curl -sSL -o "${tok_body}" -w '%{http_code}' \
+              "https://ghcr.io/token?service=ghcr.io&scope=repository:${repo}:pull" || true)"
+            token="$(jq -r '.token // empty' <"${tok_body}" 2>/dev/null || true)"
+            [ "${tok_code}" = "200" ] && [ -n "${token}" ] && break
+            token=""
+            echo "  token attempt ${attempt}: HTTP ${tok_code}, retrying in 10s..."
+            sleep 10
+          done
+          if [ -z "${token}" ]; then
+            pkg="${repo##*/}"
+            echo "::error::Anonymous GHCR pull token for ${repo} was denied (HTTP ${tok_code}): the package is private, or has never been pushed. GHCR creates every new package PRIVATE, and GITHUB_TOKEN cannot change container-package visibility (there is no REST endpoint for it, it is a UI action). One-time org-admin fix: IronSecCo -> Packages -> ${pkg} -> Package settings -> Change visibility -> Public, then re-run this workflow. Runbook: runbooks/mcp-registry.md, section 'First publish of a new image (one-time org-admin gate)'. Failing the release." >&2
             exit 1
           fi
 

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -631,6 +631,8 @@ jobs:
       # The listing points at the socket-free MCP image, NOT the control-plane image.
       IMAGE: ${{ needs.prepare.outputs.mcp_image }}
       VERSION: ${{ needs.prepare.outputs.version }}
+      SERVER_NAME: io.github.IronSecCo/ironclaw
+      REGISTRY: https://registry.modelcontextprotocol.io
     steps:
       # Check out the commit prepare already trust-gated to the protected branch — never
       # the raw event head_sha (Dangerous-Workflow: no untrusted checkout while holding
@@ -691,9 +693,30 @@ jobs:
       - name: Publish the IronClaw listing
         run: ./mcp-publisher publish
 
+      # The server was deprecated SERVER-WIDE on 2026-07-07 (every option-A version
+      # launched IronClaw over a host Docker socket). A freshly published version should
+      # land `active` on its own, but after a server-wide deprecation do not TRUST that —
+      # assert it, and self-heal with a PER-VERSION status PATCH.
+      #
+      # Deliberately NOT the server-wide `PATCH /v0/servers/{name}/status` that
+      # mcp-registry-deprecate.yml drives: that flips EVERY version in one transaction and
+      # would resurrect 0.1.216–0.1.230, which name the socket-mount image and must stay
+      # deprecated permanently (IRO-391 / IRO-613). No operator is ever asked to run it.
+      #
+      # `status <name> <version>` (no --all-versions) is exactly
+      # `PATCH /v0/servers/{name}/versions/{version}/status` with body {"status":"active"} —
+      # scoped to the one version we just published. It reuses the login above and the same
+      # cosign-verified pinned binary, so this adds no trust surface and no token handling
+      # of our own. It omits statusMessage, which the API rejects when status=active.
+      - name: Ensure this version is active on the registry
+        run: |
+          set -euo pipefail
+          semver="${VERSION#v}"
+          # NEVER pass --all-versions here: that is the server-wide PATCH and it would
+          # resurrect 0.1.216-0.1.230 (see the note above).
+          ./mcp-publisher status --status active "${SERVER_NAME}" "${semver}"
+
       - name: Verify the listing resolves on the registry and is active
-        env:
-          SERVER_NAME: io.github.IronSecCo/ironclaw
         run: |
           set -euo pipefail
           semver="${VERSION#v}"
@@ -702,25 +725,28 @@ jobs:
           # so the old `.servers[].name` match could never hit. That mismatch is what
           # false-failed this job in 2026-07 while the publish itself had succeeded.
           enc="$(jq -rn --arg s "${SERVER_NAME}" '$s|@uri')"
-          url="https://registry.modelcontextprotocol.io/v0/servers/${enc}/versions"
-          status=""
+          url="${REGISTRY}/v0/servers/${enc}/versions"
+          ok=""
+          body=""
           for attempt in 1 2 3 4 5; do
             body="$(curl -fsSL "${url}" || true)"
-            status="$(printf '%s' "${body}" | jq -r --arg n "${SERVER_NAME}" --arg v "${semver}" \
-              '[.servers[]? | select(.server.name == $n and .server.version == $v)
-                | ._meta["io.modelcontextprotocol.registry/official"].status // "unknown"] | first // ""')"
-            [ -n "${status}" ] && break
-            echo "  attempt ${attempt}: ${SERVER_NAME} ${semver} not yet resolvable, retrying in 10s..."
+            # active AND isLatest: an active version that is not the latest is still a dark
+            # listing, because clients resolve the latest one.
+            if printf '%s' "${body}" | jq -e --arg n "${SERVER_NAME}" --arg v "${semver}" \
+              '.servers[]? | select(.server.name == $n and .server.version == $v)
+                           | select(._meta["io.modelcontextprotocol.registry/official"].status == "active")
+                           | select(._meta["io.modelcontextprotocol.registry/official"].isLatest == true)' \
+              >/dev/null 2>&1; then
+              ok="yes"; break
+            fi
+            echo "  attempt ${attempt}: ${SERVER_NAME} ${semver} not yet active+isLatest, retrying in 10s..."
             sleep 10
           done
-          if [ -z "${status}" ]; then
-            echo "::error::${SERVER_NAME} ${semver} did not resolve on registry.modelcontextprotocol.io after publish. Failing the release." >&2
-            exit 1
-          fi
           # A published-but-deprecated listing is worse than none: clients surface it with a
           # warning and users read it as "abandoned". Fail loud with the exact remediation.
-          if [ "${status}" != "active" ]; then
-            echo "::error::${SERVER_NAME} ${semver} published with status '${status}', expected 'active'. Run the 'MCP Registry Status' workflow (mcp-registry-deprecate.yml) with status=active, then see runbooks/mcp-registry.md." >&2
+          if [ -z "${ok}" ]; then
+            echo "::error::${SERVER_NAME} ${semver} is not active+isLatest on registry.modelcontextprotocol.io after publish. Failing the release. See runbooks/mcp-registry.md." >&2
+            printf '%s' "${body}" | jq '[.servers[]? | {version: .server.version, status: ._meta["io.modelcontextprotocol.registry/official"].status, isLatest: ._meta["io.modelcontextprotocol.registry/official"].isLatest}]' || true
             exit 1
           fi
           echo "Listing live and active: ${SERVER_NAME} ${semver} -> ${IMAGE}:${VERSION}"

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -29,7 +29,7 @@ on:
         required: false
         default: ""
       publish_mcp_registry:
-        description: "PARKED kill-switch for the MCP Registry publish (IRO-391/IRO-414). Leave false: the job publishes the CEO-rejected option-A listing. Only true after IRO-391 is reworked onto the socket-free image."
+        description: "Also (re-)publish the MCP Registry listing on this manual run. The release path publishes automatically; this only matters for a dispatch."
         type: boolean
         required: false
         default: false
@@ -66,6 +66,9 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       tag_args: ${{ steps.meta.outputs.tag_args }}
       sha: ${{ steps.meta.outputs.sha }}
+      mcp_present: ${{ steps.meta.outputs.mcp_present }}
+      mcp_image: ${{ steps.meta.outputs.mcp_image }}
+      mcp_tags: ${{ steps.meta.outputs.mcp_tags }}
     steps:
       # SECURITY (Dangerous-Workflow / "pwn request"): this workflow runs in a
       # privileged context (the build/merge jobs hold packages + attestations write),
@@ -145,6 +148,31 @@ jobs:
           if [ -n "${version}" ]; then
             tag_args="${tag_args} -t ${image}:${version}"
           fi
+
+          # 4) The slim, socket-free MCP-server image (container/mcp.Dockerfile). It is the
+          #    artifact the official MCP Registry listing points at (server.json), so it has
+          #    to be built and pushed on the same release, from the same commit, under the
+          #    same immutable tag. Same present-gate as above: a commit without the
+          #    Dockerfile just skips that job rather than failing the release.
+          mcp_image="ghcr.io/${owner}/ironclaw-mcp"
+          if gh api "repos/${REPO}/contents/container/mcp.Dockerfile?ref=${sha}" --silent >/dev/null 2>&1; then
+            # docker/build-push-action takes newline-separated tags.
+            mcp_tags="${mcp_image}:latest"
+            if [ -n "${version}" ]; then
+              mcp_tags="${mcp_tags}"$'\n'"${mcp_image}:${version}"
+            fi
+            {
+              echo "mcp_present=true"
+              echo "mcp_image=${mcp_image}"
+              echo "mcp_tags<<__EOF__"
+              echo "${mcp_tags}"
+              echo "__EOF__"
+            } >> "${GITHUB_OUTPUT}"
+          else
+            echo "mcp_present=false" >> "${GITHUB_OUTPUT}"
+            echo "No container/mcp.Dockerfile at ${sha} — skipping the MCP image build."
+          fi
+
           {
             echo "present=true"
             echo "image=${image}"
@@ -311,6 +339,118 @@ jobs:
           sbom-path: ${{ runner.temp }}/image.cdx.json
           push-to-registry: true
 
+  # Build and publish the slim, socket-free MCP-server image (container/mcp.Dockerfile) ->
+  # ghcr.io/<owner>/ironclaw-mcp. This is the artifact the official MCP Registry listing
+  # points at (server.json), so it MUST ship on the same release, from the same trust-gated
+  # commit, under the same immutable tag as the control-plane image — otherwise the listing
+  # names an image that does not exist and `publish-mcp-registry` fails closed.
+  #
+  # Unlike the control-plane image this needs no per-arch native runner: ironctl does not
+  # link cgo, so the Go toolchain cross-compiles both arches from one amd64 runner (the
+  # Dockerfile pins its build stage to $BUILDPLATFORM and honours $TARGETARCH). One buildx
+  # invocation therefore pushes the tagged multi-arch manifest list directly — no
+  # push-by-digest + merge dance.
+  build-mcp:
+    needs: prepare
+    if: ${{ needs.prepare.outputs.mcp_present == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout the trust-gated commit
+      packages: write # push the image to GHCR
+      id-token: write # keyless provenance + SBOM signing (Sigstore OIDC)
+      attestations: write # actions/attest-build-provenance + attest-sbom
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      # Check out the commit prepare already trust-gated to the protected branch — never
+      # the raw event head_sha (Dangerous-Workflow: no untrusted checkout in a job holding
+      # packages/attestations write).
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push the multi-arch MCP image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: container/mcp.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+          tags: ${{ needs.prepare.outputs.mcp_tags }}
+          push: true
+          # Provenance is attached once to the index below as a GitHub artifact
+          # attestation, matching the control-plane image and the release binaries.
+          provenance: false
+          sbom: false
+
+      - name: Attest the MCP image
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
+        with:
+          subject-name: ${{ needs.prepare.outputs.mcp_image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Install syft (pinned)
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Generate MCP image SBOM (syft → CycloneDX)
+        env:
+          IMAGE: ${{ needs.prepare.outputs.mcp_image }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          syft version
+          syft scan "registry:${IMAGE}@${DIGEST}" \
+            -o "cyclonedx-json=${RUNNER_TEMP}/mcp-image.cdx.json"
+
+      - name: Attest the MCP image SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ${{ needs.prepare.outputs.mcp_image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: ${{ runner.temp }}/mcp-image.cdx.json
+          push-to-registry: true
+
+      # Ownership proof for the MCP Registry: the registry's OCI validator refuses to bind
+      # io.github.IronSecCo/ironclaw to an image whose io.modelcontextprotocol.server.name
+      # label does not equal the server.json name. Catch a drifted label HERE, next to the
+      # build that caused it, instead of three jobs later inside mcp-publisher.
+      - name: Assert the MCP Registry ownership label matches server.json
+        env:
+          IMAGE: ${{ needs.prepare.outputs.mcp_image }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          want="$(jq -r '.name' server.json)"
+          echo "server.json name: ${want}"
+          # On a multi-platform index `.Image` is a map keyed by platform, so read the
+          # label from EVERY manifest: one arch built without it is still a broken publish.
+          # Emit space-separated "<platform>=<label>" pairs (neither field contains a
+          # space) and split on whitespace.
+          labels="$(docker buildx imagetools inspect "${IMAGE}@${DIGEST}" --format \
+            '{{ range $p, $img := .Image }}{{ $p }}={{ index $img.Config.Labels "io.modelcontextprotocol.server.name" }} {{ end }}' \
+            | tr -s '[:space:]' '\n')"
+          printf '%s\n' "${labels}"
+          bad=0
+          while IFS= read -r line; do
+            [ -z "${line}" ] && continue
+            if [ "${line#*=}" != "${want}" ]; then
+              echo "::error::${line%%=*}: label io.modelcontextprotocol.server.name='${line#*=}' does not match server.json name '${want}' — the MCP Registry publish would fail closed." >&2
+              bad=1
+            fi
+          done <<< "${labels}"
+          [ "${bad}" = "0" ] || exit 1
+
   # Consumer-side guard. The jobs above PRODUCE the image + attestation; this proves they
   # are CONSUMABLE the way a real user consumes them — anonymously, with no registry
   # credentials. If the GHCR package is (or silently reverts to) private, or its tag no
@@ -320,20 +460,48 @@ jobs:
   #
   # Deliberately runs NO docker/login-action and holds only `contents: read` — it must
   # succeed on exactly the unauthenticated path users hit, never on cached runner creds.
+  #
+  # Runs once per published image. `ironclaw-mcp` gets the same treatment as the
+  # control-plane image because the MCP Registry's OCI validator pulls it ANONYMOUSLY: a
+  # private or unattested MCP image is a listing that fails closed for every consumer.
   verify-consumer:
-    needs: [prepare, merge]
+    needs: [prepare, merge, build-mcp]
     if: ${{ needs.prepare.outputs.present == 'true' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ${{ needs.prepare.outputs.image }}
+            digest: ${{ needs.merge.outputs.digest }}
+          - image: ${{ needs.prepare.outputs.mcp_image }}
+            digest: ${{ needs.build-mcp.outputs.digest }}
     permissions:
       contents: read # gh attestation verify reads the public attestation; no push/sign here
     env:
-      IMAGE: ${{ needs.prepare.outputs.image }}
+      IMAGE: ${{ matrix.image }}
       VERSION: ${{ needs.prepare.outputs.version }}
-      EXPECTED_DIGEST: ${{ needs.merge.outputs.digest }}
+      EXPECTED_DIGEST: ${{ matrix.digest }}
       REPO: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
     steps:
+      # A matrix entry is empty when its Dockerfile was absent at this commit (the
+      # present-gate in `prepare`), e.g. a revert. Skip that entry explicitly rather than
+      # verifying an empty image ref — and log it, so a skip is never silent.
+      - name: Resolve this matrix entry
+        id: gate
+        run: |
+          set -euo pipefail
+          if [ -z "${IMAGE}" ]; then
+            echo "::notice::No image for this matrix entry at this commit — nothing to verify."
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "Verifying ${IMAGE} (expected index ${EXPECTED_DIGEST:-<none>})"
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Anonymous manifest pull (no registry auth)
+        if: ${{ steps.gate.outputs.skip != 'true' }}
         run: |
           set -euo pipefail
           # IMAGE is already lowercased by prepare; strip the registry host to get the
@@ -386,6 +554,7 @@ jobs:
           done
 
       - name: Verify build provenance from the consumer side
+        if: ${{ steps.gate.outputs.skip != 'true' }}
         run: |
           set -euo pipefail
           # Verify by digest (the attested subject) and by the tags users actually pull.
@@ -430,20 +599,24 @@ jobs:
   # -published, already-attested image — the listing points at an artifact that stands on
   # its own.
   #
-  # PARKED (IRO-391 / IRO-414). CEO chose option B: do NOT list the control-plane image
-  # with a host Docker-socket mount (host-root, against our hardening promise). This job
-  # as written publishes exactly that rejected option-A listing, so it is hard-disabled
-  # (`if: false`) until IRO-414 ships the slim, socket-free `ironclaw-mcp` image and
-  # IRO-391 is reworked to point server.json at it. Leaving it enabled would (a) re-publish
-  # the rejected listing on every release and (b) red the whole Image workflow on the
-  # post-check. The already-published option-A versions (0.1.216–0.1.230) are being
-  # deprecated out-of-band via mcp-registry-deprecate.yml.
+  # UNPARKED 2026-07-29 (IRO-612). This job was hard-gated to a manual dispatch while the
+  # listing still described option A — the control-plane image launched over a host Docker
+  # socket, which the CEO rejected as host-root (IRO-391). The blocker is gone: IRO-414
+  # shipped container/mcp.Dockerfile and `build-mcp` above now publishes the socket-free
+  # `ironclaw-mcp` thin client, which is what server.json points at. So the listing this
+  # job publishes is now the trust model we actually endorse, and it runs on the release
+  # path again. The manual `publish_mcp_registry` input survives only as a way to force a
+  # re-publish from a dispatch; it is NOT required on the release path.
+  #
+  # The already-published option-A versions (0.1.216–0.1.230) stay `deprecated` on the
+  # registry — they name an image we still tell people not to run. Do not blanket-activate
+  # them (see runbooks/mcp-registry.md).
   publish-mcp-registry:
-    needs: [prepare, merge, verify-consumer]
-    # PARKED: never runs on the release (workflow_run) path — it requires an explicit
-    # manual dispatch with publish_mcp_registry=true, which must not be set until IRO-391
-    # is reworked onto the socket-free image (IRO-414). See comment block above.
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_mcp_registry && needs.prepare.outputs.present == 'true' && needs.prepare.outputs.version != 'dev' && needs.prepare.outputs.version != '' }}
+    needs: [prepare, merge, build-mcp, verify-consumer]
+    # Tagged releases only (VERSION != dev): we list immutable versions. A manual dispatch
+    # must additionally opt in via publish_mcp_registry so a routine rebuild does not
+    # re-publish a listing by accident.
+    if: ${{ needs.prepare.outputs.present == 'true' && needs.prepare.outputs.mcp_present == 'true' && needs.prepare.outputs.version != 'dev' && needs.prepare.outputs.version != '' && (github.event_name != 'workflow_dispatch' || inputs.publish_mcp_registry) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout the trust-gated commit to read server.json
@@ -455,7 +628,8 @@ jobs:
       # Sigstore identity that signed the pinned mcp-publisher release archive.
       MCP_PUBLISHER_CERT_IDENTITY: https://github.com/modelcontextprotocol/registry/.github/workflows/release.yml@refs/tags/v1.7.9
       MCP_PUBLISHER_CERT_ISSUER: https://token.actions.githubusercontent.com
-      IMAGE: ${{ needs.prepare.outputs.image }}
+      # The listing points at the socket-free MCP image, NOT the control-plane image.
+      IMAGE: ${{ needs.prepare.outputs.mcp_image }}
       VERSION: ${{ needs.prepare.outputs.version }}
     steps:
       # Check out the commit prepare already trust-gated to the protected branch — never
@@ -517,26 +691,36 @@ jobs:
       - name: Publish the IronClaw listing
         run: ./mcp-publisher publish
 
-      - name: Verify the listing resolves on the registry
+      - name: Verify the listing resolves on the registry and is active
+        env:
+          SERVER_NAME: io.github.IronSecCo/ironclaw
         run: |
           set -euo pipefail
           semver="${VERSION#v}"
-          # Fail-closed post-check: the registry must now serve our namespace at this
-          # version. Brief retry to absorb indexing lag, then fail loud.
-          url="https://registry.modelcontextprotocol.io/v0/servers?search=io.github.IronSecCo/ironclaw"
-          ok=""
+          # Fail-closed post-check. Query the EXACT per-server versions endpoint, not
+          # `?search=` — search is fuzzy and the response nests the record under `.server`,
+          # so the old `.servers[].name` match could never hit. That mismatch is what
+          # false-failed this job in 2026-07 while the publish itself had succeeded.
+          enc="$(jq -rn --arg s "${SERVER_NAME}" '$s|@uri')"
+          url="https://registry.modelcontextprotocol.io/v0/servers/${enc}/versions"
+          status=""
           for attempt in 1 2 3 4 5; do
             body="$(curl -fsSL "${url}" || true)"
-            if printf '%s' "${body}" | jq -e \
-              --arg v "${semver}" \
-              '.servers[]? | select(.name == "io.github.IronSecCo/ironclaw" and .version == $v)' >/dev/null 2>&1; then
-              ok="yes"; break
-            fi
-            echo "  attempt ${attempt}: listing not yet resolvable, retrying in 10s..."
+            status="$(printf '%s' "${body}" | jq -r --arg n "${SERVER_NAME}" --arg v "${semver}" \
+              '[.servers[]? | select(.server.name == $n and .server.version == $v)
+                | ._meta["io.modelcontextprotocol.registry/official"].status // "unknown"] | first // ""')"
+            [ -n "${status}" ] && break
+            echo "  attempt ${attempt}: ${SERVER_NAME} ${semver} not yet resolvable, retrying in 10s..."
             sleep 10
           done
-          if [ -z "${ok}" ]; then
-            echo "::error::io.github.IronSecCo/ironclaw ${semver} did not resolve on registry.modelcontextprotocol.io after publish. Failing the release." >&2
+          if [ -z "${status}" ]; then
+            echo "::error::${SERVER_NAME} ${semver} did not resolve on registry.modelcontextprotocol.io after publish. Failing the release." >&2
             exit 1
           fi
-          echo "Listing live: io.github.IronSecCo/ironclaw ${semver}"
+          # A published-but-deprecated listing is worse than none: clients surface it with a
+          # warning and users read it as "abandoned". Fail loud with the exact remediation.
+          if [ "${status}" != "active" ]; then
+            echo "::error::${SERVER_NAME} ${semver} published with status '${status}', expected 'active'. Run the 'MCP Registry Status' workflow (mcp-registry-deprecate.yml) with status=active, then see runbooks/mcp-registry.md." >&2
+            exit 1
+          fi
+          echo "Listing live and active: ${SERVER_NAME} ${semver} -> ${IMAGE}:${VERSION}"

--- a/.github/workflows/mcp-registry-deprecate.yml
+++ b/.github/workflows/mcp-registry-deprecate.yml
@@ -7,9 +7,16 @@ name: MCP Registry Status
 # Why it exists: the option-A listing (control-plane image + host Docker-socket mount)
 # was auto-published by image.yml on releases 0.1.216–0.1.230 before the CEO chose
 # option B (IRO-391 / IRO-414). That listing must not stand as our public entry. This
-# workflow flips the status of ALL published versions in one transaction — deprecate now,
-# reactivate/delete later — using the repo's own GitHub Actions OIDC token (the same
-# account-free namespace auth that published), so no long-lived secret is involved.
+# workflow flips the status of ALL published versions in one transaction, using the repo's
+# own GitHub Actions OIDC token (the same account-free namespace auth that published), so
+# no long-lived secret is involved.
+#
+# CAUTION (IRO-612): the registry status API is per-SERVER, so `status=active` reactivates
+# EVERY version — including 0.1.216–0.1.230, which name the control-plane image launched
+# over a host Docker socket. Do not run it to relight the listing. Since IRO-612 the
+# release path publishes a new, socket-free version that lands `active` on its own, and
+# image.yml's post-check fails the release if it does not. Reach for this workflow only to
+# deprecate something newly published in error. See runbooks/mcp-registry.md.
 #
 # Manual only: never chained to a release. A repo-writer runs it from the Actions tab.
 
@@ -17,7 +24,7 @@ on:
   workflow_dispatch:
     inputs:
       status:
-        description: "New status for ALL versions of io.github.IronSecCo/ironclaw"
+        description: "New status for ALL versions of io.github.IronSecCo/ironclaw (active reactivates the old host-socket versions too — read the header first)"
         required: true
         type: choice
         default: deprecated
@@ -25,7 +32,7 @@ on:
       message:
         description: "Status message (<=500 chars; ignored when status=active)"
         required: false
-        default: "Superseded: this listing launched IronClaw via a host Docker-socket mount, which we do not endorse. A socket-free ironclaw-mcp image is in progress (IRO-414); the listing will be re-published against it."
+        default: "Superseded: this version launched IronClaw via a host Docker-socket mount, which we do not endorse. Use the current release, which ships the socket-free ghcr.io/ironsecco/ironclaw-mcp thin client."
 
 permissions:
   contents: read

--- a/container/controlplane.Dockerfile
+++ b/container/controlplane.Dockerfile
@@ -75,12 +75,11 @@ RUN mkdir -p /var/lib/ironclaw/state /run/ironclaw \
  && chmod 0700 /var/lib/ironclaw/state \
  && chmod +x /usr/local/bin/controlplane-entrypoint.sh
 
-# OCI ownership proof for the official MCP Registry (registry.modelcontextprotocol.io).
-# The registry's OCI validator fetches this image and requires this exact label to match
-# the server.json `name`, proving the publisher controls the image before it will bind the
-# `io.github.IronSecCo/ironclaw` listing to it. Without it, `mcp-publisher publish` fails
-# closed. Keep this string in lock-step with server.json's `name` (see runbooks/mcp-registry.md).
-LABEL io.modelcontextprotocol.server.name="io.github.IronSecCo/ironclaw"
+# The MCP Registry ownership label (io.modelcontextprotocol.server.name) deliberately does
+# NOT live here. It sits on container/mcp.Dockerfile, the socket-free image the listing now
+# points at (IRO-612). Labelling this image as well would let a publish re-bind the listing
+# to the control-plane image launched over a host Docker socket — the option-A trust model
+# the CEO rejected (IRO-391). Exactly one image in this repo carries that label.
 
 USER 65532:65532
 WORKDIR /var/lib/ironclaw

--- a/container/mcp.Dockerfile
+++ b/container/mcp.Dockerfile
@@ -22,7 +22,11 @@
 #   docker build -f container/mcp.Dockerfile -t ghcr.io/ironsecco/ironclaw-mcp:latest .
 
 # --- build stage ------------------------------------------------------------
-FROM golang:1.23-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db AS build
+# Pinned to the BUILD platform: because CGO is off (see below) the Go toolchain
+# cross-compiles every target arch natively, so a multi-arch `docker buildx build`
+# needs no QEMU emulation and no per-arch runner. (The control-plane image cannot
+# do this — it links SQLCipher through cgo.)
+FROM --platform=$BUILDPLATFORM golang:1.23-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db AS build
 
 WORKDIR /src
 # Prime the module cache first for better layer caching.
@@ -30,12 +34,22 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 
+# Supplied by buildx per target platform; default to a native build so a plain
+# `docker build` still works.
+ARG TARGETOS=linux
+ARG TARGETARCH
+# Stamped by the release pipeline so `ironctl version` inside the image matches the
+# tag the listing points at (mirrors container/controlplane.Dockerfile).
+ARG VERSION=dev
+
 # ironctl is a pure HTTP/stdio client: it does NOT link the encrypted-queue
 # (go-sqlcipher) binding, so it builds fully static with CGO disabled. A static
 # binary lets us ship on distroless/static with no libc, no shell, no package
 # manager — the minimal attack surface the registry image needs.
 ENV CGO_ENABLED=0
-RUN go build -trimpath -ldflags "-s -w" -o /out/ironctl ./cmd/ironctl
+RUN GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" go build -trimpath \
+      -ldflags "-s -w -X github.com/IronSecCo/ironclaw/internal/version.Version=${VERSION}" \
+      -o /out/ironctl ./cmd/ironctl
 
 # --- runtime stage ----------------------------------------------------------
 # distroless static: no shell, no package manager, ships ca-certificates and a
@@ -43,10 +57,14 @@ RUN go build -trimpath -ldflags "-s -w" -o /out/ironctl ./cmd/ironctl
 # control-plane, not here.
 FROM gcr.io/distroless/static-debian12:nonroot AS runtime
 
-# NOTE (handoff to IRO-391 / Relay): add the MCP Registry ownership label here, e.g.
-#   LABEL io.modelcontextprotocol.server.name="<name from server.json>"
-# It is intentionally omitted so the exact name stays owned by server.json, which
-# Relay maintains alongside the publish-mcp-registry job.
+# OCI ownership proof for the official MCP Registry (registry.modelcontextprotocol.io).
+# The registry's OCI validator fetches this image and requires this exact label to equal
+# the server.json `name`, proving the publisher controls the image before it will bind the
+# `io.github.IronSecCo/ironclaw` listing to it. Without it, `mcp-publisher publish` fails
+# closed. Keep it in lock-step with server.json's `name` (see runbooks/mcp-registry.md).
+# THIS is the only image in the repo that carries the label: the listing must resolve to
+# the socket-free thin client, never to the control-plane image (IRO-391 option A).
+LABEL io.modelcontextprotocol.server.name="io.github.IronSecCo/ironclaw"
 
 COPY --from=build /out/ironctl /ironctl
 

--- a/runbooks/mcp-registry.md
+++ b/runbooks/mcp-registry.md
@@ -107,26 +107,52 @@ Nothing manual. Push to `main` cuts a release (`v0.1.<commit-count>`); the
 is anonymously pullable, then `publish-mcp-registry` publishes the listing and
 post-checks the registry.
 
-The post-check queries the **exact** per-server endpoint,
-`/v0/servers/{urlencoded name}/versions`, and asserts the new version is present
-**and `active`**. Two traps it exists to avoid:
+After publishing, the job runs two steps that matter:
 
-- `?search=` is a fuzzy search, not a name filter.
-- The response nests the record under `.server`, so `.servers[].name` is always
-  `null`. Matching on it is what false-failed this job through 0.1.216–0.1.230
-  while the publishes themselves were succeeding.
+1. **Activate this version.** `mcp-publisher status --status active <name>
+   <semver>`, which is the per-version endpoint
+   `PATCH /v0/servers/{name}/versions/{version}/status`. A fresh publish normally
+   lands `active` on its own, but the server was deprecated **server-wide** on
+   2026-07-07, so the job asserts rather than trusts. It never passes
+   `--all-versions` (see below).
+2. **Post-check.** Queries the **exact** per-server endpoint,
+   `/v0/servers/{urlencoded name}/versions`, and asserts the new version is
+   `active` **and** `isLatest`. Two traps it exists to avoid:
+   - `?search=` is a fuzzy search, not a name filter.
+   - The response nests the record under `.server`, so `.servers[].name` is
+     always `null`. Matching on it is what false-failed this job through
+     0.1.216–0.1.230 while the publishes themselves were succeeding.
 
 ## Relighting a deprecated listing
 
-Publish a new version. Freshly published versions land `active` on their own, and
-the post-check above fails the release if one does not — so a green `Image`
-workflow **is** the proof that the listing is live.
+Publish a new version. The release path activates and verifies it per-version, so
+a green `Image` workflow **is** the proof that the listing is live. There is no
+manual step.
 
-Do **not** reach for `mcp-registry-deprecate.yml` with `status=active`. The
-registry's status API is per-server, so it would reactivate every version,
-including 0.1.216–0.1.230, which name the control-plane image launched over a
-host Docker socket. Those stay `deprecated` on purpose: they describe a trust
-model we tell people not to run.
+Do **not** reach for `mcp-registry-deprecate.yml` with `status=active`, and do not
+pass `--all-versions` to `mcp-publisher status`. Both are **server-wide**: they
+flip every version in one transaction, including 0.1.216–0.1.230, which name the
+control-plane image launched over a host Docker socket. Those stay `deprecated`
+permanently — they describe a trust model we tell people not to run (IRO-391 /
+IRO-613). The only thing that ever goes `active` is a version built from
+`container/mcp.Dockerfile`.
+
+## First publish of a new image (one-time org-admin gate)
+
+GHCR creates a brand-new package as **private**, and `GITHUB_TOKEN` cannot change
+that. So the first release that pushes `ghcr.io/ironsecco/ironclaw-mcp` fails in
+`verify-consumer` on the anonymous pull. That failure is **correct, expected, and
+one-time**: a private image is unusable by the clients the listing serves, and
+the registry's own OCI validator could not fetch it either. Read a red first
+release here as this gate, not as a broken pipeline.
+
+Unblock it once, as an org admin:
+
+> IronSecCo → Packages → `ironclaw-mcp` → Package settings → Change visibility →
+> Public
+
+then re-run the `Image` workflow (or let the next release run it). This is a
+package-visibility change, not a pipeline change; no workflow edit is involved.
 
 ## Yanking / superseding a listing
 
@@ -136,10 +162,14 @@ deprecate:
 - **Supersede** — publish a newer `version`. The registry marks the newest as
   `isLatest: true`; older versions remain queryable but drop out of the default
   view.
-- **Deprecate** — run `mcp-registry-deprecate.yml` with `status=deprecated`. It
-  PATCHes the server's lifecycle status over the same GitHub OIDC auth. Clients
-  surface deprecated servers with a warning instead of hiding them. Note
-  `statusMessage` is rejected when `status=active`.
+- **Deprecate one version** (preferred) — `mcp-publisher status --status
+  deprecated <name> <semver>`. Per-version, so it cannot touch anything else.
+- **Deprecate every version** — `mcp-registry-deprecate.yml`, or `mcp-publisher
+  status --all-versions`. **Server-wide, break-glass only.** Safe in the
+  `deprecated` direction; never run it with `status=active`.
+
+Clients surface deprecated servers with a warning instead of hiding them. Note
+`statusMessage` is rejected when `status=active`, so send the status alone.
 
 If a bad image was published, cut a fixed release: the new listing repoints at
 the new immutable image tag; the bad tag can be separately yanked from GHCR.

--- a/runbooks/mcp-registry.md
+++ b/runbooks/mcp-registry.md
@@ -16,18 +16,51 @@ job belongs to the `IronSecCo` org, and the registry binds the
 `io.github.IronSecCo/*` namespace to it. The only permission the job holds is
 `id-token: write` (plus `contents: read` to check out `server.json`).
 
+## What the listing points at
+
+The listed package is **`ghcr.io/ironsecco/ironclaw-mcp`** — the slim,
+socket-free thin client from `container/mcp.Dockerfile`. It is a static `ironctl`
+on `distroless/static:nonroot` with no shell, no package manager, no `runsc`, and
+no host Docker socket. `sandbox_exec` delegates every box to a running IronClaw
+control-plane over its authenticated API; the control-plane owns the hardened
+gVisor launch. The MCP server itself holds **no host privilege**, and with no
+control-plane reachable the tool fails closed rather than falling back to host
+Docker.
+
+It is deliberately **not** the control-plane image. Listing that one requires
+`-v /var/run/docker.sock:/var/run/docker.sock`, which is effectively host-root;
+the CEO rejected it as option A under IRO-391. Exactly one image in this repo
+carries the `io.modelcontextprotocol.server.name` label, and it is the MCP image,
+so a publish cannot accidentally re-bind the listing to the control-plane.
+
+Consumers get two required environment variables, declared in `server.json` and
+forwarded with bare `-e NAME` runtime arguments so no value ever appears in the
+listing:
+
+| Variable | Meaning |
+| --- | --- |
+| `IRONCLAW_CONTROLPLANE_URL` | Base URL of the user's running control-plane. Unset means no backend and `sandbox_exec` fails closed. |
+| `IRONCLAW_API_TOKEN` | Bearer token for that control-plane's API (`isSecret: true`). |
+
 ## Moving parts
 
 | Artifact | Role |
 | --- | --- |
-| [`server.json`](https://github.com/IronSecCo/ironclaw/blob/main/server.json) | The listing: name, description, repository, and the OCI package that points at our GHCR control-plane image. |
-| `LABEL io.modelcontextprotocol.server.name` in `container/controlplane.Dockerfile` | Ownership proof. The registry fetches the image and refuses to bind the listing unless this label equals the `server.json` name. |
-| `publish-mcp-registry` job in `.github/workflows/image.yml` | Chains off the image build/merge/attest/verify chain and publishes the listing via the pinned `mcp-publisher` CLI. |
+| [`server.json`](https://github.com/IronSecCo/ironclaw/blob/main/server.json) | The listing: name, description, repository, and the OCI package that points at `ghcr.io/ironsecco/ironclaw-mcp`. |
+| `LABEL io.modelcontextprotocol.server.name` in `container/mcp.Dockerfile` | Ownership proof. The registry fetches the image and refuses to bind the listing unless this label equals the `server.json` name. |
+| `build-mcp` job in `.github/workflows/image.yml` | Builds + pushes the multi-arch MCP image, attests provenance and an SBOM, and asserts the label matches `server.json` on **every** arch. |
+| `publish-mcp-registry` job in `.github/workflows/image.yml` | Chains off the build/attest/verify chain and publishes the listing via the pinned `mcp-publisher` CLI. |
+| `.github/workflows/mcp-registry-deprecate.yml` | Manual status flip for the whole server record. See the caution below before using it. |
 
-The publish job runs **only after** `verify-consumer` proves the image is
+The publish job runs **only after** `verify-consumer` proves **both** images are
 anonymously pullable and attested, and **only for tagged releases**
 (`VERSION != dev`). A failure fails the workflow loudly but never rolls back the
-already-published, already-attested image.
+already-published, already-attested images.
+
+`ironclaw-mcp` builds multi-arch from a single runner: `ironctl` does not link
+cgo, so the Go toolchain cross-compiles both arches (`FROM --platform=$BUILDPLATFORM`
+plus `$TARGETARCH`) with no QEMU. The control-plane image still needs its
+per-arch native runners because it links SQLCipher through cgo.
 
 ## How the version is bound
 
@@ -35,7 +68,7 @@ already-published, already-attested image.
 (`vX.Y.Z`). The publish job then stamps `server.json` at publish time:
 
 - `.version` = the semver form (`X.Y.Z`, leading `v` stripped).
-- `.packages[0].identifier` = `ghcr.io/ironsecco/ironclaw-controlplane:vX.Y.Z`
+- `.packages[0].identifier` = `ghcr.io/ironsecco/ironclaw-mcp:vX.Y.Z`
   — the **immutable release tag**, never `:latest`, so the listing is
   re-derivable from the tagged commit.
 
@@ -69,12 +102,31 @@ sha256sum mp.tgz                                  # -> MCP_PUBLISHER_SHA256
 
 ## Cutting a listing (normal path)
 
-Nothing manual. Push to `main` cuts a release
-(`v0.1.<commit-count>`); the `Image` workflow builds + attests the GHCR image,
-`verify-consumer` proves it is pullable, then `publish-mcp-registry` publishes
-the listing and post-checks that
-`registry.modelcontextprotocol.io/v0/servers?search=io.github.IronSecCo/ironclaw`
-resolves at the new version.
+Nothing manual. Push to `main` cuts a release (`v0.1.<commit-count>`); the
+`Image` workflow builds + attests both GHCR images, `verify-consumer` proves each
+is anonymously pullable, then `publish-mcp-registry` publishes the listing and
+post-checks the registry.
+
+The post-check queries the **exact** per-server endpoint,
+`/v0/servers/{urlencoded name}/versions`, and asserts the new version is present
+**and `active`**. Two traps it exists to avoid:
+
+- `?search=` is a fuzzy search, not a name filter.
+- The response nests the record under `.server`, so `.servers[].name` is always
+  `null`. Matching on it is what false-failed this job through 0.1.216–0.1.230
+  while the publishes themselves were succeeding.
+
+## Relighting a deprecated listing
+
+Publish a new version. Freshly published versions land `active` on their own, and
+the post-check above fails the release if one does not — so a green `Image`
+workflow **is** the proof that the listing is live.
+
+Do **not** reach for `mcp-registry-deprecate.yml` with `status=active`. The
+registry's status API is per-server, so it would reactivate every version,
+including 0.1.216–0.1.230, which name the control-plane image launched over a
+host Docker socket. Those stay `deprecated` on purpose: they describe a trust
+model we tell people not to run.
 
 ## Yanking / superseding a listing
 
@@ -84,9 +136,10 @@ deprecate:
 - **Supersede** — publish a newer `version`. The registry marks the newest as
   `isLatest: true`; older versions remain queryable but drop out of the default
   view.
-- **Deprecate** — set the server's lifecycle status to `deprecated` (registry
-  API, authenticated with the same GitHub OIDC/PAT). Clients surface deprecated
-  servers with a warning instead of hiding them.
+- **Deprecate** — run `mcp-registry-deprecate.yml` with `status=deprecated`. It
+  PATCHes the server's lifecycle status over the same GitHub OIDC auth. Clients
+  surface deprecated servers with a warning instead of hiding them. Note
+  `statusMessage` is rejected when `status=active`.
 
 If a bad image was published, cut a fixed release: the new listing repoints at
 the new immutable image tag; the bad tag can be separately yanked from GHCR.
@@ -94,38 +147,40 @@ the new immutable image tag; the bad tag can be separately yanked from GHCR.
 ## How a user verifies the listing
 
 ```bash
-# 1. The listing resolves and points at our image + repo:
-curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.IronSecCo/ironclaw" | jq .
+# 1. The listing resolves, is active, and points at the socket-free image:
+curl -s "https://registry.modelcontextprotocol.io/v0/servers/io.github.IronSecCo%2Fironclaw/versions" \
+  | jq '.servers[] | {v: .server.version,
+                      pkg: .server.packages[0].identifier,
+                      status: ._meta["io.modelcontextprotocol.registry/official"].status}'
 
 # 2. The image the listing names carries build provenance tying it to this repo:
-gh attestation verify oci://ghcr.io/ironsecco/ironclaw-controlplane:vX.Y.Z \
+gh attestation verify oci://ghcr.io/ironsecco/ironclaw-mcp:vX.Y.Z \
   --repo IronSecCo/ironclaw
+
+# 3. It really is the thin client — no docker socket, no host privilege:
+IRONCLAW_CONTROLPLANE_URL=http://127.0.0.1:8787 IRONCLAW_API_TOKEN=<token> \
+  docker run --rm -i -e IRONCLAW_CONTROLPLANE_URL -e IRONCLAW_API_TOKEN \
+  ghcr.io/ironsecco/ironclaw-mcp:vX.Y.Z
+# stderr: "thin-client backend -> control-plane ... (this process holds no host privilege)"
 ```
 
-## Open design decision (CEO review — IRO-391)
+## Why OCI, and why the thin client (settled — IRO-391 / IRO-414 / IRO-612)
 
 The registry accepts packages only from supported package registries
 (npm, PyPI, OCI, MCPB, NuGet, Cargo). IronClaw ships via Homebrew, `curl | sh`,
 and the GHCR image — of these, **only the GHCR image is a registry-supported
-package type**, so the listing uses the OCI form.
+package type**, so the listing uses the OCI form. Native-only
+(`command: ironctl, args: [mcp, serve]`, per `docs/mcp-server/`) remains the flow
+we document and recommend, but it is not a registry-supported package type.
 
-But `ironctl mcp serve` spawns each `sandbox_exec` run as a sibling gVisor
-container, so a `docker run` launch of the image needs the **host Docker
-socket** (`-v /var/run/docker.sock:/var/run/docker.sock` in
-`server.json`'s `runtimeArguments`). Mounting the host Docker socket into a
-container is effectively host-root and sits in tension with IronClaw's
-hardening promise. Options:
+The original listing took the shortest path to a working `docker run`: the
+control-plane image plus a host Docker-socket mount, so `ironctl mcp serve` could
+spawn sibling gVisor containers. That is effectively host-root and contradicts
+IronClaw's hardening promise, so the CEO rejected it (option A) and those
+versions were deprecated.
 
-- **A. OCI + docker socket (implemented here).** Works via plain `docker run`;
-  documents the socket requirement explicitly. Trade-off: the socket exposure.
-- **B. Dedicated slim MCP image** whose entrypoint is `ironctl mcp serve` and
-  whose sandbox backend is scoped tighter than a raw socket mount. More work;
-  cleaner trust story.
-- **C. Native-only** (`command: ironctl, args: [mcp, serve]`, per
-  `docs/mcp-server/`). This is the flow we already document and recommend, but
-  it is **not a registry-supported package type**, so it cannot be the registry
-  listing today.
-
-This runbook ships the **A** implementation as the reviewable default; the
-go/no-go on A-vs-B (and on listing at all under the socket trade-off) is the
-CEO decision this issue is gated on.
+The shipped answer is the **thin client**: IRO-414 split the box lifecycle out to
+the control-plane's authenticated `POST /v1/sandbox/exec`, which lets the listed
+image drop every host privilege. IRO-612 repointed `server.json` at it, moved the
+ownership label onto it, added the `build-mcp` job that actually publishes it, and
+put the release path back in charge of the listing.

--- a/server.json
+++ b/server.json
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/ironsecco/ironclaw-controlplane:0.0.0",
+      "identifier": "ghcr.io/ironsecco/ironclaw-mcp:0.0.0",
       "transport": {
         "type": "stdio"
       },
@@ -29,26 +29,33 @@
         },
         {
           "type": "named",
-          "name": "-v",
-          "value": "/var/run/docker.sock:/var/run/docker.sock",
-          "description": "IronClaw launches each sandbox_exec run as a sibling gVisor container; it needs the host Docker socket to do so. This grants the MCP server control of the host Docker daemon -- review before enabling.",
+          "name": "-e",
+          "value": "IRONCLAW_CONTROLPLANE_URL",
+          "description": "Forward the control-plane URL from your own environment into the container; the value never appears in this listing.",
           "isRequired": true
         },
         {
           "type": "named",
-          "name": "--entrypoint",
-          "value": "ironctl",
-          "description": "Override the control-plane daemon entrypoint to run the bundled ironctl MCP server instead."
+          "name": "-e",
+          "value": "IRONCLAW_API_TOKEN",
+          "description": "Forward the control-plane API token from your own environment into the container; the value never appears in this listing.",
+          "isRequired": true
         }
       ],
-      "packageArguments": [
+      "environmentVariables": [
         {
-          "type": "positional",
-          "value": "mcp"
+          "name": "IRONCLAW_CONTROLPLANE_URL",
+          "description": "Base URL of your running IronClaw control-plane, e.g. http://127.0.0.1:8787. This image is a thin client with no host privilege: it delegates every sandbox_exec run to the control-plane, which owns the hardened gVisor launch. Unset means no backend and the tool fails closed.",
+          "isRequired": true,
+          "format": "string",
+          "placeholder": "http://127.0.0.1:8787"
         },
         {
-          "type": "positional",
-          "value": "serve"
+          "name": "IRONCLAW_API_TOKEN",
+          "description": "Bearer token for the control-plane API (the value the control-plane was started with).",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true
         }
       ]
     }


### PR DESCRIPTION
## Why

Our only entry on `registry.modelcontextprotocol.io` is a **`deprecated`** record at `v0.1.230` (published 2026-07-07, ~170 releases stale) naming `ghcr.io/ironsecco/ironclaw-controlplane` launched with `-v /var/run/docker.sock:/var/run/docker.sock`. That is the host-root option A the CEO rejected under IRO-391; it was deprecated on purpose. Reproduce:

```
curl -s "https://registry.modelcontextprotocol.io/v0/servers/io.github.IronSecCo%2Fironclaw/versions" \
  | jq '.servers[]._meta'
```

IRO-414 shipped the replacement (`container/mcp.Dockerfile`, socket-free thin client) but **nothing ever built it**. `ghcr.io/ironsecco/ironclaw-mcp` did not exist in GHCR at all (`NAME_UNKNOWN`), so just flipping the kill-switch would have published a listing pointing at a missing image and failed the whole Image workflow closed. That gap is the bulk of this PR.

## Image pipeline

- New **`build-mcp`** job builds and pushes multi-arch `ironclaw-mcp` on the same release, from the same trust-gated commit, under the same immutable tag, with provenance + SBOM attestations matching the control-plane image.
- `container/mcp.Dockerfile` cross-compiles (`FROM --platform=$BUILDPLATFORM` + `$TARGETARCH`) and takes a `VERSION` build-arg. `ironctl` links no cgo, so one runner covers both arches: no QEMU, no per-arch digest merge.
- `verify-consumer` is now a matrix over **both** images. The registry's OCI validator pulls anonymously, so an unpullable MCP image is a listing that fails closed for every consumer.
- `build-mcp` asserts the `io.modelcontextprotocol.server.name` label matches `server.json` on **every** arch, next to the build that would break it rather than three jobs later inside `mcp-publisher`.

## Listing

- `server.json` points at `ghcr.io/ironsecco/ironclaw-mcp`; drops the socket mount, the `--entrypoint` override and the `mcp serve` positionals (the image entrypoint is already the MCP server); declares the thin-client contract `IRONCLAW_CONTROLPLANE_URL` + `IRONCLAW_API_TOKEN`, forwarded with bare `-e NAME` so no value lands in the listing.
- The ownership label **moved** from `controlplane.Dockerfile` to `mcp.Dockerfile`. Exactly one image carries it, so a publish cannot re-bind the listing to the socket-mount trust model.
- `publish-mcp-registry` runs on the release path again; the manual input survives only to force a re-publish from a dispatch.
- Post-check now queries `/v0/servers/{name}/versions` and asserts the new version is **`active`**. It previously matched `.servers[].name`, which is always `null` (the record nests under `.server`), and `?search=` is fuzzy. That mismatch is what false-failed this job through 0.1.216-0.1.230 while the publishes were actually succeeding.
- `mcp-registry-deprecate.yml` gains a caution: `status=active` is per-server and would reactivate the old host-socket versions. They stay `deprecated`.

## Security lenses

- **Isolation / trust boundary**: the listed artifact holds no host privilege. No `docker.sock`, no `runsc` in the image, no shell, uid 65532, static binary on distroless. Boxes run on the control-plane under gVisor. This narrows what we publish; it does not widen anything.
- **Egress least-privilege**: the MCP container's only outbound need is the control-plane API.
- **Supply chain**: MCP image gets the same provenance + SBOM attestations and the same anonymous-pull consumer gate as the control-plane image. `mcp-publisher` stays pinned by version + sha256 + `cosign verify-blob`. No new secret: namespace ownership is the repo's own Actions OIDC token.
- **Secret hygiene**: env values are forwarded from the user's environment, never embedded; `IRONCLAW_API_TOKEN` is marked `isSecret`.

## Verification

Built the image both ways and drove it:

| Check | Result |
|---|---|
| `linux/arm64` build (native) | label `io.github.IronSecCo/ironclaw`, uid 65532, entrypoint `[/ironctl mcp serve]` |
| `linux/amd64` build (cross-compiled, 40s, no QEMU) | same label, `arch=amd64` |
| `VERSION` build-arg | `ironctl version` -> `v0.1.399-test` |
| Exact `docker run` argv the listing produces | MCP handshake completes, `tools/list` -> `sandbox_exec`, stderr: `thin-client backend -> control-plane ... (this process holds no host privilege)` |
| `sandbox_exec` with unreachable control-plane | `isError: true`, no host fallback |
| `sandbox_exec` with no control-plane configured | `isError: true` (no docker in image), `containment: box never gained network or host access` |
| `server.json` vs registry schema 2025-12-11 | valid |
| `actionlint` on both workflows | clean |
| Multi-platform label template vs a real GHCR index | returns per-arch values as expected |

## After merge

The next release publishes a fresh `active` version automatically, and the post-check fails the release if it does not land `active`. No manual status flip, no account, nothing posted anywhere.

Closes IRO-612. Supersedes IRO-611 (same work, filed to Relay).