### PR TITLE
ci(docs): guard published front-matter, and fix three pages serving the fallback meta [IRO-617]

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,7 @@ on:
       - "mkdocs.yml"
       - "overrides/**"
       - "api/openapi.yaml"
+      - "scripts/check-docs-meta.py"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
@@ -22,6 +23,7 @@ on:
       - "mkdocs.yml"
       - "overrides/**"
       - "api/openapi.yaml"
+      - "scripts/check-docs-meta.py"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -57,6 +59,15 @@ jobs:
 
       - name: Build site (strict)
         run: mkdocs build --strict --site-dir _site
+
+      - name: Check published pages carry their own title and description
+        # `mkdocs build --strict` gates broken links and nav, but never looks at
+        # front-matter, so a page with no title/description builds green and
+        # ships the site-wide fallback as its SERP snippet. This asserts on the
+        # built HTML (the bytes Google reads), not on docs/**/*.md, so it needs
+        # no second copy of the `exclude_docs` patterns and also catches
+        # front-matter that is present but silently unparseable. See IRO-617.
+        run: python3 scripts/check-docs-meta.py _site
 
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'

--- a/docs/scores/collections/index.md
+++ b/docs/scores/collections/index.md
@@ -1,6 +1,6 @@
 ---
-title: Container isolation scores by category
-description: Ranked container isolation scores by category: databases, language runtimes, web servers, CI/CD, observability, and more. Graded 0-100 by ironctl scan.
+title: "Container isolation scores by category"
+description: "Ranked container isolation scores by category: databases, language runtimes, web servers, CI/CD, observability, and more. Graded 0-100 by ironctl scan."
 ---
 
 # Container isolation scores by category

--- a/examples/isolation-survey/gen_scorecards.py
+++ b/examples/isolation-survey/gen_scorecards.py
@@ -1076,10 +1076,14 @@ def render_collections_index(groups) -> str:
     all_imgs = sum(len(m) for _c, m in groups)
     L = []
     L.append("---")
-    L.append("title: Container isolation scores by category")
-    L.append("description: Ranked container isolation scores by category: databases, "
+    # Both values are quoted because the description contains a ": ", which YAML
+    # reads as a nested mapping in an unquoted scalar. MkDocs swallows that parse
+    # error and drops the whole front-matter block, so the page silently served
+    # the site_description fallback as its SERP snippet (IRO-617).
+    L.append('title: "Container isolation scores by category"')
+    L.append('description: "Ranked container isolation scores by category: databases, '
              "language runtimes, web servers, CI/CD, observability, and more. Graded "
-             "0-100 by ironctl scan.")
+             '0-100 by ironctl scan."')
     L.append("---")
     L.append("")
     L.append("# Container isolation scores by category")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,11 +10,20 @@ docs_dir: docs
 
 # The Mintlify scaffold (docs/site/**, docs/docs.json) is a separate hosted-docs
 # experiment; it is not part of this MkDocs build.
+#
+# assets/live-containment-social/ holds the ffmpeg render script, storyboard and
+# cut media for the IRO-370 social clip. Those are internal production notes, not
+# documentation: thin, carrying an internal issue key in the heading, and not a
+# page anyone should land on from search. Excluding the directory also keeps
+# ~5.5 MB of .mp4/.gif out of the published site; nothing under docs/ links to
+# them, and the repo-relative link from examples/live-containment/README.md
+# still resolves on GitHub.
 exclude_docs: |
   site/
   docs.json
   reference/openapi.yaml
   launch/
+  assets/live-containment-social/
 
 # docs/hooks.py copies api/openapi.yaml into the build and stamps the version.
 hooks:

--- a/scripts/check-docs-meta.py
+++ b/scripts/check-docs-meta.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Fail the docs build when a published page serves the site-wide fallback meta.
+
+MkDocs' ``--strict`` catches broken links and bad nav references. It does not
+look at front-matter, so a page that declares no ``title:`` / ``description:``
+builds green forever and quietly ships the ``site_name`` / ``site_description``
+fallback from ``mkdocs.yml`` as its SERP snippet. That is what IRO-610 found by
+hand and IRO-617 found again on two more live pages.
+
+This checks the *built* site rather than globbing ``docs/**/*.md``, on purpose:
+
+* it tests exactly the set of pages that actually ship, so it needs no second
+  copy of the ``exclude_docs`` patterns in ``mkdocs.yml`` to drift out of sync;
+* it asserts on the served bytes Google reads, not on the presence of a YAML
+  key, so it stays correct if the source of a page's meta ever changes.
+
+Usage:
+
+    python3 scripts/check-docs-meta.py _site
+
+Exits 0 when every published page carries its own title and description,
+1 when any page falls back, and 2 on a usage/parse error.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MKDOCS_YML = REPO_ROOT / "mkdocs.yml"
+
+# Pages that are allowed to serve the fallback meta, relative to the site root.
+# 404.html is served with an HTTP 404 status and is never in the sitemap, so it
+# has no SERP snippet to get wrong and no page-level front-matter to read.
+EXEMPT = frozenset({"404.html"})
+
+TITLE_RE = re.compile(r"<title>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+DESCRIPTION_RE = re.compile(
+    r"""<meta\s+name=["']description["']\s+content=["'](.*?)["']\s*/?>""",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+class _TolerantLoader(yaml.SafeLoader):
+    """SafeLoader that ignores MkDocs' ``!!python/name:`` extension tags.
+
+    ``mkdocs.yml`` wires pymdownx/material extensions with ``!!python/name:``
+    tags, which ``yaml.safe_load`` refuses. We only read three scalar keys, so
+    resolving those tags to ``None`` is enough and keeps us off ``unsafe_load``.
+    """
+
+
+_TolerantLoader.add_multi_constructor("", lambda loader, suffix, node: None)
+
+
+def load_site_config() -> tuple[str, str, str]:
+    """Return ``(site_name, site_description, site_url)`` from ``mkdocs.yml``."""
+    with MKDOCS_YML.open(encoding="utf-8") as handle:
+        config = yaml.load(handle, Loader=_TolerantLoader)
+    return (
+        config.get("site_name", ""),
+        config.get("site_description", ""),
+        config.get("site_url", ""),
+    )
+
+
+def published_url(site_url: str, relative: Path) -> str:
+    """Map a built HTML path to the URL it publishes at."""
+    parts = relative.as_posix()
+    if parts.endswith("/index.html"):
+        parts = parts[: -len("index.html")]
+    elif parts == "index.html":
+        parts = ""
+    return f"{site_url.rstrip('/')}/{parts}"
+
+
+def source_markdown(relative: Path) -> str:
+    """Best-effort map from a built HTML path back to its source Markdown.
+
+    MkDocs flattens ``a/b.md``, ``a/b/index.md`` and ``a/b/README.md`` to the
+    same ``a/b/index.html``, so probe all three rather than guessing one.
+    """
+    stem = relative.as_posix().removesuffix("/index.html").removesuffix(".html")
+    if not stem or stem == "index":
+        return "docs/index.md"
+    for candidate in (f"docs/{stem}.md", f"docs/{stem}/index.md", f"docs/{stem}/README.md"):
+        if (REPO_ROOT / candidate).is_file():
+            return candidate
+    return f"docs/{stem}.md (source not found)"
+
+
+def extract(pattern: re.Pattern[str], markup: str) -> str | None:
+    match = pattern.search(markup)
+    return html.unescape(match.group(1)).strip() if match else None
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {Path(argv[0]).name} <site-dir>", file=sys.stderr)
+        return 2
+
+    site_dir = Path(argv[1])
+    if not site_dir.is_dir():
+        print(f"error: {site_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    site_name, site_description, site_url = load_site_config()
+    if not site_name or not site_description:
+        print("error: mkdocs.yml is missing site_name or site_description", file=sys.stderr)
+        return 2
+
+    pages = sorted(site_dir.rglob("*.html"))
+    failures: list[str] = []
+
+    for page in pages:
+        relative = page.relative_to(site_dir)
+        if relative.as_posix() in EXEMPT:
+            continue
+
+        markup = page.read_text(encoding="utf-8", errors="replace")
+        title = extract(TITLE_RE, markup)
+        description = extract(DESCRIPTION_RE, markup)
+
+        reasons = []
+        if description is None:
+            reasons.append("no <meta name=\"description\">")
+        elif description == site_description:
+            reasons.append("description is the site_description fallback")
+        if title is None:
+            reasons.append("no <title>")
+        elif title == site_name:
+            reasons.append("title is just the site_name")
+
+        if reasons:
+            failures.append(
+                f"  {relative.as_posix()}\n"
+                f"    publishes at: {published_url(site_url, relative)}\n"
+                f"    source:       {source_markdown(relative)}\n"
+                f"    problem:      {'; '.join(reasons)}"
+            )
+
+    if failures:
+        print(
+            f"Docs front-matter check FAILED: {len(failures)} of {len(pages)} built "
+            f"page(s) serve the site-wide fallback meta.\n",
+            file=sys.stderr,
+        )
+        print("\n".join(failures), file=sys.stderr)
+        print(
+            "\nEvery published page needs its own front-matter, so search engines get a\n"
+            "page-specific snippet instead of the site-wide fallback:\n\n"
+            "  ---\n"
+            '  title: A specific page title\n'
+            '  description: One sentence, under 160 characters, describing this page.\n'
+            "  ---\n\n"
+            "If the page is an internal note rather than documentation, add it to\n"
+            "`exclude_docs:` in mkdocs.yml instead so it stops being published at all.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Docs front-matter check passed: {len(pages)} built page(s), no fallback meta.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Closes IRO-617. Follow-on from IRO-610 / IRO-615.

## Part 1: the two asset pages, resolved by exclusion (plus a third page the audit missed)

Took the recommended resolution for `docs/assets/live-containment-social/`: `exclude_docs`, same treatment as `docs/launch/`. They are ffmpeg render notes and a storyboard for the IRO-370 social cut, so front-matter would be dressing up a page that should not be in the index at all. Nothing under `docs/` links to them, the repo-relative link from `examples/live-containment/README.md` still resolves on GitHub, and excluding the directory also drops ~5.5 MB of `.mp4`/`.gif` from the published site.

**The guard then found a third live page the `docs/**/*.md` audit could not have found.** `scores/collections/` *does* declare `title` and `description`:

```yaml
description: Ranked container isolation scores by category: databases, language runtimes, ...
```

That `": "` makes it an unquoted scalar YAML reads as a nested mapping:

```
yaml.scanner.ScannerError: mapping values are not allowed here
```

MkDocs swallows the error and drops the **whole** front-matter block, so the page served the fallback description and took its `<title>` from the nav label (`Scores by category - IronClaw`), not from the `title:` sitting right there in the file. This is precisely the case the issue predicted: a key-presence check over the Markdown would have passed this page.

The page is regenerated weekly by `render_collections_index()`, so the fix is in `examples/isolation-survey/gen_scorecards.py` (quote both values, matching the other four front-matter emitters, which were checked and are fine). The checked-in page is updated to match what the generator now emits, so the next cron refresh is a no-op rather than a revert.

## Part 2: the guard

`scripts/check-docs-meta.py`, run after `mkdocs build --strict --site-dir _site` in the existing `build` job, checking the served HTML as suggested. Fails if any built page's `<meta name="description">` equals the `site_description` fallback, or its `<title>` is only the site name, or either is missing.

`404.html` is the one exemption: served with an HTTP 404, never in the sitemap, no page-level front-matter to read.

Failure output names the built path, the URL it publishes at, the source Markdown, and the fix:

```
Docs front-matter check FAILED: 3 of 433 built page(s) serve the site-wide fallback meta.

  assets/live-containment-social/index.html
    publishes at: https://ironsecco.github.io/ironclaw/assets/live-containment-social/
    source:       docs/assets/live-containment-social/README.md
    problem:      description is the site_description fallback
```

No new dependency: the build job already has Python 3.12, and `pyyaml` comes in with mkdocs. `mkdocs.yml` is parsed with a `SafeLoader` subclass that resolves the `!!python/name:` extension tags to `None`, so reading the config never means `unsafe_load`.

## Verification

- Guard exits **1** against a build of the pre-fix tree, reporting all three pages (plus `scan/` and `scan-action/`, which IRO-610 had already fixed on a base my first build predated, so it reproduced that finding independently too)
- Guard exits **0** after the fixes: 431 built pages, no fallback meta
- `mkdocs build --strict` clean; the two "not included in the nav configuration" INFO lines for the asset pages are gone
- `_site/assets/live-containment-social/` absent from the build; `sitemap.xml` mentions of it go 2 -> 0
- `scores/collections/index.html` now serves its real description
- `actionlint .github/workflows/docs.yml` clean

## Lenses

- **Fail loud, fail closed** — the step runs *before* the Pages artifact upload, so a failure blocks the deploy instead of publishing a page with no snippet.
- **Least-privilege CI** — no permission change; the job keeps `contents: read`.
- **Reproducibility** — no new dependency, no network, no unpinned action; the check reads only the build output and the tracked `mkdocs.yml`.

## Note for Growth

You offered replacement copy if I kept the asset pages served. I excluded them instead, so no copy needed. The `scores/collections/` description is your existing copy, only quoted, so the snippet is unchanged from what was intended.