### PR TITLE
ci(release): stop a flaky Homebrew formula job from suppressing the image publish [IRO-621]

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -56,10 +56,18 @@ jobs:
   # failure.
   prepare:
     runs-on: ubuntu-latest
-    # On the workflow_run path, only build when the Release actually succeeded.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    # On the workflow_run path, admit a Release run that either SUCCEEDED or FAILED, and
+    # decide per-JOB below whether the failure actually concerns the image. Keying off the
+    # aggregate `conclusion == 'success'` made every job in Release a hard gate on the
+    # whole publish chain — so a flaky `formula` step (a cosmetic Homebrew bump that runs
+    # long after the release is cut and verified) silently skipped the control-plane
+    # image, `ironclaw-mcp`, their provenance/SBOM attestations, and the MCP Registry
+    # publish, with no red anywhere obvious (IRO-621). Cancelled/skipped Release runs are
+    # still refused here — only a real success or a real failure gets to the job gate.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
     permissions:
       contents: read # read-only API lookups + trust-gate; no push/sign here
+      actions: read # read the upstream Release run's per-job conclusions (gate below)
     outputs:
       present: ${{ steps.meta.outputs.present }}
       image: ${{ steps.meta.outputs.image }}
@@ -70,6 +78,71 @@ jobs:
       mcp_image: ${{ steps.meta.outputs.mcp_image }}
       mcp_tags: ${{ steps.meta.outputs.mcp_tags }}
     steps:
+      # Blast-radius gate (IRO-621). The Release run FAILED — work out whether anything
+      # the image chain actually depends on is what failed.
+      #
+      # Fail-closed by default: every Release job is treated as blocking unless it is
+      # named in ADVISORY below. Advisory jobs are post-release bookkeeping that runs
+      # AFTER the release is published, smoke-tested and signed, and whose output the
+      # image does not consume:
+      #
+      #   formula — regenerates Formula/ironclaw.rb from the already-published, already-
+      #             signed SHA256SUMS and opens the rolling `brew/track` PR. Cosmetic
+      #             packaging metadata. It still fails LOUD in Release (it is not
+      #             continue-on-error, and its manual runbook still lands in the job
+      #             summary); it simply no longer suppresses a security-critical publish.
+      #
+      # Everything else — version, build, release, containment-report, smoke,
+      # smoke_windows — stays blocking: those either produce the artifacts the image is
+      # built alongside or are the yank signals for a bad release, and publishing an
+      # image from a release that failed them would be publishing a green lie.
+      #
+      # Matrix jobs report as "smoke (ubuntu-latest, ...)", so match on the base name
+      # before the " (" suffix. A job that is queued/in-progress reports conclusion null;
+      # the run is `completed` by the time this fires, so null only shows up for jobs that
+      # never ran, which is not a failure.
+      - name: Gate on the Release jobs the image actually depends on
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success' }}
+        env:
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ADVISORY="formula"
+
+          jobs_tsv="$(gh api --paginate "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+            --jq '.jobs[] | [(.name | split(" (")[0]), (.conclusion | tostring)] | @tsv')"
+
+          if [ -z "${jobs_tsv}" ]; then
+            echo "::error::Could not read the job list for Release run ${RUN_ID} (${RUN_URL}) — refusing to publish an image off an unverified run." >&2
+            exit 1
+          fi
+
+          blocking=""
+          while IFS="$(printf '\t')" read -r jname jconc; do
+            [ -n "${jname}" ] || continue
+            case "${jconc}" in
+              success | skipped | neutral | null) continue ;;
+            esac
+            case " ${ADVISORY} " in
+              *" ${jname} "*)
+                echo "::warning title=Advisory Release job failed::'${jname}' concluded '${jconc}' in the upstream Release run, but it is post-release bookkeeping the image does not depend on — continuing with the image publish (IRO-621). Fix it on its own ticket: ${RUN_URL}"
+                continue
+                ;;
+            esac
+            blocking="${blocking}${blocking:+, }${jname}=${jconc}"
+          done <<EOF
+          ${jobs_tsv}
+          EOF
+
+          if [ -n "${blocking}" ]; then
+            echo "::error title=Release failed a job the image depends on::Refusing to publish: ${blocking}. See ${RUN_URL}." >&2
+            exit 1
+          fi
+          echo "Release run ${RUN_ID} failed only advisory jobs — the image chain is unaffected, proceeding."
+
       # SECURITY (Dangerous-Workflow / "pwn request"): this workflow runs in a
       # privileged context (the build/merge jobs hold packages + attestations write),
       # so it must NEVER `actions/checkout` the event-supplied head_sha — that is the

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -98,9 +98,17 @@ jobs:
       # image from a release that failed them would be publishing a green lie.
       #
       # Matrix jobs report as "smoke (ubuntu-latest, ...)", so match on the base name
-      # before the " (" suffix. A job that is queued/in-progress reports conclusion null;
-      # the run is `completed` by the time this fires, so null only shows up for jobs that
-      # never ran, which is not a failure.
+      # before the " (" suffix.
+      #
+      # Read `status` alongside `conclusion` and treat anything that is not
+      # `status=completed` as blocking (IRO-626). A queued/in-progress job reports
+      # `conclusion: null`, and a null must never be read as a pass: this step only runs
+      # for a `completed` Release run, so a job that is still not completed means the
+      # jobs API is lagging the workflow_run event rather than that the job was fine.
+      # Passing on null would be fail-OPEN in exactly the eventual-consistency window
+      # this gate exists to survive — an image published off a release whose `smoke` we
+      # never actually observed pass. Jobs that legitimately never ran come back
+      # `status=completed, conclusion=skipped`, which still passes.
       - name: Gate on the Release jobs the image actually depends on
         if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success' }}
         env:
@@ -113,7 +121,7 @@ jobs:
           ADVISORY="formula"
 
           jobs_tsv="$(gh api --paginate "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
-            --jq '.jobs[] | [(.name | split(" (")[0]), (.conclusion | tostring)] | @tsv')"
+            --jq '.jobs[] | [(.name | split(" (")[0]), (.status | tostring), (.conclusion | tostring)] | @tsv')"
 
           if [ -z "${jobs_tsv}" ]; then
             echo "::error::Could not read the job list for Release run ${RUN_ID} (${RUN_URL}) — refusing to publish an image off an unverified run." >&2
@@ -121,16 +129,29 @@ jobs:
           fi
 
           blocking=""
-          while IFS="$(printf '\t')" read -r jname jconc; do
+          while IFS="$(printf '\t')" read -r jname jstatus jconc; do
             [ -n "${jname}" ] || continue
-            case "${jconc}" in
-              success | skipped | neutral | null) continue ;;
-            esac
+
+            # Advisory jobs are exempt outright — the image consumes nothing they produce,
+            # so neither their conclusion nor their status can veto the publish.
             case " ${ADVISORY} " in
               *" ${jname} "*)
-                echo "::warning title=Advisory Release job failed::'${jname}' concluded '${jconc}' in the upstream Release run, but it is post-release bookkeeping the image does not depend on — continuing with the image publish (IRO-621). Fix it on its own ticket: ${RUN_URL}"
+                case "${jstatus}:${jconc}" in
+                  completed:success | completed:skipped | completed:neutral) ;;
+                  *)
+                    echo "::warning title=Advisory Release job did not pass::'${jname}' ended ${jstatus}/${jconc} in the upstream Release run, but it is post-release bookkeeping the image does not depend on — continuing with the image publish (IRO-621). Fix it on its own ticket: ${RUN_URL}"
+                    ;;
+                esac
                 continue
                 ;;
+            esac
+
+            if [ "${jstatus}" != "completed" ]; then
+              blocking="${blocking}${blocking:+, }${jname}=${jstatus}/not-completed"
+              continue
+            fi
+            case "${jconc}" in
+              success | skipped | neutral) continue ;;
             esac
             blocking="${blocking}${blocking:+, }${jname}=${jconc}"
           done <<EOF
@@ -138,7 +159,7 @@ jobs:
           EOF
 
           if [ -n "${blocking}" ]; then
-            echo "::error title=Release failed a job the image depends on::Refusing to publish: ${blocking}. See ${RUN_URL}." >&2
+            echo "::error title=A Release job the image depends on did not pass::Refusing to publish: ${blocking}. See ${RUN_URL}." >&2
             exit 1
           fi
           echo "Release run ${RUN_ID} failed only advisory jobs — the image chain is unaffected, proceeding."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -875,24 +875,51 @@ jobs:
             fi
           fi
 
-          # Guardrail (IRO-482): assert the rolling PR is actually MERGEABLE after
-          # the branch reset + formula commit. If a race still causes a conflict the
-          # job fails LOUD here with the manual runbook instead of silently leaving a
-          # CONFLICTING PR for the next operator to discover.
-          # Poll up to ~30 s — GitHub computes mergeability asynchronously.
+          # Guardrail (IRO-482, fixed by IRO-621): assert the rolling PR is actually
+          # MERGEABLE after the branch reset + formula commit. A REAL conflict still fails
+          # LOUD here with the manual runbook instead of silently leaving a CONFLICTING PR
+          # for the next operator to discover.
+          #
+          # GitHub computes `mergeable` asynchronously and answers JSON `null` until its
+          # background merge job finishes. `gh api --jq` renders a null field as an EMPTY
+          # STRING, never the literal text "null" — so the original loop's break condition
+          # (`!= "null" && != "UNKNOWN"`) was satisfied by "" on the very first read. It
+          # never slept, never retried, and then failed the release on `"" != "true"`,
+          # turning the exact transient race it was written to absorb into a hard release
+          # failure (IRO-621; PR #562 read `MERGEABLE` minutes later). Piping through
+          # `tostring` forces the null across as the literal string "null" so the poll can
+          # see "not computed yet" and keep waiting.
+          #
+          # Verdict policy: only a genuine conflict is fatal. `mergeable=false` with
+          # `mergeable_state=dirty` is a real CONFLICTING branch → fail loud. Anything
+          # indeterminate after the full poll — still-null mergeability, or a false/blocked
+          # state that just means "checks have not passed yet" — warns and continues: the
+          # release is published, smoke-tested and signed by this point, and "GitHub has
+          # not finished thinking" must never red a release over a cosmetic brew bump.
           pr_num="$(gh pr list --repo "${REPO}" --head "${branch}" --state open \
             --json number -q '.[0].number' 2>/dev/null || true)"
           if [ -n "${pr_num:-}" ]; then
-            mergeable="UNKNOWN"
-            for _i in 1 2 3 4 5 6; do
-              mergeable="$(gh api "repos/${REPO}/pulls/${pr_num}" --jq .mergeable 2>/dev/null || echo "UNKNOWN")"
-              [ "${mergeable}" != "null" ] && [ "${mergeable}" != "UNKNOWN" ] && break
+            mergeable="null"
+            merge_state="unknown"
+            # Poll up to ~50 s (10 x 5 s), sleeping BEFORE the retry, not after the break.
+            for _i in 1 2 3 4 5 6 7 8 9 10; do
+              pr_json="$(gh api "repos/${REPO}/pulls/${pr_num}" 2>/dev/null || printf '{}')"
+              mergeable="$(printf '%s' "${pr_json}" | jq -r '.mergeable | tostring' 2>/dev/null || printf 'null')"
+              merge_state="$(printf '%s' "${pr_json}" | jq -r '.mergeable_state // "unknown"' 2>/dev/null || printf 'unknown')"
+              case "${mergeable}" in
+                true | false) break ;;
+              esac
+              echo "PR #${pr_num}: mergeability not computed yet (mergeable=${mergeable}, state=${merge_state}) — retrying in 5s"
               sleep 5
             done
-            if [ "${mergeable}" != "true" ]; then
-              emit_manual_fallback "brew/track PR #${pr_num} is not MERGEABLE after reset (mergeable=${mergeable}). Force-reset brew/track to live main and re-run, or merge manually."
+
+            if [ "${mergeable}" = "true" ]; then
+              echo "brew/track PR #${pr_num} is MERGEABLE — conflict-free."
+            elif [ "${mergeable}" = "false" ] && [ "${merge_state}" = "dirty" ]; then
+              emit_manual_fallback "brew/track PR #${pr_num} is CONFLICTING against main (mergeable=false, mergeable_state=dirty). Force-reset brew/track to live main and re-run, or merge manually."
+            else
+              echo "::warning title=brew/track mergeability indeterminate::PR #${pr_num} reported mergeable=${mergeable} (state=${merge_state}) after ~50s of polling — GitHub had not finished computing mergeability, or the PR is merely waiting on checks. That is not a conflict, so the release continues; confirm the PR is clean before merging it."
             fi
-            echo "brew/track PR #${pr_num} is MERGEABLE — conflict-free."
           fi
 
           # Housekeeping: close any legacy per-tag bump PRs the pre-IRO-270 flow left

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -178,6 +178,13 @@ job fails, the Image run now fails **loud** with the offending job names rather 
 silently. To make another job advisory, add it to `ADVISORY` in that step — and justify it,
 because the default is "blocking".
 
+A blocking job passes the gate only when the jobs API reports it `status=completed` **and**
+`conclusion` in `success` / `skipped` / `neutral`. A job that is still `queued`/`in_progress`
+reports `conclusion: null`, and a null is read as a **block**, not a pass (IRO-626): this gate
+only runs for a Release run GitHub already called `completed`, so a not-completed job means the
+jobs API is lagging the event, and publishing on it would be publishing off a release whose
+`smoke` we never actually watched pass.
+
 ### 3.6 Bump the Homebrew formula (after a release you want `brew install` to track)
 
 `brew install ironsecco/ironclaw/ironclaw` is served by `Formula/ironclaw.rb` in this repo, tapped

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -32,7 +32,7 @@ GitHub Actions workflows are involved:
 |----------|------|---------|----------|
 | **CI** | `ci.yml` | every push + PR | `build` / `vet` / `test` with `CGO_ENABLED=1` (gating check) |
 | **Release** | `release.yml` | push to `main`, or `workflow_dispatch` | tag, GitHub Release, archives, `SHA256SUMS`, SBOMs, cosign signature, attestations |
-| **Image** | `image.yml` | `workflow_run` after Release succeeds, or `workflow_dispatch` | GHCR control-plane image (`ghcr.io/<owner>/ironclaw-controlplane`) + image attestation |
+| **Image** | `image.yml` | `workflow_run` after Release completes (every blocking Release job green — see [3.5](#what-a-failing-release-job-does-to-the-image-chain)), or `workflow_dispatch` | GHCR control-plane image (`ghcr.io/<owner>/ironclaw-controlplane`) + image attestation |
 
 The **Release** workflow runs as a chain of jobs, each gated on the previous:
 
@@ -151,9 +151,32 @@ A `smoke` job installs the freshly-cut release through the real, checksum-verify
 `scripts/install.sh` (the normal user path, **not** `--dev`) on `linux/amd64`, `linux/arm64`,
 `darwin/arm64`, and `darwin/amd64`, asserts the installer printed `Checksum OK`, and asserts
 `ironctl version` reports the exact tag. It is **fail-closed**: a failure turns the whole
-Release run red, which also blocks the Image workflow (it chains on Release `success`). A red
-smoke run on an already-published release is the signal to **yank** (the assets are out by
-that point). This gate lands with IRO-15.
+Release run red, which also blocks the Image workflow (`smoke` is a *blocking* job for the
+image chain — see below). A red smoke run on an already-published release is the signal to
+**yank** (the assets are out by that point). This gate lands with IRO-15.
+
+#### What a failing Release job does to the Image chain
+
+The Image workflow used to chain on the Release run's **aggregate** `conclusion == 'success'`,
+which made every Release job a hard gate on the whole publish chain. A flaky `formula` job — a
+cosmetic Homebrew bump that runs long after the release is cut, smoke-tested and signed — was
+therefore able to silently suppress the control-plane image, `ironclaw-mcp`, their SBOM and
+provenance attestations, and the MCP Registry publish, with no red anywhere obvious (IRO-621).
+
+`image.yml`'s `prepare` job now inspects the upstream Release run **per job** and is
+fail-closed by default — every job blocks the image unless it is explicitly advisory:
+
+| Release job | Blocks the image? |
+| --- | --- |
+| `version`, `build`, `release` | **Yes** — these produce the released artifacts |
+| `containment-report`, `smoke`, `smoke_windows` | **Yes** — these are the yank signals for a bad release |
+| `formula` | No — post-release packaging metadata the image does not consume |
+
+A failing `formula` job still turns the Release run red and still writes its manual runbook to
+the job summary; it simply no longer suppresses a security-critical publish. If a *blocking*
+job fails, the Image run now fails **loud** with the offending job names rather than skipping
+silently. To make another job advisory, add it to `ADVISORY` in that step — and justify it,
+because the default is "blocking".
 
 ### 3.6 Bump the Homebrew formula (after a release you want `brew install` to track)
 


### PR DESCRIPTION
Fixes the release-blocker in IRO-621: a cosmetic Homebrew `formula` bump could silently skip the entire Image/MCP publish chain.

## 1. Blast radius (the part that matters)

`image.yml`'s `prepare` gated on the Release run's **aggregate** `workflow_run.conclusion == 'success'`, so every Release job was a hard gate on the whole publish chain — image, `ironclaw-mcp`, SBOM/provenance attestations, and `publish-mcp-registry`.

It now admits a completed run that succeeded **or** failed and gates **per job**, fail-closed by default:

| Release job | Blocks the image? |
| --- | --- |
| `version`, `build`, `release` | **Yes** — produce the released artifacts |
| `containment-report`, `smoke`, `smoke_windows` | **Yes** — the yank signals for a bad release |
| `formula` | No — post-release packaging metadata the image does not consume |

`formula` still fails the Release run red and still emits its manual runbook — it is **not** `continue-on-error`. A *blocking* failure now fails the Image run **loud** with the offending job names instead of skipping silently. Cancelled/skipped Release runs are still refused.

## 2. The race

The IRO-482 guardrail never polled. GitHub answers `mergeable: null` until its background merge job finishes, and **`gh api --jq` renders a null field as an empty string, never the literal `null`** — so `[ "$m" != "null" ] && [ "$m" != "UNKNOWN" ] && break` fired on the first read. It never slept, never retried, then failed on `"" != "true"`. The guardrail failed on exactly the transient condition it was written to absorb.

`--jq '.mergeable | tostring'` forces the null across as the string `null` so the poll can see "not computed yet". Verdict policy narrowed to intent:

- `mergeable=false` + `mergeable_state=dirty` → real **CONFLICTING** branch, still fails loud with the manual runbook
- indeterminate after the full ~50 s poll → warns and continues

The guardrail is not deleted or weakened; a real conflict is still fatal.

## 3. Audit for the same bug elsewhere

Swept every `gh --jq` / `-q` extraction in `.github/workflows` and `scripts/`. `.mergeable` was the **only** site comparing a possibly-null field against sentinels with a *negative* assertion, where empty passes the guard. The `.[0].number` sites treat empty as "no PR" (intended); `reviewer-approve`'s `.permission` / `.state` are positive assertions that deny on empty (fail-closed); the rest read fields that are never null under `set -e`.

## Verification (no release re-cut)

- `actionlint` (incl. shellcheck) clean on both workflows.
- **Replay against the live API for the two real runs from the issue:** the gate step run against Release runs `30400168730` and `30403580627` — both `formula`-only failures — exits **0** on both, i.e. the image would have published. It refuses a fixture where `smoke (macos-14, darwin/arm64)` fails, and fails closed on an unreadable job list.
- Poll exercised across null-forever (warns, continues, 10 attempts), null-then-true (keeps polling, then passes), false+dirty (fails loud), false+blocked (warns, continues).
- `gh api --jq` confirmed against a real null field to emit a zero-length string.

## Reviewer notes

- Touches release **gating**, so per my operating contract this is for CEO review, not self-merge.
- Only scope change: `actions: read` added to `image.yml`'s `prepare` — the minimum needed to read the upstream run's per-job conclusions. No other `permissions:` block changed.
- **Does not** touch `.github/rulesets` or any enforced required check.
- The one thing I could not reproduce safely is a live release where `formula` genuinely fails; the API replay above is the closest honest evidence. The next real release exercises the new path end to end.