### PR TITLE
fix(release): stop the brew formula guard failing on not-yet-computed mergeability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -883,14 +883,22 @@ jobs:
           pr_num="$(gh pr list --repo "${REPO}" --head "${branch}" --state open \
             --json number -q '.[0].number' 2>/dev/null || true)"
           if [ -n "${pr_num:-}" ]; then
-            mergeable="UNKNOWN"
+            # Break only on a DEFINITIVE boolean. `gh api --jq .mergeable` renders the
+            # JSON null GitHub returns while it is still computing mergeability as an
+            # EMPTY STRING — NOT the literal "null" that plain `jq -r` prints. Matching
+            # on "null" therefore never recognised the still-computing case: the loop
+            # broke on the first poll and the job hard-failed with `mergeable=` on a PR
+            # that was merely not-yet-computed (v0.1.403, 2026-07-28, which skipped the
+            # chained Image publish). Enumerating the definitive answers instead of the
+            # in-flight sentinels keeps this correct whatever null renders as.
+            mergeable=""
             for _i in 1 2 3 4 5 6; do
               mergeable="$(gh api "repos/${REPO}/pulls/${pr_num}" --jq .mergeable 2>/dev/null || echo "UNKNOWN")"
-              [ "${mergeable}" != "null" ] && [ "${mergeable}" != "UNKNOWN" ] && break
+              case "${mergeable}" in true | false) break ;; esac
               sleep 5
             done
             if [ "${mergeable}" != "true" ]; then
-              emit_manual_fallback "brew/track PR #${pr_num} is not MERGEABLE after reset (mergeable=${mergeable}). Force-reset brew/track to live main and re-run, or merge manually."
+              emit_manual_fallback "brew/track PR #${pr_num} is not MERGEABLE after reset (mergeable=${mergeable:-<still computing after ~30s>}). Force-reset brew/track to live main and re-run, or merge manually."
             fi
             echo "brew/track PR #${pr_num} is MERGEABLE — conflict-free."
           fi


### PR DESCRIPTION
## What broke

The `formula` job failed on the `v0.1.403` release, which took the whole `Release` run to
`conclusion: failure` even though **every load-bearing job was green** — the full CGO build
matrix, archives, `SHA256SUMS`, cosign signature, SBOMs, attestations and all five smokes.

`image.yml` chains off `workflow_run.conclusion == 'success'`, so the container publish was
**skipped**. That included the first-ever push of `ghcr.io/ironsecco/ironclaw-mcp`, which is
the image the MCP Registry listing points at (IRO-611 / IRO-612 / IRO-618).

## Root cause

`gh api --jq .mergeable` renders the JSON `null` GitHub returns while it is still computing
mergeability as an **empty string** — not the literal `null` that plain `jq -r` prints:

```
$ gh api repos/IronSecCo/ironclaw --jq .parent   # a genuinely null field
[] len=0
$ gh api repos/IronSecCo/ironclaw | jq -r .parent
[null] len=4
```

The poll loop broke on `!= "null" && != "UNKNOWN"`, so an empty value read as a *definitive*
answer. The loop exited on the first poll — the intended ~30s wait never happened — and the
job failed with a bare `mergeable=`. PR #562 read `mergeable=true` minutes later, confirming
async latency rather than a conflict.

This is the same bug class as the `curl -f` issue fixed in `verify-consumer` on #583: a guard
whose retry sentinel does not match the value the tool actually produces.

## Fix

Break on a **definitive boolean** rather than enumerating the in-flight sentinels, so the guard
stays correct whatever `null` renders as.

## Verification

`actionlint` (which shellchecks `run:` blocks) passes. Old vs new logic against each rendering:

| successive `gh --jq` renderings | OLD | NEW |
|---|---|---|
| empty, then `true`  *(the v0.1.403 failure)* | **FAIL** `mergeable=[]` after 1 poll | PASS after 2 polls |
| empty, empty, then `true` | **FAIL** `mergeable=[]` after 1 poll | PASS after 3 polls |
| `true` immediately | PASS | PASS |
| `false` immediately *(real conflict)* | FAIL | FAIL |
| empty, then `false` *(real conflict)* | FAIL `mergeable=[]` | FAIL `mergeable=[false]` |
| literal `null`, then `true` | PASS | PASS |
| `UNKNOWN` (API error), then `true` | PASS | PASS |

The guard is **not** relaxed: a genuine conflict still fails closed, and now reports the real
reason `false` instead of an empty value.

## Lens

**Fail loud, fail closed** — restores the intended behaviour: fail on a real conflict, wait on an
undetermined one. Touches no signing, attestation, token scope, or installer verification path.

## Follow-ups (filed separately, not in this PR)

- A cosmetic Homebrew bump failure should arguably not gate the signed container publish at all.
  That is a blast-radius design change to the release chain and wants CEO review on its own ticket.
- `ironclaw-mcp:v0.1.403` was published by a manual dispatch built from `9ac92b64` (the v0.1.404
  commit), so that tag does not carry v0.1.403's source. Raised separately.
