### PR TITLE
docs(mcp): make the visibility re-check actually work when the package is private [IRO-624]

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -537,7 +537,8 @@ jobs:
           done
           if [ -z "${token}" ]; then
             pkg="${repo##*/}"
-            echo "::error::Anonymous GHCR pull token for ${repo} was denied (HTTP ${tok_code}): the package is private, or has never been pushed. GITHUB_TOKEN cannot change container-package visibility (there is no REST endpoint for it, it is a UI action). Org-admin fix: IronSecCo -> Packages -> ${pkg} -> Package settings -> Change visibility -> Public, then re-run this workflow. Runbook: runbooks/mcp-registry.md, section 'Package visibility'. Failing the release." >&2
+            owner="${repo%%/*}"
+            echo "::error::Anonymous GHCR pull token for ${repo} was denied (HTTP ${tok_code}) after 5 attempts. This is NOT an expected gate — both packages are public today and this job passes for both, so treat it as a real failure. GHCR returns the same denial for a PRIVATE package and for one that was NEVER PUSHED, so settle which it is first: 'gh api /orgs/${owner}/packages/container/${pkg}' answers 404 when the package does not exist, and 200/403 when it does. If it exists, it is private, and an org admin must flip it: ${owner} -> Packages -> ${pkg} -> Package settings -> Change visibility -> Public, then re-run this workflow (GITHUB_TOKEN cannot do it; there is no REST endpoint for container-package visibility, it is a UI action). Runbook: runbooks/mcp-registry.md, section 'Package visibility'. Failing the release." >&2
             exit 1
           fi
 

--- a/runbooks/mcp-registry.md
+++ b/runbooks/mcp-registry.md
@@ -175,16 +175,47 @@ package-visibility change, not a pipeline change; no workflow edit is involved.
 `GITHUB_TOKEN` cannot do it: there is no REST endpoint for container-package
 visibility, it is a UI action.
 
-Anyone can re-check the current state without credentials:
+Anyone can re-check the current state without credentials. Note the **absence of
+`curl -f`** on the token request: GHCR denies the token request *itself* with 403
+for a private package, and `-f` turns that into a bare `curl: (56)` with no status
+line — losing the one reading you came for. Check the token request's own status
+instead:
 
 ```bash
-curl -fsS "https://ghcr.io/token?service=ghcr.io&scope=repository:ironsecco/ironclaw-mcp:pull" \
-  | jq -r .token \
-  | xargs -I{} curl -sS -o /dev/null -w '%{http_code}\n' -H 'Authorization: Bearer {}' \
-      -H 'Accept: application/vnd.oci.image.index.v1+json' \
-      https://ghcr.io/v2/ironsecco/ironclaw-mcp/manifests/latest
-# 200 = public. 401/403 (or a denied token request) = private.
+repo=ironsecco/ironclaw-mcp
+code="$(curl -sS -o /tmp/tok.json -w '%{http_code}' \
+  "https://ghcr.io/token?service=ghcr.io&scope=repository:${repo}:pull")"
+if [ "${code}" != "200" ]; then
+  echo "token request -> HTTP ${code}: package is PRIVATE, or was never pushed"
+else
+  curl -sS -o /dev/null -w 'manifest -> HTTP %{http_code}\n' \
+    -H "Authorization: Bearer $(jq -r .token </tmp/tok.json)" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json' \
+    "https://ghcr.io/v2/${repo}/manifests/latest"   # 200 = public
+fi
 ```
+
+### Reading a red `verify-consumer`
+
+There is **no expected-red step anywhere in this pipeline** — both packages are
+public and this job passes for both. So a red is a real failure: diagnose it,
+never wave it through as a known gate. Visibility is only one of four causes, and
+not the most serious. In rough order of likelihood:
+
+1. **Propagation lag.** GHCR is eventually consistent right after a push. The job
+   already retries 5x/10s on both the token request and the manifest fetch, so a
+   red means it stayed broken for about a minute.
+2. **Digest mismatch** — the tag resolves, but not to the index this run attested.
+   This is the security-relevant one: consumers would pull something we never
+   attested. Treat it as a clobbered or racing tag and stop the release.
+3. **Attestation not verifiable from outside** — the provenance/SBOM upload
+   failed, or something other than this workflow pushed the image.
+4. **The package really is private**, per the section above. Because GHCR returns
+   the identical 403 for private *and* never-pushed, settle which one before
+   asking an admin for anything: `gh api /orgs/IronSecCo/packages/container/<pkg>`
+   answers **404 "Package not found"** when it does not exist, and **200** — or
+   **403 "needs `read:packages` scope"** if your token lacks the scope — when it
+   does. Any non-404 answer proves existence, which is the only bit you need.
 
 ## Yanking / superseding a listing
 


### PR DESCRIPTION
Follow-up to #591 (IRO-618), which correctly retracted the "expect a red `verify-consumer`" premise. Rebased onto it — this keeps only the delta #591 did not cover. Three gaps, all in the same section.

### 1. The credential-free re-check snippet does not work when the package is private

It used `curl -f` on the token request. GHCR denies that request **itself** with 403 for a private package, so under `-f` curl prints a bare `curl: (56)` and no status line — the snippet silently fails to produce its own documented `401/403 = private` reading in the exact case it exists to diagnose. Verified against a nonexistent package, which GHCR treats identically:

```
$ curl -fsS ".../token?...&scope=repository:ironsecco/definitely-not-a-package:pull" | jq -r .token | xargs ...
curl: (56) The requested URL returned error: 403      <- no HTTP code, pipeline exits 0
```

This is the same trap `image.yml`'s own inline comment warns about at length ("must not use `curl -f` ... the remediation below never prints, which is the one failure this guard exists to explain"), so the doc contradicted the code. Rewritten to check the token request's status first. Both branches now produce the documented reading:

```
public package  -> manifest -> HTTP 200
absent/private  -> token request -> HTTP 403: package is PRIVATE, or was never pushed
```

### 2. "A red means private" is one of four causes, and not the worst

Added an ordered diagnosis list under a new **Reading a red `verify-consumer`** subsection: propagation lag → **digest mismatch** → unverifiable attestation → actually-private. The digest-mismatch branch is the security-relevant one (the tag resolves, but not to the index this run attested, i.e. consumers pulling something we never attested) and nothing pointed at it before.

### 3. Private vs never-pushed was undistinguishable

GHCR returns the identical 403 for both, and neither the runbook nor the error message said how to tell them apart. Both now name the probe, verified live against a real and a nonexistent package:

```
gh api /orgs/IronSecCo/packages/container/ironclaw-mcp          -> 403 "needs read:packages" (exists)
gh api /orgs/IronSecCo/packages/container/definitely-not-a-pkg  -> 404 "Package not found"   (absent)
```

The error message also now states plainly that a red here is **not** an expected gate — the instruction #591 removed from the runbook but left implied in CI.

### Verification

- Snippet exercised against both a public and an absent package (output above).
- `image.yml` parses as YAML with all six jobs; the edited step is `bash -n` clean.

Message text only. No change to what the guard checks or when it fails.