### PR TITLE
fix(mcp): stop documenting a GHCR private-by-default gate that never happened [IRO-623]

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -536,8 +536,11 @@ jobs:
             sleep 10
           done
           if [ -z "${token}" ]; then
+            # Both must be set before the message interpolates them: under `set -u` an
+            # undefined var aborts the step and the remediation never prints.
+            owner="${repo%%/*}"
             pkg="${repo##*/}"
-            echo "::error::Anonymous GHCR pull token for ${repo} was denied (HTTP ${tok_code}): the package is private, or has never been pushed. GHCR creates every new package PRIVATE, and GITHUB_TOKEN cannot change container-package visibility (there is no REST endpoint for it, it is a UI action). One-time org-admin fix: IronSecCo -> Packages -> ${pkg} -> Package settings -> Change visibility -> Public, then re-run this workflow. Runbook: runbooks/mcp-registry.md, section 'First publish of a new image (one-time org-admin gate)'. Failing the release." >&2
+            echo "::error::Anonymous GHCR pull token for ${repo} was denied (HTTP ${tok_code}) after 5 attempts. This is a REAL failure, not an expected first-publish gate: packages in this org have come up public on first push. GHCR returns the same 403 whether the package is private or absent, so diagnose before acting -- 'gh api /orgs/${owner}/packages/container/${pkg}' returns 404 if it was never pushed (a build/push problem) and 403/200 if it exists but is not anonymously pullable. Only in the latter case, an org admin flips it: IronSecCo -> Packages -> ${pkg} -> Package settings -> Change visibility -> Public, then re-run this workflow. Runbook: runbooks/mcp-registry.md, section 'If a package is not anonymously pullable'. Failing the release." >&2
             exit 1
           fi
 

--- a/runbooks/mcp-registry.md
+++ b/runbooks/mcp-registry.md
@@ -137,22 +137,53 @@ permanently — they describe a trust model we tell people not to run (IRO-391 /
 IRO-613). The only thing that ever goes `active` is a version built from
 `container/mcp.Dockerfile`.
 
-## First publish of a new image (one-time org-admin gate)
+## If a package is not anonymously pullable (fallback, not an expected step)
 
-GHCR creates a brand-new package as **private**, and `GITHUB_TOKEN` cannot change
-that. So the first release that pushes `ghcr.io/ironsecco/ironclaw-mcp` fails in
-`verify-consumer` on the anonymous pull. That failure is **correct, expected, and
-one-time**: a private image is unusable by the clients the listing serves, and
-the registry's own OCI validator could not fetch it either. Read a red first
-release here as this gate, not as a broken pipeline.
+A red `verify-consumer` is a **real failure**. Diagnose it; never wave it through
+as a known gate.
 
-Unblock it once, as an org admin:
+An earlier revision of this runbook claimed the first push of a new GHCR package
+always lands **private**, and told you to expect one red `verify-consumer` and go
+collect an org-admin click. That did not happen for us. `ghcr.io/ironsecco/ironclaw-mcp`
+came up **public** on its very first push (`9ac92b64`, `Image` run 30408078319),
+and `verify-consumer` passed on it in that same run — the anonymous token was
+issued, both `latest` and `v0.1.403` resolved, and the multi-arch index matched
+the attested digest. New packages appear to inherit visibility from the source
+repo, which is public. Do not plan around a gate that does not exist.
 
-> IronSecCo → Packages → `ironclaw-mcp` → Package settings → Change visibility →
+The visibility fix below is a **fallback** for the day a package genuinely does
+come up (or silently reverts to) private, which `verify-consumer` will catch:
+
+> IronSecCo → Packages → `<package>` → Package settings → Change visibility →
 > Public
 
-then re-run the `Image` workflow (or let the next release run it). This is a
-package-visibility change, not a pipeline change; no workflow edit is involved.
+then re-run the `Image` workflow. That is a package-visibility change, not a
+pipeline change; no workflow edit is involved. `GITHUB_TOKEN` cannot do it —
+container-package visibility has no REST endpoint, it is a UI action.
+
+Before reaching for it, rule out the cheaper causes, in this order:
+
+1. **Propagation lag.** GHCR is eventually consistent right after a push.
+   `verify-consumer` already retries the token request and each manifest fetch
+   five times; a failure that survives that is not a lag.
+2. **The package was never pushed.** GHCR returns the same `403 DENIED` on the
+   *token request* for a private package and for one that does not exist, so the
+   token denial alone cannot tell them apart. Distinguish them with
+   `GET /orgs/IronSecCo/packages/container/<package>` — **404** means absent
+   (a `build-mcp` / push problem), **403**/200 means it exists.
+3. **A digest mismatch**, not a visibility problem — the tag resolved but points
+   at something other than the index we just attested. That is a tag race or a
+   concurrent publish, and flipping visibility will not fix it.
+
+Probe the live registry rather than trusting this document:
+
+```bash
+repo=ironsecco/ironclaw-mcp
+tok=$(curl -s "https://ghcr.io/token?service=ghcr.io&scope=repository:${repo}:pull" | jq -r .token)
+curl -sI -H "Authorization: Bearer ${tok}" \
+  -H 'Accept: application/vnd.oci.image.index.v1+json' \
+  "https://ghcr.io/v2/${repo}/manifests/latest" | head -1   # want: HTTP/2 200
+```
 
 ## Yanking / superseding a listing
 


### PR DESCRIPTION
The runbook section `First publish of a new image (one-time org-admin gate)` and the matching `image.yml` remediation both asserted that GHCR creates every new package private, so the first push of `ghcr.io/ironsecco/ironclaw-mcp` would fail `verify-consumer` and require a one-time org-admin visibility flip.

That premise never held. The package came up **public** on its first push.

## Evidence

`Image` run [30408078319](https://github.com/IronSecCo/ironclaw/actions/runs/30408078319) (dispatch at `9ac92b64`) built and pushed it, and **`verify-consumer (ghcr.io/ironsecco/ironclaw-mcp, sha256:35355740...)` passed in that same run**. So this is not a prediction that it would work; CI already ran the guard green.

Re-confirmed here from a cold client, with a freshly minted anonymous token:

```
GET  https://ghcr.io/token?...scope=repository:ironsecco/ironclaw-mcp:pull  -> 200, token issued
GET  /v2/ironsecco/ironclaw-mcp/manifests/latest                            -> 200  OCI image index
GET  /v2/ironsecco/ironclaw-mcp/manifests/sha256:00d8f07d... (by digest)    -> 200  linux/amd64
GET  /v2/ironsecco/ironclaw-mcp/blobs/sha256:04d75969...    (config)        -> 200
     label io.modelcontextprotocol.server.name = io.github.IronSecCo/ironclaw
tags: latest, v0.1.403   (latest and v0.1.403 -> same index sha256:35355740...)
```

Negative control: the same token request for a nonexistent package in the same org returns **403**, so the 200 above is meaningful and not GHCR handing out tokens indiscriminately.

## What changed

- **The inversion is the actual bug.** Telling operators to read a red `verify-consumer` as an expected gate trains them to wave through the one guard that proves an image is consumable the way real users consume it, anonymously. The section now opens by stating a red `verify-consumer` is a real failure.
- The visibility flip **survives as a fallback**, for the day a package genuinely does come up private. It is no longer described as expected or mandatory.
- The failure path now **diagnoses before it prescribes**. GHCR returns the same `403` on the *token request* for a private package and for one that does not exist, so the error points at `GET /orgs/{org}/packages/container/{pkg}` (**404** = never pushed, a build/push problem; **403**/200 = exists but not anonymously pullable), and names propagation lag and digest mismatch as the cheaper causes to rule out first.
- The runbook carries a copy-pasteable live probe. Our own runbook is not evidence.
- `owner` is now defined alongside `pkg` in the failure branch. The message interpolates it, and under `set -u` an undefined var would abort the step before the remediation printed, which is exactly the failure this guard exists to explain.

## Verification

- `actionlint .github/workflows/image.yml` clean; `shellcheck -S warning` on the extracted step body clean; `bash -n` clean.
- The **edited step body, extracted from the workflow and run unmodified**, against the live registry:
  - `ironclaw-mcp` -> `latest` and `v0.1.403` both HTTP 200, both digest-matched against the attested index, exit 0.
  - absent package -> retries 5x, prints the new remediation with `owner`/`pkg` correctly interpolated, exit 1.
- No stale references to the old section title remain anywhere in the repo.

## Lenses

**Fail loud / fail closed** (a red `verify-consumer` reads as a failure again), **checksum-first / verify-before-trust** (digest-match assertion untouched), **least-privilege CI** (no permission change; `verify-consumer` still holds only `contents: read` and does no registry login). No change to signing, attestation, or required checks.

Refs IRO-623. Closes the premise behind IRO-618 and IRO-620.