### PR TITLE
docs(mcp-registry): the GHCR visibility gate never fired, record what actually happened [IRO-618]

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -537,7 +537,7 @@ jobs:
           done
           if [ -z "${token}" ]; then
             pkg="${repo##*/}"
-            echo "::error::Anonymous GHCR pull token for ${repo} was denied (HTTP ${tok_code}): the package is private, or has never been pushed. GHCR creates every new package PRIVATE, and GITHUB_TOKEN cannot change container-package visibility (there is no REST endpoint for it, it is a UI action). One-time org-admin fix: IronSecCo -> Packages -> ${pkg} -> Package settings -> Change visibility -> Public, then re-run this workflow. Runbook: runbooks/mcp-registry.md, section 'First publish of a new image (one-time org-admin gate)'. Failing the release." >&2
+            echo "::error::Anonymous GHCR pull token for ${repo} was denied (HTTP ${tok_code}): the package is private, or has never been pushed. GITHUB_TOKEN cannot change container-package visibility (there is no REST endpoint for it, it is a UI action). Org-admin fix: IronSecCo -> Packages -> ${pkg} -> Package settings -> Change visibility -> Public, then re-run this workflow. Runbook: runbooks/mcp-registry.md, section 'Package visibility'. Failing the release." >&2
             exit 1
           fi
 

--- a/runbooks/mcp-registry.md
+++ b/runbooks/mcp-registry.md
@@ -137,22 +137,54 @@ permanently — they describe a trust model we tell people not to run (IRO-391 /
 IRO-613). The only thing that ever goes `active` is a version built from
 `container/mcp.Dockerfile`.
 
-## First publish of a new image (one-time org-admin gate)
+## Package visibility (no gate — verified on first publish)
 
-GHCR creates a brand-new package as **private**, and `GITHUB_TOKEN` cannot change
-that. So the first release that pushes `ghcr.io/ironsecco/ironclaw-mcp` fails in
-`verify-consumer` on the anonymous pull. That failure is **correct, expected, and
-one-time**: a private image is unusable by the clients the listing serves, and
-the registry's own OCI validator could not fetch it either. Read a red first
-release here as this gate, not as a broken pipeline.
+`ghcr.io/ironsecco/ironclaw-mcp` was **born anonymously pullable**. We expected
+the opposite (GHCR historically created every new package private, as
+`ironclaw-controlplane` did in June 2026, which needed a manual flip), so IRO-618
+pre-staged an org-admin gate for it. The gate never fired. Evidence from the
+first release that pushed the package — `Image` run
+[30408078319](https://github.com/IronSecCo/ironclaw/actions/runs/30408078319),
+`v0.1.403`, the first `build-mcp` on `main`:
 
-Unblock it once, as an org admin:
+```
+Anonymous manifest pull: ghcr.io/ironsecco/ironclaw-mcp:latest
+  -> HTTP 200 (anonymously pullable)
+Anonymous manifest pull: ghcr.io/ironsecco/ironclaw-mcp:v0.1.403
+  -> HTTP 200 (anonymously pullable)
+```
+
+Zero retries, and no human touched the package between the push (23:28 UTC) and
+`verify-consumer` (23:30 UTC), so this was not a flip we made and forgot. The
+likely reason is that GHCR now links a `GITHUB_TOKEN`-pushed package to the
+repository that pushed it and inherits that repository's visibility, and
+`IronSecCo/ironclaw` is public. Treat that as the probable mechanism, not a
+guarantee: it is GitHub-side behaviour we do not control and did not always get.
+
+**So do not pre-emptively flip anything.** The claim that matters is checked on
+every release by `verify-consumer`, which pulls anonymously with no registry
+credentials. If it ever goes red on the token request or the manifest fetch, the
+package is private (or was never pushed), and the fix is still the one-time
+org-admin action:
 
 > IronSecCo → Packages → `ironclaw-mcp` → Package settings → Change visibility →
 > Public
 
 then re-run the `Image` workflow (or let the next release run it). This is a
 package-visibility change, not a pipeline change; no workflow edit is involved.
+`GITHUB_TOKEN` cannot do it: there is no REST endpoint for container-package
+visibility, it is a UI action.
+
+Anyone can re-check the current state without credentials:
+
+```bash
+curl -fsS "https://ghcr.io/token?service=ghcr.io&scope=repository:ironsecco/ironclaw-mcp:pull" \
+  | jq -r .token \
+  | xargs -I{} curl -sS -o /dev/null -w '%{http_code}\n' -H 'Authorization: Bearer {}' \
+      -H 'Accept: application/vnd.oci.image.index.v1+json' \
+      https://ghcr.io/v2/ironsecco/ironclaw-mcp/manifests/latest
+# 200 = public. 401/403 (or a denied token request) = private.
+```
 
 ## Yanking / superseding a listing
 


### PR DESCRIPTION
## What

IRO-618 pre-staged a one-time org-admin action: flip `ghcr.io/ironsecco/ironclaw-mcp` to Public after the first release created it, because GHCR creates new packages private (which is exactly what `ironclaw-controlplane` did in June 2026).

**The gate never fired.** The package was born anonymously pullable.

## Evidence

`Image` run [30408078319](https://github.com/IronSecCo/ironclaw/actions/runs/30408078319) — `v0.1.403`, the first `build-mcp` on `main` after #583 merged:

```
Anonymous manifest pull: ghcr.io/ironsecco/ironclaw-mcp:latest
  -> HTTP 200 (anonymously pullable)
Anonymous manifest pull: ghcr.io/ironsecco/ironclaw-mcp:v0.1.403
  -> HTTP 200 (anonymously pullable)
```

First attempt, zero retries. Push at 23:28 UTC, `verify-consumer` at 23:30 UTC, no human in between — this was not a flip we made and forgot. Re-confirmed just now from a machine with no registry credentials: anonymous token `200`, `tags/list` `200`, and both `:latest` and `:v0.1.403` resolve to `sha256:3535574037797aac46ccfc357172353568a461ba4ceb19e4cc3e08d260c4c2e6`, which is the index `verify-consumer` attested. The `io.modelcontextprotocol.server.name` label reads `io.github.IronSecCo/ironclaw` over that same anonymous path and matches `server.json`, so the registry's OCI validator has what it needs.

Likely mechanism: GHCR now links a `GITHUB_TOKEN`-pushed package to the repo that pushed it and inherits that repo's visibility. Documented as probable, not guaranteed — it is GitHub-side behaviour we do not control and did not always get.

## Why change the docs rather than just close the ticket

A runbook that asserts a gate which does not exist costs us twice: an admin flips a package that is already public, and a genuinely red first release gets read as \"just the expected gate\" instead of the regression it would be. The section now records the verified outcome, keeps the org-admin action as the remedy **if** \`verify-consumer\` ever does go red, and adds a credential-free command to re-check visibility.

The workflow change is the same claim dropped from the `verify-consumer` error message, plus repointing its runbook cross-reference at the renamed section. **Message text only** — no change to what the guard checks or when it fails.

## Lenses

- **Fail loud, fail closed** — untouched. `verify-consumer` still fails the release on a private or digest-mismatched package; this PR only corrects what it tells you afterwards.
- **Checksum-first / verify-before-trust** — the anonymous-pull + digest-match assertion is unchanged and is now the documented source of truth for visibility, instead of a static claim in prose.

## Verification

- `actionlint .github/workflows/image.yml` clean
- `bash -n` clean on the edited `run` block
- live anonymous re-check as above (no credentials)

Closes IRO-618.