### PR TITLE
ci(image): verify a dispatch tag names the built commit, and move :latest forwards only [IRO-625]

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Version tag to stamp + publish (e.g. v0.1.99). Blank = latest only."
+        description: "Version tag to stamp + publish (e.g. v0.1.99). Must point at the commit this run builds, or the run fails. Blank = auto-detect this commit's tag."
         required: false
         default: ""
       publish_mcp_registry:
@@ -134,19 +134,86 @@ jobs:
 
           # 3) Version: an explicit dispatch input wins; otherwise the release tag this
           #    commit carries, read from the tags API (not a local checkout).
+          #
+          #    An image tag is an assertion about the source inside it, so a dispatch
+          #    input is NOT trusted verbatim: the named tag must exist and must resolve
+          #    to the very commit we are about to build. Otherwise the operator's typo
+          #    mints :v0.1.403 out of v0.1.404's tree — and because publish-mcp-registry
+          #    stamps that ref into an IMMUTABLE MCP Registry version, the lie is not
+          #    editable afterwards, only deprecatable. Fail closed instead.
           if [ "${EVENT}" = "workflow_dispatch" ] && [ -n "${INPUT_TAG}" ]; then
+            # Strict shape first. This is not just typo-catching: the input becomes an
+            # OCI tag, and the API below resolves any REF EXPRESSION, so a loose glob
+            # would let `v0.1.403^{commit}` verify against the right commit and then be
+            # stamped as the literal tag `v0.1.403^{commit}` — which is not even legal
+            # OCI. Only a plain vMAJOR.MINOR.PATCH[-prerelease] gets through.
+            if ! printf '%s' "${INPUT_TAG}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+              echo "::error::Dispatch input tag='${INPUT_TAG}' is not a release tag (expected vMAJOR.MINOR.PATCH, e.g. v0.1.403)." >&2
+              exit 1
+            fi
+            # The commits API takes any ref and always answers with the commit, so this
+            # dereferences annotated and lightweight tags alike. An unknown tag is a
+            # non-zero exit -> blanked -> refused, so a version that was never released
+            # can't be minted. gh prints the error BODY on stdout for a 4xx, hence both
+            # the exit-status check and the 40-hex shape check: neither a JSON blob nor
+            # an empty string may ever reach the comparison below as a plausible sha.
+            if ! tag_sha="$(gh api "repos/${REPO}/commits/${INPUT_TAG}" --jq '.sha' 2>/dev/null)"; then
+              tag_sha=""
+            fi
+            # `[[ =~ ]]` matches the WHOLE string, unlike line-based grep — an error
+            # body that merely contained a 40-hex line must not slip through.
+            if [[ ! "${tag_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+              tag_sha=""
+            fi
+            if [ -z "${tag_sha}" ]; then
+              echo "::error::Dispatch input tag='${INPUT_TAG}' does not exist in ${REPO} — refusing to stamp an image with a version that was never released." >&2
+              exit 1
+            fi
+            if [ "${tag_sha}" != "${sha}" ]; then
+              echo "::error::Tag mismatch — refusing to publish an image whose tag names a commit it does not contain." >&2
+              echo "::error::  tag ${INPUT_TAG} points at ${tag_sha}" >&2
+              echo "::error::  this run is building ${sha}" >&2
+              echo "::error::Re-dispatch with 'Use workflow from' set to the tag ${INPUT_TAG} (or to its commit ${tag_sha}); leaving the tag input blank then stamps it automatically." >&2
+              exit 1
+            fi
             version="${INPUT_TAG}"
+            echo "Dispatch tag ${INPUT_TAG} verified against build commit ${sha}."
           else
             version="$(gh api "repos/${REPO}/tags" --paginate \
               --jq ".[] | select(.commit.sha == \"${sha}\") | .name" \
               | grep -E '^v[0-9]' | head -1 || true)"
           fi
 
-          # `docker buildx imagetools create` takes the tags as -t flags. Always tag
-          # :latest; add the immutable :<version> tag when this commit carries one.
-          tag_args="-t ${image}:latest"
+          # 3b) Does this build get :latest? Only when it IS the default-branch tip.
+          #     :latest must move forwards only. A dispatch rebuild of an older release
+          #     (the honest way to repair a mis-stamped :<version>, see IRO-625) builds
+          #     an older tree, and unconditionally tagging it :latest would silently
+          #     DEMOTE every `docker pull ...:latest` consumer to older code — a far
+          #     worse outcome than the mis-tag being repaired. `behind` (an older commit
+          #     on the branch) and `ahead`/`diverged` (a dispatch off a side branch) both
+          #     publish their immutable :<version> only.
+          latest_status="$(gh api "repos/${REPO}/compare/${default_branch}...${sha}" --jq '.status' 2>/dev/null || true)"
+          if [ "${latest_status}" = "identical" ]; then
+            is_latest=true
+          else
+            is_latest=false
+            echo "Not tagging :latest — ${sha} is '${latest_status:-unknown}' relative to ${default_branch} tip, not that tip."
+          fi
+
+          # `docker buildx imagetools create` takes the tags as -t flags. Tag :latest
+          # only for the branch tip; add the immutable :<version> tag when this commit
+          # carries one. At least one of the two is always present: a commit that is
+          # neither the tip nor tagged has nothing meaningful to publish.
+          tag_args=""
+          if [ "${is_latest}" = "true" ]; then
+            tag_args="-t ${image}:latest"
+          fi
           if [ -n "${version}" ]; then
-            tag_args="${tag_args} -t ${image}:${version}"
+            tag_args="${tag_args:+${tag_args} }-t ${image}:${version}"
+          fi
+          if [ -z "${tag_args}" ]; then
+            echo "::error::${sha} is neither the ${default_branch} tip nor a tagged release — refusing to publish an image with no meaningful tag." >&2
+            exit 1
           fi
 
           # 4) The slim, socket-free MCP-server image (container/mcp.Dockerfile). It is the
@@ -156,10 +223,14 @@ jobs:
           #    Dockerfile just skips that job rather than failing the release.
           mcp_image="ghcr.io/${owner}/ironclaw-mcp"
           if gh api "repos/${REPO}/contents/container/mcp.Dockerfile?ref=${sha}" --silent >/dev/null 2>&1; then
-            # docker/build-push-action takes newline-separated tags.
-            mcp_tags="${mcp_image}:latest"
+            # docker/build-push-action takes newline-separated tags. Same forwards-only
+            # :latest rule as the control-plane image above.
+            mcp_tags=""
+            if [ "${is_latest}" = "true" ]; then
+              mcp_tags="${mcp_image}:latest"
+            fi
             if [ -n "${version}" ]; then
-              mcp_tags="${mcp_tags}"$'\n'"${mcp_image}:${version}"
+              mcp_tags="${mcp_tags:+${mcp_tags}$'\n'}${mcp_image}:${version}"
             fi
             {
               echo "mcp_present=true"

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -198,6 +198,50 @@ You don't have to bump on every push — refresh the formula on releases you wan
 land on. Pinning to an old/yanked tag is fail-safe: the URLs 404 and `brew install` errors rather
 than installing something unverifiable.
 
+### 3.7 Container image tags: what the Image workflow will and won't publish
+
+An image tag is an assertion about the source inside the image, so `image.yml` refuses to
+publish a tag it cannot back with the commit it just built. Two rules, both fail-closed:
+
+**The `:<version>` tag must name the commit being built.** On the normal `workflow_run`
+path the version is read from the tag the Release workflow put on that exact commit, so it
+agrees by construction. On a `workflow_dispatch` that supplies the `tag` input, `prepare`
+resolves the tag through the commits API and requires it to equal the build commit:
+
+```bash
+# Correct: the workflow ref and the tag input name the same commit.
+gh workflow run image.yml --ref v0.1.404 -f tag=v0.1.404
+
+# Equivalent and harder to get wrong — blank input auto-detects that commit's tag.
+gh workflow run image.yml --ref v0.1.404
+```
+
+Dispatching from `main` with `-f tag=v0.1.403` now fails the run with both SHAs printed,
+rather than minting an image whose tag names a commit it does not contain. This matters
+beyond cosmetics: `publish-mcp-registry` stamps the image ref into an MCP Registry version,
+and registry versions are **immutable** — a wrong ref there can only be deprecated, never
+corrected.
+
+**`:latest` moves forwards only.** It is applied only when the built commit is the current
+default-branch tip (`compare` status `identical`). A dispatch that rebuilds an older release,
+or builds from a side branch, publishes its immutable `:<version>` tag alone. Without this,
+re-running the Image workflow on an old tag would silently demote every
+`docker pull …:latest` consumer to older code. A commit that is neither the branch tip nor
+tagged has no meaningful tag to publish, and the run fails rather than guessing.
+
+**Repairing a mis-tagged image.** Note the consequence of the two rules together: an already
+mis-stamped `:<version>` cannot be repaired by dispatch, because `workflow_dispatch` runs the
+workflow file *from the ref it builds* — the only workflow file at an old tag is the one that
+predates these guards. Rebuilding from that tag would restore the version tag but demote
+`:latest` on the way. Prefer to **withdraw** a mis-tagged image (record it below, let the next
+release supersede `:latest`) over publishing a second known-wrong tag to fix the first.
+
+Withdrawn image tags:
+
+| Tag | Built from | Should have been | Disposition |
+| --- | --- | --- | --- |
+| `ironclaw-controlplane:v0.1.403`, `ironclaw-mcp:v0.1.403` | `9ac92b64` (the v0.1.404 commit) | `9ae3b9be` | **Withdrawn, do not consume** (IRO-625). Published by dispatch run `30408078319` before the tag gate existed. The build-provenance attestation is honest and records `9ac92b64`, so `gh attestation verify` on these tags will truthfully report the v0.1.404 commit — the tag, not the provenance, is the lie. Superseded by v0.1.404 and later. |
+
 ---
 
 ## 4. How to verify a release (user-facing)
@@ -441,6 +485,10 @@ gh workflow run release.yml -f version=v0.1.99
 # Re-run a failed (post-publish) release job — idempotent
 gh run rerun <run-id> --failed
 
+# Republish a container image (dispatch FROM the tag; see 3.7 — a tag input that
+# does not name the built commit fails the run, and :latest only moves forwards)
+gh workflow run image.yml --ref v0.1.99
+
 # Inspect a release
 gh release view <tag>
 gh release view <tag> --json assets -q '.assets[].name'
@@ -465,4 +513,5 @@ gh attestation verify ./ironctl --repo IronSecCo/ironclaw   # extracted binary
 
 *Related tickets:* pipeline handoff IRO-12; this runbook
 IRO-16; arm64 image IRO-13; ruleset enforcement
-IRO-14; release smoke test IRO-15; Homebrew formula IRO-175.
+IRO-14; release smoke test IRO-15; Homebrew formula IRO-175;
+image tag/`:latest` gating IRO-625.


### PR DESCRIPTION
## The defect

A manual `Image` dispatch trusted the `tag` input verbatim. Run [`30408078319`](https://github.com/IronSecCo/ironclaw/actions/runs/30408078319) published `ghcr.io/ironsecco/ironclaw-controlplane:v0.1.403` and `ironclaw-mcp:v0.1.403` while building commit `9ac92b64` — which is the **v0.1.404** commit. `v0.1.403` is `9ae3b9be`.

Nothing was forged: the build-provenance attestation honestly records `9ac92b64`. The defect is that the image **tag asserts a version whose source it does not contain**, which breaks the reproducibility lens.

Beyond cosmetics: `publish-mcp-registry` stamps the image ref into an MCP Registry version, and those are **immutable** — a wrong ref can only be deprecated, never corrected. That is precisely the hole IRO-611 is still digging out of.

## The fix

**1. A dispatch `tag` must prove itself against the built commit.** `prepare` requires the input to be shaped like a release tag, to exist, and to resolve to the exact commit being built — otherwise it fails with both SHAs and the remedy.

Two things testing forced, that a first cut would miss:

- The shape check is **load-bearing, not typo-catching**. The commits API resolves *ref expressions*, so under a loose `v[0-9]*` glob the input `v0.1.403^{commit}` verified against the right commit and was then stamped as the literal OCI tag `v0.1.403^{commit}` — not even legal OCI. Only a plain `vMAJOR.MINOR.PATCH[-prerelease]` gets through now.
- `gh api` prints the **error body on stdout** for a 4xx, so `--jq '.sha' || true` captured a JSON blob instead of an empty string. It failed closed by luck, with a wall-of-JSON message. The SHA is now accepted only on a zero exit *and* a whole-string 40-hex match.

**2. `:latest` moves forwards only.** This is the part that makes the cleanup safe. `:latest` was applied unconditionally, so rebuilding an old tag — the obvious way to repair a mis-stamped `:<version>` — would have silently demoted every `docker pull …:latest` consumer to older code. It is now applied only when the built commit is the default-branch tip (`compare` status `identical`). A rebuild of an older release publishes its immutable `:<version>` alone; a commit that is neither the tip nor tagged fails rather than publishing something meaningless.

The normal `workflow_run` release path is unchanged: the tip is `identical`, so it still gets `:latest` + `:<version>`.

## Cleanup decision: `:v0.1.403` is withdrawn, not rebuilt

The issue's stated preference was to rebuild `:v0.1.403` from `9ae3b9be` so the tag becomes true. Implementing the guard showed why that is the worse option: `workflow_dispatch` runs the workflow file **from the ref it builds**, and the only `image.yml` at tag `v0.1.403` is the pre-guard one. Rebuilding would restore the version tag while demoting `:latest` on the way — trading a cosmetic mis-tag for a real user-visible regression. With zero users and v0.1.404 superseding it, withdrawal is recorded in the runbook instead. Nothing is deleted; the attestation stays honest and verifiable.

Documented in `docs/release-runbook.md` §3.7, including a withdrawn-tags table.

## Verification

Extracted the gate verbatim from the workflow and replayed it against the live GitHub API:

| Case | Result |
| --- | --- |
| Historical defect: build `9ac92b64`, stamp `v0.1.403` | **fails closed**, prints both SHAs |
| Honest `v0.1.403` rebuild from `9ae3b9be` | passes |
| Honest `v0.1.404` rebuild from `9ac92b64` | passes |
| `v9.9.9` (never released) | **fails closed** |
| `latest; rm -rf /` | **fails closed** |
| `v0.1.403^{commit}` (ref-expression smuggle) | **fails closed** |
| `main` (branch name) | **fails closed** |

Tag composition matrix (tip/old x tagged/untagged) confirms the release path keeps `latest`+`version`, an old-tag rebuild gets `version` only, and tip-untagged gets `latest` only; neither-tip-nor-tagged fails closed. `compare` statuses confirmed against the API: current tip `identical`, `9ac92b64`/`9ae3b9be` both `behind`.

`actionlint` clean (shellcheck included). `mkdocs build --strict` green and `scripts/check-docs-meta.py` passes 431 pages.

## Lenses

**Reproducibility** (a tag now has to be backed by the commit it names), **provenance** (unchanged and honest; the guard makes the tag agree with it), **fail loud/fail closed** (every ambiguous input stops the publish), **least-privilege CI** (no permission changes).

Closes IRO-625.