### PR TITLE
fix(mcp-registry): only PATCH the listing status when it needs correcting [IRO-611]

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -725,13 +725,41 @@ jobs:
       # scoped to the one version we just published. It reuses the login above and the same
       # cosign-verified pinned binary, so this adds no trust surface and no token handling
       # of our own. It omits statusMessage, which the API rejects when status=active.
+      #
+      # SELF-HEAL, NOT UNCONDITIONAL WRITE. The registry rejects a status PATCH that would
+      # change nothing with `400 No changes to apply: status and message are already set to
+      # the provided values`. A freshly published version normally DOES land `active` by
+      # itself, so an unconditional PATCH 400s on exactly the happy path — that is what
+      # failed the v0.1.404 relight run after its publish had already succeeded. Read the
+      # per-version status first and only write when it actually needs correcting.
       - name: Ensure this version is active on the registry
         run: |
           set -euo pipefail
           semver="${VERSION#v}"
+          enc="$(jq -rn --arg s "${SERVER_NAME}" '$s|@uri')"
+          status="$(curl -fsSL "${REGISTRY}/v0/servers/${enc}/versions" \
+            | jq -r --arg n "${SERVER_NAME}" --arg v "${semver}" \
+              'first(.servers[]? | select(.server.name == $n and .server.version == $v)
+                 | ._meta["io.modelcontextprotocol.registry/official"].status) // "unknown"')"
+
+          if [ "${status}" = "active" ]; then
+            echo "${SERVER_NAME} ${semver} already published active — no status PATCH needed."
+            exit 0
+          fi
+
+          echo "${SERVER_NAME} ${semver} is '${status}' — self-healing to active."
           # NEVER pass --all-versions here: that is the server-wide PATCH and it would
           # resurrect 0.1.216-0.1.230 (see the note above).
-          ./mcp-publisher status --status active "${SERVER_NAME}" "${semver}"
+          if out="$(./mcp-publisher status --status active "${SERVER_NAME}" "${semver}" 2>&1)"; then
+            printf '%s\n' "${out}"
+          else
+            printf '%s\n' "${out}"
+            # Tolerate ONLY the idempotent no-op: the version flipped to active between the
+            # read above and this write. Any other failure is a real one — fail closed.
+            printf '%s' "${out}" | grep -q 'No changes to apply' \
+              || { echo "::error::status PATCH failed for ${SERVER_NAME} ${semver}." >&2; exit 1; }
+            echo "Version was already active by the time the PATCH landed — treating as a no-op."
+          fi
 
       - name: Verify the listing resolves on the registry and is active
         run: |


### PR DESCRIPTION
## The listing is relit

`io.github.IronSecCo/ironclaw` is **live again** on registry.modelcontextprotocol.io after three weeks dark:

```
io.github.IronSecCo/ironclaw 0.1.404 active isLatest=True
   package: oci ghcr.io/ironsecco/ironclaw-mcp:v0.1.404 transport=stdio
```

That is the socket-free image, not the rejected host-Docker-socket trust model. #583 (IRO-612) supplied the code; this run executed it, via `image.yml` dispatch on `main` at `9ac92b6` with `tag=v0.1.404` (the tag on that exact commit, so nothing drifted).

## What this PR fixes

The publish succeeded and **the job still reported failure**, one step later:

```
Updating io.github.IronSecCo/ironclaw version 0.1.404: active → active
Error: failed to update status: server returned status 400:
  {"detail":"No changes to apply: status and message are already set to the provided values"}
```

The self-heal step wrote `active` unconditionally. A freshly published version already lands `active`, and the registry rejects a PATCH that changes nothing. So the step fails on **exactly the happy path** — every future release would publish correctly and then go red, which is the kind of misleading signal that let this listing sit dark for three weeks in the first place.

Now it reads the per-version status first and writes only when the status actually needs correcting.

## What is preserved

- **Per-version only.** The write is still `status --status active <name> <version>`. Never `--all-versions`, never the server-wide PATCH — `0.1.216`-`0.1.230` name the socket-mount image and stay `deprecated` permanently (IRO-391 / IRO-613).
- **Fail closed.** A PATCH failing for any reason other than the idempotent no-op still exits 1. Only the exact `No changes to apply` 400 is tolerated, and only to cover the read/write race.
- **The real assertion is untouched.** The `active` + `isLatest` post-check still runs and still fails the release loud.

## Verification

- `actionlint` and `shellcheck` clean.
- Status read exercised against the **live** registry: `0.1.404` -> `active`, `0.1.230` -> `deprecated`, absent version -> `unknown` (so an unpublished version still attempts the PATCH and fails loud rather than passing silently).
- All four branches driven through a stubbed publisher: already-active skips the write (exit 0), deprecated self-heals (exit 0), 400 no-op tolerated (exit 0), any other error (exit 1).

Touches **fail loud / fail closed** and **provenance** (the listing pins an immutable `:v0.1.404` tag, not `:latest`). No change to signing, token scopes, or required checks.