### PR TITLE
docs(mcp-registry): make a red verify-consumer diagnose before it prescribes [IRO-623]

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -536,8 +536,11 @@ jobs:
             sleep 10
           done
           if [ -z "${token}" ]; then
+            # Both must be set before the message interpolates them: under `set -u` an
+            # undefined var aborts the step and the remediation never prints.
+            owner="${repo%%/*}"
             pkg="${repo##*/}"
-            echo "::error::Anonymous GHCR pull token for ${repo} was denied (HTTP ${tok_code}): the package is private, or has never been pushed. GITHUB_TOKEN cannot change container-package visibility (there is no REST endpoint for it, it is a UI action). Org-admin fix: IronSecCo -> Packages -> ${pkg} -> Package settings -> Change visibility -> Public, then re-run this workflow. Runbook: runbooks/mcp-registry.md, section 'Package visibility'. Failing the release." >&2
+            echo "::error::Anonymous GHCR pull token for ${repo} was denied (HTTP ${tok_code}) after 5 attempts. This is a REAL failure, not an expected first-publish gate: packages in this org have come up public on first push. GHCR returns the same 403 whether the package is private or absent, so diagnose before acting -- 'gh api /orgs/${owner}/packages/container/${pkg}' returns 404 if it was never pushed (a build/push problem) and 403/200 if it exists but is not anonymously pullable. Only in the latter case, an org admin flips it: IronSecCo -> Packages -> ${pkg} -> Package settings -> Change visibility -> Public, then re-run this workflow. Runbook: runbooks/mcp-registry.md, section 'If a package is not anonymously pullable'. Failing the release." >&2
             exit 1
           fi
 

--- a/runbooks/mcp-registry.md
+++ b/runbooks/mcp-registry.md
@@ -137,53 +137,52 @@ permanently — they describe a trust model we tell people not to run (IRO-391 /
 IRO-613). The only thing that ever goes `active` is a version built from
 `container/mcp.Dockerfile`.
 
-## Package visibility (no gate — verified on first publish)
+## If a package is not anonymously pullable (fallback, not an expected step)
 
-`ghcr.io/ironsecco/ironclaw-mcp` was **born anonymously pullable**. We expected
-the opposite (GHCR historically created every new package private, as
-`ironclaw-controlplane` did in June 2026, which needed a manual flip), so IRO-618
-pre-staged an org-admin gate for it. The gate never fired. Evidence from the
-first release that pushed the package — `Image` run
-[30408078319](https://github.com/IronSecCo/ironclaw/actions/runs/30408078319),
-`v0.1.403`, the first `build-mcp` on `main`:
+A red `verify-consumer` is a **real failure**. Diagnose it; never wave it through
+as a known gate.
 
-```
-Anonymous manifest pull: ghcr.io/ironsecco/ironclaw-mcp:latest
-  -> HTTP 200 (anonymously pullable)
-Anonymous manifest pull: ghcr.io/ironsecco/ironclaw-mcp:v0.1.403
-  -> HTTP 200 (anonymously pullable)
-```
+An earlier revision of this runbook claimed the first push of a new GHCR package
+always lands **private**, and told you to expect one red `verify-consumer` and go
+collect an org-admin click. That did not happen for us. `ghcr.io/ironsecco/ironclaw-mcp`
+came up **public** on its very first push (`9ac92b64`, `Image` run 30408078319),
+and `verify-consumer` passed on it in that same run — the anonymous token was
+issued, both `latest` and `v0.1.403` resolved, and the multi-arch index matched
+the attested digest. New packages appear to inherit visibility from the source
+repo, which is public. Do not plan around a gate that does not exist.
 
-Zero retries, and no human touched the package between the push (23:28 UTC) and
-`verify-consumer` (23:30 UTC), so this was not a flip we made and forgot. The
-likely reason is that GHCR now links a `GITHUB_TOKEN`-pushed package to the
-repository that pushed it and inherits that repository's visibility, and
-`IronSecCo/ironclaw` is public. Treat that as the probable mechanism, not a
-guarantee: it is GitHub-side behaviour we do not control and did not always get.
+The visibility fix below is a **fallback** for the day a package genuinely does
+come up (or silently reverts to) private, which `verify-consumer` will catch:
 
-**So do not pre-emptively flip anything.** The claim that matters is checked on
-every release by `verify-consumer`, which pulls anonymously with no registry
-credentials. If it ever goes red on the token request or the manifest fetch, the
-package is private (or was never pushed), and the fix is still the one-time
-org-admin action:
-
-> IronSecCo → Packages → `ironclaw-mcp` → Package settings → Change visibility →
+> IronSecCo → Packages → `<package>` → Package settings → Change visibility →
 > Public
 
-then re-run the `Image` workflow (or let the next release run it). This is a
-package-visibility change, not a pipeline change; no workflow edit is involved.
-`GITHUB_TOKEN` cannot do it: there is no REST endpoint for container-package
-visibility, it is a UI action.
+then re-run the `Image` workflow. That is a package-visibility change, not a
+pipeline change; no workflow edit is involved. `GITHUB_TOKEN` cannot do it —
+container-package visibility has no REST endpoint, it is a UI action.
 
-Anyone can re-check the current state without credentials:
+Before reaching for it, rule out the cheaper causes, in this order:
+
+1. **Propagation lag.** GHCR is eventually consistent right after a push.
+   `verify-consumer` already retries the token request and each manifest fetch
+   five times; a failure that survives that is not a lag.
+2. **The package was never pushed.** GHCR returns the same `403 DENIED` on the
+   *token request* for a private package and for one that does not exist, so the
+   token denial alone cannot tell them apart. Distinguish them with
+   `GET /orgs/IronSecCo/packages/container/<package>` — **404** means absent
+   (a `build-mcp` / push problem), **403**/200 means it exists.
+3. **A digest mismatch**, not a visibility problem — the tag resolved but points
+   at something other than the index we just attested. That is a tag race or a
+   concurrent publish, and flipping visibility will not fix it.
+
+Probe the live registry rather than trusting this document:
 
 ```bash
-curl -fsS "https://ghcr.io/token?service=ghcr.io&scope=repository:ironsecco/ironclaw-mcp:pull" \
-  | jq -r .token \
-  | xargs -I{} curl -sS -o /dev/null -w '%{http_code}\n' -H 'Authorization: Bearer {}' \
-      -H 'Accept: application/vnd.oci.image.index.v1+json' \
-      https://ghcr.io/v2/ironsecco/ironclaw-mcp/manifests/latest
-# 200 = public. 401/403 (or a denied token request) = private.
+repo=ironsecco/ironclaw-mcp
+tok=$(curl -s "https://ghcr.io/token?service=ghcr.io&scope=repository:${repo}:pull" | jq -r .token)
+curl -sI -H "Authorization: Bearer ${tok}" \
+  -H 'Accept: application/vnd.oci.image.index.v1+json' \
+  "https://ghcr.io/v2/${repo}/manifests/latest" | head -1   # want: HTTP/2 200
 ```
 
 ## Yanking / superseding a listing


### PR DESCRIPTION
Recovers the half of closed PR #590 that was worth keeping.

Two runs reached the same conclusion about the GHCR visibility gate within minutes of each other. #591 landed the correction and merged; #590 was closed as the duplicate. But #590 was the better version of the remediation, and closing it dropped that.

## The defect #591 left behind

#591's `verify-consumer` error says *"the package is private, or has never been pushed"* and then sends you straight to the visibility toggle. GHCR returns the **same 403 on the token request** for a private package and for one that was never pushed, so that advice is a coin flip — half the time it points an org admin at a button that cannot fix a `build-mcp` / push failure, while the real cause goes unlooked-at.

The message now names the ambiguity and hands over the probe that resolves it:

- `GET /orgs/{org}/packages/container/{pkg}` -> **404** = never pushed (build/push problem)
- **403 / 200** = exists, so visibility is genuinely the issue

and prescribes the flip only for the case it actually fixes.

## Runbook

The section becomes a diagnostic ladder in cost order — propagation lag (already retried 5x), never pushed, digest mismatch — with the org-admin flip demoted to the fallback for the one cause it addresses. It leads with the standing rule: **a red `verify-consumer` is a real failure, never wave it through as a known gate.** The package name is parameterised so it covers `ironclaw-controlplane` too.

## Verification

Executed the error path rather than only linting it:

```
$ IMAGE=ghcr.io/ironsecco/ironclaw-does-not-exist VERSION=dev bash vc.sh
  token attempt 1: HTTP 403, retrying in 10s...
  ... (5 attempts)
::error::Anonymous GHCR pull token for ironsecco/ironclaw-does-not-exist was denied (HTTP 403)
after 5 attempts. This is a REAL failure, not an expected first-publish gate: ...
exit=1
```

Both `owner` and `pkg` interpolate, the full text prints, and the step exits 1. That check is not ceremony: **this branch has twice been unreachable in the exact failure it exists to explain** — first via `curl -f` aborting at `curl: (56)` under `set -e`, then via an undefined `owner` under `set -u`. `actionlint` and `bash -n` clean.

## Lenses

- **Fail loud, fail closed** — unchanged in what it checks; strictly better at explaining itself, and the error path is now proven to run.
- **Least-privilege CI** — untouched; the probe it suggests is a human `gh api` call, not a new token scope.