### PR TITLE
ci(mcp-registry): watch the listing on a clock, not only when we publish it [IRO-611]

### DIFF
--- a/.github/workflows/mcp-registry-watch.yml
+++ b/.github/workflows/mcp-registry-watch.yml
@@ -1,0 +1,202 @@
+name: MCP Registry Watch
+
+# Standing liveness guard for the IronClaw listing on the official MCP Registry
+# (registry.modelcontextprotocol.io), namespace io.github.IronSecCo/ironclaw.
+#
+# Why it exists (IRO-611): the listing sat DEPRECATED for three weeks and ~170 releases
+# and nobody noticed. Not because a check failed — because no check ran. image.yml's
+# post-publish check only executes on a publish, and the publish path was gated off, so
+# the listing could rot for as long as the release path stayed red and every workflow in
+# the repo would still be green. A guard that only runs when the thing it guards is being
+# changed cannot detect the thing decaying on its own.
+#
+# So this runs on a clock, from the OUTSIDE, and asserts what a real MCP client actually
+# needs in order to use us:
+#
+#   1. io.github.IronSecCo/ironclaw resolves on the registry at all.
+#   2. Its isLatest version is `active` — clients resolve the latest version, so an active
+#      old version behind a deprecated latest is still a dark listing.
+#   3. The OCI image that version names is ANONYMOUSLY pullable from GHCR. A listing
+#      pointing at a private or deleted image is dark for every consumer and for the
+#      registry's own OCI validator, however healthy the registry record looks.
+#
+# Any of those failing is a real outage of our only MCP directory presence, and fails the
+# run loudly (fail-loud / fail-closed).
+#
+# Version drift — the listing trailing the newest release tag — is reported as a WARNING,
+# not a failure. It is a known, ticketed condition whenever the release path is red
+# (IRO-621), and a guard that goes red every day for an expected reason is a guard people
+# learn to ignore. That is the same "misleading signal" pathology this workflow exists to
+# kill, so drift stays visible without being fatal.
+#
+# Read-only: no registry auth, no GHCR auth, no publish. It cannot repair the listing, by
+# design — relighting is a deliberate operator action (runbooks/mcp-registry.md).
+
+on:
+  schedule:
+    # Daily, offset off the hour. PulseMCP and other aggregators ingest the registry
+    # roughly daily, so a day is the resolution at which a dark listing starts costing us.
+    - cron: "37 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read # read the newest release tag for the drift report; nothing else
+
+concurrency:
+  group: mcp-registry-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    env:
+      SERVER_NAME: io.github.IronSecCo/ironclaw
+      REGISTRY: https://registry.modelcontextprotocol.io
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Resolve the listing and assert it is live
+        id: listing
+        run: |
+          set -euo pipefail
+          enc="$(jq -rn --arg s "${SERVER_NAME}" '$s|@uri')"
+          url="${REGISTRY}/v0/servers/${enc}/versions"
+
+          # Exact per-server endpoint, never `?search=`: search is fuzzy and nests the
+          # record under `.server`, so a `.servers[].name` match silently never hits. That
+          # selector is what false-failed the 2026-07 publish check (IRO-611).
+          body=""
+          for attempt in 1 2 3; do
+            body="$(curl -fsSL --max-time 30 "${url}" || true)"
+            [ -n "${body}" ] && break
+            echo "  attempt ${attempt}: no response from ${url}, retrying in 15s..."
+            sleep 15
+          done
+          if [ -z "${body}" ]; then
+            echo "::error::${SERVER_NAME} did not resolve on ${REGISTRY} after 3 attempts. Either the registry is down or our listing was removed. Check ${url} by hand before escalating; see runbooks/mcp-registry.md." >&2
+            exit 1
+          fi
+
+          # `official` isolates the registry's metadata block so the dotted key is spelled
+          # once; every jq program below stays single-quoted, with no shell interpolation
+          # into a jq expression.
+          official='def official: ._meta["io.modelcontextprotocol.registry/official"];'
+
+          # Inventory first, so a failure below is readable without re-running anything.
+          echo "Published versions:"
+          printf '%s' "${body}" | jq -r "${official}"'
+            .servers[]? | "  \(.server.version)  \(official.status)  isLatest=\(official.isLatest)"' || true
+
+          latest="$(printf '%s' "${body}" | jq -c --arg n "${SERVER_NAME}" "${official}"'
+            [.servers[]? | select(.server.name == $n and official.isLatest == true)] | first // empty')"
+
+          if [ -z "${latest}" ]; then
+            echo "::error::${SERVER_NAME} has no isLatest version on ${REGISTRY}. Clients resolve the latest version, so there is nothing for them to install. See runbooks/mcp-registry.md." >&2
+            exit 1
+          fi
+
+          version="$(printf '%s' "${latest}" | jq -r '.server.version')"
+          status="$(printf '%s' "${latest}" | jq -r "${official}"'official.status')"
+          # `.identifier | tostring` never `// "null"`: --jq/jq print an EMPTY string for a
+          # null field, and `// ` also swallows `false`, so an absent package would read as
+          # a plausible-looking empty ref instead of an error.
+          package="$(printf '%s' "${latest}" | jq -r '(.server.packages[0].identifier // "") | tostring')"
+
+          echo "isLatest: ${version} status=${status} package=${package}"
+          {
+            echo "version=${version}"
+            echo "package=${package}"
+          } >> "${GITHUB_OUTPUT}"
+
+          if [ "${status}" != "active" ]; then
+            echo "::error::${SERVER_NAME} ${version} is the isLatest version but its status is '${status}', not 'active'. The listing is DARK: MCP clients surface a deprecated server as abandoned. Relight per runbooks/mcp-registry.md (dispatch image.yml with a tag that resolves to the built commit and publish_mcp_registry=true). Do NOT run mcp-registry-deprecate.yml with status=active: it is server-wide and would resurrect 0.1.216-0.1.230, which mount the host Docker socket." >&2
+            exit 1
+          fi
+
+          if [ -z "${package}" ]; then
+            echo "::error::${SERVER_NAME} ${version} is active but declares no OCI package identifier. Nothing for a client to run." >&2
+            exit 1
+          fi
+
+      - name: Anonymous GHCR pull of the image the listing names
+        env:
+          PACKAGE: ${{ steps.listing.outputs.package }}
+        run: |
+          set -euo pipefail
+          # A green registry record pointing at an unpullable image is still an outage:
+          # the registry's own OCI validator fetches anonymously, and so does every user.
+          # Deliberately unauthenticated — this must pass on exactly the path users hit.
+          # Assert the HOST explicitly. Stripping a `ghcr.io/` prefix that is not there is a
+          # silent no-op, and the fetch below would then ask ghcr.io for someone else's
+          # repository path — a confusing failure attributed to the wrong registry (or, if
+          # that path happened to exist on GHCR, a pass that verified the wrong image).
+          case "${PACKAGE}" in
+            ghcr.io/*) ;;
+            *)
+              echo "::error::Listed package '${PACKAGE}' is not on ghcr.io. This guard only knows how to anonymously resolve GHCR. If the listing intentionally moved registries, teach this workflow the new host; until then it cannot vouch for the image." >&2
+              exit 1
+              ;;
+          esac
+          ref="${PACKAGE#ghcr.io/}"
+          repo="${ref%:*}"
+          tag="${ref##*:}"
+          # `repo == ref` means no ':' was present, i.e. no tag. A digest ref (@sha256:...)
+          # lands here too and is equally unsupported: the listing pins immutable :vX.Y.Z.
+          if [ "${repo}" = "${ref}" ] || [ -z "${tag}" ] || [ "${ref}" != "${ref#*@}" ]; then
+            echo "::error::Listed package '${PACKAGE}' is not a ghcr.io/<repo>:<tag> reference; cannot verify it anonymously." >&2
+            exit 1
+          fi
+          echo "Anonymously resolving ${repo}:${tag}"
+
+          # No `curl -f` on the token request: GHCR denies the TOKEN ITSELF with 403 for a
+          # private or nonexistent package, and under `set -e` -f aborts the step with a
+          # bare `curl: (56)` — swallowing the remediation this guard exists to print
+          # (IRO-624).
+          tok_body="$(mktemp)"
+          tok_code=""
+          token=""
+          for attempt in 1 2 3; do
+            tok_code="$(curl -sSL --max-time 30 -o "${tok_body}" -w '%{http_code}' \
+              "https://ghcr.io/token?service=ghcr.io&scope=repository:${repo}:pull" || true)"
+            token="$(jq -r '.token // empty' <"${tok_body}" 2>/dev/null || true)"
+            [ "${tok_code}" = "200" ] && [ -n "${token}" ] && break
+            token=""
+            echo "  token attempt ${attempt}: HTTP ${tok_code}, retrying in 15s..."
+            sleep 15
+          done
+          if [ -z "${token}" ]; then
+            pkg="${repo##*/}"
+            owner="${repo%%/*}"
+            echo "::error::Anonymous GHCR pull token for ${repo} was denied (HTTP ${tok_code}). The MCP listing names an image no unauthenticated client can pull. GHCR returns the same denial for a PRIVATE package and for one that was DELETED, so settle which: 'gh api /orgs/${owner}/packages/container/${pkg}' answers 404 when it does not exist, 200/403 when it does. If it exists it is private, and an org admin must flip it: ${owner} -> Packages -> ${pkg} -> Package settings -> Change visibility -> Public. Runbook: runbooks/mcp-registry.md, section 'Package visibility'." >&2
+            exit 1
+          fi
+
+          accept='application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json'
+          code="$(curl -sSL --max-time 30 -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer ${token}" -H "Accept: ${accept}" \
+            "https://ghcr.io/v2/${repo}/manifests/${tag}" || true)"
+          if [ "${code}" != "200" ]; then
+            echo "::error::Anonymous manifest fetch for ${repo}:${tag} returned HTTP ${code}, not 200. The tag the MCP listing publishes does not resolve for consumers. If the tag was deleted or retagged, re-publish the listing against a tag that exists; see runbooks/mcp-registry.md." >&2
+            exit 1
+          fi
+          echo "OK: ${PACKAGE} resolves anonymously (HTTP 200)."
+
+      - name: Report drift between the listing and the newest release
+        if: ${{ always() && steps.listing.outputs.version != '' }}
+        env:
+          LISTED: ${{ steps.listing.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Non-fatal on purpose (see the header). `gh api --jq` renders a null field as an
+          # EMPTY string, so test for empty rather than the string "null".
+          tag="$(gh api "repos/${REPO}/releases/latest" --jq '.tag_name' 2>/dev/null || true)"
+          if [ -z "${tag}" ]; then
+            echo "::notice::Could not read the newest release tag; skipping the drift report."
+            exit 0
+          fi
+          newest="${tag#v}"
+          if [ "${newest}" = "${LISTED}" ]; then
+            echo "In sync: listing ${LISTED} == newest release ${tag}."
+            exit 0
+          fi
+          echo "::warning::MCP listing is at ${LISTED} but the newest release is ${tag}. The listing is live, so this is not an outage — but the release path is not re-publishing it. Expected while the Release -> Image chain is broken (IRO-621). If that chain is green and this warning persists, the publish job is being skipped and needs investigating."

--- a/runbooks/mcp-registry.md
+++ b/runbooks/mcp-registry.md
@@ -51,6 +51,7 @@ listing:
 | `build-mcp` job in `.github/workflows/image.yml` | Builds + pushes the multi-arch MCP image, attests provenance and an SBOM, and asserts the label matches `server.json` on **every** arch. |
 | `publish-mcp-registry` job in `.github/workflows/image.yml` | Chains off the build/attest/verify chain and publishes the listing via the pinned `mcp-publisher` CLI. |
 | `.github/workflows/mcp-registry-deprecate.yml` | Manual status flip for the whole server record. See the caution below before using it. |
+| `.github/workflows/mcp-registry-watch.yml` | Daily read-only liveness guard. Asserts the listing still resolves, is `active` + `isLatest`, and names an anonymously pullable image. See [Standing liveness guard](#standing-liveness-guard). |
 
 The publish job runs **only after** `verify-consumer` proves **both** images are
 anonymously pullable and attested, and **only for tagged releases**
@@ -126,8 +127,27 @@ After publishing, the job runs two steps that matter:
 ## Relighting a deprecated listing
 
 Publish a new version. The release path activates and verifies it per-version, so
-a green `Image` workflow **is** the proof that the listing is live. There is no
-manual step.
+a green `Image` workflow **is** the proof that the listing is live.
+
+The trap is the other direction: a workflow that **never ran** is also never red.
+`Image` chains off `Release`, so anything that fails `Release` — including a purely
+cosmetic packaging job — silently skips the publish, and every workflow in the repo
+stays green while the listing rots. That is exactly how 0.1.230 sat `deprecated` for
+three weeks and ~170 releases (IRO-611). So: green `Image` proves the listing is
+live; the **absence** of a red `Image` proves nothing. That gap is what
+[`mcp-registry-watch.yml`](#standing-liveness-guard) covers.
+
+When the release path is broken and the listing needs relighting now, dispatch the
+publish by hand:
+
+```bash
+# The tag MUST resolve to the commit being built: workflow_dispatch runs the workflow
+# file from the ref it builds, and a tag naming a different commit stamps the listing
+# with a version that does not describe the image (IRO-625).
+gh workflow run image.yml --ref main \
+  -f tag=<tag on the current main tip> \
+  -f publish_mcp_registry=true
+```
 
 Do **not** reach for `mcp-registry-deprecate.yml` with `status=active`, and do not
 pass `--all-versions` to `mcp-publisher status`. Both are **server-wide**: they
@@ -216,6 +236,30 @@ not the most serious. In rough order of likelihood:
    answers **404 "Package not found"** when it does not exist, and **200** — or
    **403 "needs `read:packages` scope"** if your token lacks the scope — when it
    does. Any non-404 answer proves existence, which is the only bit you need.
+
+## Standing liveness guard
+
+`.github/workflows/mcp-registry-watch.yml` runs daily (and on demand) and asserts,
+from the outside and with no credentials, the three things a real MCP client needs:
+
+1. `io.github.IronSecCo/ironclaw` resolves on the registry.
+2. Its **`isLatest`** version is `active`. Clients resolve the latest version, so an
+   `active` old version sitting behind a `deprecated` latest is still a dark listing.
+3. The OCI image that version names is **anonymously pullable** from GHCR. A healthy
+   registry record pointing at a private or deleted image is dark for every consumer
+   and for the registry's own OCI validator.
+
+Any of those failing is a real outage of our only MCP directory presence and fails
+the run. It is read-only — no registry auth, no GHCR auth, no publish — so it can
+report the outage but never repair it; relighting stays a deliberate operator action
+(above).
+
+**Version drift is a warning, not a failure.** When the listing trails the newest
+release tag, the run warns and stays green. Drift is expected whenever the
+`Release → Image` chain is broken (IRO-621), and a guard that goes red every day for
+a known reason is a guard people learn to ignore — the same misleading-signal
+pathology this workflow exists to kill. If the chain is green and the drift warning
+persists, the publish job is being skipped and needs investigating.
 
 ## Yanking / superseding a listing
 


### PR DESCRIPTION
## Why

The MCP Registry listing sat `deprecated` for three weeks and ~170 releases and **no check ever went red — because no check ever ran.**

`image.yml`'s post-publish verification only executes on a publish. `Image` chains off `Release`, so a cosmetic packaging failure (the Homebrew `formula` job, IRO-621) skipped the publish entirely, and every workflow in the repo stayed green while our only MCP directory presence rotted.

A guard that runs only when the thing it guards is being changed cannot detect that thing decaying on its own. This closes that hole.

It is live right now: the listing is `0.1.404` while the newest release is `v0.1.407`, because the release path is still red. The listing is up, but nothing is re-publishing it and nothing would tell us if it went down.

## What it asserts

Daily, read-only, unauthenticated — exactly the path a real MCP client and the registry's own OCI validator take:

1. `io.github.IronSecCo/ironclaw` resolves on the registry.
2. Its **`isLatest`** version is `active`. An `active` old version behind a `deprecated` latest is still a dark listing, because clients resolve the latest.
3. The OCI image that version names is **anonymously pullable** from GHCR. A healthy registry record pointing at a private or deleted image is dark for every consumer.

Any of those fails the run, with the remediation in the error text.

**Version drift is a warning, not a failure.** Drift is expected while the `Release → Image` chain is broken, and a guard that goes red every day for a known reason is a guard people learn to ignore — the same misleading-signal pathology this exists to kill.

## Verification

`actionlint` clean (it shellchecks the `run:` bodies). Then, per the CI-gate verify pattern: each step's `run:` body extracted from the YAML with `yaml.safe_load` and **executed unmodified**, first against the live registry and live GHCR, then against a `curl` stub on `PATH` for the branches live data cannot reach.

Live:

| Case | Result |
| --- | --- |
| Resolve listing, live registry | `exit=0`, `isLatest: 0.1.404 status=active package=ghcr.io/ironsecco/ironclaw-mcp:v0.1.404`, outputs set |
| Anonymous GHCR pull, live | `exit=0`, HTTP 200 |
| Drift, live | `exit=0` + `::warning::` — listing `0.1.404` vs newest release `v0.1.407` |
| Drift, in-sync | `exit=0`, `In sync` |

Stubbed (fixtures derived from the live response so only the field under test differs):

| Case | Result |
| --- | --- |
| `isLatest` is `deprecated` — **the exact three-week state** | `exit=1`, dark-listing error |
| No `isLatest` version | `exit=1` |
| `active` but zero packages | `exit=1` |
| Registry unreachable (3 attempts) | `exit=1` |
| GHCR token denied 403 (private/deleted) | `exit=1`, private-vs-nonexistent triage |
| Manifest 404 (tag deleted/retagged) | `exit=1` |
| Package ref has no tag / is a digest | `exit=1` |
| Unstubbed healthy fixture (control) | `exit=0` |

The deprecated-`isLatest` case is the one that matters: **this guard would have gone red on day one of the outage.**

### A defect the stubbing found in my own guard

The first draft stripped a `ghcr.io/` prefix with `${PACKAGE#ghcr.io/}` and only checked that a tag was present. For a non-GHCR ref (`docker.io/library/nginx:1`) the strip is a silent no-op, so the guard would have asked **ghcr.io** for someone else's repository path — a failure attributed to the wrong registry, or, if that path happened to exist on GHCR, a pass that verified the wrong image. Now the host is asserted explicitly, and digest refs are rejected too. Driven both ways.

## Lenses

- **Fail loud, fail closed** — the point of the change.
- **Least-privilege CI** — `contents: read` only, for the release-tag drift read. No registry auth, no GHCR auth, no publish. It reports outages and cannot repair them, by design.
- **Verify-before-trust** — asserts consumability on the anonymous path, never on cached runner credentials.
- Nothing weakened: no signing, attestation, token-scope, required-check or installer change.

## Note

Scheduled workflows only fire from the default branch, so the guard starts running once this is on `main`. `workflow_dispatch` is enabled to exercise it on demand.

Does not touch #593 (same ticket, the idempotent activation fix) — separate files, no conflict.