### PR TITLE
docs(cla): lead with the one-click signing link, say comments do not sign [IRO-637]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,8 @@ Closes #
 - [ ] **Threat model:** no change to the sandbox seal / `network=none` / approval-gateway posture — or it is called out and reviewed.
 - [ ] **Docs updated:** README / `docs/**` reflect any user-facing or behavioral change.
 - [ ] **No secrets:** no tokens, keys, or credentials in code, tests, fixtures, or logs.
+- [ ] **CLA signed:** first PR here? One click at <https://cla-assistant.io/IronSecCo/ironclaw>.
+      Signing by comment does **not** work on this repo, the link is the only path.
 
 ## Validation
 

--- a/CLA.md
+++ b/CLA.md
@@ -83,8 +83,21 @@ that would make these representations inaccurate in any respect.
 
 ---
 
-**To sign:** the CLA Assistant bot prompts You on Your first pull request; signing is
-electronic, through Your GitHub account, and is remembered for future PRs.
+## How to sign
+
+Sign here: **<https://cla-assistant.io/IronSecCo/ironclaw>**
+
+It is one click through Your GitHub account, it takes a few seconds, and it is recorded
+per contributor, so it covers every pull request You open from then on. The CLA Assistant
+bot also posts that same link on Your first pull request.
+
+> **Commenting on the pull request does not sign the CLA.** Some projects accept a
+> "I have read the CLA Document and I hereby sign the CLA" comment. We do not. The bot we
+> run only reads pull request events, so a sign comment here is silently ignored and the
+> `license/cla` check stays red. Use the link above.
+
+If the check still shows red after You have signed, use the `recheck` link in the bot's
+comment on Your pull request.
 
 **Contributing for a company?** Contact a maintainer on LinkedIn for a Corporate CLA —
 [Omer Zamir](https://www.linkedin.com/in/omerzamir) or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,9 @@
 > permanent, non-exclusive, worldwide, royalty-free license to use, modify, and
 > commercially dual-license your contributions.** This is formalized in the
 > [Contributor License Agreement](CLA.md), which the CLA Assistant bot asks you to sign
-> on your first pull request.
+> on your first pull request. Sign it in one click at
+> **<https://cla-assistant.io/IronSecCo/ironclaw>**. Posting a sign comment on the pull
+> request does **not** work here, see [Signing the CLA](#signing-the-cla).
 
 Thanks for your interest in IronClaw! Contributions of every kind are welcome —
 bug reports, fixes, new channel adapters, docs, and tests.
@@ -34,14 +36,29 @@ git push -u origin my-change
 ```
 
 Then open the pull request, fill in the template, and link the issue it closes.
-The **CLA Assistant** bot comments on your first PR with a one-click signing link —
-that's all the setup there is. A maintainer reviews and merges.
+A maintainer reviews and merges.
 
 **Looking for something to work on?** Grab a
 [**good first issue**](https://github.com/IronSecCo/ironclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 (comment to claim it first), or ask in
 [**Discussions**](https://github.com/IronSecCo/ironclaw/discussions). The rest of this
 guide covers the ground rules, the frozen contract, and the code layout in detail.
+
+### Signing the CLA
+
+One click, and it is the only setup step there is:
+
+**<https://cla-assistant.io/IronSecCo/ironclaw>**
+
+The signature is recorded against your GitHub account, so you sign once and every later
+pull request is covered. The **CLA Assistant** bot posts that same link on your first PR.
+
+**Do not try to sign by comment.** Other projects accept a
+`I have read the CLA Document and I hereby sign the CLA` comment on the pull request.
+This one does not: the bot we run only reads pull request events, so a sign comment is
+silently ignored and `license/cla` stays red no matter how many times you post it.
+If you have signed and the check is still red, use the `recheck` link in the bot's
+comment rather than replying to it.
 
 ### Good places to start
 


### PR DESCRIPTION
## What & why

Contributor-facing CLA guidance never named the signing URL and never ruled out signing by comment. A contributor who carried the `I have read the CLA Document and I hereby sign the CLA` convention over from another project had no way to learn it does not apply here. One did: six sign comments across #568, #569 and #574, five days, no effect.

## The actual mechanism

`cla-assistant` loads webhook handlers by filename from `src/server/src/webhooks/`, and that directory holds exactly `merge_group.js`, `ping.js`, `pull_request.js`. Any other event falls through to `res.status(400).send('Unsupported event')` in `src/server/src/app.js`. There is no `issue_comment` handler and no reference to the sign phrase anywhere in its source, so a sign comment on this repo cannot ever register.

Confirmed live rather than only from source. Subscribing our hook to `issue_comment` and sending one produced the first `issue_comment` delivery in the hook's history, and it came back `400 Unsupported event`:

```
2026-07-29T05:20:20.706Z issue_comment.created -> 400   guid 30cd1b60-8b0d-11f1-815d-69775ffea9f8
```

The subscription has since been reverted, since it only generates failing deliveries.

## Changes

- `CLA.md`: `How to sign` section leading with the link, plus a callout that commenting does not sign.
- `CONTRIBUTING.md`: link in the opening CLA note, and a `Signing the CLA` section in the quickstart.
- `.github/pull_request_template.md`: CLA checklist item with the link.

## Validation

Docs only, no build surface. `docs_dir: docs`, so none of these three files are in the MkDocs site and no markdown lint or link-check job covers them. Both signing URLs verified to return 200:

```
curl -sIL https://cla-assistant.io/IronSecCo/ironclaw            -> 200
curl -sIL 'https://cla-assistant.io/IronSecCo/ironclaw?pullRequest=574' -> 200
```

Rendered headings checked: the new `#signing-the-cla` anchor referenced from the top-of-file note resolves.