### PR TITLE
build(image): stamp and assert org.opencontainers.image.revision/source on the controlplane image [IRO-640]

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -415,6 +415,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             VERSION=${{ needs.prepare.outputs.version }}
+            REVISION=${{ needs.prepare.outputs.sha }}
+            SOURCE=${{ github.server_url }}/${{ github.repository }}
           # Push by digest only; the merge job applies the real tags. name-canonical
           # keeps the pushed ref pinned to the digest under the target repo.
           outputs: type=image,name=${{ needs.prepare.outputs.image }},push-by-digest=true,name-canonical=true,push=true
@@ -520,6 +522,60 @@ jobs:
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
           echo "Published ${IMAGE} index ${digest} as: ${TAGS}"
           docker buildx imagetools inspect "${IMAGE}@${digest}"
+
+      # Assert the image's own origin labels BEFORE attesting it (IRO-633). A label that
+      # nobody checks is decoration; this is what makes org.opencontainers.image.revision
+      # load-bearing.
+      #
+      # The value is baked into the image bytes and is therefore part of the digest, so
+      # unlike an attestation subject it cannot be re-pointed after the fact. Checking it
+      # against the commit `prepare` trust-gated means the index we are about to sign has
+      # to agree, from the inside, about which commit it came from — an independent
+      # cross-check on provenance rather than a restatement of it.
+      #
+      # Same shape as the MCP ownership-label assertion in build-mcp: on a multi-platform
+      # index `.Image` is a map keyed by platform, so read the label from EVERY manifest.
+      # One arch built without it is still a broken publish. An empty or unreadable label
+      # is a FAIL, never a pass.
+      - name: Assert the image's revision label matches the built commit
+        env:
+          IMAGE: ${{ needs.prepare.outputs.image }}
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+          WANT_SHA: ${{ needs.prepare.outputs.sha }}
+          WANT_SOURCE: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          set -euo pipefail
+          labels="$(docker buildx imagetools inspect "${IMAGE}@${DIGEST}" --format \
+            '{{ range $p, $img := .Image }}{{ $p }}={{ index $img.Config.Labels "org.opencontainers.image.revision" }}={{ index $img.Config.Labels "org.opencontainers.image.source" }}
+            {{ end }}' | tr -d '\r')"
+          seen=0
+          bad=0
+          while IFS= read -r line; do
+            line="$(printf '%s' "${line}" | tr -d '[:space:]')"
+            [ -z "${line}" ] && continue
+            seen=$((seen + 1))
+            plat="${line%%=*}"
+            rest="${line#*=}"
+            rev="${rest%%=*}"
+            src="${rest#*=}"
+            echo "  ${plat}: revision=${rev:-<empty>} source=${src:-<empty>}"
+            if [ "${rev}" != "${WANT_SHA}" ]; then
+              echo "::error::${plat}: org.opencontainers.image.revision='${rev}' does not match the trust-gated build commit '${WANT_SHA}' — refusing to attest an image that disagrees about its own origin." >&2
+              bad=1
+            fi
+            if [ "${src}" != "${WANT_SOURCE}" ]; then
+              echo "::error::${plat}: org.opencontainers.image.source='${src}' does not match '${WANT_SOURCE}'." >&2
+              bad=1
+            fi
+          done <<< "${labels}"
+          # No manifests read at all means the inspect returned nothing useful; that is an
+          # unchecked publish, not a clean one.
+          if [ "${seen}" = "0" ]; then
+            echo "::error::Read no platform manifests for ${IMAGE}@${DIGEST} — could not verify the origin labels. Failing the release." >&2
+            exit 1
+          fi
+          [ "${bad}" = "0" ] || exit 1
+          echo "Origin labels agree with the built commit on all ${seen} platform manifest(s)."
 
       - name: Attest the control-plane image
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4

--- a/container/controlplane.Dockerfile
+++ b/container/controlplane.Dockerfile
@@ -75,6 +75,23 @@ RUN mkdir -p /var/lib/ironclaw/state /run/ironclaw \
  && chmod 0700 /var/lib/ironclaw/state \
  && chmod +x /usr/local/bin/controlplane-entrypoint.sh
 
+# Standard OCI source labels (IRO-633). `revision` is the git commit this image was built
+# from and `source` is the repository it came from, so the image itself carries an
+# independent claim about its own origin. That matters because provenance does not:
+# actions/attest-build-provenance takes the subject digest as a free input and signs
+# whatever it is handed, so an attestation can describe an image the run never built
+# (IRO-629). These labels are baked into the image bytes at build time and are part of the
+# digest, so they cannot be re-pointed after the fact the way an attestation subject can —
+# which makes them a cross-check on it rather than a duplicate of it. image.yml asserts
+# `revision` against the commit it trust-gated, on every published arch, before attesting.
+#
+# `source` additionally links the GHCR package to this repo, which is what lets consumers
+# run `gh attestation verify --repo` against it at all.
+ARG REVISION=unknown
+ARG SOURCE=https://github.com/IronSecCo/ironclaw
+LABEL org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.source="${SOURCE}"
+
 # The MCP Registry ownership label (io.modelcontextprotocol.server.name) deliberately does
 # NOT live here. It sits on container/mcp.Dockerfile, the socket-free image the listing now
 # points at (IRO-612). Labelling this image as well would let a publish re-bind the listing


### PR DESCRIPTION
Ships part (c) of the CEO scope decision on IRO-633 (IRO-640). Independent of #602 (part a) — non-overlapping hunks, either order merges.

## Why

The control-plane image carried **no OCI labels at all**, so nothing inside it recorded which commit produced it. Provenance does not supply that binding either: `actions/attest-build-provenance` takes `subject-digest` as a **free input** and signs whatever it is handed — which is precisely how a run attested an index it had never built (IRO-629).

`org.opencontainers.image.revision` is baked into the image bytes and is therefore **part of the digest**. Unlike an attestation subject it cannot be re-pointed after the fact, which makes it a genuine cross-check on provenance rather than a restatement of it. `org.opencontainers.image.source` additionally links the GHCR package to this repo, which is what lets consumers run `gh attestation verify --repo` against it.

## What

- `container/controlplane.Dockerfile`: `ARG REVISION` / `ARG SOURCE` → `LABEL org.opencontainers.image.revision` / `.source`.
- `build` job passes `REVISION=<the trust-gated commit>` and `SOURCE=<server_url>/<repo>`.
- `merge` job asserts both labels **before attesting**, on **every platform manifest** in the index — one arch built without them is still a broken publish. Same idiom as the MCP ownership-label assertion in `build-mcp`. An empty or unreadable label, or an inspect yielding no manifests, is a FAIL.

A label nobody checks is decoration; the assertion is what makes it load-bearing. That is the same reasoning behind declining part (b): the gap was never a missing tool, it was that nothing looked at what we already had.

## Verification

Real `docker build -f container/controlplane.Dockerfile` with the build-args:

```
$ docker inspect ... --format '{{json .Config.Labels}}'
{
  "org.opencontainers.image.revision": "e0ef131deadbeefcafe0123456789abcdef01234",
  "org.opencontainers.image.source": "https://github.com/IronSecCo/ironclaw"
}
```

Assertion body extracted from the YAML and run **unmodified** over stubbed `imagetools inspect` output:

| case | expect | result |
|---|---|---|
| both arches correct | PASS | PASS (`agree ... on all 2 platform manifest(s)`) |
| single arch correct | PASS | PASS |
| one arch missing the label | FAIL | FAIL |
| one arch wrong revision | FAIL | FAIL |
| wrong source | FAIL | FAIL |
| empty inspect output | FAIL | FAIL |

`actionlint` clean.

**Not exercised:** the assertion has not been run against a live multi-arch index — Docker Desktop refused the plain-HTTP local-registry push. The `imagetools inspect --format` map-iteration idiom it depends on is the one already running in production in `build-mcp`; the new logic is the shell parsing, which the stub matrix covers. First real release run is the confirmation.