### PR TITLE
ci(brew): diff PRs against a real merge base, not a stale base tip [IRO-673]

### DIFF
--- a/.github/workflows/brew-formula-verify.yml
+++ b/.github/workflows/brew-formula-verify.yml
@@ -49,11 +49,21 @@ jobs:
   brew-formula-verify:
     runs-on: ubuntu-latest
     steps:
-      # fetch-depth: 0 so the base commit is present locally; the script diffs the
+      # fetch-depth: 0 so the merge base is computable locally; the script diffs the
       # head against it to decide which paths changed.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          # Deliberately NO `ref:` override. On a pull_request event checkout resolves
+          # GitHub's refs/pull/N/merge, and that is what we want for two reasons:
+          #   - it is a real merge commit whose first parent is the base commit, so
+          #     `git merge-base` against the base branch resolves to exactly that
+          #     parent and the diff is precisely what the merge would write;
+          #   - the checkout therefore contains main's copy of this script even when
+          #     the PR head predates it. Pinning `ref: head.sha` instead makes
+          #     scripts/verify-homebrew-formula.sh vanish on any PR opened before
+          #     IRO-670 landed, and this required check then fails those PRs with
+          #     "no such file" — a different flavour of the same IRO-673 outage.
 
       # Same 2.x cosign the Release workflow signs SHA256SUMS with. cosign 3.x
       # deprecates the detached --output-signature/--output-certificate pair this
@@ -66,15 +76,37 @@ jobs:
       - name: Resolve the base commit to diff against
         id: base
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           EVENT: ${{ github.event_name }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+
+          # Materialise a base BRANCH ref locally so `git merge-base` has a real ref
+          # to work against. checkout above already fetched full history, so this only
+          # adds the ref itself. Deliberately NOT silenced with `|| true`: if the base
+          # branch is not visible we must fail loud rather than diff against something
+          # arbitrary and report a confident wrong answer.
+          fetch_branch() {
+            git fetch --no-tags --quiet origin "+refs/heads/$1:refs/remotes/origin/$1"
+          }
+
           case "$EVENT:$GITHUB_REF_NAME" in
             pull_request:*)
-              # The real merge base GitHub computed for this PR.
-              base="$PR_BASE_SHA"
+              # A TRUE merge base — NOT `github.event.pull_request.base.sha`.
+              #
+              # That field is a snapshot of the base branch TIP, and in webhook
+              # payloads a stale one; it is not a merge base at any point. Diffing the
+              # head against it charges the PR with every commit that landed on the
+              # base after the PR forked. Because the rolling bump touches
+              # Formula/ironclaw.rb 1-2x/day, that made this REQUIRED check hard-fail
+              # PRs it exists to wave through: a one-file docs PR was reported as a
+              # 17-path formula edit and failed the formula-only assertion (IRO-673).
+              #
+              # Resolved against base.ref, not a hardcoded main, so this stays correct
+              # if the gate is ever extended to another protected branch.
+              fetch_branch "$PR_BASE_REF"
+              base="$(git merge-base "refs/remotes/origin/${PR_BASE_REF}" HEAD)"
               ;;
             push:test/brew-formula-verify-*)
               # Negative-control branches (acceptance criterion 5). Diff against the
@@ -92,9 +124,10 @@ jobs:
               base="$(git rev-parse HEAD^)"
               ;;
             *)
-              # Push to brew/**: compare against where this branch left main.
-              git fetch --no-tags --depth=0 origin main >/dev/null 2>&1 || true
-              base="$(git merge-base origin/main HEAD)"
+              # Push to brew/**: compare against where this branch left main. Same
+              # merge-base resolution as the pull_request arm above.
+              fetch_branch main
+              base="$(git merge-base refs/remotes/origin/main HEAD)"
               ;;
           esac
           [ -n "$base" ] || { echo "::error::could not resolve a base commit to diff against." >&2; exit 1; }

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -165,6 +165,44 @@ runs and short-circuits to a pass when the diff has no formula change.
 > `.github/rulesets/main.json`. Renaming the job (or giving it a `name:`) orphans
 > the required check and the gate silently stops gating.
 
+#### The base commit must be a merge base (IRO-673)
+
+Assertion 1 above is only as good as the base it diffs against, and the first
+version of this gate got that wrong: it used
+`github.event.pull_request.base.sha`. **That field is not a merge base.** It is a
+snapshot of the base branch *tip*, and in webhook payloads a stale one. Diffing a
+PR head against it attributes every commit that landed on `main` after the PR
+forked to the PR itself — and since the rolling bump touches
+`Formula/ironclaw.rb` once or twice a day, a *required* check hard-failed PRs it
+exists to wave through. A one-file docs PR (#569) was reported as an 84-path
+formula edit and told to split itself up.
+
+Both arms now resolve a real merge base, against
+`github.event.pull_request.base.ref` rather than a hardcoded `main`:
+
+```sh
+git fetch --no-tags --quiet origin "+refs/heads/$1:refs/remotes/origin/$1"
+base="$(git merge-base "refs/remotes/origin/${PR_BASE_REF}" HEAD)"
+```
+
+Two things this depends on, both easy to break by accident:
+
+- **`fetch-depth: 0`** on the checkout. Without full history there is no merge
+  base to compute.
+- **No `ref:` override on the checkout.** On a `pull_request` event, checkout
+  resolves GitHub's `refs/pull/N/merge`, whose first parent *is* the base commit,
+  so `git merge-base` lands exactly there and the diff is precisely what the
+  merge would write — stale merge ref or not. Pinning
+  `ref: ${{ github.event.pull_request.head.sha }}` looks tidier and is a trap: it
+  removes `main`'s copy of `scripts/verify-homebrew-formula.sh` from the
+  checkout, so this required check fails every PR opened before the gate landed
+  with `No such file or directory`. Same outage, different message.
+
+The lesson generalises past this workflow: **a required check that can fail a PR
+for something the PR did not do is worse than no check**, because the only
+remedies on offer are relaxing the check or bypassing protection. Fix the base
+resolution instead.
+
 ### Squash only. This is load-bearing, not a style preference
 
 `allowed_merge_methods` is `["squash", "rebase"]`, but a bump PR **must** be
@@ -203,14 +241,32 @@ signatures, linear history — to work around a stale cache. Taking the flag `gh
 suggests here trades the whole gate for a cosmetic convenience. Use the REST API
 form above.
 
-> **Still one human action: the approving review.** `brew-formula-verify` removes
-> the *review value* of the click but cannot remove the click itself, because
-> `pull_request.required_approving_review_count: 1` needs an approval from an
-> actor that is not the PR author, and the reviewer App **is** the author. Closing
-> that last gap needs a second identity; the ask and its trade-offs are on
-> IRO-670. Until then: dispatch `reviewer-approve.yml`, then merge with the REST
-> API form above. Do not reach for `--admin`, and do not add a `bypass_actors`
-> entry for the App.
+### The last click stays. Settled, not pending (IRO-670)
+
+`pull_request.required_approving_review_count: 1` needs an approval from an actor
+that is not the PR author, and the reviewer App **is** the author of the bump PR.
+So one human action per release remains: dispatch `reviewer-approve.yml`, then
+merge with the REST API form above.
+
+Two ways to remove it were put to the board and **both were declined**:
+
+- **a second long-lived credential** (another App or account to approve as) — one
+  more standing credential with write reach on a protected branch, to save a
+  keystroke;
+- **a `bypass_actors` entry for the reviewer App** — rulesets cannot scope a
+  bypass to one path, so exempting the App for `Formula/ironclaw.rb` exempts it
+  for all of `main`.
+
+The reasoning, recorded so it is not re-litigated: the 17 issues of recurring
+toil were never the *click*, they were the *judgment* — a maintainer squinting at
+a generated `sha256` they had no way to validate. `brew-formula-verify` removes
+100% of that judgment, which was the entire win. What is left is one mechanical
+action per release on the protected branch of a container-security product, and
+that is a reasonable place to keep a human. **Revisit only if release cadence
+makes it material** — not as a tidiness argument.
+
+Until then, and regardless of how tempting a green-but-blocked PR makes it: do
+not reach for `--admin`, and do not add a `bypass_actors` entry for the App.
 
 ## Branch protection: the reviewer path needs no change
 


### PR DESCRIPTION
## The bug

`brew-formula-verify` (landed in #611) resolved the `pull_request` base from
`github.event.pull_request.base.sha`, under a comment calling it *"the real merge base
GitHub computed for this PR"*. It is neither a merge base nor current: it is a
**base-branch tip snapshot**, stale in webhook payloads. The gate therefore diffed the
PR head against a `main` commit that had already moved, and charged the PR with every
commit that landed in between.

The rolling Homebrew bump touches `Formula/ironclaw.rb` 1-2x/day, so those phantom paths
routinely included the formula — and the formula-only assertion then hard-failed the PR.
A **required** check was failing PRs for something they did not do. Run
[30508217567](https://github.com/IronSecCo/ironclaw/actions/runs/30508217567) on #569
(one docs file) went red with `changes Formula/ironclaw.rb AND 17 paths in total`.

## The fix

Both arms resolve a real merge base, against `pull_request.base.ref` rather than a
hardcoded `main` so the gate stays correct if another branch is ever protected:

```sh
git fetch --no-tags --quiet origin "+refs/heads/$1:refs/remotes/origin/$1"
base="$(git merge-base "refs/remotes/origin/${PR_BASE_REF}" HEAD)"
```

Measured on the four open PRs (`git diff --name-only <base> <merge ref>`):

| PR | old `base.sha` | fixed merge-base | verdict |
|---|---|---|---|
| #569 docs-only | **84 paths, formula included** | 1 path, no formula | red → **pass** |
| #574 tests | **76 paths, formula included** | 2 paths, no formula | red → **pass** |
| #568 feature | 3 paths, none | 3 paths, none | unchanged |
| #612 rolling bump | 1 path, formula | 1 path, formula | unchanged, still byte-checked |

(#569 was 17 paths when the CEO reproduced it and is 84 now — `base.sha` advanced to
main's tip, so the bug was getting worse, not settling.)

## What is deliberately NOT changed, and why

- **No `ref:` override on the checkout.** Pinning `ref: head.sha` looks tidier and is a
  trap. `refs/pull/N/merge` is what makes `git merge-base` land on the base commit even
  when the merge ref is stale, *and* it is what puts main's copy of
  `scripts/verify-homebrew-formula.sh` in the checkout. Verified: that script is absent
  from the head commit of #568, #569 and #574, so head-pinning would fail all three with
  `No such file or directory` — the same outage with a different message. Written into
  the workflow as a comment so the next reader does not "clean it up".
- **Step 2 is not loosened**, and there is no `paths:` filter or job-level `if:`. The
  header already explains why a required check must always report.
- The negative-control arm (`push:test/brew-formula-verify-*`, diff against `HEAD^`) is
  **byte-identical**.

Also drops `git fetch --depth=0`, which never worked: git rejects it with
`fatal: depth 0 is not a positive number` and the `|| true` swallowed it, so the
`brew/**` arm only functioned because checkout happened to leave `origin/main` behind.
The shared helper is not silenced — an unreachable base branch now fails loud.

## Verification (local, against real refs)

1. **Criterion 1, stale base.** Ran the real script on #569's merge ref with a base two
   formula bumps + one gate commit behind main (`e01a9fb`):
   `Paths changed vs e01a9fb: 1 / docs/scan.md → PASS (not a formula change)`.
   Also proved the stale-merge-ref case: `merge-base(origin/main, <merge ref built on
   e01a9fb>)` resolves to `e01a9fb`, never to main's tip, so no phantom paths either way.
2. **Criterion 3, no false negative.** Crafted a commit editing `Formula/ironclaw.rb`
   *and* `docs/scan.md`; the gate still fails step 2:
   `FAIL: this PR changes Formula/ironclaw.rb AND 2 paths in total`.
3. **Criterion 2, non-vacuity preserved.** The negative-control arm is unchanged; run
   [30505450985](https://github.com/IronSecCo/ironclaw/actions/runs/30505450985) stays
   valid, and the in-script self-test still re-proves detection on every run.
4. `actionlint` clean.

This PR's own green run is *not* the evidence — it has a fresh base and no formula
change, so it short-circuits at step 1. The table above is the evidence.

Docs: `docs/pr-review-process.md` records the merge-base rule (with both checkout traps)
and the board's IRO-670 decision — the last human click stays; neither a second
long-lived credential nor a `bypass_actors` entry for the App.

Refs IRO-673, IRO-670.