### PR TITLE
docs(readme): stop claiming Homebrew always installs the latest release [IRO-670]

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,13 +561,18 @@ brew tap IronSecCo/ironclaw https://github.com/IronSecCo/ironclaw
 brew install ironsecco/ironclaw/ironclaw
 ```
 
-This installs `ironctl`, `ironclaw-controlplane`, and `ironclaw-sandbox` from the latest release. The
-formula pins each archive to the SHA-256 recorded in the release's signed `SHA256SUMS`, so Homebrew
-verifies the download before installing. Confirm it with `ironctl version`.
+This installs `ironctl`, `ironclaw-controlplane`, and `ironclaw-sandbox` from the release the
+formula currently pins. The formula pins each archive to the SHA-256 recorded in that release's
+signed `SHA256SUMS`, so Homebrew verifies the download before installing. Confirm it with
+`ironctl version`.
 
-Homebrew always installs the **latest** release. To pin an older version, use the installer
-script's `IRONCLAW_VERSION` ([below](#prebuilt-binaries-installer-script)) or grab the archive
-by hand — the tap carries only the current release.
+The tap carries exactly one version at a time. An automated pull request bumps the formula after
+every release, and it lands only once a required CI check has re-derived the formula from that
+release's cosign-verified `SHA256SUMS`, so the tap can briefly trail the newest release. Run
+`brew update` first, and see
+[Releases](https://github.com/IronSecCo/ironclaw/releases/latest) for the newest version. To
+install a specific version, including one the tap has not picked up yet, use the installer
+script's `IRONCLAW_VERSION` ([below](#prebuilt-binaries-installer-script)).
 
 > **Use the fully-qualified name.** homebrew-core ships an *unrelated* formula also called `ironclaw`,
 > and core wins the bare name — so install `ironsecco/ironclaw/ironclaw`, not bare `ironclaw`. The


### PR DESCRIPTION
Closes the last open item on IRO-670: the CEO flagged that README line 568 published a freshness claim we know is false, and asked for either automation that makes it true or a corrected sentence. The residual approving-review click on the rolling bump is now a settled decision (`docs/pr-review-process.md`, "The last click stays"), so the automation will not make it true. The sentence changes.

## The claim was false, with receipts

- `#607` (v0.1.426) merged `22:35:58Z`; `v0.1.428` was cut `22:41:37Z`. The tap was current for **six minutes**.
- Right now: `main` pins **v0.1.430**, current release is **v0.1.432** (bump PR #614 open and green).

## What it says instead

The tap carries exactly one version; an automated PR bumps it after every release and lands only once `brew-formula-verify` has re-derived the formula from that release's cosign-verified `SHA256SUMS`, so it can briefly trail. Readers get `brew update`, the Releases link, and `IRONCLAW_VERSION` for a specific version.

No em/en dashes in the new copy (IRO-254 standing rule); the one dash in range is pre-existing.

## Scope

README prose only. Does not touch `Formula/ironclaw.rb`, the gate, the ruleset, or any signing/verification path. `brew-formula-verify` should short-circuit to a pass here, which incidentally exercises its non-formula-diff arm.