### PR TITLE
ci(brew): make a waiting rolling-bump PR announce itself [IRO-676]

### DIFF
--- a/.github/workflows/brew-bump-waiting.yml
+++ b/.github/workflows/brew-bump-waiting.yml
@@ -1,0 +1,130 @@
+# Freshness guard for the Homebrew tap (IRO-676).
+#
+# Goes RED when a rolling `brew/track` bump PR has been sitting open past a threshold,
+# so a waiting bump ANNOUNCES ITSELF instead of being found by someone sweeping open
+# PRs by hand. A red scheduled run is a real notification path: GitHub emails on
+# scheduled-workflow failure and it is visible in the Actions tab.
+#
+# WHY A RED CRON AND NOT A PAPERCLIP ISSUE
+# ----------------------------------------
+# The alternative was having the Release workflow file a Paperclip issue so the bump
+# lands in the board's normal queue. It was priced and rejected, for two independent
+# reasons: the Paperclip API listens on 127.0.0.1:3100 with no public ingress, so a
+# GitHub-hosted runner cannot reach it at all; and reaching it would require a
+# long-lived Paperclip credential in repo secrets, which is a new credential this
+# issue explicitly rules out. The cron needs no credential beyond the run's own
+# read-only GITHUB_TOKEN. One mechanism was built, not both.
+#
+# WHAT THIS DELIBERATELY IS NOT
+# -----------------------------
+#   - NOT a required status check. It gates nothing. Adding it to
+#     required_status_checks in .github/rulesets/main.json would block every
+#     unrelated PR whenever the tap happened to be trailing.
+#   - NOT a merger or an approver. It has no write scope. The approving-review click
+#     on the bump PR stays human; that was settled on IRO-670 and this workflow does
+#     not touch the approval model, the ruleset, or Formula/ironclaw.rb.
+#
+# NOTIFICATION TARGET — load-bearing
+# ----------------------------------
+# GitHub sends scheduled-workflow failure email to the user who most recently edited
+# the cron expression in this file, NOT to the repo's watchers. So whoever last
+# touched the `schedule:` block below is the person this guard pages. Keep that a
+# human who can perform the merge; if a bot identity ever rewrites the cron, the
+# alarm silently redirects to an inbox nobody reads and this whole file becomes
+# decoration.
+
+name: Brew bump waiting
+
+on:
+  schedule:
+    # Hourly, offset off the hour to dodge top-of-hour scheduler congestion. Detection
+    # latency is therefore <= 60 min, comfortably inside the 240 min staleness
+    # threshold, so a bump that crosses the threshold is reported well within one
+    # threshold window rather than at the far end of it.
+    - cron: "23 * * * *"
+  workflow_dispatch:
+    inputs:
+      threshold_minutes:
+        description: "Override the staleness threshold in minutes (blank = the script default, 240)"
+        required: false
+        default: ""
+  # Negative-control path. The standing rule is that a guard which has never gone red
+  # is not evidence that it can, and this one cannot be proven from a schedule without
+  # waiting hours for a real stall. Pushing a branch named
+  # `test/brew-bump-waiting-<minutes>` runs the guard against the LIVE repo with that
+  # threshold, so both arms are demonstrable on demand: a small number reports the
+  # currently-open bump PR (red), a large one reports it as within the window (green).
+  # It reads the same live API as the scheduled run — nothing is stubbed.
+  push:
+    branches:
+      - "test/brew-bump-waiting-*"
+
+# Least privilege. Read the open PR list and its check rollup; nothing else. No
+# `pull-requests: write` (it does not comment), no `contents: write` (it does not
+# merge). Notify-only means read-only.
+permissions:
+  contents: read # checkout the script + the ruleset spec it reads required contexts from
+  pull-requests: read # list open brew/track PRs
+  checks: read # CheckRun conclusions in the status rollup
+  statuses: read # legacy StatusContext states in the same rollup
+
+concurrency:
+  group: brew-bump-waiting-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  brew-bump-waiting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false # nothing here pushes; do not leave a token in .git/config
+
+      - name: Resolve the staleness threshold
+        id: threshold
+        env:
+          EVENT: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          # Via env, never interpolated into the script body: a dispatch input is
+          # attacker-influenceable text and `${{ }}` inside `run:` is substituted
+          # before bash ever sees it.
+          INPUT_MINUTES: ${{ inputs.threshold_minutes }}
+        run: |
+          set -euo pipefail
+          # Emitted EMPTY when there is no override, so the 240 min default lives in
+          # exactly one place (scripts/check-brew-bump-waiting.sh) and cannot drift
+          # between the script and this workflow.
+          minutes=""
+          case "${EVENT}" in
+            workflow_dispatch)
+              minutes="${INPUT_MINUTES}"
+              ;;
+            push)
+              # Suffix after the last '-' is the threshold. Validated here rather than
+              # left to the script so a typo'd control branch fails on the typo instead
+              # of silently exercising the default and looking like a clean pass.
+              minutes="${REF_NAME##*-}"
+              case "${minutes}" in
+                ''|*[!0-9]*)
+                  echo "::error::branch '${REF_NAME}' must end in '-<minutes>' (e.g. test/brew-bump-waiting-10) so the threshold under test is explicit." >&2
+                  exit 1
+                  ;;
+              esac
+              ;;
+          esac
+          echo "minutes=${minutes}" >> "$GITHUB_OUTPUT"
+
+      - name: Report any rolling-bump PR waiting past the threshold
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          OVERRIDE: ${{ steps.threshold.outputs.minutes }}
+        run: |
+          set -euo pipefail
+          # Only export THRESHOLD_MINUTES when actually overriding: exporting an empty
+          # value would trip the script's numeric validation and go red for the wrong
+          # reason.
+          if [ -n "${OVERRIDE}" ]; then
+            export THRESHOLD_MINUTES="${OVERRIDE}"
+          fi
+          exec scripts/check-brew-bump-waiting.sh

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -268,6 +268,42 @@ makes it material** — not as a tidiness argument.
 Until then, and regardless of how tempting a green-but-blocked PR makes it: do
 not reach for `--admin`, and do not add a `bypass_actors` entry for the App.
 
+### A waiting bump PR announces itself (IRO-676)
+
+Keeping the click has one cost the click itself does not name: the tap's freshness
+then depends on someone *noticing* the bump PR, and for a while nothing did.
+[#610](https://github.com/IronSecCo/ironclaw/pull/610) sat green and unmerged as
+the third untracked bump in three days and was found by a manual sweep of open
+PRs; [#614](https://github.com/IronSecCo/ironclaw/pull/614) was green and unmerged
+while IRO-670 was being closed out. The README says the tap **can briefly trail**
+the newest release, and "briefly" needs an enforcer.
+
+[`brew-bump-waiting.yml`](https://github.com/IronSecCo/ironclaw/blob/main/.github/workflows/brew-bump-waiting.yml)
+runs hourly and goes **red** when an open `brew/track` PR is older than 240
+minutes. A red scheduled run *is* the notification: GitHub emails on
+scheduled-workflow failure and it is visible in the Actions tab. Notes that matter
+if you touch it:
+
+- **240 min is derived, not picked.** Real merge latency over the last 60
+  `brew/track` PRs was p50 59m, p75 118m, p90 264m, max 8.2 days. The threshold
+  sits above the routine path so an ordinary release never pages, and below every
+  genuinely-late bump on record (#600 9h, #607 8.3h, #562 8.2d).
+- **It fires on age, not on "all required checks green."** Gating the alarm on
+  green builds in a silent-green hole: a required check that never *reports* — the
+  IRO-670 and IRO-673 failure mode, twice — reads as "not green", so the alarm
+  would go quiet on exactly the PRs that are most stuck. Check state is reported
+  in the error message as the remediation hint instead.
+- **Scheduled-failure email goes to whoever last edited the `cron:` line**, not to
+  the repo's watchers. If a bot identity ever rewrites that line the alarm
+  silently redirects to an unread inbox. Keep it a human who can do the merge.
+- **It is notify-only and must stay that way.** Read-only scopes, no merge, no
+  approve, and deliberately **not** in `required_status_checks` — it gates
+  nothing, and requiring it would block unrelated PRs whenever the tap trailed.
+- **To re-prove it** (a guard that has never gone red is not evidence that it
+  can), push a branch named `test/brew-bump-waiting-<minutes>`. It runs against
+  the live API with that threshold, so a small number reports the currently-open
+  bump PR and a large one reports it as within the window.
+
 ## Branch protection: the reviewer path needs no change
 
 The machine-reviewer path above needs **no edit** to

--- a/scripts/check-brew-bump-waiting.sh
+++ b/scripts/check-brew-bump-waiting.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Freshness guard for the Homebrew tap (IRO-676).
+#
+#   scripts/check-brew-bump-waiting.sh
+#
+# Exits non-zero when a rolling `brew/track` bump PR has been sitting open longer
+# than THRESHOLD_MINUTES. Run from a schedule (.github/workflows/brew-bump-waiting.yml)
+# so a waiting bump ANNOUNCES ITSELF instead of waiting to be found by someone
+# sweeping open PRs by hand.
+#
+# Why this exists
+# ---------------
+# IRO-670 removed the per-release human judgement on four sha256 values (the required
+# `brew-formula-verify` check re-derives the formula from a cosign-verified
+# SHA256SUMS), but the board settled that the approving-review click stays. So tap
+# freshness now depends entirely on someone NOTICING the bump PR, and nothing
+# announced one. #610 sat green and unmerged and was the third untracked bump in
+# three days; #614 was green and unmerged while IRO-670 was being closed out. The tap
+# once carried the newest release for six minutes.
+#
+# README says the tap "can briefly trail" the newest release. This is the thing that
+# makes "briefly" true rather than aspirational.
+#
+# Fire condition: AGE, not check state
+# ------------------------------------
+# This goes red on any open bump PR older than the threshold, whatever its checks
+# say, and reports the required-check state in the message as a remediation hint
+# (all green => only the click is missing; not green => CI is the blocker, fix that
+# first). Gating the alarm on "all required checks green" would have been the natural
+# reading, but it builds in a silent-green hole: a required check that never REPORTS
+# (the IRO-673 / IRO-670 failure mode, twice now) would mean "not all green", so the
+# alarm would stay quiet on exactly the PRs that are most stuck. A stale tap is a
+# stale tap either way.
+#
+# Age is measured from PR creation, deliberately. If the branch is ever force-pushed
+# onto a reused PR, that only makes the measured age LARGER than the newest bump's
+# real wait, so the guard over-fires rather than under-fires. Wrong in the loud
+# direction is the only acceptable direction here.
+#
+# Read-only. No merge, no approve, no write scope of any kind. It notifies; it does
+# not repair, and it is deliberately NOT a required status check (it gates nothing,
+# and adding it to required_status_checks would block unrelated PRs).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Overridable so the threshold can be driven from a workflow_dispatch input: tuning it
+# needs to be possible, and proving the red path needs a value smaller than a real
+# wait. Default 240 (4h) is derived from the actual merge latency of the last 60
+# `brew/track` PRs: p50 59m, p75 118m, p90 264m, max 8.2 DAYS. 4h sits above the
+# routine path (so an ordinary release never pages) and below every genuinely-late
+# bump on record (#600 9h, #607 8.3h, #562 8.2d).
+THRESHOLD_MINUTES="${THRESHOLD_MINUTES:-240}"
+REPO="${REPO:-IronSecCo/ironclaw}"
+HEAD_BRANCH="${HEAD_BRANCH:-brew/track}"
+RULESET="${ROOT}/.github/rulesets/main.json"
+
+say()  { printf '==> %s\n' "$*"; }
+fail() { printf '::error::%s\n' "$*" >&2; exit 1; }
+
+case "$THRESHOLD_MINUTES" in
+  ''|*[!0-9]*) fail "THRESHOLD_MINUTES must be a whole number of minutes, got '${THRESHOLD_MINUTES}'." ;;
+esac
+[ "$THRESHOLD_MINUTES" -gt 0 ] || fail "THRESHOLD_MINUTES must be > 0; a zero threshold pages on every release the instant the bump PR opens."
+
+# ---------------------------------------------------------------------------
+# Required contexts come from the checked-in ruleset spec, which is the source of
+# truth for what is applied to main. Read via the live API instead would need
+# `administration: read`, which this workflow deliberately does not have. Parsed
+# fail-loud: an empty or unparseable list would make the remediation hint below
+# silently vacuous.
+# ---------------------------------------------------------------------------
+[ -f "$RULESET" ] || fail "missing ${RULESET}; cannot tell which status checks are required on main."
+REQUIRED_CONTEXTS="$(jq -r '
+  [.rules[]? | select(.type == "required_status_checks")
+             | .parameters.required_status_checks[]?.context] | unique | .[]' "$RULESET")" \
+  || fail "could not parse required_status_checks out of ${RULESET}."
+[ -n "$REQUIRED_CONTEXTS" ] || fail "${RULESET} declares no required_status_checks contexts; refusing to report a check state this script cannot actually derive."
+
+say "Repo:      ${REPO}"
+say "Head:      ${HEAD_BRANCH}"
+say "Threshold: ${THRESHOLD_MINUTES} minutes"
+say "Required:  $(printf '%s' "$REQUIRED_CONTEXTS" | tr '\n' ' ')"
+
+# ---------------------------------------------------------------------------
+# Discovery. NO `|| true` anywhere on this path: an API failure must go red, not
+# skip to a green "no waiting PRs". A guard that can only ever be green is the exact
+# bug this whole cluster is about.
+# ---------------------------------------------------------------------------
+PRS="$(gh pr list --repo "$REPO" --state open --head "$HEAD_BRANCH" \
+        --json number,createdAt,isDraft,headRefOid,url --limit 100)" \
+  || fail "could not list open PRs for ${REPO} head=${HEAD_BRANCH}. Treating an unreadable API as 'nothing waiting' would make this guard unfalsifiable, so this is a failure."
+
+# gh exits 0 on success, so an empty or non-array body means something changed under
+# us rather than "no results" (which is a literal `[]`).
+printf '%s' "$PRS" | jq -e 'type == "array"' >/dev/null \
+  || fail "unexpected response listing open PRs (not a JSON array): ${PRS}"
+
+COUNT="$(printf '%s' "$PRS" | jq 'length')"
+if [ "$COUNT" -eq 0 ]; then
+  say "No open ${HEAD_BRANCH} PR. The tap is not waiting on a click."
+  exit 0
+fi
+
+NOW="$(date -u +%s)"
+WAITING=""
+
+while IFS=$'\t' read -r num created draft sha url; do
+  [ -n "$num" ] || continue
+  # `date -d` is GNU (ubuntu runners); fall back to BSD `date -j` for local macOS runs.
+  created_epoch="$(date -u -d "$created" +%s 2>/dev/null || date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$created" +%s)" \
+    || fail "could not parse createdAt '${created}' for PR #${num}."
+  age=$(( (NOW - created_epoch) / 60 ))
+
+  if [ "$age" -le "$THRESHOLD_MINUTES" ]; then
+    say "PR #${num} open ${age}m, under the ${THRESHOLD_MINUTES}m threshold. Not reporting."
+    continue
+  fi
+
+  # Only reached for a PR that is already over the threshold, so this extra API call
+  # is not on the routine path. Fail loud for the same reason as the list above.
+  rollup="$(gh pr view "$num" --repo "$REPO" --json statusCheckRollup)" \
+    || fail "PR #${num} is over the threshold but its check rollup could not be read; refusing to report an age without a check state."
+
+  # StatusContext entries carry `.context`, CheckRun entries carry `.name` — a
+  # rollup mixes both, and selecting on `.name` alone silently drops legacy
+  # statuses. Latest run per context wins; anything not SUCCESS (including a
+  # context that never reported at all) reads as not-green.
+  missing="$(printf '%s' "$rollup" | jq -r --arg want "$REQUIRED_CONTEXTS" '
+    ([.statusCheckRollup[]? | {ctx: (.name // .context // ""), state: (.conclusion // .state // "PENDING")}]
+       | map(select(.ctx != "")) | INDEX(.ctx)) as $seen
+    | ($want | split("\n") | map(select(length > 0)))
+    | map(select(($seen[.].state // "MISSING") != "SUCCESS")
+          | "\(.)=\($seen[.].state // "MISSING")") | join(", ")')" \
+    || fail "could not evaluate required checks for PR #${num}."
+
+  if [ -n "$missing" ]; then
+    verdict="required checks NOT green (${missing})"
+  elif [ "$draft" = "true" ]; then
+    verdict="all required checks green but the PR is a DRAFT, so it cannot merge"
+  else
+    verdict="all required checks green — only the approving-review click is missing"
+  fi
+
+  WAITING="${WAITING}
+  #${num} open ${age}m (threshold ${THRESHOLD_MINUTES}m), head ${sha:0:12}: ${verdict}
+    ${url}"
+done < <(printf '%s' "$PRS" | jq -r '.[] | [.number, .createdAt, (.isDraft|tostring), .headRefOid, .url] | @tsv')
+
+if [ -z "$WAITING" ]; then
+  say "${COUNT} open ${HEAD_BRANCH} PR(s), none past the ${THRESHOLD_MINUTES}m threshold. Tap freshness is within the advertised window."
+  exit 0
+fi
+
+cat >&2 <<EOF
+::error::A Homebrew rolling-bump PR has been waiting past the ${THRESHOLD_MINUTES}-minute threshold. The tap is serving an older release than the newest one, which breaks the README's "can briefly trail the newest release" claim.${WAITING}
+
+  What to do: merge the bump PR. If its required checks are green the only thing
+  missing is the approving review — that click is deliberately still human
+  (settled on IRO-670). \`brew-formula-verify\` has already re-derived
+  Formula/ironclaw.rb from a cosign-verified SHA256SUMS, so there is nothing left
+  to eyeball in the diff. Squash-merge it:
+    gh api -X PUT repos/${REPO}/pulls/<N>/merge -f merge_method=squash
+
+  If the required checks are NOT green, that is the blocker, not the click; fix or
+  re-run them first. Never relax a required check to land a bump.
+
+  This guard notifies only. It has no write scope and is not a required status
+  check, so it does not block any PR.
+EOF
+exit 1


### PR DESCRIPTION
Makes the README's "the tap can briefly trail the newest release" claim
self-enforcing, so a waiting `brew/track` bump PR announces itself instead of
being found by a manual sweep of open PRs.

Closes IRO-676. Approval model, `.github/rulesets/main.json`, and
`Formula/ironclaw.rb` are untouched — the click settled on IRO-670 stays.

## What landed

- `.github/workflows/brew-bump-waiting.yml` — hourly cron, red when an open
  `brew/track` PR is older than the threshold. Read-only scopes only
  (`contents`/`pull-requests`/`checks`/`statuses`), `persist-credentials: false`,
  action pinned by SHA. **Not** added to `required_status_checks`.
- `scripts/check-brew-bump-waiting.sh` — the logic, runnable locally.
- `docs/pr-review-process.md` — recorded next to the click it backs.

## Why a red cron and not a Paperclip issue

Priced first, as the issue asked. Rejected on two independent grounds: the
Paperclip API listens on `127.0.0.1:3100` with no public ingress, so a
GitHub-hosted runner cannot reach it at all; and reaching it would need a
long-lived Paperclip credential in repo secrets, which IRO-676 rules out. The
cron needs no credential beyond the run's own read-only `GITHUB_TOKEN`. One
mechanism was built, not both.

## Why 240 minutes

Derived from real merge latency over the last 60 `brew/track` PRs: p50 59m,
p75 118m, p90 264m, max 8.2 days. Above the routine path so an ordinary release
never pages; below every genuinely-late bump on record (#600 9h, #607 8.3h,
#562 8.2d). Hourly cron puts detection latency under 60 min, well inside the
window.

## Why it fires on age, not on "all required checks green"

The brief's natural reading builds in a silent-green hole: a required check that
never *reports* — the IRO-670 and IRO-673 failure mode, twice over — reads as
"not all green", so the alarm would stay quiet on exactly the PRs that are most
stuck. Age is the fire condition; check state goes in the error message as the
remediation hint (green ⇒ only the click is missing; not green ⇒ CI is the
blocker, fix that first). A stale tap is a stale tap either way.

Age is measured from PR creation on purpose. The rolling PR is force-pushed in
place (#614 moved v0.1.432 → v0.1.433 mid-verification here), which makes the
measured age *larger* than the newest bump's real wait — so the guard over-fires
rather than under-fires. Wrong in the loud direction is the only acceptable
direction.

## Proven non-vacuously, on real Actions runs

Both arms, same live repo state, differing only by threshold:

| run | threshold | result | log |
|---|---|---|---|
| [30510647752](https://github.com/IronSecCo/ironclaw/actions/runs/30510647752) | 10m | **failure** — `#614 open 31m (threshold 10m) ... required checks NOT green (CodeQL=MISSING, brew-formula-verify=MISSING, build=MISSING)` | red for the right reason |
| [30510649615](https://github.com/IronSecCo/ironclaw/actions/runs/30510649615) | 1440m | **success** — `PR #614 open 31m, under the 1440m threshold` | real PR, real age, correctly silent |

The red run's "NOT green" verdict was accurate live state, not a jq bug: #614 had
been force-pushed to v0.1.433 at 03:14:02Z, so its three required checks genuinely
had not reported on the new head yet. That run also proves the mixed-rollup
handling — `license/cla` is a legacy `StatusContext` (`.context`, not `.name`) and
was read correctly.

Locally, five arms, all against the live API:

- **red** — live #614 past a 10m threshold, reported `all required checks green — only the approving-review click is missing` (before the force-push).
- **green, under threshold** — same PR, default 240m.
- **green, zero bump PRs** — `REPO=IronSecCo/asdf-ironclaw` (real, reachable, genuinely `[]`).
- **fail-loud, unreadable API** — nonexistent repo goes red rather than skipping to a green "nothing waiting".
- **fail-loud, bad config** — `THRESHOLD_MINUTES=0` and a mis-suffixed control branch both refuse to run.

## Verification

`actionlint` clean on the workflow, `shellcheck` clean on the script, threshold
resolution exercised under `bash -c` across all six event/ref combinations.

## Re-proving it later

A guard that has never gone red is not evidence that it can. Push a branch named
`test/brew-bump-waiting-<minutes>` to run it against the live API at that
threshold. (The two control branches used above have been deleted.)