### PR TITLE
ci(sched): measure what GitHub's cron actually delivers, and stop over-promising it [IRO-679]

### DIFF
--- a/.github/workflows/brew-bump-waiting.yml
+++ b/.github/workflows/brew-bump-waiting.yml
@@ -37,10 +37,26 @@ name: Brew bump waiting
 
 on:
   schedule:
-    # Hourly, offset off the hour to dodge top-of-hour scheduler congestion. Detection
-    # latency is therefore <= 60 min, comfortably inside the 240 min staleness
-    # threshold, so a bump that crosses the threshold is reported well within one
-    # threshold window rather than at the far end of it.
+    # Hourly, offset off the hour to dodge top-of-hour scheduler congestion.
+    #
+    # Detection latency is NOT <= 60 min. That is what this comment used to claim and it
+    # rested on the cron expression rather than on the scheduler (IRO-679). Measured
+    # 2026-07-30 with `scripts/measure-cron-latency.py` over 55 intervals of this repo's
+    # daily and weekly crons, the gap GitHub actually delivers runs p50 -7 / p90 +36 /
+    # p95 +51 / max +75 minutes against the period the cron asked for. Carrying that
+    # overshoot onto a 60 min period gives a realistic worst case near 135 min, not 60.
+    #
+    # That still clears the 240 min staleness threshold with ~105 min of headroom, so the
+    # guard's design is unaffected and this is a correction to the claim, not to the cron.
+    # Two caveats worth keeping:
+    #   - The hourly cadence itself is UNMEASURED. The 55 intervals above are daily and
+    #     weekly. The one sub-hourly cron in the repo (`fork-ci-approval-backstop`) was
+    #     being dropped hard, so if hourly falls in GitHub's high-frequency bucket the
+    #     bound is worse than 135 min. This workflow is now the experiment that settles it
+    #     -- after a day of runs, re-run the script and replace this paragraph with data.
+    #   - Declared clock time is not honoured either: every daily/weekly cron in this repo
+    #     fires roughly 3h after its stated UTC time. Cadence survives that, phase does
+    #     not, so never write "runs at HH:MM" about this file.
     - cron: "23 * * * *"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/fork-ci-approval-backstop.yml
+++ b/.github/workflows/fork-ci-approval-backstop.yml
@@ -61,10 +61,36 @@ name: Fork CI approval backstop
 # code compiled, not that anyone reviewed it. If you are removing that notice, you are
 # removing the half of this trade that we gave a maintainer's click away for.
 
+# TRIGGER GUARDRAIL, load-bearing (IRO-679). This workflow approves contributor-controlled
+# code, so it must stay `schedule`/`workflow_dispatch`-triggered ONLY. Never `pull_request`,
+# never `pull_request_target`: contributor-controlled content must not be able to influence
+# the thing that approves contributor-controlled content. The scanner below must likewise
+# keep reading the default-branch checkout, never the PR's copy of these files. Latency is
+# not a reason to trade this away -- if you are here because a cron was slow, read the note
+# on the `schedule:` block and price an event-driven trigger as the trust-model change it is.
 on:
   schedule:
-    # Every 30 minutes. A contributor should never wait longer than one cycle.
-    - cron: "*/30 * * * *"
+    # Asks for every 30 minutes. DO NOT restate that as a contributor-facing promise --
+    # this file used to say "a contributor should never wait longer than one cycle" and
+    # that was measurably false (IRO-679). Measured 2026-07-30 with
+    # `scripts/measure-cron-latency.py`: the two observed intervals of the `*/30` form of
+    # this cron were 66 and 159 minutes, i.e. 2.2x and 5.3x the requested period, and it
+    # was the only cron in the repo whose overshoot exceeded its own period. Over the same
+    # window 55 intervals of daily and weekly crons here came in at p50 -7 / p90 +36 /
+    # max +75 minutes against nominal, so the scheduler honours low-frequency cadence and
+    # was dropping this one -- consistent with GitHub's documented deprioritisation of
+    # high-frequency schedules. n=2 cannot prove that on its own; the useful independent
+    # observation is the 92-minute silence caught live with no run pending.
+    #
+    # The minutes are offset off :00/:30 as a cheap, strictly-dominating experiment: same
+    # 30-minute cadence and the same promise, but off the two most congested minutes of
+    # the hour. It costs nothing if it does not help. It is NOT yet known to help -- re-run
+    # the script before anyone writes a latency number based on it.
+    #
+    # If a real latency bound is ever needed here, it needs an event-driven trigger, and
+    # that is a trust-model decision (a run entering `action_required` is contributor-
+    # initiated), not a cron tweak. See the TRIGGER GUARDRAIL above before proposing one.
+    - cron: "13,43 * * * *"
   workflow_dispatch:
     inputs:
       dry_run:

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -304,6 +304,52 @@ if you touch it:
   the live API with that threshold, so a small number reports the currently-open
   bump PR and a large one reports it as within the window.
 
+### What the cron actually delivers (IRO-679)
+
+This guard, and the fork-CI approval backstop next to it, are both `schedule:`
+crons. A cron promise is worth what the scheduler delivers, and an earlier
+version of this page put detection latency at **"≤ 60 min"** on the strength of
+the cron expression alone. That was not measured, and it is not true.
+
+[`scripts/measure-cron-latency.py`](https://github.com/IronSecCo/ironclaw/blob/main/scripts/measure-cron-latency.py)
+measures it. Run it before writing any latency number here. Measured
+2026-07-30 over **55 intervals** of this repo's daily and weekly crons:
+
+| quantity | measured |
+|---|---|
+| gap delivered vs period requested | p50 **-7 min**, p90 **+36**, p95 **+51**, max **+75** |
+| intervals overshooting nominal by >60 min | **2 / 55** |
+| declared clock time vs actual fire time | daily/weekly crons fire **~3h late**, consistently |
+
+Two things follow, and they pull in opposite directions:
+
+- **Cadence is honoured.** A daily cron runs daily to within about an hour. So
+  the hourly guard's realistic worst case is roughly **135 min** (60 nominal +
+  75 measured overshoot), not 60. That still sits **~105 min inside** the 240
+  min threshold, so the 240 min number survives the correction untouched — the
+  claim was wrong, the design was not.
+- **Phase is not honoured.** Every daily/weekly cron here fires about three
+  hours after its declared UTC time. Cadence survives this; a sentence of the
+  form *"runs at 03:17 UTC"* does not. Do not write one.
+
+Caveats, because this is the part that is easy to overstate:
+
+- **The hourly cadence is unmeasured.** Those 55 intervals are daily and weekly.
+  The repo's one sub-hourly cron — the fork-CI approval backstop at `*/30` —
+  was being dropped hard (two observed intervals of 66 and 159 min, 2.2x and
+  5.3x its period; the only cron here whose overshoot exceeded its own period),
+  which matches GitHub's documented deprioritisation of high-frequency
+  schedules. **n=2 proves nothing on its own**; the load-bearing observation is
+  a 92-minute silence caught live with no run pending. If hourly lands in that
+  same bucket, 135 min is optimistic. This workflow is now the experiment that
+  settles it — after a day of runs, re-run the script and update this table.
+- **A cron is the wrong tool for a hard latency bound.** Getting a real one
+  needs an event-driven trigger, and for the approval backstop that is a
+  trust-model change, not a scheduling tweak: the safety net must stay
+  `schedule`/`workflow_dispatch`-only so contributor-controlled content cannot
+  influence the thing that approves contributor-controlled content. Latency is
+  not a reason to trade that away.
+
 ## Branch protection: the reviewer path needs no change
 
 The machine-reviewer path above needs **no edit** to

--- a/scripts/measure-cron-latency.py
+++ b/scripts/measure-cron-latency.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Measure what GitHub's scheduler actually delivers for this repo's `schedule:` workflows.
+
+Motivation (IRO-679): two safety nets for the rolling Homebrew bump are `schedule:` crons,
+and both carry a documented latency promise. A cron promise is only worth what the
+scheduler delivers, and GitHub documents that `schedule` events are delayed or dropped
+under load. This script measures the delivery so the promises can be checked against it
+instead of against the cron expression.
+
+The metric is EXCESS OVER NOMINAL PERIOD: for consecutive runs of one workflow, the
+observed gap minus the period the cron asks for. That is the quantity a "detection latency
+is <= N minutes" claim actually rests on.
+
+Deliberately NOT measured: delay from the declared clock time. For a high-frequency cron
+every slot is close to every run, so nearest-slot matching cannot produce a delay larger
+than the period -- it reports a small number no matter how badly the cron is being dropped.
+That metric flatters exactly the case we care about, so it is not used here. (Phase drift
+is reported separately and read-only, because it is real -- see --phase -- but it does not
+affect cadence and no promise in this repo depends on it.)
+
+Usage:
+    scripts/measure-cron-latency.py                 # all schedule: workflows in this repo
+    scripts/measure-cron-latency.py --phase         # also report declared-vs-actual clock time
+    scripts/measure-cron-latency.py --repo O/N      # another repo
+
+Requires `gh` authenticated with read access to the repo's Actions history. Read-only:
+issues no writes and takes no action on any workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+import re
+import statistics
+import subprocess
+import sys
+
+# Periods we can score. A cron only has a well-defined nominal period when it fires on a
+# fixed stride; anything else (e.g. "0 6 * * 1,4") is listed but not scored, because
+# "excess over nominal" is meaningless without a single nominal.
+_MINUTE_STRIDE = re.compile(r"^\*/(\d+)$")
+
+
+def _period_minutes(cron: str) -> int | None:
+    """Nominal period of a 5-field cron in minutes, or None if it has no single stride."""
+    try:
+        minute, hour, dom, month, dow = cron.split()
+    except ValueError:
+        return None
+    if month != "*" or dom != "*":
+        return None
+    stride = _MINUTE_STRIDE.match(minute)
+    if stride and hour == "*" and dow == "*":
+        return int(stride.group(1))
+    # A comma list of fixed minutes at every hour, e.g. "13,43 * * * *".
+    if hour == "*" and dow == "*" and all(p.isdigit() for p in minute.split(",")):
+        parts = sorted(int(p) for p in minute.split(","))
+        if len(parts) == 1:
+            return 60
+        gaps = {b - a for a, b in zip(parts, parts[1:])} | {parts[0] + 60 - parts[-1]}
+        return gaps.pop() if len(gaps) == 1 else None
+    if not minute.isdigit():
+        return None
+    if hour == "*" and dow == "*":
+        return 60
+    if hour.isdigit() and dow == "*":
+        return 1440
+    if hour.isdigit() and dow.isdigit():
+        return 10080
+    return None
+
+
+def _crons(path: pathlib.Path) -> list[str]:
+    """Cron expressions under a `schedule:` block. Text-scanned on purpose: PyYAML is not a
+    dependency of this repo and a wrong answer here is visible, not silent."""
+    out: list[str] = []
+    in_schedule = False
+    saw_schedule = False
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if re.match(r"^schedule:\s*$", stripped):
+            in_schedule = saw_schedule = True
+            continue
+        if in_schedule:
+            # Trailing `# ...` comments after the cron are common in this repo, so strip
+            # them before matching rather than requiring end-of-line right after the quote.
+            body = re.sub(r"\s+#.*$", "", stripped)
+            m = re.match(r"^-\s*cron:\s*[\"']?([^\"']+?)[\"']?\s*$", body)
+            if m:
+                out.append(m.group(1).strip())
+                continue
+            if body and not body.startswith("-"):
+                in_schedule = False
+    if saw_schedule and not out:
+        # A parser that silently drops a scheduled workflow reports a smaller, healthier
+        # looking sample than reality. Refuse to do that quietly.
+        raise SystemExit(f"{path.name}: has a `schedule:` block but no cron parsed out of it")
+    return out
+
+
+def _runs(repo: str, workflow: str) -> list[dt.datetime]:
+    """created_at of every scheduled run, oldest first. created_at is when GitHub created
+    the run, i.e. when the schedule actually fired -- not when a runner picked it up."""
+    proc = subprocess.run(
+        ["gh", "api", "--paginate",
+         f"repos/{repo}/actions/workflows/{workflow}/runs?event=schedule&per_page=100",
+         "--jq", ".workflow_runs[].created_at"],
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        return []
+    return sorted(
+        dt.datetime.fromisoformat(line.replace("Z", "+00:00"))
+        for line in proc.stdout.split() if line
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default="IronSecCo/ironclaw")
+    ap.add_argument("--phase", action="store_true",
+                    help="also report declared vs actual clock time (drift, not cadence)")
+    args = ap.parse_args()
+
+    wf_dir = pathlib.Path(__file__).resolve().parent.parent / ".github" / "workflows"
+    pooled: list[tuple[str, float]] = []
+    rows = []
+
+    for path in sorted(wf_dir.glob("*.yml")):
+        crons = _crons(path)
+        if len(crons) != 1:
+            # Zero: not scheduled. More than one: no single nominal period to score.
+            continue
+        cron = crons[0]
+        period = _period_minutes(cron)
+        runs = _runs(args.repo, path.name)
+        gaps = [(b - a).total_seconds() / 60 for a, b in zip(runs, runs[1:])]
+        rows.append((path.name, cron, period, runs, gaps))
+        if period and gaps:
+            # Pool only cadences we have enough of to say anything about, and keep the
+            # sub-hourly arm out of the pool -- it is the hypothesis under test, not evidence.
+            if period >= 1440:
+                pooled += [(path.name, g - period) for g in gaps]
+
+    print(f"repo: {args.repo}    measured: {dt.datetime.now(dt.timezone.utc):%Y-%m-%dT%H:%MZ}\n")
+    print(f"{'workflow':<34}{'cron':<16}{'runs':>5}{'gaps':>5}   excess over nominal (min)")
+    print("-" * 96)
+    for name, cron, period, runs, gaps in rows:
+        if not period:
+            print(f"{name:<34}{cron:<16}{len(runs):>5}{len(gaps):>5}   (no single nominal period)")
+            continue
+        if not gaps:
+            print(f"{name:<34}{cron:<16}{len(runs):>5}{len(gaps):>5}   (no interval yet)")
+            continue
+        ex = sorted(g - period for g in gaps)
+        flag = "  <-- exceeds its own period" if max(ex) > period else ""
+        print(f"{name:<34}{cron:<16}{len(runs):>5}{len(gaps):>5}   "
+              f"min {min(ex):+.0f}  p50 {statistics.median(ex):+.0f}  max {max(ex):+.0f}{flag}")
+
+    if pooled:
+        vals = sorted(v for _, v in pooled)
+        pct = lambda p: vals[min(len(vals) - 1, int(p * len(vals)))]
+        print(f"\nPOOLED (daily and weekly crons only): {len(vals)} intervals")
+        print(f"  excess over nominal:  p50 {pct(.5):+.0f}   p90 {pct(.9):+.0f}   "
+              f"p95 {pct(.95):+.0f}   max {max(vals):+.0f} min")
+        over = sum(1 for v in vals if v > 60)
+        print(f"  intervals overshooting nominal by >60 min: {over}/{len(vals)}")
+        print("\n  Read this as: the cadence a cron asks for is delivered to within roughly")
+        print("  this much. A 'detection latency <= one period' claim must add the max above.")
+
+    if args.phase:
+        print(f"\n{'workflow':<34}{'declared':>10}{'observed fire time (UTC)':>34}")
+        print("-" * 80)
+        for name, cron, period, runs, _ in rows:
+            if not runs or not period or period < 1440:
+                continue
+            f = cron.split()
+            declared = f"{int(f[1]):02d}:{int(f[0]):02d}" if f[1].isdigit() else "--:--"
+            tod = [r.hour * 60 + r.minute for r in runs]
+            fmt = lambda m: f"{m // 60:02d}:{m % 60:02d}"
+            med = int(statistics.median(tod))
+            print(f"{name:<34}{declared:>10}"
+                  f"{fmt(min(tod)) + '-' + fmt(max(tod)) + '  median ' + fmt(med):>34}")
+        print("\n  Phase drift does not affect cadence. It does mean the declared clock time")
+        print("  in a cron expression does not predict when the workflow runs, so do not")
+        print("  write a doc claim of the form 'runs at HH:MM'.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Both safety nets for the rolling Homebrew bump are `schedule:` crons, and both carried a latency promise derived from the **cron expression** rather than from the **scheduler**. This measures the scheduler and makes the promises match it.

## Measured

`scripts/measure-cron-latency.py` (new, read-only) over this repo's entire scheduled-run history:

| | |
|---|---|
| **55 intervals**, daily + weekly crons | delivered gap vs period requested: p50 **-7**, p90 **+36**, p95 **+51**, max **+75** min |
| intervals overshooting nominal by >60 min | **2 / 55** |
| `*/30` backstop (the only sub-hourly cron) | intervals of **66** and **159** min = **2.2x / 5.3x** requested, the only cron whose overshoot exceeded its own period |
| declared clock time vs actual | daily/weekly crons fire **~3h after** their stated UTC time, consistently |

Two independent conclusions:

- **Cadence is honoured** for daily and weekly. A daily cron runs daily to within about an hour.
- **Phase is not honoured at all.** Never write "runs at HH:MM" about a cron in this repo.

## Changes

- **`scripts/measure-cron-latency.py`** so the numbers are auditable and re-measuring is free. It scores *excess over nominal period*, deliberately **not** delay-from-declared-slot: for a high-frequency cron every slot is near every run, so nearest-slot matching cannot report a delay larger than the period. That metric flatters exactly the case we care about, and it is why the first cut of this analysis briefly made `*/30` look fine. It also refuses to parse a `schedule:` block into zero crons (that bug silently dropped 3 workflows and undercounted the sample 40 vs 55).
- **`brew-bump-waiting.yml`** the `<= 60 min` claim was false. Measured overshoot on a 60 min period gives a realistic worst case near **135 min**. That still clears the 240 min threshold with **~105 min of headroom**, so this corrects the *claim*, not the design. The 240 min number survives untouched.
- **`fork-ci-approval-backstop.yml`** dropped "a contributor should never wait longer than one cycle". Cron offset off `:00`/`:30` as a cheap **same-cadence** experiment against top-of-hour congestion, explicitly **not** claimed as a fix until re-measured. Trigger guardrail now written into the file.

## What this does NOT do

- **No event-driven trigger.** A real latency bound needs one, and for the backstop that is a trust-model decision, not a scheduling tweak. The backstop stays `schedule`/`workflow_dispatch` **only**.
- **No relaxation of `fork-pr-contributor-approval`**, and **nothing added to `required_status_checks`**.
- **The hourly cadence is still unmeasured** (the 55 intervals are daily/weekly). `brew-bump-waiting` is now the experiment that settles it; re-run the script after a day of runs.

## Verification

- `actionlint` clean on both workflows.
- Backstop asserted to expose only `schedule` + `workflow_dispatch`.
- New `13,43 * * * *` confirmed to keep the same **30 min** period.
- `mkdocs build` clean; new section verified present in the **built HTML**, with the retracted `<= 60 min` string surviving only inside the sentence that retracts it.

Does **not** touch `release.yml` (concurrent IRO-677 work is live in that file).

Refs IRO-679. Scope-separated from IRO-677, which owns *why* the gate re-arms; this owns *why nothing cleared it automatically*.