### PR TITLE
ci(release): write the rolling bump branch as the App, not GITHUB_TOKEN [IRO-677]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -733,15 +733,40 @@ jobs:
           scripts/update-homebrew-formula.sh "${TAG}"
 
       # Mint a short-lived, least-privilege token for the existing reviewer App so
-      # the bump PR opens itself. The default GITHUB_TOKEN cannot create PRs while
-      # the repo setting "Allow GitHub Actions to create and approve pull requests"
-      # stays OFF (IRO-203 chose to keep it off and use a scoped App token instead).
-      # Scoped to pull-requests:write (+ contents:read to resolve the branch); NO
-      # other App permission is requested, and the token is used ONLY to open the PR
-      # — never to approve or merge it (a human/reviewer still does that).
+      # the bump PR opens itself AND its branch is pushed under an identity GitHub
+      # already trusts. The default GITHUB_TOKEN cannot create PRs while the repo
+      # setting "Allow GitHub Actions to create and approve pull requests" stays OFF
+      # (IRO-203 chose to keep it off and use a scoped App token instead).
+      #
+      # WHY THIS ALSO NEEDS contents:write (IRO-677) — THE SECOND HUMAN CLICK.
+      # ---------------------------------------------------------------------------
+      # This job used to push the rolling branch with GITHUB_TOKEN and use the App
+      # only for `gh pr create`. That split is what produced a SECOND approval click
+      # nobody signed up for. GitHub arms the workflow-approval gate on the identity
+      # that PUSHED the head ref, not on the PR author:
+      #   - opening the rolling PR pushes nothing, so the `opened` event's actor is
+      #     the App — a real contributor here (90 merged PRs) — and CI just runs;
+      #   - force-pushing the NEXT bump onto that still-open PR fires `synchronize`
+      #     with actor `github-actions[bot]`, which has zero merged PRs and is absent
+      #     from /contributors, so all six runs land in `action_required`.
+      # Measured over every run ever on `brew/track`: 165 of 165 `action_required`
+      # runs were pushed by `github-actions[bot]`; 0 of 352 App-pushed runs stalled.
+      # A parked run never REPORTS, so `build`, `CodeQL` and `brew-formula-verify`
+      # were simply MISSING and the PR sat at "waiting for status" forever (#614).
+      # Pushing as the App removes the re-arm at the source. It does NOT touch
+      # `fork-pr-contributor-approval`, which still gates every genuine fork PR.
+      #
+      # Least privilege is preserved, not spent: this replaces GITHUB_TOKEN's
+      # `contents: write` on the same two writes rather than adding a new writer, and
+      # an App installation token is repo-scoped, permission-scoped, expires in an
+      # hour and is revoked by the action's post step. It cannot land on main either
+      # way — main's ruleset requires a reviewed PR and signed commits, and the App
+      # is deliberately NOT in `bypass_actors` (IRO-670). The token is still never
+      # used to approve or merge anything; a human still does that.
+      #
       # continue-on-error so a missing/rotated App secret degrades to the loud manual
-      # fallback below instead of aborting before the signed branch is even pushed.
-      - name: Mint a scoped reviewer-App token to open the formula PR
+      # fallback below instead of aborting before the branch is even pushed.
+      - name: Mint a scoped reviewer-App token to push the bump branch and open its PR
         id: pr-app-token
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -749,7 +774,7 @@ jobs:
           app-id: ${{ secrets.REVIEWER_APP_ID }}
           private-key: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
           permission-pull-requests: write
-          permission-contents: read
+          permission-contents: write
 
       - name: Open a PR if the formula changed
         env:
@@ -788,6 +813,26 @@ jobs:
           file_sha="$(gh api "repos/${REPO}/contents/Formula/ironclaw.rb?ref=main" --jq .sha)"
           content_b64="$(base64 -w0 < Formula/ironclaw.rb)"
 
+          # Which identity PUSHES the rolling branch decides whether the bump PR needs
+          # a second human click (IRO-677 — see the mint step above). The App is a
+          # known contributor here and its pushes run CI immediately; a
+          # `github-actions[bot]` push re-arms the workflow-approval gate and the
+          # required checks never report. So every write below goes through the App
+          # token when we have one.
+          #
+          # The fallback is deliberate and is exactly today's behaviour: if the App
+          # secret is missing or rotated we still push the branch (a stale `brew
+          # install` is worse than a click) — but we say out loud that the bump will
+          # stall on approval, because the alternative is a PR that silently sits at
+          # "waiting for status" and looks merely slow.
+          if [ -n "${PR_TOKEN:-}" ]; then
+            BUMP_TOKEN="${PR_TOKEN}"
+            echo "Pushing ${branch} as the reviewer App (no workflow-approval re-arm)."
+          else
+            BUMP_TOKEN="${GH_TOKEN}"
+            echo "::warning title=Bump branch pushed as github-actions[bot]::The reviewer-App token was not minted, so ${branch} is being pushed with GITHUB_TOKEN. If the rolling PR is already open this force-push will park all of its workflow runs in \`action_required\` and the required checks (build, CodeQL, brew-formula-verify) will NOT report until a maintainer approves the runs (IRO-677)."
+          fi
+
           # Create the rolling branch at the current main tip, or force-reset it there
           # if it already exists (leftover from a prior release whose PR is still open,
           # or was merged without deleting the branch). Force-reset is what keeps the
@@ -802,10 +847,10 @@ jobs:
           # "gh: Reference does not exist (HTTP 422)" (IRO-318). The singular endpoint
           # matches the ref exactly and 404s when brew/track is truly absent.
           if gh api "repos/${REPO}/git/ref/heads/${branch}" >/dev/null 2>&1; then
-            gh api -X PATCH "repos/${REPO}/git/refs/heads/${branch}" \
+            GH_TOKEN="${BUMP_TOKEN}" gh api -X PATCH "repos/${REPO}/git/refs/heads/${branch}" \
               -f "sha=${base_sha}" -F "force=true"
           else
-            gh api -X POST "repos/${REPO}/git/refs" \
+            GH_TOKEN="${BUMP_TOKEN}" gh api -X POST "repos/${REPO}/git/refs" \
               -f "ref=refs/heads/${branch}" \
               -f "sha=${base_sha}"
           fi
@@ -828,7 +873,14 @@ jobs:
           # writes to main — so main's required_signatures rule is still satisfied. (A
           # rebase-merge would replay this unsigned commit and be blocked; do not switch
           # the merge method for this PR to rebase.)
-          gh api -X PUT "repos/${REPO}/contents/Formula/ironclaw.rb" \
+          #
+          # The `author` pin is what makes the commit unsigned, and it is independent of
+          # WHICH token writes it (IRO-677 changed the token, not the authorship): the
+          # Contents API mirrors committer=author whenever `author` is supplied, so this
+          # commit is `verified: false, reason: unsigned` under the App token exactly as
+          # it was under GITHUB_TOKEN, `license/cla` still passes on the pinned author,
+          # and the squash still mints main's signature.
+          GH_TOKEN="${BUMP_TOKEN}" gh api -X PUT "repos/${REPO}/contents/Formula/ironclaw.rb" \
             -f "message=chore(brew): track ${TAG} in the Homebrew formula" \
             -f "content=${content_b64}" \
             -f "sha=${file_sha}" \

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -136,6 +136,64 @@ legacy `brew/track-*`) **and** the diff is exactly `Formula/ironclaw.rb` — and
 exits cleanly with a pointer to this section instead of failing. **Every other
 self-authored PR still hard-fails:** the gate is unchanged for product code.
 
+### The bump branch is written by the App, not by `GITHUB_TOKEN` (IRO-677)
+
+The `formula` job used to open the PR with the App token but write the branch with
+the default `GITHUB_TOKEN`. That split cost a **second** human click on more than a
+third of bumps, and a worse one than the approving review: it stopped the required
+checks from *reporting* at all.
+
+GitHub arms the workflow-approval gate on the identity that **wrote the head ref**,
+not on the PR author. Opening the rolling PR pushes nothing, so the `opened` event's
+actor is the App — a real contributor here — and CI just runs. Force-pushing the
+*next* bump onto that still-open PR fires `synchronize` with actor
+`github-actions[bot]`, which has no merged PR in this repo and does not appear in
+`/contributors`, so every run lands in `action_required`. A parked run never
+reports, so `build`, `CodeQL` and `brew-formula-verify` were simply **missing** and
+the PR sat at "waiting for status" indefinitely (#614).
+
+Measured over every run ever on `brew/track`: **165 of 165** `action_required` runs
+were written by `github-actions[bot]`; **0 of 352** App-written runs stalled. A
+controlled two-arm probe (one virgin App-opened PR per arm, identical REST calls,
+identical pinned commit author, only the token differing) reproduced it on demand —
+`GITHUB_TOKEN` arm 3/3 `action_required`, App arm 0/3.
+
+So the job now mints the App token with `contents: write` and uses it for the ref
+force-reset and the Contents commit as well as for `gh pr create`. Things this
+deliberately does **not** do:
+
+- it does not touch `fork-pr-contributor-approval`, which stays
+  `first_time_contributors_new_to_github` and still gates every genuine fork PR;
+- it does not add a credential — the App and its two secrets already existed, and
+  this replaces `GITHUB_TOKEN`'s `contents: write` on the same two writes rather
+  than adding a writer;
+- it does not widen reach into `main`. The App is **not** in the ruleset's
+  `bypass_actors` (only the admin repository role is), so main still requires a
+  reviewed PR, passing required checks and signed commits;
+- it does not change the commit. The `author` pin is what makes the head commit
+  unsigned, and that is independent of the token, so `license/cla` still passes and
+  the squash still mints main's signature — see *Squash only* below.
+
+Two consequences worth knowing before you read a run list:
+
+- **`push`-triggered workflows now actually fire on `brew/track`.** They never did
+  before: GitHub suppresses workflow runs for `GITHUB_TOKEN` pushes entirely, so
+  `brew-formula-verify`'s `push: branches: [brew/**]` trigger was **vacuous** for
+  ~90 bumps. Expect one extra `CI` and one extra `brew-formula-verify` run per bump.
+  They do not fight the PR runs: `brew-formula-verify`'s concurrency group keys on
+  `pull_request.number || github.ref`, so push and PR land in different groups, and
+  `ci.yml` has no concurrency group at all.
+- **You cannot unstall a bump PR by closing and reopening it.** That fires a
+  `reopened` event and would work in general, but not here: the API refuses with
+  `422 state cannot be changed. The brew/track branch was force-pushed or
+  recreated.` The only remedies for an already-parked run are the maintainer's
+  approve click or `POST /actions/runs/{id}/approve`.
+
+If the App secret is missing or rotated, the job falls back to `GITHUB_TOKEN` and
+still pushes the branch — a stale `brew install` is worse than a click — but it
+emits a `::warning` saying the bump will park on approval, because a PR that
+silently sits at "waiting for status" reads as merely slow.
+
 ### The `brew-formula-verify` gate replaced the human eyeball (IRO-670)
 
 A maintainer reading a generated single-file diff cannot tell a correct `sha256`


### PR DESCRIPTION
Closes the second, unauthorised human click on the rolling Homebrew bump PR.

## Root cause, demonstrated

The issue's hypothesis was that squash merges starve the reviewer App of contributor history. **That is not it.** `ironclaw-reviewer[bot]` is `author_association: CONTRIBUTOR` on #614/#612, has **90 merged PRs** here, and sits 2nd on `/contributors` with 89 contributions.

The gate arms on the identity that **wrote the head ref**, not on the PR author:

| brew/track run actor | success | `action_required` |
|---|---|---|
| `ironclaw-reviewer[bot]` | 352 | **0** |
| `github-actions[bot]` | 26 | **165** |
| `omerzamir` | 44 | 0 |

Repo-wide those 165 are the *only* same-repo stalls; every other one is a genuine fork contributor. #614's timeline shows the split cleanly: opened `02:42:55Z` by the App (ran clean), `head_ref_force_pushed 03:14:01Z` by `github-actions[bot]` (all six parked).

`release.yml` minted the App token for `gh pr create` only; the `git/refs` force-reset and the `contents` PUT both ran under `GH_TOKEN: ${{ github.token }}`. First bump after a merge opens a fresh PR (App actor, clean); every bump onto a still-open PR force-pushes as `github-actions[bot]`. That is the 37%.

## Verified against a real force-push, not a fresh PR

Two-arm probe, one **virgin App-opened PR per arm**, identical REST calls and identical pinned commit author, only the bump token differing:

| arm | bump token | force-push attributed to | `pull_request` runs | `action_required` |
|---|---|---|---|---|
| A | `GITHUB_TOKEN` | `github-actions[bot]` | 3 | **3** |
| B | reviewer-App | `ironclaw-reviewer[bot]` | 3 | **0** |

Run `30512921726`. Arm A is the negative control and the probe fails if it does not reproduce.

Two earlier probe revisions were wrong and are worth recording:
- a `git push` arm B silently re-authenticated as `github-actions[bot]` because `actions/checkout` persists `GITHUB_TOKEN` as `http.https://github.com/.extraheader`, which outranks userinfo in the push URL. Both arms now use the same REST calls `release.yml` uses.
- reusing one PR across arms decoupled it from its head ref after repeated force-pushes and it stopped emitting `synchronize` entirely.

## What this does not do

- `fork-pr-contributor-approval` is untouched: still `first_time_contributors_new_to_github`, still gating every genuine fork PR. Re-read after the change.
- No new credential. The App and its two secrets already existed; this replaces `GITHUB_TOKEN`'s `contents: write` on the same two writes.
- No new reach into `main`: the ruleset's only `bypass_actors` entry is the admin repository role, so main still requires a reviewed PR, passing checks and signed commits.
- `.github/rulesets/main.json`, the approving-review click and `Formula/ironclaw.rb` are all untouched.
- The `author` pin (not the token) is what makes the head commit unsigned, so `license/cla` still passes and the squash still mints main's signature.

## Known consequence

`push`-triggered workflows will now actually fire on `brew/track` -- they never did, because GitHub suppresses runs for `GITHUB_TOKEN` pushes, which means `brew-formula-verify`'s `push: branches: [brew/**]` trigger has been **vacuous** for ~90 bumps. Expect one extra `CI` and one extra `brew-formula-verify` run per bump. They cannot cancel the PR runs: `brew-formula-verify` keys concurrency on `pull_request.number || github.ref`, and `ci.yml` has no concurrency group.

Also recorded in the docs: an App-driven close+reopen is **not** an available unstall path -- the API refuses with `422 state cannot be changed. The <branch> branch was force-pushed or recreated.`

## Verification

- `actionlint .github/workflows/release.yml` clean.
- `bash -n` + `shellcheck` on both `run:` bodies of the `formula` job (only SC2153, a false positive on a step-`env` variable).
- Token-selection block replayed under `bash` in both states: App token present -> App token selected; absent -> falls back to `GITHUB_TOKEN` and emits the `::warning`.
- Full release re-cut deliberately NOT run; the next real release exercises it.

Trust-model surface (token scope), so this needs CEO review before merge -- and the reviewer-bot self-serve path excludes `.github/workflows/*` anyway.