### PR TITLE
ci(sched): make the load-bearing cron observation reproducible, and re-measure it [IRO-679]

### DIFF
--- a/.github/workflows/fork-ci-approval-backstop.yml
+++ b/.github/workflows/fork-ci-approval-backstop.yml
@@ -79,13 +79,23 @@ on:
     # window 55 intervals of daily and weekly crons here came in at p50 -7 / p90 +36 /
     # max +75 minutes against nominal, so the scheduler honours low-frequency cadence and
     # was dropping this one -- consistent with GitHub's documented deprioritisation of
-    # high-frequency schedules. n=2 cannot prove that on its own; the useful independent
-    # observation is the 92-minute silence caught live with no run pending.
+    # high-frequency schedules.
+    #
+    # n=2 cannot prove that on its own, so do not lean on those two gaps. The load-bearing
+    # number is the script's LIVE SILENCE column, which needs no sample at all: re-measured
+    # 2026-07-30 06:08Z, this cron had been silent 236 minutes against a 30-minute period
+    # (7.9x) while `state: active` with nothing queued, and over the 7h40m since its
+    # first-ever scheduled run the scheduler delivered 3 runs where a 30-minute cron
+    # predicts ~15. Every daily/weekly cron in the repo sat at 0.0x-0.9x of its period in
+    # that same table, so the metric is not just flagging everything it looks at.
     #
     # The minutes are offset off :00/:30 as a cheap, strictly-dominating experiment: same
     # 30-minute cadence and the same promise, but off the two most congested minutes of
-    # the hour. It costs nothing if it does not help. It is NOT yet known to help -- re-run
-    # the script before anyone writes a latency number based on it.
+    # the hour. It costs nothing if it does not help. It is still NOT known to help, and
+    # the early read is that it has not: in the 79 minutes after the offset landed on main
+    # the scheduler delivered 0 runs where `13,43` predicts 2. That is n=0 and settles
+    # nothing on its own -- do not write a latency number off it either way. Re-run the
+    # script before anyone does.
     #
     # If a real latency bound is ever needed here, it needs an event-driven trigger, and
     # that is a trust-model decision (a run entering `action_required` is contributor-

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -393,14 +393,28 @@ Two things follow, and they pull in opposite directions:
 Caveats, because this is the part that is easy to overstate:
 
 - **The hourly cadence is unmeasured.** Those 55 intervals are daily and weekly.
-  The repo's one sub-hourly cron — the fork-CI approval backstop at `*/30` —
-  was being dropped hard (two observed intervals of 66 and 159 min, 2.2x and
-  5.3x its period; the only cron here whose overshoot exceeded its own period),
-  which matches GitHub's documented deprioritisation of high-frequency
-  schedules. **n=2 proves nothing on its own**; the load-bearing observation is
-  a 92-minute silence caught live with no run pending. If hourly lands in that
-  same bucket, 135 min is optimistic. This workflow is now the experiment that
-  settles it — after a day of runs, re-run the script and update this table.
+  The repo's one sub-hourly cron — the fork-CI approval backstop at `*/30` — is
+  being dropped hard, and it is the only cron here whose overshoot exceeds its
+  own period (two observed intervals of 66 and 159 min, 2.2x and 5.3x). That
+  matches GitHub's documented deprioritisation of high-frequency schedules. If
+  hourly lands in that same bucket, 135 min is optimistic. The hourly guard is
+  now the experiment that settles it — after a day of runs, re-run the script
+  and update this table.
+- **Quote the silence, not the gap count.** Two intervals cannot carry that
+  conclusion on their own. What carries it is the script's second table: **live
+  silence**, the still-open interval since the last scheduled run. Re-measured
+  2026-07-30 06:08Z, the backstop had been silent **236 min against a 30 min
+  period (7.9x)** while `state: active` with nothing queued — and across the
+  7h40m since its first-ever scheduled run, a 30-min cron predicts ~15 runs
+  where the scheduler delivered **3**. That is one direct observation with no
+  sample-size caveat attached. In the same table every daily/weekly cron in the
+  repo sat at **0.0x–0.9x** of its period, so the metric is not merely flagging
+  everything it looks at.
+- **The `13,43` offset is not known to help.** It was a free experiment — same
+  cadence, off the two most congested minutes of the hour — but in the 79 min
+  after it landed the scheduler delivered **0** runs where `13,43` predicts 2.
+  That is n=0, which is not evidence it failed either. Keep the offset, and keep
+  saying "not known to help" until the script has a real post-offset sample.
 - **A cron is the wrong tool for a hard latency bound.** Getting a real one
   needs an event-driven trigger, and for the approval backstop that is a
   trust-model change, not a scheduling tweak: the safety net must stay

--- a/scripts/measure-cron-latency.py
+++ b/scripts/measure-cron-latency.py
@@ -11,6 +11,15 @@ The metric is EXCESS OVER NOMINAL PERIOD: for consecutive runs of one workflow, 
 observed gap minus the period the cron asks for. That is the quantity a "detection latency
 is <= N minutes" claim actually rests on.
 
+Also reported: LIVE SILENCE, the still-open interval between the last scheduled run and
+now. Gaps need two runs, so on a cron that is being dropped hard the gap sample is tiny
+and cannot carry a conclusion by itself -- whereas "it has been N minutes with nothing
+pending" is a single direct observation that does not depend on the sample size at all.
+That is the load-bearing evidence on IRO-679, so it is measured here rather than by hand.
+Silence is only reported for an ACTIVE workflow with no run in flight: a disabled or
+auto-disabled workflow is silent for a reason that has nothing to do with the scheduler,
+and reporting that as latency would be a false positive.
+
 Deliberately NOT measured: delay from the declared clock time. For a high-frequency cron
 every slot is close to every run, so nearest-slot matching cannot produce a delay larger
 than the period -- it reports a small number no matter how badly the cron is being dropped.
@@ -103,21 +112,44 @@ def _crons(path: pathlib.Path) -> list[str]:
     return out
 
 
-def _runs(repo: str, workflow: str) -> list[dt.datetime]:
-    """created_at of every scheduled run, oldest first. created_at is when GitHub created
-    the run, i.e. when the schedule actually fired -- not when a runner picked it up."""
+def _runs(repo: str, workflow: str) -> tuple[list[dt.datetime], bool]:
+    """(created_at of every scheduled run oldest-first, whether one is still in flight).
+
+    created_at is when GitHub created the run, i.e. when the schedule actually fired --
+    not when a runner picked it up. The in-flight flag matters for the silence column:
+    a queued run means the scheduler has already fired and we are merely waiting on a
+    runner, which is not the failure this script is looking for."""
     proc = subprocess.run(
         ["gh", "api", "--paginate",
          f"repos/{repo}/actions/workflows/{workflow}/runs?event=schedule&per_page=100",
-         "--jq", ".workflow_runs[].created_at"],
+         "--jq", r'.workflow_runs[] | "\(.created_at) \(.status)"'],
         capture_output=True, text=True,
     )
     if proc.returncode != 0:
-        return []
-    return sorted(
-        dt.datetime.fromisoformat(line.replace("Z", "+00:00"))
-        for line in proc.stdout.split() if line
+        return [], False
+    stamps: list[dt.datetime] = []
+    in_flight = False
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        created, _, status = line.partition(" ")
+        stamps.append(dt.datetime.fromisoformat(created.replace("Z", "+00:00")))
+        if status.strip() != "completed":
+            in_flight = True
+    return sorted(stamps), in_flight
+
+
+def _state(repo: str, workflow: str) -> str:
+    """The workflow's `state` (active / disabled_manually / disabled_inactivity / ...).
+
+    Load-bearing negative control. GitHub auto-disables scheduled workflows in dormant
+    repos, and a disabled cron is perfectly silent -- scoring that as scheduler latency
+    would manufacture the exact finding this script exists to test."""
+    proc = subprocess.run(
+        ["gh", "api", f"repos/{repo}/actions/workflows/{workflow}", "--jq", ".state"],
+        capture_output=True, text=True,
     )
+    return proc.stdout.strip() if proc.returncode == 0 else "unknown"
 
 
 def main() -> int:
@@ -128,6 +160,7 @@ def main() -> int:
     args = ap.parse_args()
 
     wf_dir = pathlib.Path(__file__).resolve().parent.parent / ".github" / "workflows"
+    now = dt.datetime.now(dt.timezone.utc)
     pooled: list[tuple[str, float]] = []
     rows = []
 
@@ -138,19 +171,20 @@ def main() -> int:
             continue
         cron = crons[0]
         period = _period_minutes(cron)
-        runs = _runs(args.repo, path.name)
+        runs, in_flight = _runs(args.repo, path.name)
         gaps = [(b - a).total_seconds() / 60 for a, b in zip(runs, runs[1:])]
-        rows.append((path.name, cron, period, runs, gaps))
+        rows.append((path.name, cron, period, runs, gaps,
+                     _state(args.repo, path.name), in_flight))
         if period and gaps:
             # Pool only cadences we have enough of to say anything about, and keep the
             # sub-hourly arm out of the pool -- it is the hypothesis under test, not evidence.
             if period >= 1440:
                 pooled += [(path.name, g - period) for g in gaps]
 
-    print(f"repo: {args.repo}    measured: {dt.datetime.now(dt.timezone.utc):%Y-%m-%dT%H:%MZ}\n")
+    print(f"repo: {args.repo}    measured: {now:%Y-%m-%dT%H:%MZ}\n")
     print(f"{'workflow':<34}{'cron':<16}{'runs':>5}{'gaps':>5}   excess over nominal (min)")
     print("-" * 96)
-    for name, cron, period, runs, gaps in rows:
+    for name, cron, period, runs, gaps, state, in_flight in rows:
         if not period:
             print(f"{name:<34}{cron:<16}{len(runs):>5}{len(gaps):>5}   (no single nominal period)")
             continue
@@ -161,6 +195,30 @@ def main() -> int:
         flag = "  <-- exceeds its own period" if max(ex) > period else ""
         print(f"{name:<34}{cron:<16}{len(runs):>5}{len(gaps):>5}   "
               f"min {min(ex):+.0f}  p50 {statistics.median(ex):+.0f}  max {max(ex):+.0f}{flag}")
+
+    print(f"\n{'workflow':<34}{'cron':<16}   live silence since last run")
+    print("-" * 96)
+    for name, cron, period, runs, _gaps, state, in_flight in rows:
+        if not runs:
+            print(f"{name:<34}{cron:<16}   (never fired on a schedule)")
+            continue
+        silence = (now - runs[-1]).total_seconds() / 60
+        if state != "active":
+            # Never score a disabled workflow's silence. See _state().
+            print(f"{name:<34}{cron:<16}   {silence:.0f} min, NOT SCORED (state: {state})")
+            continue
+        if in_flight:
+            print(f"{name:<34}{cron:<16}   {silence:.0f} min, NOT SCORED (a run is in flight)")
+            continue
+        if not period:
+            print(f"{name:<34}{cron:<16}   {silence:.0f} min (no single nominal period)")
+            continue
+        flag = "  <-- over 2x its period, nothing pending" if silence > 2 * period else ""
+        print(f"{name:<34}{cron:<16}   {silence:.0f} min vs {period} min asked "
+              f"({silence / period:.1f}x){flag}")
+    print("\n  A flagged row is a single direct observation and does not need a sample of")
+    print("  gaps to stand up: the workflow is active, nothing is queued, and the schedule")
+    print("  has still not fired. Quote this, not the gap count, when the gap count is small.")
 
     if pooled:
         vals = sorted(v for _, v in pooled)
@@ -176,7 +234,7 @@ def main() -> int:
     if args.phase:
         print(f"\n{'workflow':<34}{'declared':>10}{'observed fire time (UTC)':>34}")
         print("-" * 80)
-        for name, cron, period, runs, _ in rows:
+        for name, cron, period, runs, _gaps, _state_, _in_flight in rows:
             if not runs or not period or period < 1440:
                 continue
             f = cron.split()


### PR DESCRIPTION
Recovers work that was committed locally but **never pushed** when the 07-30 session-limit outage killed the run (IRO-680 found it as an orphaned commit). It is the follow-up #620 implied but did not contain.

## Why

The IRO-679 conclusion rests on a **live silence** -- the `*/30` backstop cron having gone quiet with nothing pending -- because the gap sample is n=2 and cannot carry it. That number was **hand-measured**, so the one piece of evidence doing the work was the one piece nobody could re-derive. This makes it a script output.

## What

`scripts/measure-cron-latency.py` grows a second table: **live silence**, minutes since the last scheduled run vs the period the cron asked for. Two guards, both load-bearing:

- **NOT SCORED unless `state: active`.** GitHub auto-disables scheduled workflows in dormant repos, and a disabled cron is perfectly silent -- scoring it would manufacture the exact finding the script exists to test.
- **NOT SCORED while a run is in flight.** A queued run means the schedule *did* fire and we are waiting on a runner. Different failure.

## Re-measured 2026-07-30 06:08Z -- the finding got stronger

```
fork-ci-approval-backstop  13,43 * * * *   236 min vs 30 min asked (7.9x)
                                           <-- over 2x its period, nothing pending
```

Still **3** scheduled runs in its entire history; over the 7h40m since the first, a 30-min cron predicts **~15** and the scheduler delivered **3**.

The control that makes that row mean something: every daily/weekly cron in the repo sat at **0.0x-0.9x** of its period in the same table. The metric is not flagging everything it looks at.

## What this does NOT claim

- **The `13,43` offset is still not known to help.** In the 79 min since it landed, 0 runs delivered where it predicts 2. That is **n=0** -- not evidence it failed either. Both the workflow comment and the doc keep saying "not known to help" instead of shipping a number.
- **The hourly cadence remains unmeasured.** `brew-bump-waiting` has **0** scheduled runs so far, and the script prints `(never fired on a schedule)` rather than inventing one. That measurement is owed on IRO-680 Task 2 (due 2026-07-31).

The 92-minute hand-measured figure is replaced everywhere it appeared.

## Unchanged on purpose

Cron stays `13,43 * * * *` at the same cadence. Pooled figures unchanged (56 intervals, p50 -7 / p90 +36 / p95 +51 / max +75). The 240 min staleness threshold still survives with ~105 min of headroom -- **no escalation is triggered.**

## Verification

- `actionlint` clean on both touched workflows.
- **TRIGGER GUARDRAIL asserted**: the backstop`s `on:` keys are still `schedule` + `workflow_dispatch` only (no `pull_request` / `pull_request_target`), and its cron is byte-identical.
- Script runs warning-free and reproduces the pooled figures.

No signing, attestation, ruleset, token-scope or installer surface is touched. Workflow-touching, so it is outside the reviewer-bot self-serve path -- **the merge click is yours.**