### PR TITLE
ci: identify the reviewer App by client-id, not the deprecated app-id [IRO-684]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -764,14 +764,22 @@ jobs:
       # is deliberately NOT in `bypass_actors` (IRO-670). The token is still never
       # used to approve or merge anything; a human still does that.
       #
-      # continue-on-error so a missing/rotated App secret degrades to the loud manual
-      # fallback below instead of aborting before the branch is even pushed.
+      # continue-on-error so a missing/rotated App credential degrades to the loud
+      # manual fallback below instead of aborting before the branch is even pushed.
+      #
+      # `client-id` (not the deprecated `app-id`) identifies the App: the action reads
+      # `client-id` first and only falls back to `app-id`, which now emits a
+      # deprecation warning and will eventually be dropped (IRO-684). Losing the mint
+      # here is a QUIET degradation -- the fallback below re-opens the bump PR under
+      # GITHUB_TOKEN, which parks every run in `action_required` (the IRO-677
+      # regression) -- so this identifier must stay valid. It is the App's Client ID,
+      # re-derivable with `gh api /apps/ironclaw-reviewer --jq .client_id`.
       - name: Mint a scoped reviewer-App token to push the bump branch and open its PR
         id: pr-app-token
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.REVIEWER_APP_ID }}
+          client-id: ${{ vars.REVIEWER_APP_CLIENT_ID }}
           private-key: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
           permission-pull-requests: write
           permission-contents: write
@@ -903,7 +911,7 @@ jobs:
               printf '%s\n' "${1}"
               echo '```'
               echo
-              echo "Usual cause: the scoped **reviewer-App** token could not be minted — check that the \`REVIEWER_APP_ID\` / \`REVIEWER_APP_PRIVATE_KEY\` secrets are present and the App still has \`pull-requests: write\` on this repo (board owns org-secret provisioning). Then re-run, or open the PR manually from the already-signed branch:"
+              echo "Usual cause: the scoped **reviewer-App** token could not be minted — check that the \`REVIEWER_APP_CLIENT_ID\` variable and \`REVIEWER_APP_PRIVATE_KEY\` secret are present and the App still has \`pull-requests: write\` on this repo (board owns org-secret provisioning). Then re-run, or open the PR manually from the already-signed branch:"
               echo
               echo '```'
               echo "gh pr create --repo ${REPO} --base main --head ${branch} \\"

--- a/.github/workflows/reviewer-approve.yml
+++ b/.github/workflows/reviewer-approve.yml
@@ -9,9 +9,10 @@
 # the human/board decision). The GitHub approval mechanically reflects that
 # recorded decision. See docs/pr-review-process.md.
 #
-# Inert until the App is installed: without the REVIEWER_APP_* secrets a dispatch
-# fails fast with a clear message. It never runs on push/PR, so it adds no
-# required-check surface and changes no current behaviour.
+# Inert until the App is installed: without the REVIEWER_APP_CLIENT_ID variable and
+# the REVIEWER_APP_PRIVATE_KEY secret a dispatch fails fast with a clear message. It
+# never runs on push/PR, so it adds no required-check surface and changes no current
+# behaviour.
 
 name: Reviewer approval
 
@@ -43,7 +44,7 @@ jobs:
           ACTOR: ${{ github.actor }}
           PR: ${{ inputs.pr }}
           ROR: ${{ inputs.review_of_record }}
-          APP_ID: ${{ secrets.REVIEWER_APP_ID }}
+          APP_CLIENT_ID: ${{ vars.REVIEWER_APP_CLIENT_ID }}
           APP_KEY: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
@@ -56,8 +57,8 @@ jobs:
             ''|*[!0-9]*) echo "::error::pr must be a numeric PR number." >&2; exit 1 ;;
           esac
 
-          if [ -z "${APP_ID:-}" ] || [ -z "${APP_KEY:-}" ]; then
-            echo "::error::Reviewer App not installed: set REVIEWER_APP_ID and REVIEWER_APP_PRIVATE_KEY secrets first (see docs/pr-review-process.md)." >&2
+          if [ -z "${APP_CLIENT_ID:-}" ] || [ -z "${APP_KEY:-}" ]; then
+            echo "::error::Reviewer App not installed: set the REVIEWER_APP_CLIENT_ID variable and the REVIEWER_APP_PRIVATE_KEY secret first (see docs/pr-review-process.md)." >&2
             exit 1
           fi
 
@@ -79,7 +80,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.REVIEWER_APP_ID }}
+          client-id: ${{ vars.REVIEWER_APP_CLIENT_ID }}
           private-key: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
 
       - name: Post approving review as the reviewer App

--- a/.github/workflows/scores-refresh.yml
+++ b/.github/workflows/scores-refresh.yml
@@ -97,7 +97,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.REVIEWER_APP_ID }}
+          client-id: ${{ vars.REVIEWER_APP_CLIENT_ID }}
           private-key: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
           permission-pull-requests: write
           permission-contents: read
@@ -160,7 +160,7 @@ jobs:
               printf '%s\n' "${1}"
               echo '```'
               echo
-              echo "Usual cause: the scoped reviewer-App token could not be minted (check \`REVIEWER_APP_ID\` / \`REVIEWER_APP_PRIVATE_KEY\`). Open it manually from the already-pushed branch:"
+              echo "Usual cause: the scoped reviewer-App token could not be minted (check the \`REVIEWER_APP_CLIENT_ID\` variable / \`REVIEWER_APP_PRIVATE_KEY\` secret). Open it manually from the already-pushed branch:"
               echo
               echo '```'
               echo "gh pr create --repo ${REPO} --base main --head ${branch} \\"

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -100,14 +100,17 @@ The mechanics live in
   `pull-requests: read`; the approving review is posted with the **App
   installation token** (`pull_requests: write`), minted at run time via
   [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token)
-  (SHA-pinned). The App private key is read from `secrets.REVIEWER_APP_PRIVATE_KEY`
-  and masked by the action — it is never logged.
+  (SHA-pinned). The App is identified by `vars.REVIEWER_APP_CLIENT_ID` (the App's
+  Client ID — a non-secret identifier, useless without the key) and the App private
+  key is read from `secrets.REVIEWER_APP_PRIVATE_KEY` and masked by the action — it is
+  never logged.
 - **Safety:** the workflow refuses to approve if the App secret is absent, if
   the PR is not open, or if the PR author is the App itself — except the one
   recognised formula-bump case below, where it exits cleanly with an
   admin-merge runbook rather than a red run.
 
-Until the App is installed and the two secrets exist, the workflow is **inert**
+Until the App is installed and both the Client ID variable and the private-key
+secret exist, the workflow is **inert**
 (a manual dispatch fails fast with a clear message). Nothing in CI or the
 release path depends on it, so landing the scaffold changes no current behaviour.
 
@@ -452,18 +455,23 @@ Click-by-click (≈5 minutes, repo admin):
    - **Where can this App be installed?** *Only on this account.*
    - Click **Create GitHub App**.
    *(The values above match [`.github/reviewer-app-manifest.yml`](https://github.com/IronSecCo/ironclaw/blob/main/.github/reviewer-app-manifest.yml).)*
-2. **Note the App ID** shown on the App's settings page.
+2. **Note the Client ID** shown on the App's settings page (the `Iv23...` value, not
+   the numeric App ID — `actions/create-github-app-token` deprecated the `app-id`
+   input in favour of `client-id`). It is also readable with
+   `gh api /apps/ironclaw-reviewer --jq .client_id`.
 3. **Generate a private key:** on the App page → **Private keys** →
    **Generate a private key**. A `.pem` downloads. Treat it as a secret.
 4. **Install the App:** App page → **Install App** → install on **IronSecCo**,
    scoped to **only the `ironclaw` repository**.
-5. **Store the credentials as repo secrets** (Settings → Secrets and variables →
-   Actions → New repository secret), or via CLI:
+5. **Store the Client ID as a repo variable and the key as a repo secret**
+   (Settings → Secrets and variables → Actions), or via CLI:
    ```bash
-   gh secret set REVIEWER_APP_ID --repo IronSecCo/ironclaw --body "<the App ID>"
+   gh variable set REVIEWER_APP_CLIENT_ID --repo IronSecCo/ironclaw --body "<the Client ID>"
    gh secret set REVIEWER_APP_PRIVATE_KEY --repo IronSecCo/ironclaw < path/to/ironclaw-reviewer.*.private-key.pem
    ```
-   Then delete the local `.pem`.
+   Then delete the local `.pem`. The Client ID is a variable, not a secret: it is a
+   public identifier that grants nothing without the private key, and keeping it
+   readable makes a failed mint diagnosable from the run log.
 6. *(Optional, only if adopting Option B / CODEOWNERS enforcement)* create the
    `@IronSecCo/reviewers` team and add the reviewer as a member so the
    [CODEOWNERS](https://github.com/IronSecCo/ironclaw/blob/main/.github/CODEOWNERS)


### PR DESCRIPTION
Closes IRO-684.

`actions/create-github-app-token@v3.2.0` deprecated the `app-id` input in favour of `client-id`. Every release run that opened a formula-bump PR carried the annotation:

> Input 'app-id' has been deprecated with message: Use 'client-id' instead.

## Why this is worth fixing now

The action reads `client-id` first and only falls back to `app-id`. If a future major drops `app-id`, the mint fails -- and because the mint is `continue-on-error` with a *deliberate* `GITHUB_TOKEN` fallback, the failure is **quiet**: every bump PR silently goes back to parking in `action_required`, reopening IRO-677 with a green build rather than a red one.

## What changed

- `client-id` at all **three** call sites: `release.yml`, `reviewer-approve.yml`, and `scores-refresh.yml`. The third was not in the issue scope -- the audit turned it up.
- Identifier moves from `secrets.REVIEWER_APP_ID` to `vars.REVIEWER_APP_CLIENT_ID` (already provisioned). The Client ID is a public identifier that grants nothing without the private key, so it is a **variable, not a secret**; keeping it readable makes a failed mint diagnosable from the run log.
- `REVIEWER_APP_PRIVATE_KEY` is untouched -- **no second credential**.
- Three things that would otherwise have gone stale and silent:
  - the `reviewer-approve` preflight guard was checking `REVIEWER_APP_ID`, which after the rename would have been a **vacuous check on a secret nothing reads**;
  - the two manual-fallback messages named the wrong knob;
  - the setup runbook told an operator to set `REVIEWER_APP_ID`.

## Verification

A temporary probe workflow (run `30519270060`) with a **negative control**, so "no annotation" is a real observation rather than a vacuous one:

| job | input | annotations | result |
|---|---|---|---|
| `control-app-id` | `app-id` | **deprecation warning present** | success |
| `candidate-client-id` | `client-id` | **zero** | success |

The candidate minted a *working* token, not just a non-empty one: `app-slug: ironclaw-reviewer`, `GET /repos/IronSecCo/ironclaw -> 200`. Token never printed.

Annotations were read from the **check-runs API**, not by grepping the log -- the runner echoes script source, which false-positives on `::warning`. The probe branch is deleted; the probe file was never on this branch.

`actionlint` clean on all three workflows.

## Guardrails

No change to `bypass_actors`, no second credential, no change to token scopes or the approving-review click. This is an input rename plus the references that had to move with it.

## Residual risk (not fixed here, deliberately)

If the App is ever rotated, `REVIEWER_APP_CLIENT_ID` must be updated alongside the private key or the mint degrades quietly to `GITHUB_TOKEN`. That silent-fallback design predates this PR and is out of scope per the issue guardrails ("an input-rename, nothing more"); the release.yml comment now spells out the hazard and how to re-derive the ID. Worth its own ticket if you want the fallback to be loud.

## Review

Release-path auth -> CEO review per my role instructions. Per the standing rule that the reviewer-bot self-serve path excludes any `.github/workflows/*` PR, I am not self-approving this.