### PR TITLE
fix(scripts): a failed cron measurement must not read as a healthy cron [IRO-685]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,31 @@ jobs:
             echo "::endgroup::"
           done
 
+  # Regression tests for the repo's Python tooling scripts (IRO-685). Small surface, but
+  # these scripts produce the numbers that go into doc claims, and their failure modes are
+  # fail-QUIET: measure-cron-latency.py used to render a 403 from `gh` as the factual claim
+  # "(never fired on a schedule)" and still exit 0. A defect that erases evidence is
+  # invisible to a smoke test that only checks the script runs, so it needs assertions on
+  # what the output must NOT say — and those assertions need a job that runs them, or they
+  # are decoration. Stdlib unittest only: no test dependency to install or pin.
+  script-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          # Same pin as docs.yml, so both Python jobs run one toolchain.
+          python-version: "3.12"
+      - name: unittest (scripts/tests)
+        # `discover` is silent about finding nothing, which would be a green vacuous job,
+        # so assert the suite is non-empty before trusting the result.
+        run: |
+          set -euo pipefail
+          found=$(find scripts/tests -name 'test_*.py' | wc -l | tr -d ' ')
+          echo "test modules found: ${found}"
+          [ "${found}" -gt 0 ] || { echo "::error::no test modules under scripts/tests" >&2; exit 1; }
+          python3 -m unittest discover -s scripts/tests -v
+
   # Guard the published Linux binaries' glibc floor on every PR (IRO-192). The release job
   # builds the linux artifacts inside a pinned glibc-2.31 (Debian 11 "bullseye") container
   # so they run on every mainstream server LTS (Ubuntu 22.04 = 2.35, Debian 12 = 2.36,

--- a/scripts/measure-cron-latency.py
+++ b/scripts/measure-cron-latency.py
@@ -16,9 +16,17 @@ now. Gaps need two runs, so on a cron that is being dropped hard the gap sample 
 and cannot carry a conclusion by itself -- whereas "it has been N minutes with nothing
 pending" is a single direct observation that does not depend on the sample size at all.
 That is the load-bearing evidence on IRO-679, so it is measured here rather than by hand.
-Silence is only reported for an ACTIVE workflow with no run in flight: a disabled or
-auto-disabled workflow is silent for a reason that has nothing to do with the scheduler,
-and reporting that as latency would be a false positive.
+Silence is only reported for an ACTIVE workflow with no run in flight for the current
+interval: a disabled or auto-disabled workflow is silent for a reason that has nothing to
+do with the scheduler, and reporting that as latency would be a false positive.
+
+A FAILED MEASUREMENT IS NEVER RENDERED AS A HEALTHY CRON (IRO-685). Every `gh` call
+that returns non-zero produces a visible `MEASUREMENT FAILED: <reason>` row, is kept out
+of the pooled sample, and makes the whole script exit non-zero. The alternative -- the
+original behaviour -- was to treat a 403, a rate limit or a network blip as an empty run
+history, which the tables print as the factual claim "(never fired on a schedule)" while
+quietly shrinking the sample every published figure rests on. A count of zero and a
+failure to count are different observations and this script must not conflate them.
 
 Deliberately NOT measured: delay from the declared clock time. For a high-frequency cron
 every slot is close to every run, so nearest-slot matching cannot produce a delay larger
@@ -39,8 +47,8 @@ issues no writes and takes no action on any workflow.
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import datetime as dt
-import json
 import pathlib
 import re
 import statistics
@@ -51,6 +59,26 @@ import sys
 # fixed stride; anything else (e.g. "0 6 * * 1,4") is listed but not scored, because
 # "excess over nominal" is meaningless without a single nominal.
 _MINUTE_STRIDE = re.compile(r"^\*/(\d+)$")
+
+# Failure reasons share a table row with the workflow name, so keep them to one line.
+_MAX_REASON = 120
+
+
+@dataclasses.dataclass
+class Row:
+    """One workflow's measurement. `runs_error` / `state_error` are set when the
+    underlying `gh` call failed, and are what keep a failed measurement from being
+    rendered as an observation about the scheduler. See IRO-685."""
+
+    name: str
+    cron: str
+    period: int | None
+    runs: list[dt.datetime]
+    gaps: list[float]
+    in_flight: bool
+    state: str
+    runs_error: str | None = None
+    state_error: str | None = None
 
 
 def _period_minutes(cron: str) -> int | None:
@@ -112,13 +140,36 @@ def _crons(path: pathlib.Path) -> list[str]:
     return out
 
 
-def _runs(repo: str, workflow: str) -> tuple[list[dt.datetime], bool]:
-    """(created_at of every scheduled run oldest-first, whether one is still in flight).
+def _gh_failure(proc: subprocess.CompletedProcess[str]) -> str:
+    """A one-line reason from a failed `gh` invocation, for a `MEASUREMENT FAILED` row.
+
+    Enough of stderr survives to tell an auth failure ("HTTP 401", "Bad credentials")
+    from a rate limit ("API rate limit exceeded") from a genuinely empty history -- the
+    three cases the original `return [], False` collapsed into one silent zero."""
+    detail = " ".join((proc.stderr or "").split()) or "no stderr"
+    if len(detail) > _MAX_REASON:
+        detail = detail[: _MAX_REASON - 3] + "..."
+    return f"gh exit {proc.returncode}: {detail}"
+
+
+def _runs(repo: str, workflow: str) -> tuple[list[dt.datetime], bool, str | None]:
+    """(created_at of every scheduled run oldest-first, newest run in flight, failure).
 
     created_at is when GitHub created the run, i.e. when the schedule actually fired --
     not when a runner picked it up. The in-flight flag matters for the silence column:
     a queued run means the scheduler has already fired and we are merely waiting on a
-    runner, which is not the failure this script is looking for."""
+    runner, which is not the failure this script is looking for.
+
+    In flight is a fact about runs[-1] and nothing else. An OR over the whole history
+    would be pinned true forever by one run parked in `waiting` / `queued` -- and in this
+    repo runs parked awaiting approval are the expected case, not an edge case -- so the
+    silence column would print a plausible-looking `NOT SCORED (a run is in flight)`
+    excuse for going dark ever after. See IRO-685.
+
+    A non-zero exit yields a failure reason rather than an empty history. `--paginate`
+    can also fail partway with some pages already on stdout; that partial history is
+    discarded rather than measured, because a truncated sample reports a healthier
+    cadence than reality."""
     proc = subprocess.run(
         ["gh", "api", "--paginate",
          f"repos/{repo}/actions/workflows/{workflow}/runs?event=schedule&per_page=100",
@@ -126,30 +177,40 @@ def _runs(repo: str, workflow: str) -> tuple[list[dt.datetime], bool]:
         capture_output=True, text=True,
     )
     if proc.returncode != 0:
-        return [], False
-    stamps: list[dt.datetime] = []
-    in_flight = False
+        return [], False, _gh_failure(proc)
+    entries: list[tuple[dt.datetime, str]] = []
     for line in proc.stdout.splitlines():
         if not line.strip():
             continue
         created, _, status = line.partition(" ")
-        stamps.append(dt.datetime.fromisoformat(created.replace("Z", "+00:00")))
-        if status.strip() != "completed":
-            in_flight = True
-    return sorted(stamps), in_flight
+        entries.append((dt.datetime.fromisoformat(created.replace("Z", "+00:00")),
+                        status.strip()))
+    entries.sort(key=lambda e: e[0])
+    in_flight = bool(entries) and entries[-1][1] != "completed"
+    return [created for created, _ in entries], in_flight, None
 
 
-def _state(repo: str, workflow: str) -> str:
-    """The workflow's `state` (active / disabled_manually / disabled_inactivity / ...).
+def _state(repo: str, workflow: str) -> tuple[str, str | None]:
+    """(the workflow's `state`, failure reason).
 
-    Load-bearing negative control. GitHub auto-disables scheduled workflows in dormant
-    repos, and a disabled cron is perfectly silent -- scoring that as scheduler latency
-    would manufacture the exact finding this script exists to test."""
+    State is active / disabled_manually / disabled_inactivity / ... and is a load-bearing
+    negative control. GitHub auto-disables scheduled workflows in dormant repos, and a
+    disabled cron is perfectly silent -- scoring that as scheduler latency would
+    manufacture the exact finding this script exists to test.
+
+    A failed call must not read as a state, either: `unknown` is not `active`, so the old
+    fail-quiet return sent the row down the "NOT SCORED (state: ...)" path and erased the
+    silence observation while looking like a deliberate exclusion."""
     proc = subprocess.run(
         ["gh", "api", f"repos/{repo}/actions/workflows/{workflow}", "--jq", ".state"],
         capture_output=True, text=True,
     )
-    return proc.stdout.strip() if proc.returncode == 0 else "unknown"
+    if proc.returncode != 0:
+        return "unknown", _gh_failure(proc)
+    value = proc.stdout.strip()
+    if not value:
+        return "unknown", "gh exit 0: no `state` in the response"
+    return value, None
 
 
 def main() -> int:
@@ -162,7 +223,7 @@ def main() -> int:
     wf_dir = pathlib.Path(__file__).resolve().parent.parent / ".github" / "workflows"
     now = dt.datetime.now(dt.timezone.utc)
     pooled: list[tuple[str, float]] = []
-    rows = []
+    rows: list[Row] = []
 
     for path in sorted(wf_dir.glob("*.yml")):
         crons = _crons(path)
@@ -171,10 +232,18 @@ def main() -> int:
             continue
         cron = crons[0]
         period = _period_minutes(cron)
-        runs, in_flight = _runs(args.repo, path.name)
+        runs, in_flight, runs_error = _runs(args.repo, path.name)
+        # Don't ask for state when the history call already failed: same API, same
+        # failure, and if the cause is a rate limit a second call only deepens it. The
+        # row is already reported as a failed measurement on the strength of runs_error.
+        state, state_error = ("unknown", None) if runs_error else _state(args.repo, path.name)
         gaps = [(b - a).total_seconds() / 60 for a, b in zip(runs, runs[1:])]
-        rows.append((path.name, cron, period, runs, gaps,
-                     _state(args.repo, path.name), in_flight))
+        rows.append(Row(path.name, cron, period, runs, gaps, in_flight, state,
+                        runs_error, state_error))
+        if runs_error:
+            # An unmeasured workflow contributes nothing -- not even zero rows. Folding a
+            # failed call in as "no intervals" is how a 403 becomes a published figure.
+            continue
         if period and gaps:
             # Pool only cadences we have enough of to say anything about, and keep the
             # sub-hourly arm out of the pool -- it is the hypothesis under test, not evidence.
@@ -184,38 +253,57 @@ def main() -> int:
     print(f"repo: {args.repo}    measured: {now:%Y-%m-%dT%H:%MZ}\n")
     print(f"{'workflow':<34}{'cron':<16}{'runs':>5}{'gaps':>5}   excess over nominal (min)")
     print("-" * 96)
-    for name, cron, period, runs, gaps, state, in_flight in rows:
-        if not period:
-            print(f"{name:<34}{cron:<16}{len(runs):>5}{len(gaps):>5}   (no single nominal period)")
+    for r in rows:
+        if r.runs_error:
+            # Counts print as "-", never 0: zero runs is a claim about the scheduler and
+            # we did not earn the right to make it.
+            print(f"{r.name:<34}{r.cron:<16}{'-':>5}{'-':>5}   "
+                  f"MEASUREMENT FAILED: {r.runs_error}")
             continue
-        if not gaps:
-            print(f"{name:<34}{cron:<16}{len(runs):>5}{len(gaps):>5}   (no interval yet)")
+        if not r.period:
+            print(f"{r.name:<34}{r.cron:<16}{len(r.runs):>5}{len(r.gaps):>5}   "
+                  f"(no single nominal period)")
             continue
-        ex = sorted(g - period for g in gaps)
-        flag = "  <-- exceeds its own period" if max(ex) > period else ""
-        print(f"{name:<34}{cron:<16}{len(runs):>5}{len(gaps):>5}   "
+        if not r.gaps:
+            print(f"{r.name:<34}{r.cron:<16}{len(r.runs):>5}{len(r.gaps):>5}   "
+                  f"(no interval yet)")
+            continue
+        ex = sorted(g - r.period for g in r.gaps)
+        flag = "  <-- exceeds its own period" if max(ex) > r.period else ""
+        print(f"{r.name:<34}{r.cron:<16}{len(r.runs):>5}{len(r.gaps):>5}   "
               f"min {min(ex):+.0f}  p50 {statistics.median(ex):+.0f}  max {max(ex):+.0f}{flag}")
 
     print(f"\n{'workflow':<34}{'cron':<16}   live silence since last run")
     print("-" * 96)
-    for name, cron, period, runs, _gaps, state, in_flight in rows:
-        if not runs:
-            print(f"{name:<34}{cron:<16}   (never fired on a schedule)")
+    for r in rows:
+        if r.runs_error:
+            print(f"{r.name:<34}{r.cron:<16}   MEASUREMENT FAILED: {r.runs_error}")
             continue
-        silence = (now - runs[-1]).total_seconds() / 60
-        if state != "active":
+        if not r.runs:
+            print(f"{r.name:<34}{r.cron:<16}   (never fired on a schedule)")
+            continue
+        silence = (now - r.runs[-1]).total_seconds() / 60
+        if r.state_error:
+            # Checked before the state value: `unknown` is not `active`, so without this
+            # a failed state call would masquerade as a deliberate exclusion.
+            print(f"{r.name:<34}{r.cron:<16}   {silence:.0f} min, MEASUREMENT FAILED "
+                  f"(state unknown): {r.state_error}")
+            continue
+        if r.state != "active":
             # Never score a disabled workflow's silence. See _state().
-            print(f"{name:<34}{cron:<16}   {silence:.0f} min, NOT SCORED (state: {state})")
+            print(f"{r.name:<34}{r.cron:<16}   {silence:.0f} min, NOT SCORED "
+                  f"(state: {r.state})")
             continue
-        if in_flight:
-            print(f"{name:<34}{cron:<16}   {silence:.0f} min, NOT SCORED (a run is in flight)")
+        if r.in_flight:
+            print(f"{r.name:<34}{r.cron:<16}   {silence:.0f} min, NOT SCORED "
+                  f"(the newest run is in flight)")
             continue
-        if not period:
-            print(f"{name:<34}{cron:<16}   {silence:.0f} min (no single nominal period)")
+        if not r.period:
+            print(f"{r.name:<34}{r.cron:<16}   {silence:.0f} min (no single nominal period)")
             continue
-        flag = "  <-- over 2x its period, nothing pending" if silence > 2 * period else ""
-        print(f"{name:<34}{cron:<16}   {silence:.0f} min vs {period} min asked "
-              f"({silence / period:.1f}x){flag}")
+        flag = "  <-- over 2x its period, nothing pending" if silence > 2 * r.period else ""
+        print(f"{r.name:<34}{r.cron:<16}   {silence:.0f} min vs {r.period} min asked "
+              f"({silence / r.period:.1f}x){flag}")
     print("\n  A flagged row is a single direct observation and does not need a sample of")
     print("  gaps to stand up: the workflow is active, nothing is queued, and the schedule")
     print("  has still not fired. Quote this, not the gap count, when the gap count is small.")
@@ -234,20 +322,33 @@ def main() -> int:
     if args.phase:
         print(f"\n{'workflow':<34}{'declared':>10}{'observed fire time (UTC)':>34}")
         print("-" * 80)
-        for name, cron, period, runs, _gaps, _state_, _in_flight in rows:
-            if not runs or not period or period < 1440:
+        for r in rows:
+            if r.runs_error or not r.runs or not r.period or r.period < 1440:
                 continue
-            f = cron.split()
+            f = r.cron.split()
             declared = f"{int(f[1]):02d}:{int(f[0]):02d}" if f[1].isdigit() else "--:--"
-            tod = [r.hour * 60 + r.minute for r in runs]
+            tod = [run.hour * 60 + run.minute for run in r.runs]
             fmt = lambda m: f"{m // 60:02d}:{m % 60:02d}"
             med = int(statistics.median(tod))
-            print(f"{name:<34}{declared:>10}"
+            print(f"{r.name:<34}{declared:>10}"
                   f"{fmt(min(tod)) + '-' + fmt(max(tod)) + '  median ' + fmt(med):>34}")
         print("\n  Phase drift does not affect cadence. It does mean the declared clock time")
         print("  in a cron expression does not predict when the workflow runs, so do not")
         print("  write a doc claim of the form 'runs at HH:MM'.")
 
+    # Exit non-zero on any failed measurement. Every table above already carries a
+    # MEASUREMENT FAILED row, but a human skimming for the pooled figure will read past
+    # it, and a caller that only checks the exit status would read the run as clean.
+    failed = [r for r in rows if r.runs_error or r.state_error]
+    if failed:
+        print(f"\n{len(failed)} of {len(rows)} scheduled workflows could not be measured:",
+              file=sys.stderr)
+        for r in failed:
+            print(f"  {r.name}: {r.runs_error or r.state_error}", file=sys.stderr)
+        print("\nThe numbers above are computed over the workflows that DID measure, so "
+              "they\nunder-report. Fix the failures (auth, rate limit, network) and re-run "
+              "before\nquoting any figure from this output.", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/scripts/tests/test_measure_cron_latency.py
+++ b/scripts/tests/test_measure_cron_latency.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Regression tests for the two fail-quiet defects in scripts/measure-cron-latency.py.
+
+Both defects (IRO-685) fail in the SUPPRESSING direction: they cannot manufacture a
+finding, they erase one. That makes them invisible to a smoke test that only checks the
+script runs, so each gets an explicit test that asserts on what the output must NOT say.
+
+Run:
+    python3 -m unittest discover -s scripts/tests -v
+
+Manual reproduction of the same two cases against the live API, for the record:
+
+  Defect 2 (a failed call rendered as "never fired on a schedule"):
+      GH_TOKEN=invalid gh auth logout --hostname github.com 2>/dev/null; \
+      GH_TOKEN=invalid scripts/measure-cron-latency.py; echo "exit=$?"
+  Before the fix: every row reads `0 runs / 0 gaps` and `(never fired on a schedule)`,
+  the pooled block is absent, and exit=0. After: every row reads
+  `MEASUREMENT FAILED: gh exit 1: ... HTTP 401 ...` and exit=1.
+
+  Defect 1 (one stuck historical run pins in_flight forever):
+      gh api "repos/IronSecCo/ironclaw/actions/workflows/brew-bump-waiting.yml/runs\
+?event=schedule&per_page=100" --jq '.workflow_runs[] | "\\(.created_at) \\(.status)"'
+  Any line whose status is not `completed` used to pin the silence row to
+  `NOT SCORED (a run is in flight)`. Runs parked in `waiting` awaiting approval are this
+  repo's normal state, so that was the expected case, not an edge case. After the fix
+  only the newest line's status can suppress the row.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "measure-cron-latency.py"
+
+# A fixed date safely in the past, so the live-silence figure the end-to-end tests
+# exercise is a large positive number that does not depend on when the suite runs.
+_PAST_COMPLETED = "2025-01-02T14:00:00Z completed\n"
+
+
+def _load() -> types.ModuleType:
+    """Import the script as a module. The filename has a dash, so it is not importable
+    by name; loading it by path keeps the script executable as a script."""
+    spec = importlib.util.spec_from_file_location("measure_cron_latency", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    # Registered before exec: @dataclasses.dataclass resolves its class's module out of
+    # sys.modules, and blows up on None if the module is not there yet.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mcl = _load()
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(args=["gh"], returncode=returncode,
+                                       stdout=stdout, stderr=stderr)
+
+
+def _fake_gh(runs_result, state_result):
+    """A subprocess.run stand-in that answers the two calls the script makes. The runs
+    call is the one carrying `/runs?`; anything else is the workflow-state call."""
+
+    def run(cmd, *_a, **_kw):
+        return runs_result if any("/runs?" in str(part) for part in cmd) else state_result
+
+    return run
+
+
+class InFlightIsAboutTheNewestRunOnly(unittest.TestCase):
+    """Defect 1: `in_flight` was an OR over the entire run history."""
+
+    def test_stuck_historical_run_does_not_pin_in_flight(self):
+        # Newest run (14:00) completed; an older one is parked in `waiting` forever --
+        # the repo's normal state, since runs park awaiting approval.
+        stdout = ("2026-07-30T14:00:00Z completed\n"
+                  "2026-07-29T14:00:00Z waiting\n"
+                  "2026-07-28T14:00:00Z completed\n")
+        with mock.patch.object(mcl.subprocess, "run",
+                               _fake_gh(_completed(stdout=stdout), _completed())):
+            runs, in_flight, err = mcl._runs("o/n", "wf.yml")
+        self.assertIsNone(err)
+        self.assertFalse(in_flight, "a stuck HISTORICAL run must not report as in flight")
+        self.assertEqual(len(runs), 3)
+        # Oldest first, regardless of the newest-first order the API returns.
+        self.assertEqual(runs, sorted(runs))
+        self.assertEqual(runs[-1].hour, 14)
+        self.assertEqual(runs[-1].day, 30)
+
+    def test_newest_run_in_flight_still_reports(self):
+        # The flag must keep working for what it is actually for: the scheduler has
+        # fired for the current interval and we are only waiting on a runner.
+        stdout = ("2026-07-30T14:00:00Z queued\n"
+                  "2026-07-29T14:00:00Z completed\n")
+        with mock.patch.object(mcl.subprocess, "run",
+                               _fake_gh(_completed(stdout=stdout), _completed())):
+            _runs, in_flight, err = mcl._runs("o/n", "wf.yml")
+        self.assertIsNone(err)
+        self.assertTrue(in_flight)
+
+    def test_no_runs_is_not_in_flight(self):
+        with mock.patch.object(mcl.subprocess, "run",
+                               _fake_gh(_completed(stdout=""), _completed())):
+            runs, in_flight, err = mcl._runs("o/n", "wf.yml")
+        self.assertEqual(runs, [])
+        self.assertFalse(in_flight)
+        self.assertIsNone(err, "an empty history is a real measurement, not a failure")
+
+
+class FailedCallIsNotAnObservation(unittest.TestCase):
+    """Defect 2: a non-zero `gh` exit was returned as an empty run history."""
+
+    def test_runs_failure_returns_a_reason_not_an_empty_history(self):
+        err_text = "gh: Bad credentials (HTTP 401)"
+        with mock.patch.object(mcl.subprocess, "run",
+                               _fake_gh(_completed(1, stderr=err_text), _completed())):
+            runs, in_flight, err = mcl._runs("o/n", "wf.yml")
+        self.assertEqual(runs, [])
+        self.assertFalse(in_flight)
+        self.assertIsNotNone(err)
+        # The reason must distinguish an auth failure from an empty history.
+        self.assertIn("401", err)
+        self.assertIn("Bad credentials", err)
+
+    def test_partial_paginate_output_is_discarded_on_failure(self):
+        # `--paginate` can fail on a later page with earlier pages already on stdout.
+        # A truncated history reports a healthier cadence than reality, so it is dropped.
+        with mock.patch.object(mcl.subprocess, "run",
+                               _fake_gh(_completed(1, stdout="2026-07-30T14:00:00Z completed\n",
+                                                   stderr="API rate limit exceeded"),
+                                        _completed())):
+            runs, _in_flight, err = mcl._runs("o/n", "wf.yml")
+        self.assertEqual(runs, [])
+        self.assertIn("rate limit", err)
+
+    def test_state_failure_is_distinct_from_a_state_value(self):
+        with mock.patch.object(mcl.subprocess, "run",
+                               _fake_gh(_completed(), _completed(1, stderr="HTTP 403"))):
+            state, err = mcl._state("o/n", "wf.yml")
+        self.assertEqual(state, "unknown")
+        self.assertIn("403", err)
+
+    def test_state_success_carries_no_error(self):
+        with mock.patch.object(mcl.subprocess, "run",
+                               _fake_gh(_completed(), _completed(stdout="active\n"))):
+            state, err = mcl._state("o/n", "wf.yml")
+        self.assertEqual(state, "active")
+        self.assertIsNone(err)
+
+    def test_reason_is_one_line_and_bounded(self):
+        proc = _completed(1, stderr="a\nb\n" + "x" * 500)
+        reason = mcl._gh_failure(proc)
+        self.assertNotIn("\n", reason)
+        self.assertLessEqual(len(reason), mcl._MAX_REASON + len("gh exit 1: "))
+
+    def test_empty_stderr_still_yields_a_reason(self):
+        self.assertIn("no stderr", mcl._gh_failure(_completed(7)))
+
+
+class EndToEndOutput(unittest.TestCase):
+    """The tables and exit code, over this repo's real `schedule:` workflows with every
+    `gh` call stubbed. Asserts on what the output must not say."""
+
+    def _main(self, runs_result, state_result, argv=("measure-cron-latency.py",)):
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch.object(mcl.subprocess, "run", _fake_gh(runs_result, state_result)), \
+                mock.patch.object(sys, "argv", list(argv)), \
+                contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = mcl.main()
+        return code, out.getvalue(), err.getvalue()
+
+    def test_repo_has_scheduled_workflows_to_measure(self):
+        # Guards the tests below from becoming vacuous: if nothing in this repo parses as
+        # a single-cron scheduled workflow, the end-to-end assertions prove nothing.
+        _code, out, _err = self._main(_completed(stdout=_PAST_COMPLETED),
+                                      _completed(stdout="active"))
+        self.assertIn(".yml", out, "no scheduled workflow rows were produced")
+
+    def test_total_gh_failure_reports_failure_not_never_fired(self):
+        code, out, err = self._main(_completed(1, stderr="gh: Bad credentials (HTTP 401)"),
+                                    _completed(1, stderr="gh: Bad credentials (HTTP 401)"))
+        self.assertIn("MEASUREMENT FAILED", out)
+        self.assertNotIn("never fired on a schedule", out,
+                         "a failed call must never print as a claim about the scheduler")
+        self.assertNotIn("0 runs", out)
+        self.assertNotIn("POOLED", out, "a failed measurement must not reach the pool")
+        self.assertIn("could not be measured", err)
+        self.assertEqual(code, 1, "a failed measurement must exit non-zero")
+
+    def test_clean_measurement_exits_zero(self):
+        code, out, err = self._main(_completed(stdout=_PAST_COMPLETED),
+                                    _completed(stdout="active"))
+        self.assertEqual(code, 0, err)
+        self.assertNotIn("MEASUREMENT FAILED", out)
+
+    def test_stuck_historical_run_still_scores_silence(self):
+        stdout = _PAST_COMPLETED + "2025-01-01T14:00:00Z waiting\n"
+        code, out, _err = self._main(_completed(stdout=stdout), _completed(stdout="active"))
+        self.assertEqual(code, 0)
+        self.assertNotIn("is in flight", out,
+                         "a stuck historical run must not suppress the silence row")
+
+    def test_state_failure_does_not_masquerade_as_an_exclusion(self):
+        # `unknown` is not `active`, so before the fix this printed the same
+        # "NOT SCORED (state: ...)" as a deliberately-skipped disabled workflow.
+        code, out, _err = self._main(_completed(stdout=_PAST_COMPLETED),
+                                     _completed(1, stderr="HTTP 403"))
+        self.assertIn("MEASUREMENT FAILED (state unknown)", out)
+        self.assertNotIn("NOT SCORED (state: unknown)", out)
+        self.assertEqual(code, 1)
+
+    def test_phase_flag_skips_failed_measurements(self):
+        code, _out, _err = self._main(_completed(1, stderr="HTTP 403"),
+                                      _completed(stdout="active"),
+                                      argv=("measure-cron-latency.py", "--phase"))
+        self.assertEqual(code, 1)
+
+
+class ArithmeticIsUnchanged(unittest.TestCase):
+    """IRO-685 explicitly must not alter the measurement arithmetic. These pin the
+    `_period_minutes` answers the published 135 min / 7.9x figures were derived from."""
+
+    def test_period_minutes(self):
+        for cron, expected in [
+            ("*/30 * * * *", 30),
+            ("13,43 * * * *", 30),
+            ("17 * * * *", 60),
+            ("41 6 * * *", 1440),
+            ("23 7 * * 1", 10080),
+            ("0 6 * * 1,4", None),
+            ("0 6 1 * *", None),
+            ("nonsense", None),
+        ]:
+            with self.subTest(cron=cron):
+                self.assertEqual(mcl._period_minutes(cron), expected)
+
+    def test_schedule_block_with_no_parsable_cron_still_raises(self):
+        # The file's own standard: refuse to under-report rather than drop a workflow.
+        with tempfile.TemporaryDirectory() as d:
+            bad = pathlib.Path(d) / "bad.yml"
+            bad.write_text("on:\n  schedule:\n    - notacron: x\n")
+            with self.assertRaises(SystemExit):
+                mcl._crons(bad)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes IRO-685. Fixes the two fail-quiet defects the CEO found in the pre-merge review of #625 (merged as `3938c0ce`). Both fail in the *suppressing* direction, so neither can manufacture a finding — but both silently erase the evidence #625 designated load-bearing.

## Defect 1 — `in_flight` was an OR over the entire run history

One run parked in `waiting` *anywhere* in history pinned `in_flight = True` permanently, so the silence row printed `NOT SCORED (a run is in flight)` from then on — a plausible-looking reason for going dark. Runs parked awaiting approval are this repo's normal state, so that was the expected case, not an edge case.

In flight is now a fact about `runs[-1]` and nothing else, which is what the docstring always claimed. Entries are sorted by `created_at` before the newest is picked, so it does not depend on the API's return order.

## Defect 2 — an API failure was rendered as "never fired on a schedule"

`return [], False` discarded `stderr`, so a 403 / rate limit / network blip printed as the factual claim `(never fired on a schedule)` and `0 runs / 0 gaps`, and quietly shrank the pooled sample. Same "403s counted as zero" pattern that has already produced confident wrong numbers in this repo twice, and inconsistent with the file's own `_crons()` standard ("Refuse to do that quietly").

A failed call now:
- prints `MEASUREMENT FAILED: gh exit 1: gh: Bad credentials (HTTP 401)` — enough of `stderr` to tell an auth failure from a rate limit from a genuinely empty history;
- is excluded from the pooled sample (not folded in as "zero intervals");
- prints its counts as `-`, never `0` — zero runs is a claim about the scheduler and a failed call did not earn the right to make it;
- makes the script **exit non-zero**, with a stderr summary, so a caller that only checks the status cannot read the run as clean;
- discards `--paginate` partial output rather than measuring it, because a truncated history reports a healthier cadence than reality.

### Third instance of the same pattern, in `_state()`

`_state()` returned `"unknown"` on failure. `"unknown"` is not `"active"`, so the row fell through to `NOT SCORED (state: ...)` — indistinguishable from a deliberately-skipped disabled workflow. It now reports as a failed measurement, and is skipped entirely when the history call already failed (same API, same failure, and if the cause is a rate limit a second call only deepens it).

## No figure moves

IRO-685 required the arithmetic untouched, and asked me to escalate if the fix changed what counts as a valid sample in a way that moved the published 135 min / 7.9x numbers. **It does not, and this is measured, not asserted.** Running the pre-fix and post-fix scripts against the live API minutes apart, the gap table and the entire POOLED block are byte-identical:

```
POOLED (daily and weekly crons only): 56 intervals
  excess over nominal:  p50 -7   p90 +36   p95 +51   max +75 min
  intervals overshooting nominal by >60 min: 2/56
```

The only diff is a 1-minute wall-clock drift in three `live silence` rows, because the two runs happened a minute apart. `_period_minutes`, the timezone handling and the `--paginate` usage are unchanged; `ArithmeticIsUnchanged` in the new suite pins the `_period_minutes` answers those figures were derived from.

## Verification

**Regression suite** — `scripts/tests/test_measure_cron_latency.py`, 17 stdlib-unittest cases, asserting on what the output must **not** say:

```
$ python3 -m unittest discover -s scripts/tests
Ran 17 tests in 0.037s
OK
```

**Non-vacuity (negative control)** — the same suite against the pre-fix script, so the tests are shown to actually catch these two defects rather than merely pass:

```
$ python3 -m unittest discover -s <pre-fix copy>/scripts/tests
Ran 17 tests in 0.041s
FAILED (failures=4, errors=9)
```

The pre-fix failure output is the defect verbatim — every workflow row read `(never fired on a schedule)` on a total 401, and the script exited 0.

**Live forced failure** (the manual reproduction IRO-685 asks for, also recorded in the test docstring):

```
$ GH_TOKEN=invalid_token python3 scripts/measure-cron-latency.py; echo "exit=$?"
brew-bump-waiting.yml   23 * * * *   -   -   MEASUREMENT FAILED: gh exit 1: gh: Bad credentials (HTTP 401)
...
10 of 10 scheduled workflows could not be measured:
exit=1
```

**Live healthy run**: `exit=0`, no `MEASUREMENT FAILED` row. **`actionlint .github/workflows/ci.yml`**: clean.

## CI wiring

Nothing in CI ran these tests, and a guard nobody runs is decoration — so the second commit adds a `script-tests` job to `ci.yml`. Additive and least-privilege: stdlib unittest only (no test dependency to install or pin), inherits the workflow's `contents: read`, and **does not touch any required status check on `main`**. `setup-python` is pinned to the same commit SHA and 3.12 as `docs.yml`. Because `unittest discover` is silent about finding nothing, the step asserts the suite is non-empty first.

Flagging that second commit explicitly since IRO-685 scoped the work to "script-only plus tests" — happy to drop it if you'd rather the runner land on its own ticket.

## Guardrails honoured

- `.github/workflows/fork-ci-approval-backstop.yml` — **untouched** (verified by `git diff --name-only`; only `ci.yml` and `scripts/measure-cron-latency.py` are modified).
- `docs/pr-review-process.md` — **untouched**. The conclusion "a cron is the wrong tool for a hard latency bound" stands.
- No `--admin`. Squash merge. Ready for a `review_of_record` dispatch of `reviewer-approve.yml` whenever you are.