### PR TITLE
fix(scripts): score cron gaps only against the schedule that delivered them [IRO-680]

### DIFF
--- a/scripts/measure-cron-latency.py
+++ b/scripts/measure-cron-latency.py
@@ -20,6 +20,17 @@ Silence is only reported for an ACTIVE workflow with no run in flight for the cu
 interval: a disabled or auto-disabled workflow is silent for a reason that has nothing to
 do with the scheduler, and reporting that as latency would be a false positive.
 
+RUNS ARE SCORED ONLY AGAINST THE CRON THEY WERE DELIVERED UNDER (IRO-680). A run is
+produced by whatever schedule was on the default branch at the time, but the cron this
+script prints is the one in the file today. Pooling across a cron change therefore labels
+the OLD schedule's gaps with the NEW expression -- and that inverts the one question a
+cron change is made to answer, because "did the new offset help?" gets computed from the
+offset it replaced. Each workflow's window is bounded at the commit where its current
+cron landed, older runs are excluded, and the exclusion is printed rather than applied
+silently. Where the window cannot be determined (no git history, shallow clone, `--repo`
+pointing at another repository) nothing is excluded: an unknown window must not
+masquerade as a narrow one.
+
 A FAILED MEASUREMENT IS NEVER RENDERED AS A HEALTHY CRON (IRO-685). Every `gh` call
 that returns non-zero produces a visible `MEASUREMENT FAILED: <reason>` row, is kept out
 of the pooled sample, and makes the whole script exit non-zero. The alternative -- the
@@ -79,6 +90,12 @@ class Row:
     state: str
     runs_error: str | None = None
     state_error: str | None = None
+    # When the cron currently in the file landed on the default branch, and how many
+    # older runs were dropped because they were delivered under a different schedule.
+    # See _cron_landed_at(): scoring across a cron change mislabels the old regime's
+    # gaps as evidence about the new one.
+    cron_since: dt.datetime | None = None
+    dropped: int = 0
 
 
 def _period_minutes(cron: str) -> int | None:
@@ -111,12 +128,21 @@ def _period_minutes(cron: str) -> int | None:
 
 
 def _crons(path: pathlib.Path) -> list[str]:
+    """Cron expressions under a `schedule:` block in the working-tree file."""
+    return _crons_from_text(path.read_text(), path.name)
+
+
+def _crons_from_text(text: str, name: str) -> list[str]:
     """Cron expressions under a `schedule:` block. Text-scanned on purpose: PyYAML is not a
-    dependency of this repo and a wrong answer here is visible, not silent."""
+    dependency of this repo and a wrong answer here is visible, not silent.
+
+    Takes text rather than a path so the same parser reads historical blobs out of git
+    (see _cron_landed_at()); a second, drifting parser for the history would be able to
+    report a cron change that never happened, or miss one that did."""
     out: list[str] = []
     in_schedule = False
     saw_schedule = False
-    for line in path.read_text().splitlines():
+    for line in text.splitlines():
         stripped = line.strip()
         if stripped.startswith("#"):
             continue
@@ -136,8 +162,70 @@ def _crons(path: pathlib.Path) -> list[str]:
     if saw_schedule and not out:
         # A parser that silently drops a scheduled workflow reports a smaller, healthier
         # looking sample than reality. Refuse to do that quietly.
-        raise SystemExit(f"{path.name}: has a `schedule:` block but no cron parsed out of it")
+        raise SystemExit(f"{name}: has a `schedule:` block but no cron parsed out of it")
     return out
+
+
+def _git(root: pathlib.Path, *argv: str) -> str | None:
+    """stdout of a read-only `git` call, or None if it failed. Never raises: this is a
+    refinement of the measurement window, and losing it must not lose the measurement."""
+    proc = subprocess.run(["git", "-C", str(root), *argv], capture_output=True, text=True)
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def _local_repo(root: pathlib.Path) -> str | None:
+    """`Owner/Name` of the checkout's `origin`, or None. Used to refuse to apply this
+    checkout's git history to a `--repo` that is some other repository."""
+    url = _git(root, "remote", "get-url", "origin")
+    if not url:
+        return None
+    m = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?\s*$", url.strip())
+    return m.group(1) if m else None
+
+
+def _cron_landed_at(root: pathlib.Path, path: pathlib.Path,
+                    current: list[str]) -> dt.datetime | None:
+    """When the cron set now in `path` first landed, or None if it cannot be determined.
+
+    Runs are delivered under whatever schedule was on the default branch AT THE TIME.
+    `_crons()` reads the file at HEAD, so without this bound a cron change silently
+    pools the OLD regime's gaps into the new expression's row and labels them with the
+    new cron -- which is precisely the "did the new offset help?" question inverted:
+    the answer would be computed from the schedule the offset replaced. IRO-680 hit
+    this live. `fork-ci-approval-backstop` moved `*/30` -> `13,43`, and every scored
+    gap predated the change, so the row read as a measurement of an offset that had in
+    fact produced no complete interval at all.
+
+    Walks the file's history newest-first and returns the commit date of the OLDEST
+    consecutive commit whose cron set still equals `current` -- i.e. the commit that
+    introduced the schedule in force today. Committer date is deliberate: this repo
+    squash-merges, so it is when the change landed on main, not when it was authored.
+
+    Returns None (meaning "do not bound") when git is unavailable or the history is
+    truncated, because an unknown window must not masquerade as a narrow one."""
+    # git wants a repo-relative POSIX path on every platform, including Windows.
+    rel = path.as_posix()
+    log = _git(root, "log", "--format=%H %cI", "--", rel)
+    if not log:
+        return None
+    entries = [line.split(" ", 1) for line in log.splitlines() if line.strip()]
+    landed: str | None = None
+    for sha, when in entries:
+        blob = _git(root, "show", f"{sha}:{rel}")
+        if blob is None:
+            break
+        if _crons_from_text(blob, path.name) != current:
+            break
+        landed = when
+    else:
+        # Fell off the end of available history with every commit still matching. In a
+        # full clone that is the file's first commit and the bound is real; in a shallow
+        # one there may be older commits we cannot see. Only trust it if history is complete.
+        if (_git(root, "rev-parse", "--is-shallow-repository") or "").strip() == "true":
+            return None
+    if landed is None:
+        return None
+    return dt.datetime.fromisoformat(landed).astimezone(dt.timezone.utc)
 
 
 def _gh_failure(proc: subprocess.CompletedProcess[str]) -> str:
@@ -220,10 +308,15 @@ def main() -> int:
                     help="also report declared vs actual clock time (drift, not cadence)")
     args = ap.parse_args()
 
-    wf_dir = pathlib.Path(__file__).resolve().parent.parent / ".github" / "workflows"
+    root = pathlib.Path(__file__).resolve().parent.parent
+    wf_dir = root / ".github" / "workflows"
     now = dt.datetime.now(dt.timezone.utc)
     pooled: list[tuple[str, float]] = []
     rows: list[Row] = []
+
+    # This checkout's git history only describes this checkout's repo. Measuring some
+    # other repo with `--repo` must not inherit our cron-change dates.
+    same_repo = _local_repo(root) == args.repo
 
     for path in sorted(wf_dir.glob("*.yml")):
         crons = _crons(path)
@@ -233,13 +326,23 @@ def main() -> int:
         cron = crons[0]
         period = _period_minutes(cron)
         runs, in_flight, runs_error = _runs(args.repo, path.name)
+        cron_since = _cron_landed_at(root, path.relative_to(root), crons) if same_repo else None
+        dropped = 0
+        if cron_since and runs:
+            kept = [r for r in runs if r >= cron_since]
+            dropped = len(runs) - len(kept)
+            runs = kept
+            # in_flight is a fact about the newest run. Only OLD runs are ever dropped,
+            # so it survives -- unless the filter emptied the list, in which case there
+            # is no newest run for it to be a fact about.
+            in_flight = in_flight and bool(runs)
         # Don't ask for state when the history call already failed: same API, same
         # failure, and if the cause is a rate limit a second call only deepens it. The
         # row is already reported as a failed measurement on the strength of runs_error.
         state, state_error = ("unknown", None) if runs_error else _state(args.repo, path.name)
         gaps = [(b - a).total_seconds() / 60 for a, b in zip(runs, runs[1:])]
         rows.append(Row(path.name, cron, period, runs, gaps, in_flight, state,
-                        runs_error, state_error))
+                        runs_error, state_error, cron_since, dropped))
         if runs_error:
             # An unmeasured workflow contributes nothing -- not even zero rows. Folding a
             # failed call in as "no intervals" is how a 403 becomes a published figure.
@@ -265,19 +368,38 @@ def main() -> int:
                   f"(no single nominal period)")
             continue
         if not r.gaps:
-            print(f"{r.name:<34}{r.cron:<16}{len(r.runs):>5}{len(r.gaps):>5}   "
-                  f"(no interval yet)")
+            why = ("no interval yet under this cron" if r.dropped else "no interval yet")
+            print(f"{r.name:<34}{r.cron:<16}{len(r.runs):>5}{len(r.gaps):>5}   ({why})")
             continue
         ex = sorted(g - r.period for g in r.gaps)
         flag = "  <-- exceeds its own period" if max(ex) > r.period else ""
         print(f"{r.name:<34}{r.cron:<16}{len(r.runs):>5}{len(r.gaps):>5}   "
               f"min {min(ex):+.0f}  p50 {statistics.median(ex):+.0f}  max {max(ex):+.0f}{flag}")
 
+    changed = [r for r in rows if r.dropped]
+    if changed:
+        print("\n  Counts above are scoped to the cron now in the file. Runs delivered under a")
+        print("  previous schedule are excluded -- they measure the expression they ran under,")
+        print("  not this one, and pooling them answers 'did the new offset help?' with data")
+        print("  from the offset it replaced (IRO-680).")
+        for r in changed:
+            print(f"    {r.name:<32} cron in force since {r.cron_since:%Y-%m-%dT%H:%MZ}"
+                  f"  ({r.dropped} older run(s) excluded)")
+
     print(f"\n{'workflow':<34}{'cron':<16}   live silence since last run")
     print("-" * 96)
     for r in rows:
         if r.runs_error:
             print(f"{r.name:<34}{r.cron:<16}   MEASUREMENT FAILED: {r.runs_error}")
+            continue
+        if not r.runs and r.dropped:
+            # Not "never fired": it fired under the old cron. The honest observation is
+            # that the schedule now in force has not delivered once since it landed --
+            # and that is a direct observation, not a sample-size-limited one.
+            quiet = (now - r.cron_since).total_seconds() / 60
+            asked = f" vs {r.period} min asked" if r.period else ""
+            print(f"{r.name:<34}{r.cron:<16}   {quiet:.0f} min since this cron landed"
+                  f"{asked}, NOT ONE RUN under it")
             continue
         if not r.runs:
             print(f"{r.name:<34}{r.cron:<16}   (never fired on a schedule)")

--- a/scripts/tests/test_measure_cron_latency.py
+++ b/scripts/tests/test_measure_cron_latency.py
@@ -29,8 +29,10 @@ Manual reproduction of the same two cases against the live API, for the record:
 from __future__ import annotations
 
 import contextlib
+import datetime as dt
 import importlib.util
 import io
+import os
 import pathlib
 import subprocess
 import sys
@@ -251,6 +253,102 @@ class ArithmeticIsUnchanged(unittest.TestCase):
             bad.write_text("on:\n  schedule:\n    - notacron: x\n")
             with self.assertRaises(SystemExit):
                 mcl._crons(bad)
+
+
+def _wf(cron: str) -> str:
+    return f'name: w\non:\n  schedule:\n    - cron: "{cron}"\njobs: {{}}\n'
+
+
+class CronChangeBoundsTheMeasurementWindow(unittest.TestCase):
+    """IRO-680: runs delivered under a REPLACED cron were scored and then labelled with
+    the cron currently in the file.
+
+    This is not a fail-quiet defect like the two above -- it manufactures a finding
+    rather than erasing one, and it does so with a confident-looking sample. Live case:
+    `fork-ci-approval-backstop` moved `*/30` -> `13,43`, and the row reported
+    `4 runs / 3 gaps / p50 +129 / max +299` for `13,43` when every one of those gaps was
+    delivered by `*/30`. The offset under test had produced no complete interval at all."""
+
+    @staticmethod
+    def _repo(commits: list[tuple[str, str]]) -> tempfile.TemporaryDirectory:
+        """A git repo whose workflow file takes each (cron, ISO-8601 date) in turn."""
+        tmp = tempfile.TemporaryDirectory()
+        root = pathlib.Path(tmp.name)
+        wf = root / ".github" / "workflows"
+        wf.mkdir(parents=True)
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e",
+        }
+        subprocess.run(["git", "-C", str(root), "init", "-q"], check=True, env=env)
+        for cron, when in commits:
+            (wf / "w.yml").write_text(_wf(cron))
+            subprocess.run(["git", "-C", str(root), "add", "-A"], check=True, env=env)
+            subprocess.run(
+                # --allow-empty: an "unchanged cron" case commits an identical file, and
+                # that touching-but-not-changing commit is exactly what the walk must
+                # step over to find where the cron really landed.
+                ["git", "-C", str(root), "commit", "-q", "--allow-empty", "-m", cron],
+                check=True, env={**env, "GIT_AUTHOR_DATE": when, "GIT_COMMITTER_DATE": when},
+            )
+        return tmp
+
+    _REL = pathlib.Path(".github/workflows/w.yml")
+
+    def test_returns_when_the_current_cron_landed_not_the_first_commit(self):
+        with self._repo([("*/30 * * * *", "2026-07-29T00:00:00+00:00"),
+                         ("13,43 * * * *", "2026-07-30T04:49:11+00:00")]) as d:
+            landed = mcl._cron_landed_at(pathlib.Path(d), self._REL, ["13,43 * * * *"])
+        self.assertIsNotNone(landed, "a cron change in full history must be locatable")
+        # The replacement's landing time, NOT the file's first commit.
+        self.assertEqual(landed.astimezone(dt.timezone.utc).isoformat(),
+                         "2026-07-30T04:49:11+00:00")
+
+    def test_pre_change_runs_fall_outside_the_window(self):
+        # The actual regression: three runs under the old cron, one under the new. The
+        # window must admit only the last, leaving zero gaps -- not three.
+        with self._repo([("*/30 * * * *", "2026-07-29T00:00:00+00:00"),
+                         ("13,43 * * * *", "2026-07-30T04:49:11+00:00")]) as d:
+            landed = mcl._cron_landed_at(pathlib.Path(d), self._REL, ["13,43 * * * *"])
+        runs = [dt.datetime.fromisoformat(t) for t in (
+            "2026-07-29T22:28:16+00:00", "2026-07-29T23:33:53+00:00",
+            "2026-07-30T02:12:42+00:00", "2026-07-30T07:41:30+00:00")]
+        # The counterfactual, pinned so this test cannot go vacuous: unbounded, these
+        # same four timestamps yield the three gaps that were published as `13,43`.
+        self.assertEqual(len(list(zip(runs, runs[1:]))), 3)
+        kept = [r for r in runs if r >= landed]
+        self.assertEqual(len(kept), 1, "only the post-change run measures this cron")
+        self.assertEqual(len(list(zip(kept, kept[1:]))), 0,
+                         "one run is zero intervals; there is nothing to report yet")
+
+    def test_unchanged_cron_keeps_its_whole_history(self):
+        # No change means no exclusions: the bound must not quietly shrink a good sample.
+        with self._repo([("17 3 * * *", "2026-07-01T00:00:00+00:00"),
+                         ("17 3 * * *", "2026-07-20T00:00:00+00:00")]) as d:
+            landed = mcl._cron_landed_at(pathlib.Path(d), self._REL, ["17 3 * * *"])
+        self.assertEqual(landed.astimezone(dt.timezone.utc).isoformat(),
+                         "2026-07-01T00:00:00+00:00")
+
+    def test_no_git_history_does_not_bound_the_window(self):
+        # Fail open. An undeterminable window must not masquerade as a narrow one, which
+        # would silently discard every run and report a healthy cron as never firing.
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            (root / ".github" / "workflows").mkdir(parents=True)
+            (root / ".github" / "workflows" / "w.yml").write_text(_wf("*/30 * * * *"))
+            self.assertIsNone(
+                mcl._cron_landed_at(root, self._REL, ["*/30 * * * *"]),
+                "outside a git repo the script must measure everything, not nothing")
+
+    def test_history_and_worktree_share_one_parser(self):
+        # A second parser for historical blobs could report a cron change that never
+        # happened, or miss one that did.
+        text = _wf("13,43 * * * *")
+        with tempfile.TemporaryDirectory() as d:
+            p = pathlib.Path(d) / "w.yml"
+            p.write_text(text)
+            self.assertEqual(mcl._crons(p), mcl._crons_from_text(text, "w.yml"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Found while getting the measurement tool ready for the hourly re-run IRO-680 Task 2 owes tomorrow.

## The defect

`measure-cron-latency.py` reads each workflow's cron from the file at HEAD, but pulls that workflow's **entire** run history. A cron change therefore pools the old schedule's gaps into the new expression's row and prints them under the new cron.

That inverts the one question a cron change exists to answer. IRO-679 moved `fork-ci-approval-backstop` from `*/30` to `13,43` precisely to test whether dodging the two most congested minutes of the hour helps. The tool then reported:

```
fork-ci-approval-backstop.yml   13,43 * * * *   4  3   min +36  p50 +129  max +299  <-- exceeds its own period
```

The offset landed `2026-07-30T04:49:11Z` (`f81aed3`). Three of those four runs (22:28, 23:33, 02:12) predate it. **Every scored gap was delivered by `*/30`** — so the row answered "did the offset help?" with data from the offset it replaced, while `13,43` had produced no complete interval at all.

## The fix

Bound each workflow's window at the commit where its current cron landed (committer date — this repo squash-merges, so that is when it reached main). Excluded runs are **reported, not dropped silently**:

```
fork-ci-approval-backstop.yml   13,43 * * * *   1  0   (no interval yet under this cron)
...
    fork-ci-approval-backstop.yml    cron in force since 2026-07-30T04:49Z  (3 older run(s) excluded)
```

Fails open: no git, a shallow clone, or `--repo` pointing at another repository excludes nothing, because an unknown window must not masquerade as a narrow one (that would discard every run and report a healthy cron as never firing).

## Non-vacuity

Unlike the two IRO-685 defects, this one **manufactures** a finding rather than erasing one, so it shows up directly in a live before/after — the row above is that diff, run against the real API minutes apart.

- **Pooled figure unchanged**: 56 intervals, p50 -7 / p90 +36 / p95 +51 / max +75. That is what the 135 min bound rests on, and sub-hourly crons were never pooled, so **the bound is untouched**.
- The regression test pins the counterfactual (unbounded, those four timestamps yield 3 gaps) so it cannot go vacuous.
- Tests build real git repos: window lands on the replacement commit, the three pre-change runs fall outside it, an unchanged cron keeps its whole history, missing history fails open, and history/worktree share one parser.

## No published claim was wrong

The prose in `fork-ci-approval-backstop.yml` and `docs/pr-review-process.md` already attributed those intervals to `*/30` by hand, and says the offset is "not known to help". This makes the **tool** agree with the prose instead of quietly contradicting it — which matters because the tool, not the prose, is what gets re-run tomorrow for the hourly number.

Docs prose is deliberately left alone here; it gets rewritten with real data on the Task 2 pass rather than churned twice.

## Verification

- `python3 -m unittest discover -s scripts/tests` — 22 tests, OK (CI runs this via `ci.yml`).
- Script run end-to-end against the live API, exit 0.
- `_local_repo` parses this repo's SSH origin to `IronSecCo/ironclaw`; a different `--repo` correctly disables the window.

## Lenses

Reproducibility (a measurement must be re-derivable and mean the same thing on re-run) and fail-loud/fail-closed. No workflow, permission, signing, attestation, or installer surface touched — tooling and its tests only.