### PR TITLE
ci(brew): measure whether the tap is STALE, not just whether a bump is waiting [IRO-690]

### DIFF
--- a/.github/workflows/brew-bump-waiting.yml
+++ b/.github/workflows/brew-bump-waiting.yml
@@ -1,9 +1,26 @@
-# Freshness guard for the Homebrew tap (IRO-676).
+# Freshness guard for the Homebrew tap (IRO-676, second arm added by IRO-690).
 #
-# Goes RED when a rolling `brew/track` bump PR has been sitting open past a threshold,
-# so a waiting bump ANNOUNCES ITSELF instead of being found by someone sweeping open
-# PRs by hand. A red scheduled run is a real notification path: GitHub emails on
+# Goes RED so a stale tap ANNOUNCES ITSELF instead of being found by someone sweeping
+# open PRs by hand. A red scheduled run is a real notification path: GitHub emails on
 # scheduled-workflow failure and it is visible in the Actions tab.
+#
+# Two arms, two failure modes:
+#   A. an open `brew/track` bump PR older than the threshold — a bump that IS trying to
+#      land but is stuck on a human click;
+#   B. Formula/ironclaw.rb's `version` on main against `releases/latest` — the tap
+#      actually serving an older release than the newest one.
+#
+# Arm A alone was the whole guard until IRO-690, and it discovers work by LISTING OPEN
+# PRs, so it exits 0 whenever there is no bump PR at all. That is exactly the state
+# IRO-689 produced (GitHub auto-closed #636 when its head became == its base, leaving
+# the tap on v0.1.447 against a published v0.1.450 with zero open bump PRs), and it is
+# why that outage had to be found by a human PR sweep. Arm B needs no PR to exist.
+#
+# Arm B's negative control is scripts/tests/test_check_brew_bump_waiting.py, NOT a
+# control-branch push: arm B reads main over the API on purpose, so a doctored branch
+# cannot drive it red (see TRACK_BRANCH in the script). The test drives it with the real
+# IRO-689 pair and asserts non-zero, and the pre-fix script is recorded green on the
+# same fixture — a guard only ever observed green is indistinguishable from `exit 0`.
 #
 # WHY A RED CRON AND NOT A PAPERCLIP ISSUE
 # ----------------------------------------
@@ -39,47 +56,69 @@ on:
   schedule:
     # Hourly, offset off the hour to dodge top-of-hour scheduler congestion.
     #
-    # Detection latency is NOT <= 60 min. That is what this comment used to claim and it
-    # rested on the cron expression rather than on the scheduler (IRO-679). Measured
-    # 2026-07-30 with `scripts/measure-cron-latency.py` over 55 intervals of this repo's
-    # daily and weekly crons, the gap GitHub actually delivers runs p50 -7 / p90 +36 /
-    # p95 +51 / max +75 minutes against the period the cron asked for. Carrying that
-    # overshoot onto a 60 min period gives a realistic worst case near 135 min, not 60.
+    # DO NOT write a detection-latency bound here. An earlier version claimed "<= 60 min"
+    # off the cron expression (IRO-679), a later one claimed "~135 min" by carrying the
+    # daily/weekly overshoot onto a 60 min period. The second is also wrong, and this
+    # workflow is the experiment that showed it. Measured 2026-07-30T11:47Z with
+    # `scripts/measure-cron-latency.py`:
     #
-    # That still clears the 240 min staleness threshold with ~105 min of headroom, so the
-    # guard's design is unaffected and this is a correction to the claim, not to the cron.
-    # Two caveats worth keeping:
-    #   - The hourly cadence itself is UNMEASURED. The 55 intervals above are daily and
-    #     weekly. The one sub-hourly cron in the repo (`fork-ci-approval-backstop`) was
-    #     being dropped hard, so if hourly falls in GitHub's high-frequency bucket the
-    #     bound is worse than 135 min. This workflow is now the experiment that settles it
-    #     -- after a day of runs, re-run the script and replace this paragraph with data.
-    #   - Declared clock time is not honoured either: every daily/weekly cron in this repo
-    #     fires roughly 3h after its stated UTC time. Cadence survives that, phase does
-    #     not, so never write "runs at HH:MM" about this file.
+    #   - Daily+weekly pooled, 57 intervals: p50 -8 / p90 +36 / p95 +51 / max +75 min
+    #     excess over the period asked for. Cadence roughly holds at those frequencies.
+    #   - THIS workflow, 1 interval: +121 min excess -- a 181 min gap against the 60 min
+    #     it asked for, i.e. GitHub delivered 2 of the 7 due slots and dropped 5. Live
+    #     silence hit 2.0x its period with nothing queued.
+    #   - `fork-ci-approval-backstop` (`13,43 * * * *`), the repo's other sub-hourly cron:
+    #     +113 min excess, live silence 3.5x. Same behaviour, independently.
+    #
+    # So hourly IS in GitHub's dropped bucket, which settles the open question this
+    # paragraph used to carry. One interval is not a distribution, so there is no bound to
+    # state -- and 181 min against a 240 min threshold leaves ~59 min of headroom, not the
+    # ~105 min previously claimed. IRO-680 re-runs the measurement with more intervals.
+    #
+    # Why the guard's design survives that anyway: BOTH arms fire on a LEVEL, not an edge.
+    # An open bump PR stays open and a stale formula stays stale, so a dropped run delays
+    # detection and never loses it. Only the time-to-notice degrades.
+    #
+    # Declared clock time is not honoured either: every daily/weekly cron in this repo
+    # fires roughly 3h after its stated UTC time. Cadence survives that, phase does not,
+    # so never write "runs at HH:MM" about this file.
     - cron: "23 * * * *"
   workflow_dispatch:
     inputs:
       threshold_minutes:
-        description: "Override the staleness threshold in minutes (blank = the script default, 240)"
+        description: "Arm A: how long an open brew/track PR may wait, in minutes (blank = the script default, 240). Also becomes arm B's default."
         required: false
         default: ""
-  # Negative-control path. The standing rule is that a guard which has never gone red
-  # is not evidence that it can, and this one cannot be proven from a schedule without
+      stale_threshold_minutes:
+        description: "Arm B: how long the tap may trail the newest release, in minutes (blank = whatever arm A resolved to)"
+        required: false
+        default: ""
+  # Live control path for ARM A. The standing rule is that a guard which has never gone
+  # red is not evidence that it can, and arm A cannot be proven from a schedule without
   # waiting hours for a real stall. Pushing a branch named
   # `test/brew-bump-waiting-<minutes>` runs the guard against the LIVE repo with that
-  # threshold, so both arms are demonstrable on demand: a small number reports the
+  # threshold, so both outcomes are demonstrable on demand: a small number reports the
   # currently-open bump PR (red), a large one reports it as within the window (green).
   # It reads the same live API as the scheduled run — nothing is stubbed.
+  #
+  # This path canNOT prove arm B, and that is by design: arm B reads Formula/ironclaw.rb
+  # from main over the API, so pushing a branch with a doctored formula does not move what
+  # it measures. Arm B's red path is proven in scripts/tests/test_check_brew_bump_waiting.py
+  # against pinned stale inputs. (The branch suffix does reach arm B, since its threshold
+  # defaults to arm A's — so right after a release a `-1` push can catch a real brief
+  # trail. Incidental, not a control: it depends on when you push.)
   push:
     branches:
       - "test/brew-bump-waiting-*"
 
-# Least privilege. Read the open PR list and its check rollup; nothing else. No
-# `pull-requests: write` (it does not comment), no `contents: write` (it does not
-# merge). Notify-only means read-only.
+# Least privilege. Read the open PR list, its check rollup, the newest release, and the
+# formula on main; nothing else. No `pull-requests: write` (it does not comment), no
+# `contents: write` (it does not merge). Notify-only means read-only.
 permissions:
-  contents: read # checkout the script + the ruleset spec it reads required contexts from
+  # Checkout the script + the ruleset spec it reads required contexts from, and — for arm
+  # B — read `releases/latest` and `contents/Formula/ironclaw.rb?ref=main` over the API.
+  # Arm B added no new scope: both of those are covered by this same read.
+  contents: read
   pull-requests: read # list open brew/track PRs
   checks: read # CheckRun conclusions in the status rollup
   statuses: read # legacy StatusContext states in the same rollup
@@ -96,7 +135,7 @@ jobs:
         with:
           persist-credentials: false # nothing here pushes; do not leave a token in .git/config
 
-      - name: Resolve the staleness threshold
+      - name: Resolve the thresholds
         id: threshold
         env:
           EVENT: ${{ github.event_name }}
@@ -105,20 +144,25 @@ jobs:
           # attacker-influenceable text and `${{ }}` inside `run:` is substituted
           # before bash ever sees it.
           INPUT_MINUTES: ${{ inputs.threshold_minutes }}
+          INPUT_STALE_MINUTES: ${{ inputs.stale_threshold_minutes }}
         run: |
           set -euo pipefail
-          # Emitted EMPTY when there is no override, so the 240 min default lives in
+          # Both emitted EMPTY when there is no override, so the 240 min default lives in
           # exactly one place (scripts/check-brew-bump-waiting.sh) and cannot drift
           # between the script and this workflow.
           minutes=""
+          stale_minutes=""
           case "${EVENT}" in
             workflow_dispatch)
               minutes="${INPUT_MINUTES}"
+              stale_minutes="${INPUT_STALE_MINUTES}"
               ;;
             push)
               # Suffix after the last '-' is the threshold. Validated here rather than
               # left to the script so a typo'd control branch fails on the typo instead
               # of silently exercising the default and looking like a clean pass.
+              # Left to drive BOTH arms (the script defaults arm B to arm A's value) —
+              # a control push is meant to exercise the whole guard at that threshold.
               minutes="${REF_NAME##*-}"
               case "${minutes}" in
                 ''|*[!0-9]*)
@@ -129,18 +173,22 @@ jobs:
               ;;
           esac
           echo "minutes=${minutes}" >> "$GITHUB_OUTPUT"
+          echo "stale_minutes=${stale_minutes}" >> "$GITHUB_OUTPUT"
 
-      - name: Report any rolling-bump PR waiting past the threshold
+      - name: Report a waiting rolling-bump PR (arm A) or a stale tap (arm B)
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           OVERRIDE: ${{ steps.threshold.outputs.minutes }}
+          STALE_OVERRIDE: ${{ steps.threshold.outputs.stale_minutes }}
         run: |
           set -euo pipefail
-          # Only export THRESHOLD_MINUTES when actually overriding: exporting an empty
-          # value would trip the script's numeric validation and go red for the wrong
-          # reason.
+          # Only export a threshold when actually overriding: exporting an empty value
+          # would trip the script's numeric validation and go red for the wrong reason.
           if [ -n "${OVERRIDE}" ]; then
             export THRESHOLD_MINUTES="${OVERRIDE}"
+          fi
+          if [ -n "${STALE_OVERRIDE}" ]; then
+            export STALE_THRESHOLD_MINUTES="${STALE_OVERRIDE}"
           fi
           exec scripts/check-brew-bump-waiting.sh

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -329,7 +329,7 @@ makes it material** — not as a tidiness argument.
 Until then, and regardless of how tempting a green-but-blocked PR makes it: do
 not reach for `--admin`, and do not add a `bypass_actors` entry for the App.
 
-### A waiting bump PR announces itself (IRO-676)
+### A stale tap announces itself (IRO-676, IRO-690)
 
 Keeping the click has one cost the click itself does not name: the tap's freshness
 then depends on someone *noticing* the bump PR, and for a while nothing did.
@@ -340,30 +340,73 @@ while IRO-670 was being closed out. The README says the tap **can briefly trail*
 the newest release, and "briefly" needs an enforcer.
 
 [`brew-bump-waiting.yml`](https://github.com/IronSecCo/ironclaw/blob/main/.github/workflows/brew-bump-waiting.yml)
-runs hourly and goes **red** when an open `brew/track` PR is older than 240
-minutes. A red scheduled run *is* the notification: GitHub emails on
-scheduled-workflow failure and it is visible in the Actions tab. Notes that matter
-if you touch it:
+runs on a schedule and has **two independent arms**. A red scheduled run *is* the
+notification: GitHub emails on scheduled-workflow failure and it is visible in the
+Actions tab.
+
+| | Arm A — waiting bump PR | Arm B — stale tap |
+| --- | --- | --- |
+| Question | Is a bump blocked on a human click? | Is the tap serving an older release than the newest one? |
+| Measures | open `brew/track` PRs, age from creation | `version` in `Formula/ironclaw.rb` on `main` vs `releases/latest` |
+| Threshold | `THRESHOLD_MINUTES`, default 240 | `STALE_THRESHOLD_MINUTES`, defaults to arm A's |
+| Clock starts | PR creation | release publication |
+| Needs a PR to exist | yes | **no** |
+
+**Arm B exists because arm A was blind to the outage it claimed to prevent
+(IRO-690).** Arm A discovers work by listing open PRs, so with zero open bump PRs
+it exits 0 — while its own error text claimed to protect "the tap is serving an
+older release than the newest one", which it never measured. Those two come apart
+precisely when no bump PR exists, and that is what IRO-689 produced: GitHub
+auto-closed [#636](https://github.com/IronSecCo/ironclaw/pull/636) when its head
+became `==` its base, so the tap served v0.1.447 against a published v0.1.450 with
+**zero** open `brew/track` PRs. A scheduled run landing in that window would have
+said "not waiting on a click" and passed. Same blindness covers every other cause
+of a missing PR: a hand-closed bump PR, a `gh pr create` that fails after the
+branch is pushed, a skipped formula job, or a bump that merges carrying a formula
+which does not match the newest release.
+
+Notes that matter if you touch it:
 
 - **240 min is derived, not picked.** Real merge latency over the last 60
   `brew/track` PRs was p50 59m, p75 118m, p90 264m, max 8.2 days. The threshold
   sits above the routine path so an ordinary release never pages, and below every
   genuinely-late bump on record (#600 9h, #607 8.3h, #562 8.2d).
-- **It fires on age, not on "all required checks green."** Gating the alarm on
+- **Arm A fires on age, not on "all required checks green."** Gating the alarm on
   green builds in a silent-green hole: a required check that never *reports* — the
   IRO-670 and IRO-673 failure mode, twice — reads as "not green", so the alarm
   would go quiet on exactly the PRs that are most stuck. Check state is reported
   in the error message as the remediation hint instead.
+- **Arm B reads `main` over the API, never the local checkout.** The guard also
+  runs on `test/brew-bump-waiting-*` branches, and measuring whatever ref happens
+  to be checked out would report that branch's formula as "what users get". This
+  is also why a control-branch push cannot drive arm B red.
+- **Arm B has no grace window when the formula is *ahead* of `releases/latest`.**
+  Behind is ordinary staleness and gets the threshold. Ahead means the formula's
+  download URLs point at a release that was deleted, unpublished, or demoted to a
+  prerelease — that does not heal with time, so waiting out a threshold would only
+  delay the alarm.
+- **A trail inside the threshold is not a bug.** The README advertises that the tap
+  **can briefly trail**; arm B bounds that window rather than forbidding it. The
+  IRO-689 window as observed was ~40 min, which arm B would also have passed, and
+  correctly. What arm B changes is that the window can no longer persist
+  *unbounded and silently*.
 - **Scheduled-failure email goes to whoever last edited the `cron:` line**, not to
   the repo's watchers. If a bot identity ever rewrites that line the alarm
   silently redirects to an unread inbox. Keep it a human who can do the merge.
 - **It is notify-only and must stay that way.** Read-only scopes, no merge, no
   approve, and deliberately **not** in `required_status_checks` — it gates
   nothing, and requiring it would block unrelated PRs whenever the tap trailed.
-- **To re-prove it** (a guard that has never gone red is not evidence that it
-  can), push a branch named `test/brew-bump-waiting-<minutes>`. It runs against
-  the live API with that threshold, so a small number reports the currently-open
-  bump PR and a large one reports it as within the window.
+  Arm B added no new scope: `releases/latest` and the formula both read under the
+  `contents: read` the checkout already needed.
+- **To re-prove it** (a guard that has never gone red is not evidence that it can),
+  the two arms have different controls. Arm A: push a branch named
+  `test/brew-bump-waiting-<minutes>`, which runs against the live API with that
+  threshold, so a small number reports the currently-open bump PR and a large one
+  reports it as within the window. Arm B: `scripts/tests/test_check_brew_bump_waiting.py`
+  drives the script through a stubbed `gh` with the real IRO-689 pair (formula
+  0.1.447, release v0.1.450) and asserts non-zero, with the fresh pair asserted
+  green on the same code path. The pre-IRO-690 script is recorded green on that same
+  fixture, which is what makes the red assertion evidence rather than decoration.
 
 ### What the cron actually delivers (IRO-679)
 
@@ -373,36 +416,48 @@ version of this page put detection latency at **"≤ 60 min"** on the strength o
 the cron expression alone. That was not measured, and it is not true.
 
 [`scripts/measure-cron-latency.py`](https://github.com/IronSecCo/ironclaw/blob/main/scripts/measure-cron-latency.py)
-measures it. Run it before writing any latency number here. Measured
-2026-07-30 over **55 intervals** of this repo's daily and weekly crons:
+measures it. Run it before writing any latency number here. Re-measured
+2026-07-30 **11:47Z**, over **57 intervals** of this repo's daily and weekly crons:
 
 | quantity | measured |
 |---|---|
-| gap delivered vs period requested | p50 **-7 min**, p90 **+36**, p95 **+51**, max **+75** |
-| intervals overshooting nominal by >60 min | **2 / 55** |
+| gap delivered vs period requested (daily+weekly) | p50 **-8 min**, p90 **+36**, p95 **+51**, max **+75** |
+| intervals overshooting nominal by >60 min | **2 / 57** |
 | declared clock time vs actual fire time | daily/weekly crons fire **~3h late**, consistently |
 
 Two things follow, and they pull in opposite directions:
 
-- **Cadence is honoured.** A daily cron runs daily to within about an hour. So
-  the hourly guard's realistic worst case is roughly **135 min** (60 nominal +
-  75 measured overshoot), not 60. That still sits **~105 min inside** the 240
-  min threshold, so the 240 min number survives the correction untouched — the
-  claim was wrong, the design was not.
+- **Cadence is honoured at daily and weekly frequency.** A daily cron runs daily
+  to within about an hour. It does **not** follow that an hourly cron runs hourly
+  — see below.
 - **Phase is not honoured.** Every daily/weekly cron here fires about three
   hours after its declared UTC time. Cadence survives this; a sentence of the
   form *"runs at 03:17 UTC"* does not. Do not write one.
 
 Caveats, because this is the part that is easy to overstate:
 
-- **The hourly cadence is unmeasured.** Those 55 intervals are daily and weekly.
-  The repo's one sub-hourly cron — the fork-CI approval backstop at `*/30` — is
-  being dropped hard, and it is the only cron here whose overshoot exceeds its
-  own period (two observed intervals of 66 and 159 min, 2.2x and 5.3x). That
-  matches GitHub's documented deprioritisation of high-frequency schedules. If
-  hourly lands in that same bucket, 135 min is optimistic. The hourly guard is
-  now the experiment that settles it — after a day of runs, re-run the script
-  and update this table.
+- **Hourly is in the dropped bucket. There is no latency bound to quote.** This
+  used to read "the hourly cadence is unmeasured", with a projected worst case of
+  ~135 min (60 nominal + the 75 min daily/weekly overshoot) and ~105 min of
+  headroom against the 240 min threshold. The hourly guard was made the experiment
+  that settles it, and it has now returned data that kills the projection:
+
+  | cron | period asked | delivered gap | excess | live silence |
+  |---|---|---|---|---|
+  | `brew-bump-waiting` `23 * * * *` | 60 min | **181 min** | **+121** | 122 min = **2.0x**, nothing queued |
+  | `fork-ci-approval-backstop` `13,43 * * * *` | 30 min | 143 min | **+113** | 104 min = **3.5x**, nothing queued |
+
+  GitHub delivered **2 of the 7 slots due** to the brew guard and dropped five.
+  Both sub-hourly crons in the repo now exceed their own period, independently,
+  which matches GitHub's documented deprioritisation of high-frequency schedules.
+  One interval is not a distribution, so do not turn 181 min into a bound either —
+  it is a floor on what has been observed, not a ceiling. IRO-680 re-runs the
+  measurement once there are more intervals.
+- **The 240 min threshold survives, with less headroom than claimed.** 181 min
+  against 240 leaves ~59 min, not ~105. The design still holds for a reason
+  independent of the numbers: **both arms fire on a level, not an edge.** An open
+  bump PR stays open and a stale formula stays stale, so a dropped run delays
+  detection and never loses it. Only time-to-notice degrades.
 - **Quote the silence, not the gap count.** Two intervals cannot carry that
   conclusion on their own. What carries it is the script's second table: **live
   silence**, the still-open interval since the last scheduled run. Re-measured
@@ -413,11 +468,13 @@ Caveats, because this is the part that is easy to overstate:
   sample-size caveat attached. In the same table every daily/weekly cron in the
   repo sat at **0.0x–0.9x** of its period, so the metric is not merely flagging
   everything it looks at.
-- **The `13,43` offset is not known to help.** It was a free experiment — same
-  cadence, off the two most congested minutes of the hour — but in the 79 min
-  after it landed the scheduler delivered **0** runs where `13,43` predicts 2.
-  That is n=0, which is not evidence it failed either. Keep the offset, and keep
-  saying "not known to help" until the script has a real post-offset sample.
+- **The `13,43` offset did not help.** It was a free experiment — same cadence,
+  off the two most congested minutes of the hour. It now has a post-offset sample
+  and the answer is no: under `13,43`, the backstop delivered 2 runs with a 143 min
+  gap against a 30 min period, and sat at 3.5x live silence. Keep the offset (it
+  costs nothing and n=1 gap is thin), but stop treating minute-of-hour as the lever.
+  The brew guard's own `23 * * * *` is off-peak too and is dropped just as hard, so
+  the deprioritisation is about frequency, not about which minute you ask for.
 - **A cron is the wrong tool for a hard latency bound.** Getting a real one
   needs an event-driven trigger, and for the approval backstop that is a
   trust-model change, not a scheduling tweak: the safety net must stay

--- a/scripts/check-brew-bump-waiting.sh
+++ b/scripts/check-brew-bump-waiting.sh
@@ -3,10 +3,38 @@
 #
 #   scripts/check-brew-bump-waiting.sh
 #
-# Exits non-zero when a rolling `brew/track` bump PR has been sitting open longer
-# than THRESHOLD_MINUTES. Run from a schedule (.github/workflows/brew-bump-waiting.yml)
-# so a waiting bump ANNOUNCES ITSELF instead of waiting to be found by someone
-# sweeping open PRs by hand.
+# Run from a schedule (.github/workflows/brew-bump-waiting.yml) so a stale tap
+# ANNOUNCES ITSELF instead of waiting to be found by someone sweeping open PRs by hand.
+#
+# TWO ARMS, TWO FAILURE MODES (arm B added by IRO-690)
+# ---------------------------------------------------
+#   A. "Is a bump waiting on a human?" — an open `brew/track` PR older than
+#      THRESHOLD_MINUTES.
+#   B. "Is the tap actually stale?" — the `version` in Formula/ironclaw.rb on
+#      TRACK_BRANCH (what `brew install` serves) against `releases/latest` (what it
+#      should serve), red once the newest release has been published longer than
+#      STALE_THRESHOLD_MINUTES.
+#
+# Arm A alone was the whole guard until IRO-690, and it is blind to the exact outage
+# IRO-689 produced. It discovers work by LISTING OPEN PRs, so with zero open bump PRs
+# it exits 0 — while claiming in its own error text to protect a property it never
+# measured ("the tap is serving an older release than the newest one"). Those two come
+# apart precisely when no bump PR exists, which is what IRO-689 did: GitHub auto-closed
+# #636 when its head became == its base, so the tap served v0.1.447 against a published
+# v0.1.450 with zero open `brew/track` PRs. Arm A would have said "not waiting on a
+# click" and passed. Same blindness covers every other missing-PR cause: a hand-closed
+# bump PR, a `gh pr create` that fails after the branch is pushed, a skipped formula
+# job, or a bump that merges carrying a formula which does not match the newest release.
+#
+# Arm B measures the user-visible property directly and needs no PR to exist, so it is
+# non-vacuous by construction. Arm A is kept: it catches a different thing (a bump that
+# IS trying to land but is blocked on a human click), and it catches it before the tap
+# has gone stale enough for arm B to fire.
+#
+# Honest scope: arm B would NOT have fired during IRO-689's observed window either,
+# because that window was ~40 min and the threshold is 240 — a 40-minute trail is
+# inside the README's advertised "can briefly trail" budget, so green there is correct.
+# What arm B changes is that the window can no longer persist UNBOUNDED and silently.
 #
 # Why this exists
 # ---------------
@@ -21,8 +49,8 @@
 # README says the tap "can briefly trail" the newest release. This is the thing that
 # makes "briefly" true rather than aspirational.
 #
-# Fire condition: AGE, not check state
-# ------------------------------------
+# Arm A fire condition: AGE, not check state
+# ------------------------------------------
 # This goes red on any open bump PR older than the threshold, whatever its checks
 # say, and reports the required-check state in the message as a remediation hint
 # (all green => only the click is missing; not green => CI is the blocker, fix that
@@ -55,13 +83,32 @@ REPO="${REPO:-IronSecCo/ironclaw}"
 HEAD_BRANCH="${HEAD_BRANCH:-brew/track}"
 RULESET="${ROOT}/.github/rulesets/main.json"
 
+# Arm B's clock is a DIFFERENT quantity from arm A's (release publication -> tap in
+# sync, versus bump-PR open -> merged), so it gets its own knob. It defaults to arm A's
+# value rather than a second hardcoded number: the two windows differ by only the few
+# minutes between the release publishing and its bump PR opening, and one number that
+# cannot drift beats two that can.
+STALE_THRESHOLD_MINUTES="${STALE_THRESHOLD_MINUTES:-$THRESHOLD_MINUTES}"
+
+# The branch `brew tap` actually serves. Read over the API rather than from the local
+# checkout on purpose: this script also runs on `test/brew-bump-waiting-*` control
+# branches, and measuring whatever ref happens to be checked out would report that
+# branch's formula as "what users get". Pinning the ref keeps arm B measuring the tap.
+TRACK_BRANCH="${TRACK_BRANCH:-main}"
+FORMULA_PATH="${FORMULA_PATH:-Formula/ironclaw.rb}"
+
 say()  { printf '==> %s\n' "$*"; }
 fail() { printf '::error::%s\n' "$*" >&2; exit 1; }
 
-case "$THRESHOLD_MINUTES" in
-  ''|*[!0-9]*) fail "THRESHOLD_MINUTES must be a whole number of minutes, got '${THRESHOLD_MINUTES}'." ;;
-esac
-[ "$THRESHOLD_MINUTES" -gt 0 ] || fail "THRESHOLD_MINUTES must be > 0; a zero threshold pages on every release the instant the bump PR opens."
+require_positive_minutes() {
+  local name="$1" value="$2"
+  case "$value" in
+    ''|*[!0-9]*) fail "${name} must be a whole number of minutes, got '${value}'." ;;
+  esac
+  [ "$value" -gt 0 ] || fail "${name} must be > 0; a zero threshold pages on every release the instant it is cut."
+}
+require_positive_minutes THRESHOLD_MINUTES "$THRESHOLD_MINUTES"
+require_positive_minutes STALE_THRESHOLD_MINUTES "$STALE_THRESHOLD_MINUTES"
 
 # ---------------------------------------------------------------------------
 # Required contexts come from the checked-in ruleset spec, which is the source of
@@ -79,14 +126,25 @@ REQUIRED_CONTEXTS="$(jq -r '
 
 say "Repo:      ${REPO}"
 say "Head:      ${HEAD_BRANCH}"
-say "Threshold: ${THRESHOLD_MINUTES} minutes"
+say "Tap ref:   ${TRACK_BRANCH}:${FORMULA_PATH}"
+say "Threshold: ${THRESHOLD_MINUTES} minutes waiting PR / ${STALE_THRESHOLD_MINUTES} minutes stale tap"
 say "Required:  $(printf '%s' "$REQUIRED_CONTEXTS" | tr '\n' ' ')"
 
-# ---------------------------------------------------------------------------
+NOW="$(date -u +%s)"
+
+# Parse an ISO-8601 Z timestamp to epoch seconds. `date -d` is GNU (ubuntu runners);
+# BSD `date -j` is the fallback for local macOS runs.
+to_epoch() {
+  date -u -d "$1" +%s 2>/dev/null || date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$1" +%s
+}
+
+# ===========================================================================
+# ARM A — is a rolling bump PR waiting on a human past the threshold?
+#
 # Discovery. NO `|| true` anywhere on this path: an API failure must go red, not
 # skip to a green "no waiting PRs". A guard that can only ever be green is the exact
 # bug this whole cluster is about.
-# ---------------------------------------------------------------------------
+# ===========================================================================
 PRS="$(gh pr list --repo "$REPO" --state open --head "$HEAD_BRANCH" \
         --json number,createdAt,isDraft,headRefOid,url --limit 100)" \
   || fail "could not list open PRs for ${REPO} head=${HEAD_BRANCH}. Treating an unreadable API as 'nothing waiting' would make this guard unfalsifiable, so this is a failure."
@@ -97,18 +155,16 @@ printf '%s' "$PRS" | jq -e 'type == "array"' >/dev/null \
   || fail "unexpected response listing open PRs (not a JSON array): ${PRS}"
 
 COUNT="$(printf '%s' "$PRS" | jq 'length')"
-if [ "$COUNT" -eq 0 ]; then
-  say "No open ${HEAD_BRANCH} PR. The tap is not waiting on a click."
-  exit 0
-fi
-
-NOW="$(date -u +%s)"
 WAITING=""
+
+# Zero open bump PRs is NOT an exit any more, only an empty arm A. Arm B still has to
+# run: "nothing is waiting on a click" and "the tap is current" are different claims,
+# and IRO-689 is the case where the first is true and the second is false.
+[ "$COUNT" -gt 0 ] || say "No open ${HEAD_BRANCH} PR, so nothing is waiting on a click. Checking whether the tap is stale anyway (arm B)."
 
 while IFS=$'\t' read -r num created draft sha url; do
   [ -n "$num" ] || continue
-  # `date -d` is GNU (ubuntu runners); fall back to BSD `date -j` for local macOS runs.
-  created_epoch="$(date -u -d "$created" +%s 2>/dev/null || date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$created" +%s)" \
+  created_epoch="$(to_epoch "$created")" \
     || fail "could not parse createdAt '${created}' for PR #${num}."
   age=$(( (NOW - created_epoch) / 60 ))
 
@@ -147,13 +203,134 @@ while IFS=$'\t' read -r num created draft sha url; do
     ${url}"
 done < <(printf '%s' "$PRS" | jq -r '.[] | [.number, .createdAt, (.isDraft|tostring), .headRefOid, .url] | @tsv')
 
-if [ -z "$WAITING" ]; then
-  say "${COUNT} open ${HEAD_BRANCH} PR(s), none past the ${THRESHOLD_MINUTES}m threshold. Tap freshness is within the advertised window."
+if [ "$COUNT" -gt 0 ] && [ -z "$WAITING" ]; then
+  say "${COUNT} open ${HEAD_BRANCH} PR(s), none past the ${THRESHOLD_MINUTES}m threshold."
+fi
+
+# ===========================================================================
+# ARM B — is the tap serving an older release than the newest one? (IRO-690)
+#
+# This is the property the README's "can briefly trail the newest release" claim is
+# about, and until IRO-690 nothing measured it. It needs no PR to exist, so it holds
+# whatever arm A's PR list says, and it adds no credential: both calls are plain reads
+# on a public repo, covered by the run's existing read-only GITHUB_TOKEN.
+#
+# Same no-`|| true` rule as arm A. An unreadable release endpoint or an unreadable
+# formula must go red; rendering either as "in sync" is how a guard becomes decoration.
+# ===========================================================================
+STALE=""
+
+# `releases/latest` deliberately, not `git tag`: it excludes drafts and prereleases and
+# resolves to exactly what a user browsing the repo (and `gh release view`, which
+# scripts/update-homebrew-formula.sh uses to pick a tag) calls the latest release.
+LATEST="$(gh api "repos/${REPO}/releases/latest" \
+            --jq '[.tag_name, .published_at, (.draft|tostring), (.prerelease|tostring)] | @tsv')" \
+  || fail "could not read repos/${REPO}/releases/latest. Treating an unreadable release endpoint as 'the tap is current' would make arm B unfalsifiable, so this is a failure."
+
+IFS=$'\t' read -r LATEST_TAG LATEST_PUBLISHED LATEST_DRAFT LATEST_PRERELEASE <<<"$LATEST"
+[ -n "${LATEST_TAG:-}" ] && [ -n "${LATEST_PUBLISHED:-}" ] \
+  || fail "repos/${REPO}/releases/latest returned no tag_name/published_at pair: ${LATEST}"
+# The endpoint guarantees both are false. If one is ever true the endpoint's semantics
+# changed under us, and arm B would be comparing against something users cannot install.
+[ "${LATEST_DRAFT}" = "false" ] && [ "${LATEST_PRERELEASE}" = "false" ] \
+  || fail "releases/latest returned ${LATEST_TAG} with draft=${LATEST_DRAFT} prerelease=${LATEST_PRERELEASE}; refusing to compare the tap against a release users cannot install."
+
+LATEST_VERSION="${LATEST_TAG#v}"
+case "$LATEST_VERSION" in
+  ''|*[!0-9.]*) fail "latest release tag '${LATEST_TAG}' does not look like v<dotted-version>; arm B cannot compare it to a formula version." ;;
+esac
+
+# Raw media type, so there is no base64 hop whose failure could be mistaken for an
+# empty formula. Pinned to ?ref= so the answer is "what the tap serves", not "what this
+# checkout happens to contain" (see TRACK_BRANCH above). IRO-499's fail-open contents-API
+# hazard applies here: no `|| true`.
+FORMULA_SRC="$(gh api -H "Accept: application/vnd.github.raw" \
+                 "repos/${REPO}/contents/${FORMULA_PATH}?ref=${TRACK_BRANCH}")" \
+  || fail "could not read ${FORMULA_PATH} at ${TRACK_BRANCH} in ${REPO}. Arm B cannot tell what the tap is serving, so this is a failure rather than a pass."
+
+# First `version` line only, and no `| head -1`: under `set -o pipefail` head can close
+# the pipe before sed finishes and turn a successful parse into exit 141. `q` inside the
+# address block does the same job without a second process.
+FORMULA_VERSION="$(printf '%s\n' "$FORMULA_SRC" \
+  | sed -n '/^  version "/{s/^  version "\([^"]*\)".*/\1/p;q;}')"
+[ -n "$FORMULA_VERSION" ] || fail "no \`  version \"...\"\` line found in ${FORMULA_PATH} at ${TRACK_BRANCH}. Either the formula's shape changed (update this parser AND scripts/verify-homebrew-formula.sh, which reads it the same way) or the fetch returned something other than the formula."
+
+say "Tap serves:  ${FORMULA_VERSION} (${TRACK_BRANCH}:${FORMULA_PATH})"
+say "Newest rel:  ${LATEST_VERSION} (${LATEST_TAG}, published ${LATEST_PUBLISHED})"
+
+if [ "$FORMULA_VERSION" = "$LATEST_VERSION" ]; then
+  say "Tap is in sync with the newest release."
+else
+  published_epoch="$(to_epoch "$LATEST_PUBLISHED")" \
+    || fail "could not parse published_at '${LATEST_PUBLISHED}' for ${LATEST_TAG}."
+  stale_min=$(( (NOW - published_epoch) / 60 ))
+  older="$(printf '%s\n%s\n' "$FORMULA_VERSION" "$LATEST_VERSION" | sort -V | head -n1)"
+
+  if [ "$older" = "$FORMULA_VERSION" ]; then
+    # BEHIND — the ordinary staleness case. Clocked from the release's publication,
+    # because that is when the user-visible trail starts: from that moment
+    # `brew install` hands out the older binary.
+    if [ "$stale_min" -le "$STALE_THRESHOLD_MINUTES" ]; then
+      say "Tap trails by ${LATEST_VERSION} but ${LATEST_TAG} has only been published ${stale_min}m, under the ${STALE_THRESHOLD_MINUTES}m threshold. Inside the advertised brief-trail window."
+    else
+      STALE="the tap has been serving ${FORMULA_VERSION} for ${stale_min}m while ${LATEST_TAG} is the newest release (threshold ${STALE_THRESHOLD_MINUTES}m)"
+    fi
+  else
+    # AHEAD — no grace window. The formula is pinned to a version that releases/latest
+    # does not name, so its download URLs point at a release that is not the latest:
+    # either it was deleted/unpublished, or it was demoted to a prerelease. Both mean
+    # `brew install` is already resolving against something users are not meant to get,
+    # and neither heals with time, so waiting out a threshold only delays the alarm.
+    STALE="the tap is pinned to ${FORMULA_VERSION}, which is NEWER than the newest release ${LATEST_TAG}. A formula ahead of releases/latest means its download URLs point at a release that was deleted, unpublished, or demoted to a prerelease"
+  fi
+fi
+
+# ===========================================================================
+# Verdict. Both arms are always evaluated and both are always reported, so a run that
+# trips one does not hide the other.
+# ===========================================================================
+if [ -z "$WAITING" ] && [ -z "$STALE" ]; then
+  say "Both arms clear: nothing waiting past ${THRESHOLD_MINUTES}m, and the tap serves the newest release. Tap freshness is within the advertised window."
   exit 0
 fi
 
-cat >&2 <<EOF
-::error::A Homebrew rolling-bump PR has been waiting past the ${THRESHOLD_MINUTES}-minute threshold. The tap is serving an older release than the newest one, which breaks the README's "can briefly trail the newest release" claim.${WAITING}
+if [ -n "$STALE" ]; then
+  # The remediation branches on whether a bump PR exists, and only the applicable branch
+  # is printed. Emitting both and letting the reader pick would hand someone "merge the
+  # bump PR" as a next action when there is no bump PR to merge.
+  if [ "$COUNT" -gt 0 ]; then
+    remedy="  A bump PR IS open, so the bump exists and has not landed. Merge it — see the
+  waiting-PR error below if it is listed there, and merge it anyway if it is not: being
+  under the ${THRESHOLD_MINUTES}m PR threshold does not help once the tap is already past its own."
+  else
+    remedy="  ZERO open ${HEAD_BRANCH} PRs: nothing is even trying to fix this, which is the IRO-689
+  shape. GitHub auto-closes a PR whose head becomes == its base and never reopens it, so
+  the rolling bump PR can vanish while the formula stays behind. Look for a
+  closed-unmerged one first, then re-cut the bump:
+    gh pr list --repo ${REPO} --state closed --head ${HEAD_BRANCH} --limit 5 \\
+      --json number,state,mergedAt,url
+    scripts/update-homebrew-formula.sh ${LATEST_TAG}   # cosign-verifies SHA256SUMS first
+    # then commit Formula/ironclaw.rb onto ${HEAD_BRANCH} and open a PR"
+  fi
+
+  cat >&2 <<EOF
+::error::The Homebrew tap is STALE: ${STALE}. That breaks the README's "can briefly trail the newest release" claim.
+
+  Tap serves:      ${FORMULA_VERSION}  (${TRACK_BRANCH}:${FORMULA_PATH})
+  Newest release:  ${LATEST_VERSION}  (${LATEST_TAG}, published ${LATEST_PUBLISHED})
+  Open ${HEAD_BRANCH} PRs: ${COUNT}
+
+${remedy}
+
+  Do NOT hand-edit the formula's version/url/sha256 lines. \`brew-formula-verify\` is a
+  required check and re-derives the whole file from the release's cosign-verified
+  SHA256SUMS, so a hand-edit fails the gate rather than landing.
+EOF
+fi
+
+if [ -n "$WAITING" ]; then
+  cat >&2 <<EOF
+::error::A Homebrew rolling-bump PR has been waiting past the ${THRESHOLD_MINUTES}-minute threshold, so the tap is at risk of trailing the newest release.${WAITING}
 
   What to do: merge the bump PR. If its required checks are green the only thing
   missing is the approving review — that click is deliberately still human
@@ -164,8 +341,8 @@ cat >&2 <<EOF
 
   If the required checks are NOT green, that is the blocker, not the click; fix or
   re-run them first. Never relax a required check to land a bump.
-
-  This guard notifies only. It has no write scope and is not a required status
-  check, so it does not block any PR.
 EOF
+fi
+
+printf '%s\n' "  This guard notifies only. It has no write scope and is not a required status check, so it does not block any PR." >&2
 exit 1

--- a/scripts/tests/test_check_brew_bump_waiting.py
+++ b/scripts/tests/test_check_brew_bump_waiting.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check-brew-bump-waiting.sh, and specifically for arm B (IRO-690).
+
+WHY THESE EXIST
+---------------
+The guard's whole job is to go RED, and until IRO-690 it had exactly one arm, which
+discovered work by listing open `brew/track` PRs and exited 0 when there were none. So
+the tap could be serving an older release than the newest one with zero open bump PRs
+and the guard would say "not waiting on a click" and pass. That is what IRO-689
+produced: GitHub auto-closed #636 when its head became == its base, and between 10:39Z
+and ~11:19Z on 2026-07-30 the tap served v0.1.447 against a published v0.1.450.
+
+Arm B measures the user-visible property instead — `version` in Formula/ironclaw.rb on
+main versus `releases/latest` — so it needs no PR to exist. Per the IRO-685 standing
+rule, a guard only ever observed green is indistinguishable from `exit 0`, so the
+load-bearing test here is test_stale_tap_with_no_open_pr_is_red: it drives the script
+with the real IRO-689 pair (formula 0.1.447, release v0.1.450) and asserts non-zero.
+
+PROOF THAT THAT TEST IS NON-VACUOUS
+-----------------------------------
+Asserting red against the FIXED script only shows the fixed script is red. The pre-fix
+file has to be shown GREEN on the same input, or the test is compatible with the arm
+never having been added. Reproduction, run against the pre-IRO-690 blob:
+
+    git show <pre-IRO-690-sha>:scripts/check-brew-bump-waiting.sh > /tmp/prefix.sh
+    chmod +x /tmp/prefix.sh
+    python3 -m unittest scripts.tests.test_check_brew_bump_waiting \
+        -k stale_tap_with_no_open_pr   # with SCRIPT pointed at /tmp/prefix.sh
+
+Recorded result: the pre-fix script prints "No open brew/track PR. The tap is not
+waiting on a click." and exits 0 on the exact fixture test_stale_tap_with_no_open_pr_is_red
+uses. The test fails against it (expected 1, got 0) and passes against the fixed file.
+
+THE SAME RED, WITH NOTHING STUBBED
+----------------------------------
+Arm B's red path is also reproducible against the LIVE API, because TRACK_BRANCH accepts
+any git ref — including the commit where the formula really did say 0.1.447. Recorded
+2026-07-30T11:54Z, with v0.1.450 the live newest release:
+
+    TRACK_BRANCH=495269e8f09510fd6761857b0dfb3aad57c95826 \
+    STALE_THRESHOLD_MINUTES=10 scripts/check-brew-bump-waiting.sh; echo "exit=$?"
+
+  ::error::The Homebrew tap is STALE: the tap has been serving 0.1.447 for 76m while
+  v0.1.450 is the newest release (threshold 10m). ...
+  Open brew/track PRs: 0
+  ZERO open brew/track PRs: nothing is even trying to fix this, which is the IRO-689 shape.
+  exit=1
+
+Both readings are real: a real formula blob, the real releases/latest, zero real open bump
+PRs. The stubbed tests below exist to pin the cases that cannot be conjured from live state
+(a formula ahead of latest, an unreadable endpoint, a draft "latest").
+
+HOW THE STUB WORKS
+------------------
+`gh` is replaced by a shell script earlier on PATH. It answers the four calls the guard
+makes from fixture files, and it pipes fixture JSON through the REAL `jq` when the guard
+passed `--jq`, so the guard's own jq filters are exercised rather than bypassed. It also
+appends every argv it sees to a log, which is how test_arm_b_reads_the_track_branch_ref
+pins that arm B measures the tap's branch and not whatever ref is checked out.
+
+Run:
+    python3 -m unittest discover -s scripts/tests -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import time
+import unittest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "check-brew-bump-waiting.sh"
+REPO = "IronSecCo/ironclaw"
+
+# The two versions from the real IRO-689 outage. Used deliberately instead of made-up
+# numbers so the fixture is the outage rather than a rhyme with it.
+IRO689_FORMULA_VERSION = "0.1.447"
+IRO689_LATEST_TAG = "v0.1.450"
+
+_FORMULA_TEMPLATE = textwrap.dedent(
+    """\
+    # typed: false
+    # frozen_string_literal: true
+    class Ironclaw < Formula
+      desc "Security-hardened, self-hosted AI assistant platform (secured Go port)"
+      homepage "https://github.com/IronSecCo/ironclaw"
+      version "{version}"
+      license "AGPL-3.0-or-later"
+    end
+    """
+)
+
+# A `gh` stand-in. Dispatches on argv, answers from $STUB_DIR, and applies the caller's
+# own --jq filter with real jq so the guard's filters are under test too.
+_STUB_GH = r"""#!/usr/bin/env bash
+set -uo pipefail
+printf '%s\n' "$*" >> "${STUB_DIR}/argv.log"
+
+# fixture <name> [<jq-filter-arg-index-scan...>]: emit $STUB_DIR/<name>, honouring an
+# optional <name>.rc file that forces a non-zero exit (an API failure).
+emit() {
+  local name="$1"; shift
+  if [ -f "${STUB_DIR}/${name}.rc" ]; then
+    printf 'stub: forced failure for %s\n' "$name" >&2
+    exit "$(cat "${STUB_DIR}/${name}.rc")"
+  fi
+  local filter=""
+  while [ $# -gt 0 ]; do
+    if [ "$1" = "--jq" ]; then filter="$2"; break; fi
+    shift
+  done
+  if [ -n "$filter" ]; then
+    jq -r "$filter" < "${STUB_DIR}/${name}"
+  else
+    cat "${STUB_DIR}/${name}"
+  fi
+}
+
+case "$1" in
+  pr)
+    case "$2" in
+      list) emit pr_list.json "$@" ;;
+      view) emit pr_view.json "$@" ;;
+      *) printf 'stub: unhandled gh pr %s\n' "$2" >&2; exit 64 ;;
+    esac
+    ;;
+  api)
+    case "$*" in
+      *releases/latest*) emit release.json "$@" ;;
+      *contents/*)       emit formula.rb "$@" ;;
+      *) printf 'stub: unhandled gh api %s\n' "$*" >&2; exit 64 ;;
+    esac
+    ;;
+  *) printf 'stub: unhandled gh %s\n' "$1" >&2; exit 64 ;;
+esac
+"""
+
+
+def _iso(minutes_ago: int) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - minutes_ago * 60))
+
+
+class GuardHarness:
+    """A temp $STUB_DIR pre-loaded with an all-green fixture set, plus a runner."""
+
+    def __init__(self, tmp: pathlib.Path) -> None:
+        self.dir = tmp / "stub"
+        self.dir.mkdir()
+        bindir = tmp / "bin"
+        bindir.mkdir()
+        gh = bindir / "gh"
+        gh.write_text(_STUB_GH)
+        gh.chmod(0o755)
+        self.bindir = bindir
+
+        # Default: no open bump PRs, and the tap in sync with a release cut 10h ago.
+        self.set_open_prs([])
+        self.set_release("v0.1.450", published_minutes_ago=600)
+        self.set_formula_version("0.1.450")
+
+    # --- fixture setters -------------------------------------------------
+    def set_open_prs(self, prs: list[dict]) -> None:
+        (self.dir / "pr_list.json").write_text(json.dumps(prs))
+
+    def set_open_pr_age(self, number: int, minutes_ago: int, *, draft: bool = False) -> None:
+        self.set_open_prs(
+            [
+                {
+                    "number": number,
+                    "createdAt": _iso(minutes_ago),
+                    "isDraft": draft,
+                    "headRefOid": "deadbeefcafe0000",
+                    "url": f"https://github.com/{REPO}/pull/{number}",
+                }
+            ]
+        )
+
+    def set_check_rollup(self, entries: list[dict]) -> None:
+        (self.dir / "pr_view.json").write_text(json.dumps({"statusCheckRollup": entries}))
+
+    def set_release(self, tag: str, *, published_minutes_ago: int, draft: bool = False,
+                    prerelease: bool = False) -> None:
+        (self.dir / "release.json").write_text(
+            json.dumps(
+                {
+                    "tag_name": tag,
+                    "published_at": _iso(published_minutes_ago),
+                    "draft": draft,
+                    "prerelease": prerelease,
+                }
+            )
+        )
+
+    def set_formula_version(self, version: str) -> None:
+        (self.dir / "formula.rb").write_text(_FORMULA_TEMPLATE.format(version=version))
+
+    def set_formula_source(self, text: str) -> None:
+        (self.dir / "formula.rb").write_text(text)
+
+    def force_failure(self, fixture: str, rc: int = 1) -> None:
+        (self.dir / f"{fixture}.rc").write_text(str(rc))
+
+    @property
+    def argv_log(self) -> str:
+        path = self.dir / "argv.log"
+        return path.read_text() if path.exists() else ""
+
+    # --- runner ----------------------------------------------------------
+    def run(self, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+        env = dict(os.environ)
+        env["PATH"] = f"{self.bindir}{os.pathsep}{env['PATH']}"
+        env["STUB_DIR"] = str(self.dir)
+        env["REPO"] = REPO
+        env.update(env_overrides)
+        return subprocess.run(
+            [str(SCRIPT)], capture_output=True, text=True, env=env, timeout=120
+        )
+
+
+class BrewBumpWaitingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        if shutil.which("jq") is None:  # pragma: no cover - jq is a hard dep of the guard
+            self.skipTest("jq is required by the guard and by the gh stub")
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.h = GuardHarness(pathlib.Path(self._tmp.name))
+
+    def assertRed(self, proc: subprocess.CompletedProcess[str]) -> str:
+        self.assertEqual(
+            proc.returncode,
+            1,
+            f"expected the guard to go RED.\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+        )
+        return proc.stderr
+
+    def assertGreen(self, proc: subprocess.CompletedProcess[str]) -> str:
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"expected the guard to be GREEN.\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+        )
+        return proc.stdout
+
+    # -----------------------------------------------------------------
+    # Arm B — the IRO-690 gap.
+    # -----------------------------------------------------------------
+    def test_stale_tap_with_no_open_pr_is_red(self) -> None:
+        """The load-bearing case. Pinned to the real IRO-689 pair, with the release old
+        enough to be past the threshold. Zero open bump PRs, so arm A has nothing to say
+        and the pre-fix script exited 0 right here."""
+        self.h.set_open_prs([])
+        self.h.set_formula_version(IRO689_FORMULA_VERSION)
+        self.h.set_release(IRO689_LATEST_TAG, published_minutes_ago=500)
+
+        err = self.assertRed(self.h.run())
+        self.assertIn("tap is STALE", err)
+        self.assertIn(IRO689_FORMULA_VERSION, err)
+        self.assertIn(IRO689_LATEST_TAG, err)
+        # The zero-PR branch of the remediation is the IRO-689 shape and must be the one
+        # shown: telling someone to merge a PR that does not exist is not a next action.
+        self.assertIn("ZERO open brew/track PRs", err)
+        self.assertIn("auto-closes a PR whose head becomes == its base", err)
+        self.assertIn(f"update-homebrew-formula.sh {IRO689_LATEST_TAG}", err)
+        self.assertNotIn("A bump PR IS open", err)
+
+    def test_fresh_tap_with_no_open_pr_is_green(self) -> None:
+        """The other half of the discrimination proof: same code path, same absence of
+        PRs, in-sync formula => green. Red-on-stale only means something next to this."""
+        self.h.set_formula_version("0.1.450")
+        self.h.set_release("v0.1.450", published_minutes_ago=500)
+        out = self.assertGreen(self.h.run())
+        self.assertIn("Tap is in sync with the newest release", out)
+        self.assertIn("Both arms clear", out)
+
+    def test_stale_tap_inside_the_threshold_is_green(self) -> None:
+        """The IRO-689 window as actually observed: ~40 min of trail. The README
+        advertises that the tap "can briefly trail", so green here is correct — arm B
+        bounds the window, it does not forbid one."""
+        self.h.set_formula_version(IRO689_FORMULA_VERSION)
+        self.h.set_release(IRO689_LATEST_TAG, published_minutes_ago=40)
+        out = self.assertGreen(self.h.run())
+        self.assertIn("Inside the advertised brief-trail window", out)
+
+    def test_stale_threshold_is_independently_tunable(self) -> None:
+        """Same 40-minute trail goes red under a tighter arm-B threshold, and arm A's
+        threshold does not silently drive arm B."""
+        self.h.set_formula_version(IRO689_FORMULA_VERSION)
+        self.h.set_release(IRO689_LATEST_TAG, published_minutes_ago=40)
+        err = self.assertRed(self.h.run(STALE_THRESHOLD_MINUTES="10"))
+        self.assertIn("threshold 10m", err)
+
+    def test_formula_ahead_of_latest_release_is_red_with_no_grace(self) -> None:
+        """A formula pinned past releases/latest means its download URLs point at a
+        release that was deleted, unpublished, or demoted. Time does not heal that, so
+        it fires even though the release was published one minute ago."""
+        self.h.set_formula_version("0.1.451")
+        self.h.set_release("v0.1.450", published_minutes_ago=1)
+        err = self.assertRed(self.h.run())
+        self.assertIn("NEWER than the newest release", err)
+
+    def test_arm_b_reads_the_track_branch_ref(self) -> None:
+        """Arm B must measure the branch `brew tap` serves, not the working copy. The
+        guard also runs on `test/brew-bump-waiting-*` control branches, where reading the
+        local file would report that branch's formula as "what users get"."""
+        self.h.run()
+        self.assertIn("contents/Formula/ironclaw.rb?ref=main", self.h.argv_log)
+
+    # -----------------------------------------------------------------
+    # Fail-loud: an unreadable API must never render as "the tap is current".
+    # -----------------------------------------------------------------
+    def test_unreadable_release_endpoint_is_red(self) -> None:
+        self.h.force_failure("release.json")
+        err = self.assertRed(self.h.run())
+        self.assertIn("releases/latest", err)
+
+    def test_unreadable_formula_is_red(self) -> None:
+        self.h.force_failure("formula.rb")
+        err = self.assertRed(self.h.run())
+        self.assertIn("cannot tell what the tap is serving", err)
+
+    def test_formula_with_no_version_line_is_red(self) -> None:
+        """If the formula's shape changes, the parser must say so rather than compare an
+        empty string and read as "not equal" or "equal" by accident."""
+        self.h.set_formula_source("class Ironclaw < Formula\nend\n")
+        err = self.assertRed(self.h.run())
+        self.assertIn("no `  version", err)
+
+    def test_draft_or_prerelease_latest_is_red(self) -> None:
+        """releases/latest is documented to exclude both. If one ever appears, the
+        endpoint's semantics changed and arm B would be comparing the tap against
+        something users cannot install."""
+        self.h.set_release("v0.1.450", published_minutes_ago=500, prerelease=True)
+        err = self.assertRed(self.h.run())
+        self.assertIn("prerelease=true", err)
+
+    # -----------------------------------------------------------------
+    # Arm A — preserved behaviour.
+    # -----------------------------------------------------------------
+    def test_waiting_pr_arm_still_fires_on_an_in_sync_tap(self) -> None:
+        """Arm A catches a bump that IS trying to land, before the tap has trailed long
+        enough for arm B. So it must fire with the formula in sync — and must not claim
+        the tap is stale, which is the overclaim IRO-690 also fixed."""
+        self.h.set_open_pr_age(700, minutes_ago=500)
+        self.h.set_check_rollup(
+            [
+                {"name": "build", "conclusion": "SUCCESS"},
+                {"name": "brew-formula-verify", "conclusion": "SUCCESS"},
+                {"context": "CodeQL", "state": "SUCCESS"},
+            ]
+        )
+        err = self.assertRed(self.h.run())
+        self.assertIn("#700 open", err)
+        self.assertIn("only the approving-review click is missing", err)
+        self.assertNotIn("tap is STALE", err)
+
+    def test_waiting_pr_under_threshold_with_in_sync_tap_is_green(self) -> None:
+        self.h.set_open_pr_age(701, minutes_ago=5)
+        out = self.assertGreen(self.h.run())
+        self.assertIn("none past the 240m threshold", out)
+
+    def test_missing_required_check_is_reported_as_the_blocker(self) -> None:
+        """A required context that never REPORTS reads as not-green, so the alarm stays
+        loud on exactly the PRs that are most stuck."""
+        self.h.set_open_pr_age(702, minutes_ago=500)
+        self.h.set_check_rollup([{"name": "build", "conclusion": "SUCCESS"}])
+        err = self.assertRed(self.h.run())
+        self.assertIn("required checks NOT green", err)
+        self.assertIn("brew-formula-verify=MISSING", err)
+
+    def test_both_arms_report_together(self) -> None:
+        """One arm tripping must not hide the other: a stale tap AND a stuck bump PR are
+        two different next actions and both belong in the notification. Arm B's
+        remediation must also switch to its bump-PR-exists branch and drop the
+        re-cut-the-bump instructions, which do not apply when a bump PR is sitting there."""
+        self.h.set_open_pr_age(703, minutes_ago=500)
+        self.h.set_check_rollup([{"name": "build", "conclusion": "FAILURE"}])
+        self.h.set_formula_version(IRO689_FORMULA_VERSION)
+        self.h.set_release(IRO689_LATEST_TAG, published_minutes_ago=500)
+        err = self.assertRed(self.h.run())
+        self.assertIn("tap is STALE", err)
+        self.assertIn("#703 open", err)
+        self.assertIn("A bump PR IS open", err)
+        self.assertNotIn("ZERO open", err)
+        self.assertNotIn("update-homebrew-formula.sh", err)
+
+    def test_unreadable_pr_list_is_red(self) -> None:
+        self.h.force_failure("pr_list.json")
+        err = self.assertRed(self.h.run())
+        self.assertIn("would make this guard unfalsifiable", err)
+
+    def test_zero_threshold_is_rejected(self) -> None:
+        err = self.assertRed(self.h.run(THRESHOLD_MINUTES="0"))
+        self.assertIn("must be > 0", err)
+
+    def test_non_numeric_stale_threshold_is_rejected(self) -> None:
+        err = self.assertRed(self.h.run(STALE_THRESHOLD_MINUTES="4h"))
+        self.assertIn("STALE_THRESHOLD_MINUTES must be a whole number", err)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## The gap

`scripts/check-brew-bump-waiting.sh` (the IRO-676 hourly freshness guard) discovered work by **listing open PRs**:

```sh
COUNT="$(printf %s "$PRS" | jq length)"
if [ "$COUNT" -eq 0 ]; then
  say "No open ${HEAD_BRANCH} PR. The tap is not waiting on a click."
  exit 0
fi
```

So it measured *"is a rolling bump PR waiting on a human?"* — not *"is the tap serving an older release than the newest one?"*, which is the user-facing property its own error text claimed to protect.

Those come apart precisely when there is **no open bump PR at all**, which is exactly what IRO-689 produced: GitHub auto-closed #636 when its head became `==` its base, so between 10:39Z and ~11:19Z on 2026-07-30 the tap served v0.1.447 against a published v0.1.450 with **zero** open `brew/track` PRs. A scheduled run landing in that window would have said "not waiting on a click" and exited **0**. That is why the outage had to be found by a human PR sweep.

Honest scoping, unchanged from the issue: this never fired wrongly in anger. No scheduled run landed inside the stale window (runs were 06:45Z and 09:46Z, and at 09:46Z main tracked 0.1.447 while the newest release *was* v0.1.447, so that green was correct). The gap is structural — the `COUNT -eq 0` early exit — not observed.

## The fix: two arms, two failure modes

| | Arm A — waiting bump PR | Arm B — stale tap (new) |
| --- | --- | --- |
| Question | Is a bump blocked on a human click? | Is the tap serving an older release than the newest one? |
| Measures | open `brew/track` PRs, age from creation | `version` in `Formula/ironclaw.rb` on `main` vs `releases/latest` |
| Threshold | `THRESHOLD_MINUTES`, default 240 | `STALE_THRESHOLD_MINUTES`, defaults to arm A's |
| Clock starts | PR creation | release publication |
| Needs a PR to exist | yes | **no** |

Arm A stays — it catches a bump that *is* trying to land, and catches it earlier than arm B would. Arm B needs no PR to exist, so it is non-vacuous by construction. Both are always evaluated and both are always reported, so one tripping cannot hide the other. **No new credential**: `releases/latest` and the formula both read under the `contents: read` the checkout already needed.

Design decisions worth reviewing:

- **Arm B reads `main` over the API, never the local checkout.** The guard also runs on `test/brew-bump-waiting-*` control branches, and measuring the checked-out ref would report that branch's formula as "what users get". IRO-499's fail-open contents-API hazard applies, so there is no `|| true` on that path.
- **Behind gets the threshold; AHEAD of `releases/latest` fires immediately.** A formula ahead means its download URLs point at a release that was deleted, unpublished, or demoted to a prerelease. That does not heal with time, so a grace window would only delay the alarm.
- **Arm B's remediation branches on whether a bump PR exists.** Handing someone "merge the bump PR" when there is no bump PR is not a next action; the zero-PR branch names the IRO-689 auto-close shape and gives the re-cut commands.
- **Arm A's error text no longer claims to have measured staleness.**

## Non-vacuity (IRO-685 standing rule)

Arm B's red path is proven two ways, and the **pre-fix script is recorded green on the same fixture** — that is what makes the red assertion evidence rather than decoration.

1. `scripts/tests/test_check_brew_bump_waiting.py` — 17 tests, picked up by the existing `script-tests` CI job. It drives the real script through a stubbed `gh` (fixture JSON piped through real `jq`, so the guard's own filters are exercised) with the real IRO-689 pair and asserts exit 1, with the fresh pair asserted green on the same code path. Against the pre-IRO-690 blob the load-bearing test fails `0 != 1`, printing `No open brew/track PR. The tap is not waiting on a click.`

2. **Live, nothing stubbed.** `TRACK_BRANCH` takes any ref, including the commit where the formula really said 0.1.447:

   ```
   TRACK_BRANCH=495269e8f09510fd6761857b0dfb3aad57c95826 \
   STALE_THRESHOLD_MINUTES=10 scripts/check-brew-bump-waiting.sh
   ```
   ```
   ::error::The Homebrew tap is STALE: the tap has been serving 0.1.447 for 76m while
   v0.1.450 is the newest release (threshold 10m). ...
     Open brew/track PRs: 0
     ZERO open brew/track PRs: nothing is even trying to fix this, which is the IRO-689 shape.
   exit=1
   ```

   Real formula blob, real `releases/latest`, zero real open bump PRs. The stubbed tests cover what live state cannot conjure (a formula ahead of latest, an unreadable endpoint, a draft "latest").

Arm B would **not** have fired during IRO-689's observed window either — that window was ~40 min against a 240 min threshold, and a 40-minute trail is inside the README's advertised "can briefly trail" budget, so green there is correct. What arm B changes is that the window can no longer persist **unbounded and silently**. `test_stale_tap_inside_the_threshold_is_green` pins that.

## Also corrected: the cron claims this workflow was the experiment for

The `schedule:` arm **has** now fired (06:45Z and 09:46Z on 2026-07-30, both success), so any note saying it never has is stale. More importantly, the workflow comment asked to be replaced with data once hourly runs existed. Re-measured with `scripts/measure-cron-latency.py` at 2026-07-30T11:47Z:

| cron | period asked | delivered gap | excess | live silence |
|---|---|---|---|---|
| `brew-bump-waiting` `23 * * * *` | 60 min | **181 min** | **+121** | 122 min = **2.0x**, nothing queued |
| `fork-ci-approval-backstop` `13,43 * * * *` | 30 min | 143 min | **+113** | 104 min = **3.5x**, nothing queued |
| daily+weekly pooled (57 intervals) | — | — | p50 −8 / p90 +36 / p95 +51 / max +75 | 0.0x–0.9x |

**Hourly is in GitHub's dropped bucket** — 2 of 7 due slots delivered, five dropped. So the previously-claimed ~135 min worst case and ~105 min of headroom are both **retracted**. One interval is not a distribution, so no bound is stated at all; 181 min is a floor on what has been observed, not a ceiling. The `13,43` offset now has a post-offset sample and did not help, and the brew guard's own off-peak `23` is dropped just as hard, so frequency is the lever, not minute-of-hour.

The 240 min threshold survives for a reason independent of the numbers: **both arms fire on a level, not an edge.** An open bump PR stays open and a stale formula stays stale, so a dropped run delays detection and never loses it.

## Security lenses

Read-only throughout, and no lens is touched. Permissions are unchanged (`contents/pull-requests/checks/statuses: read`) — arm B added no scope. No merge, no approve, no write of any kind; the guard remains deliberately **not** a required status check, so it gates nothing and cannot block an unrelated PR. No secret is read, logged, or introduced. `persist-credentials: false` on the checkout is unchanged.

## Verification

- `shellcheck scripts/check-brew-bump-waiting.sh` — clean
- `python3 -m unittest discover -s scripts/tests` — **56 tests OK** (39 existing + 17 new)
- `python3 scripts/check_links.py` — 105 relative links resolve
- `mkdocs build --strict` — exit 0, no warnings (gates the `docs/**` anchors; the renamed heading has no inbound links)
- Live green against real state (in-sync tap, zero open bump PRs) and live red as shown above

Success condition from the issue: *a scheduled run goes RED when main's formula version differs from `releases/latest` past the threshold, with that red proven against pinned stale inputs; and an ordinary release, where the bump lands promptly, stays green.* Both halves are proven above.
