### PR TITLE
ci(brew): let the freshness guard's green verdict say what arm B actually found [IRO-694]

### DIFF
--- a/scripts/check-brew-bump-waiting.sh
+++ b/scripts/check-brew-bump-waiting.sh
@@ -219,6 +219,11 @@ fi
 # formula must go red; rendering either as "in sync" is how a guard becomes decoration.
 # ===========================================================================
 STALE=""
+# Arm B's green wording, filled in by whichever branch below actually runs, so the
+# final verdict quotes what arm B found instead of a hardcoded claim. Under `set -u`
+# an unset value would be a hard error, which is the intent: every arm-B path that can
+# reach the green verdict must say what it saw.
+TAP_VERDICT=""
 
 # `releases/latest` deliberately, not `git tag`: it excludes drafts and prereleases and
 # resolves to exactly what a user browsing the repo (and `gh release view`, which
@@ -259,6 +264,7 @@ say "Tap serves:  ${FORMULA_VERSION} (${TRACK_BRANCH}:${FORMULA_PATH})"
 say "Newest rel:  ${LATEST_VERSION} (${LATEST_TAG}, published ${LATEST_PUBLISHED})"
 
 if [ "$FORMULA_VERSION" = "$LATEST_VERSION" ]; then
+  TAP_VERDICT="the tap serves the newest release (${LATEST_VERSION})"
   say "Tap is in sync with the newest release."
 else
   published_epoch="$(to_epoch "$LATEST_PUBLISHED")" \
@@ -271,7 +277,8 @@ else
     # because that is when the user-visible trail starts: from that moment
     # `brew install` hands out the older binary.
     if [ "$stale_min" -le "$STALE_THRESHOLD_MINUTES" ]; then
-      say "Tap trails by ${LATEST_VERSION} but ${LATEST_TAG} has only been published ${stale_min}m, under the ${STALE_THRESHOLD_MINUTES}m threshold. Inside the advertised brief-trail window."
+      TAP_VERDICT="the tap trails ${LATEST_TAG} by ${stale_min}m, inside the ${STALE_THRESHOLD_MINUTES}m brief-trail window"
+      say "Tap serves ${FORMULA_VERSION} while ${LATEST_TAG} is newest, but ${LATEST_TAG} has only been published ${stale_min}m, under the ${STALE_THRESHOLD_MINUTES}m threshold. Inside the advertised brief-trail window."
     else
       STALE="the tap has been serving ${FORMULA_VERSION} for ${stale_min}m while ${LATEST_TAG} is the newest release (threshold ${STALE_THRESHOLD_MINUTES}m)"
     fi
@@ -290,7 +297,13 @@ fi
 # trips one does not hide the other.
 # ===========================================================================
 if [ -z "$WAITING" ] && [ -z "$STALE" ]; then
-  say "Both arms clear: nothing waiting past ${THRESHOLD_MINUTES}m, and the tap serves the newest release. Tap freshness is within the advertised window."
+  # ${TAP_VERDICT} is arm B's own words for the branch it actually took, not a fixed
+  # sentence. Observed in run 30546035595: arm B reported the tap trailing v0.1.452
+  # inside the grace window, and this line then asserted "the tap serves the newest
+  # release" one line below it. A green that states a property arm B did not find is
+  # the same class of dishonesty arm B was written to remove (IRO-690), just in the
+  # reporting half rather than the discovery half.
+  say "Both arms clear: nothing waiting past ${THRESHOLD_MINUTES}m, and ${TAP_VERDICT}. Tap freshness is within the advertised window."
   exit 0
 fi
 

--- a/scripts/tests/test_check_brew_bump_waiting.py
+++ b/scripts/tests/test_check_brew_bump_waiting.py
@@ -276,6 +276,8 @@ class BrewBumpWaitingTest(unittest.TestCase):
         out = self.assertGreen(self.h.run())
         self.assertIn("Tap is in sync with the newest release", out)
         self.assertIn("Both arms clear", out)
+        # Only in THIS branch may the summary claim the newest release is served.
+        self.assertIn("the tap serves the newest release (0.1.450)", out)
 
     def test_stale_tap_inside_the_threshold_is_green(self) -> None:
         """The IRO-689 window as actually observed: ~40 min of trail. The README
@@ -285,6 +287,26 @@ class BrewBumpWaitingTest(unittest.TestCase):
         self.h.set_release(IRO689_LATEST_TAG, published_minutes_ago=40)
         out = self.assertGreen(self.h.run())
         self.assertIn("Inside the advertised brief-trail window", out)
+
+    def test_green_summary_does_not_claim_a_trailing_tap_is_in_sync(self) -> None:
+        """The load-bearing negative for the SUMMARY line (IRO-694). Arm B is allowed to
+        be green while the tap trails inside the grace window, but the summary must then
+        say so rather than assert the opposite one line below arm B's own finding.
+
+        NON-VACUITY: this is a suppressing/report-half defect, so it passes against the
+        fixed script by construction and proves nothing on its own. Run it against the
+        pre-fix file (`git show 84e7594:scripts/check-brew-bump-waiting.sh`) and it FAILS
+        on the assertNotIn: that summary hardcoded "the tap serves the newest release"
+        and printed it verbatim under a trailing tap. Observed live in run 30546035595,
+        which reported the tap on 0.1.450 against a published v0.1.452 and then called
+        itself in sync. Same rule as IRO-676's "an honest green must ENUMERATE a real
+        row", applied to the verdict instead of the discovery."""
+        self.h.set_formula_version(IRO689_FORMULA_VERSION)
+        self.h.set_release(IRO689_LATEST_TAG, published_minutes_ago=40)
+        out = self.assertGreen(self.h.run())
+        self.assertIn("Both arms clear", out)
+        self.assertNotIn("the tap serves the newest release", out)
+        self.assertIn(f"the tap trails {IRO689_LATEST_TAG} by 40m", out)
 
     def test_stale_threshold_is_independently_tunable(self) -> None:
         """Same 40-minute trail goes red under a tighter arm-B threshold, and arm A's


### PR DESCRIPTION
## What this is

A one-sentence honesty fix to `scripts/check-brew-bump-waiting.sh`, found while verifying that IRO-690's arm B behaves in a real run rather than a test.

Arm B is *allowed* to be green while the tap trails the newest release, as long as the trail is inside the grace window - the README advertises that the tap "can briefly trail". But the final verdict line hardcoded the other branch's conclusion, so a run in that state printed arm B's real finding and then contradicted it one line later.

Run [30546035595](https://github.com/IronSecCo/ironclaw/actions/runs/30546035595), verbatim:

```
==> Tap serves:  0.1.450 (main:Formula/ironclaw.rb)
==> Newest rel:  0.1.452 (v0.1.452, published 2026-07-30T13:10:44Z)
==> Tap trails by 0.1.452 but v0.1.452 has only been published 4m, under the 240m threshold. Inside the advertised brief-trail window.
==> Both arms clear: nothing waiting past 240m, and the tap serves the newest release. Tap freshness is within the advertised window.
```

The exit code was right. The sentence was not, and the last line of a green run is the line people actually read.

This is the reporting half of the defect IRO-690 fixed in the discovery half: a guard asserting a property it did not measure.

## The change

Arm B fills in `TAP_VERDICT` on whichever branch it takes, and the summary quotes it - so a green enumerates the state that was observed instead of a fixed sentence. Deliberately hostile to omission: under `set -u`, a future arm-B path that reaches the green verdict without recording what it saw is a hard error, not a silent reversion.

The trailing-but-green log line also stopped saying "trails by \<newer version\>", which read as a delta.

## Verification

Two proofs, and only the second one counts:

1. `scripts/tests/`: **18 tests, all pass** (the `script-tests` CI job runs these).
2. **The negative control.** This is a suppressing defect, so a test for it passes against the fixed script by construction. Both new assertions were run against the pre-fix file (`git show 84e7594:scripts/check-brew-bump-waiting.sh` swapped in) and **both fail there** - `test_green_summary_does_not_claim_a_trailing_tap_is_in_sync` failing with the contradictory sentence printed in its own failure message.

`shellcheck` clean.

## Scope

Notify-only guard. No workflow file, no permissions, no ruleset, no `Formula/ironclaw.rb`, no change to any fire condition or threshold - green stays green and red stays red in every case the suite covers. Wording and one new variable.