### PR TITLE
docs(blog): link the hardening-guides hub from the blog index [IRO-696]

### DIFF
--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -46,6 +46,10 @@ adjectives standing in for numbers.
 Per-image, data-driven walkthroughs: the default isolation grade, the exact dimensions that
 fail, and the precise `ironctl scan --fix` flags that close the gap, with before and after scores.
 
+A selection is written up below. The
+[**container hardening guides hub**](hardening-guides.md) carries the complete set, every
+image we have graded, with its default and hardened score in one table.
+
 - [How to harden a Postgres container](harden-postgres-container-isolation.md) -
   `postgres:17-alpine` scores 48 of 100 (D) on defaults: root, full capabilities, writable
   rootfs. Four flags take it to 100 of 100 (A). Is it safe for untrusted workloads?


### PR DESCRIPTION
Reported by @Phoenix1504e on #643. They noticed `harden-haproxy` was missing from `docs/blog/index.md` while contributing an unrelated guide, which is our bug, not theirs.

## What the sweep found

HAProxy was not special. All 55 `harden-*.md` guides against the four surfaces that list them:

| surface | exhaustive? | gaps |
|---|---|---|
| `docs/blog/.nav.yml` | yes | 0/55 |
| `docs/blog/hardening-guides.md` | yes | 0/55 |
| `README.md` | no | **32/55** |
| `docs/blog/index.md` | no | **40/55** |

The two curated surfaces are not drifting at random. `index.md` holds exactly the guides published through wave 5 (`023aa44`, 2026-07-15) and nothing after it; `README.md` holds exactly those through wave 8 (`b6dde80`). Each one stopped being updated at a point in time.

## What this changes

**Not** a backfill of 40 hand-written entries into `index.md`. Those entries quote real before/after scores per guide, and a list that must be extended by hand on every publish is precisely what broke twice already.

`README.md` already links the hardening-guides hub. `index.md` did not link it at all, and that is the real defect: the blog landing page offered 15 guides and no route to the other 40. It links the hub now, so every guide is reachable and the hub stays the single exhaustive prose surface.

## Verification

`mkdocs build --strict` exits 0; the new link renders as `hardening-guides/` on the built blog index.

## Related

The CI guard that keeps the two exhaustive surfaces exhaustive is **#646**, split out because it touches `.github/workflows/` — a gated change-kind that needs a real review of record, which I should not mint for myself. This PR is docs-only and ungated.

Whether the curated lists (`index.md`, `README.md`) should be backfilled, capped at a deliberate "selected guides" set, or generated from the hub is a content decision for @omerzamir. Flagged on IRO-696.