### PR TITLE
ci(docs): gate that every hardening guide is wired into its indexes [IRO-696]

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,7 @@ on:
       - "api/openapi.yaml"
       - "scripts/check-docs-meta.py"
       - "scripts/check_links.py"
+      - "scripts/check-guide-index.py"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
@@ -28,6 +29,7 @@ on:
       - "api/openapi.yaml"
       - "scripts/check-docs-meta.py"
       - "scripts/check_links.py"
+      - "scripts/check-guide-index.py"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -71,6 +73,21 @@ jobs:
         # The other half of the gate is validation.links.anchors in mkdocs.yml,
         # which covers docs/** against the real rendered heading tree.
         run: python3 scripts/check_links.py
+
+      - name: Check every hardening guide is wired into its indexes
+        # A guide missing from an index is not a broken link, so neither
+        # check_links.py nor `mkdocs build --strict` can see it: both only follow
+        # links that already exist. IRO-696 is what that costs -- an outside
+        # contributor found harden-haproxy missing from docs/blog/index.md by
+        # hand, and the sweep that followed showed the drift ran to 40 guides.
+        # This asserts presence on the two surfaces that claim to be exhaustive
+        # (the nav and the hub); index.md and README.md are curated prose and are
+        # deliberately out of scope, see the module docstring. A step in `build`
+        # for the same reason as the two checks around it: `build` is the
+        # required check on ruleset 17917971 and a new job name would not be.
+        # Stdlib only, so it runs before the toolchain install and fails fast.
+        # Negative controls: scripts/tests/test_check_guide_index.py (ci.yml).
+        run: python3 scripts/check-guide-index.py
 
       - name: Install MkDocs toolchain (hash-pinned)
         # --require-hashes makes pip refuse any wheel whose SHA-256 isn't in the

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -46,6 +46,10 @@ adjectives standing in for numbers.
 Per-image, data-driven walkthroughs: the default isolation grade, the exact dimensions that
 fail, and the precise `ironctl scan --fix` flags that close the gap, with before and after scores.
 
+A selection is written up below. The
+[**container hardening guides hub**](hardening-guides.md) carries the complete set, every
+image we have graded, with its default and hardened score in one table.
+
 - [How to harden a Postgres container](harden-postgres-container-isolation.md) -
   `postgres:17-alpine` scores 48 of 100 (D) on defaults: root, full capabilities, writable
   rootfs. Four flags take it to 100 of 100 (A). Is it safe for untrusted workloads?

--- a/scripts/check-guide-index.py
+++ b/scripts/check-guide-index.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Fail the docs build when a hardening guide is not wired into its indexes.
+
+A guide that exists on disk but is listed nowhere is invisible: it never appears
+in the site nav, nothing links to it, and no check notices. ``mkdocs build
+--strict`` and ``scripts/check_links.py`` both only look at links that *exist* --
+a *missing* entry is not a broken link, so neither one can see this. That is
+exactly how IRO-696 was found: by an outside contributor, by hand, not by CI.
+
+Two surfaces are required to be exhaustive, and this asserts both:
+
+* ``docs/blog/.nav.yml`` -- the nav is code (``docs/hooks.py::_assemble_nav``),
+  and a guide absent from it is unreachable by navigation.
+* ``docs/blog/hardening-guides.md`` -- the hub page, which opens with the words
+  "Every guide below", so an omission there makes the page's own claim false.
+
+``docs/blog/index.md`` and ``README.md`` are deliberately *not* checked. Both are
+curated prose with a hand-written, per-guide summary quoting real before/after
+scores, so "every guide appears" is not a property either one claims or should
+claim; both instead link the hub, which is exhaustive. Enforcing presence there
+would demand a fabricated summary per guide, and a check that pressures an
+author into inventing scores is worse than no check.
+
+Usage:
+
+    python3 scripts/check-guide-index.py [repo-root]
+
+Exits 0 when every guide is wired into both surfaces, 1 when any is missing, and
+2 on a usage/IO error. Negative controls: scripts/tests/test_check_guide_index.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Every doc matching this glob is a published hardening guide and must be wired
+# into each SURFACES entry below.
+GUIDE_GLOB = "harden-*.md"
+
+# (path relative to repo root, human name used in the failure message).
+SURFACES = [
+    (Path("docs/blog/.nav.yml"), "the blog nav"),
+    (Path("docs/blog/hardening-guides.md"), "the hardening-guides hub"),
+]
+
+BLOG_DIR = Path("docs/blog")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 2:
+        print(f"usage: {argv[0]} [repo-root]", file=sys.stderr)
+        return 2
+    root = Path(argv[1]) if len(argv) == 2 else Path.cwd()
+
+    blog = root / BLOG_DIR
+    if not blog.is_dir():
+        print(f"::error::{blog} is not a directory", file=sys.stderr)
+        return 2
+
+    guides = sorted(p.name for p in blog.glob(GUIDE_GLOB))
+    # A glob that matches nothing would make every assertion below pass over an
+    # empty set and report a green "all guides wired". Refuse to be that check.
+    if not guides:
+        print(
+            f"::error::no {GUIDE_GLOB} guides found under {blog}; "
+            "this check would pass vacuously",
+            file=sys.stderr,
+        )
+        return 2
+
+    texts = {}
+    for rel, _name in SURFACES:
+        path = root / rel
+        try:
+            texts[rel] = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"::error::cannot read {rel}: {exc}", file=sys.stderr)
+            return 2
+
+    missing = []
+    for guide in guides:
+        for rel, name in SURFACES:
+            if guide not in texts[rel]:
+                missing.append((guide, rel, name))
+
+    if missing:
+        for guide, rel, name in missing:
+            print(
+                f"::error file={BLOG_DIR / guide}::{guide} is not referenced from "
+                f"{rel} ({name}); add it there or the guide ships invisible",
+                file=sys.stderr,
+            )
+        print(
+            f"\n{len(missing)} missing reference(s) across {len(guides)} guide(s).",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Name the count that was actually enumerated: "no failures" and "nothing was
+    # checked" have to be distinguishable in the log.
+    print(
+        f"ok: {len(guides)} hardening guides, each referenced from "
+        f"{' and '.join(rel.name for rel, _ in SURFACES)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/tests/test_check_guide_index.py
+++ b/scripts/tests/test_check_guide_index.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check-guide-index.py (IRO-696).
+
+This checker's passing output is "exit 0", which is also what a checker that
+enumerates nothing produces. So the tests below are negative controls: each one
+builds a tree where a guide IS missing from a surface and asserts the checker
+says so, or builds a degenerate tree and asserts the checker refuses to call it
+green.
+
+The specific defect being pinned is the one IRO-696 found on `main`: a guide can
+be present on disk, in the nav, and on the hub, yet absent from an index, and
+nothing in CI notices, because a missing entry is not a broken link. The real
+pre-fix repo state is reproduced in test_missing_from_hub_is_caught.
+
+Run:
+    python3 -m unittest discover -s scripts/tests -v
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import tempfile
+import unittest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / 'check-guide-index.py'
+REPO_ROOT = SCRIPT.parent.parent
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location('check_guide_index', SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run(root: pathlib.Path):
+    """Run the checker against `root`, returning (exit code, stderr+stdout)."""
+    module = load_module()
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        code = module.main(['check-guide-index.py', str(root)])
+    return code, out.getvalue() + err.getvalue()
+
+
+def build_tree(root: pathlib.Path, guides, in_nav=None, in_hub=None):
+    """Write a minimal docs/blog tree.
+
+    `guides` land on disk; `in_nav` / `in_hub` default to all of them, so a test
+    creates a gap by passing a subset.
+    """
+    blog = root / 'docs' / 'blog'
+    blog.mkdir(parents=True)
+    for name in guides:
+        (blog / name).write_text('# guide\n', encoding='utf-8')
+    nav = guides if in_nav is None else in_nav
+    hub = guides if in_hub is None else in_hub
+    (blog / '.nav.yml').write_text(
+        ''.join(f'  - "A guide": {n}\n' for n in nav), encoding='utf-8'
+    )
+    (blog / 'hardening-guides.md').write_text(
+        ''.join(f'| [X]({n}) | 48/100 D | 100/100 A | root |\n' for n in hub),
+        encoding='utf-8',
+    )
+    return root
+
+
+class CheckGuideIndexTest(unittest.TestCase):
+    def test_fully_wired_tree_passes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = build_tree(pathlib.Path(tmp), ['harden-a-container-isolation.md',
+                                                  'harden-b-container-isolation.md'])
+            code, output = run(root)
+            self.assertEqual(code, 0, output)
+            # An honest green names the count it enumerated, so "all wired" and
+            # "checked nothing" cannot read the same in a CI log.
+            self.assertIn('2 hardening guides', output)
+
+    def test_missing_from_nav_is_caught(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = build_tree(
+                pathlib.Path(tmp),
+                ['harden-a-container-isolation.md', 'harden-b-container-isolation.md'],
+                in_nav=['harden-a-container-isolation.md'],
+            )
+            code, output = run(root)
+            self.assertEqual(code, 1, output)
+            self.assertIn('harden-b-container-isolation.md', output)
+            self.assertIn('.nav.yml', output)
+
+    def test_missing_from_hub_is_caught(self):
+        """The IRO-696 shape: on disk and in the nav, absent from an index."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = build_tree(
+                pathlib.Path(tmp),
+                ['harden-a-container-isolation.md', 'harden-haproxy-container-isolation.md'],
+                in_hub=['harden-a-container-isolation.md'],
+            )
+            code, output = run(root)
+            self.assertEqual(code, 1, output)
+            self.assertIn('harden-haproxy-container-isolation.md', output)
+            self.assertIn('hardening-guides.md', output)
+
+    def test_no_guides_is_not_a_pass(self):
+        """A glob matching nothing must fail, not report a vacuous all-clear."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = build_tree(pathlib.Path(tmp), [])
+            code, output = run(root)
+            self.assertEqual(code, 2, output)
+            self.assertIn('vacuous', output)
+
+    def test_missing_blog_dir_is_not_a_pass(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            code, output = run(pathlib.Path(tmp))
+            self.assertEqual(code, 2, output)
+
+    def test_real_repo_is_wired(self):
+        """The committed tree must satisfy the check it ships."""
+        code, output = run(REPO_ROOT)
+        self.assertEqual(code, 0, output)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Split out of #645 because it touches `.github/workflows/`. **@omerzamir this needs your review of record** — a workflows change is a gated change-kind and I should not mint one for myself, even though IRO-696 pre-authorized wiring a check into the docs CI job.

## Why this check exists

IRO-696 started with an outside contributor finding `harden-haproxy` missing from `docs/blog/index.md` by hand. Nothing in CI could have found it, because **a guide missing from an index is not a broken link** — `scripts/check_links.py` (IRO-688) and `mkdocs build --strict` both only follow links that already exist. A guide can sit on disk, listed nowhere, forever.

## What it gates, and what it deliberately does not

Two surfaces claim to be exhaustive, and both are asserted:

- `docs/blog/.nav.yml` — the nav is code (`docs/hooks.py::_assemble_nav`); a guide absent from it is unreachable by navigation.
- `docs/blog/hardening-guides.md` — the hub opens with the words "Every guide below", so an omission makes the page's own claim false.

`docs/blog/index.md` and `README.md` are **out of scope on purpose**. Both are curated prose with a hand-written per-guide summary quoting real before/after scores. "Every guide appears" is not a property either one claims. A check that pressures an author into inventing a score to satisfy it is worse than no check.

## Wiring

A step in `docs.yml`'s `build` job, not a new job: `build` is the required check on ruleset `17917971`, and a new job name would not be — a red standalone job could be merged straight past. Same placement and same reason as `check_links.py` and `check-docs-meta.py`. Stdlib only, so it runs before the toolchain install and fails fast.

Note it ships wired. A checker that lands referenced by no workflow is inert, which is what happened to the first cut of `check_links.py` in #635.

## Verification

- Enumerates **55** guides and passes. Proven in CI on the previous combined run, which logged the count rather than a bare exit 0: `ok: 55 hardening guides, each referenced from .nav.yml and hardening-guides.md`.
- **Negative control against the real tree:** deleting the real haproxy row from the real `hardening-guides.md` turns it red naming that file; restoring it turns it green, byte-identical (empty `git diff`).
- Refuses to pass vacuously: a glob matching zero guides exits 2, not 0.
- 6 unit tests in `scripts/tests/test_check_guide_index.py`, run by `ci.yml` `script-tests`, covering both missing-surface shapes, the vacuous glob, a missing tree, and the committed repo.