### PR TITLE
ci(brew): refuse an all-clear the freshness guard cannot back with a finding [IRO-693]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ node_modules/
 _site/
 docs/reference/openapi.yaml
 __pycache__/
+
+# Mutation copies of scripts/check-brew-bump-waiting.sh, written next to the real script
+# by scripts/tests/test_check_brew_bump_waiting.py because the guard derives ${ROOT}
+# from $0. Unlinked on cleanup; ignored so a crashed run cannot leave one committable.
+scripts/.mutant-*.sh

--- a/scripts/check-brew-bump-waiting.sh
+++ b/scripts/check-brew-bump-waiting.sh
@@ -220,9 +220,12 @@ fi
 # ===========================================================================
 STALE=""
 # Arm B's green wording, filled in by whichever branch below actually runs, so the
-# final verdict quotes what arm B found instead of a hardcoded claim. Under `set -u`
-# an unset value would be a hard error, which is the intent: every arm-B path that can
-# reach the green verdict must say what it saw.
+# final verdict quotes what arm B found instead of a hardcoded claim. Every arm-B path
+# that can reach the green verdict must say what it saw; the empty initialiser is not
+# the enforcement of that (an empty string interpolates silently and would print
+# "... and . Tap freshness is within the advertised window."), the non-empty assertion
+# at the verdict is. Initialised anyway so the assertion is what fires, rather than a
+# bare `set -u` unbound-variable trace that says nothing about which branch is at fault.
 TAP_VERDICT=""
 
 # `releases/latest` deliberately, not `git tag`: it excludes drafts and prereleases and
@@ -303,6 +306,13 @@ if [ -z "$WAITING" ] && [ -z "$STALE" ]; then
   # release" one line below it. A green that states a property arm B did not find is
   # the same class of dishonesty arm B was written to remove (IRO-690), just in the
   # reporting half rather than the discovery half.
+  #
+  # Reaching here with it empty means an arm-B branch was added that fills neither
+  # TAP_VERDICT nor STALE, so the guard has a green with nothing behind it. That is the
+  # same overclaim one level down and it is the harder one to spot, because an empty
+  # interpolation still reads as a well-formed all-clear to anyone skimming the last
+  # line. Fail loud instead: a guard that cannot say what it found has not found it.
+  [ -n "$TAP_VERDICT" ] || fail "arm B finished without recording what it found, so the all-clear line has no verdict to quote. Some arm-B branch reached the green path filling neither TAP_VERDICT nor STALE; every branch must set exactly one. Refusing to print an all-clear this run did not earn."
   say "Both arms clear: nothing waiting past ${THRESHOLD_MINUTES}m, and ${TAP_VERDICT}. Tap freshness is within the advertised window."
   exit 0
 fi

--- a/scripts/tests/test_check_brew_bump_waiting.py
+++ b/scripts/tests/test_check_brew_bump_waiting.py
@@ -67,6 +67,7 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import tempfile
@@ -211,15 +212,38 @@ class GuardHarness:
         return path.read_text() if path.exists() else ""
 
     # --- runner ----------------------------------------------------------
-    def run(self, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+    def run(self, *, script: pathlib.Path | None = None,
+            **env_overrides: str) -> subprocess.CompletedProcess[str]:
         env = dict(os.environ)
         env["PATH"] = f"{self.bindir}{os.pathsep}{env['PATH']}"
         env["STUB_DIR"] = str(self.dir)
         env["REPO"] = REPO
         env.update(env_overrides)
         return subprocess.run(
-            [str(SCRIPT)], capture_output=True, text=True, env=env, timeout=120
+            [str(script or SCRIPT)], capture_output=True, text=True, env=env, timeout=120
         )
+
+
+def _mutant(drop_pattern: str, suffix: str) -> pathlib.Path:
+    """A copy of the guard with every line matching `drop_pattern` removed.
+
+    Proves a defence is load-bearing without waiting for someone to reintroduce the
+    defect for real: delete what the defence protects against and the defence must fire.
+    Written next to the real script because the guard derives `${ROOT}` from `$0`, so a
+    copy anywhere else would read a different (missing) ruleset and fail for the wrong
+    reason. The caller unlinks it.
+    """
+    src = SCRIPT.read_text().splitlines(keepends=True)
+    kept = [line for line in src if not re.search(drop_pattern, line)]
+    if len(kept) == len(src):
+        raise AssertionError(
+            f"mutation pattern {drop_pattern!r} matched nothing in {SCRIPT}; the test it "
+            "backs would pass against an unmutated script and prove nothing"
+        )
+    out = SCRIPT.parent / f".mutant-{suffix}.sh"
+    out.write_text("".join(kept))
+    out.chmod(0o755)
+    return out
 
 
 class BrewBumpWaitingTest(unittest.TestCase):
@@ -307,6 +331,34 @@ class BrewBumpWaitingTest(unittest.TestCase):
         self.assertIn("Both arms clear", out)
         self.assertNotIn("the tap serves the newest release", out)
         self.assertIn(f"the tap trails {IRO689_LATEST_TAG} by 40m", out)
+
+    def test_green_verdict_refuses_to_print_without_an_arm_b_finding(self) -> None:
+        """IRO-693. Carrying arm B's finding into the verdict fixed the wording for the
+        two branches that exist today; it did not stop a THIRD branch from being added
+        that fills neither TAP_VERDICT nor STALE. That case still reaches the all-clear,
+        and an empty interpolation reads as a well-formed green ("...waiting past 240m,
+        and . Tap freshness is within the advertised window.") to anyone skimming the
+        last line — the same overclaim, one level down and harder to see.
+
+        Driven by MUTATION rather than by a fixture, because no input can reach that
+        state on today's four branches: strip the in-branch `TAP_VERDICT=` assignments
+        and run the otherwise-green in-sync fixture. Without the assertion this mutant
+        exits 0 with the empty sentence; with it, it exits 1 naming the cause."""
+        mutant = _mutant(r'^\s+TAP_VERDICT=', "no-tap-verdict")
+        self.addCleanup(mutant.unlink)
+
+        self.h.set_formula_version("0.1.450")
+        self.h.set_release("v0.1.450", published_minutes_ago=500)
+        proc = self.h.run(script=mutant)
+
+        self.assertEqual(
+            proc.returncode,
+            1,
+            "a green verdict with no arm-B finding behind it must be RED.\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+        )
+        self.assertIn("arm B finished without recording what it found", proc.stderr)
+        self.assertNotIn("Both arms clear", proc.stdout)
 
     def test_stale_threshold_is_independently_tunable(self) -> None:
         """Same 40-minute trail goes red under a tighter arm-B threshold, and arm A's


### PR DESCRIPTION
## What IRO-693 asked for is already on main

IRO-693 reported that `check-brew-bump-waiting.sh` printed arm B's real finding and then contradicted it:

```
==> Tap trails by 0.1.452 but v0.1.452 has only been published 4m, under the 240m threshold.
==> Both arms clear: ... and the tap serves the newest release.
```

That fix landed in `ad9e316` (PR #642), filed under the wrong ticket id — `[IRO-694]`, which on the board is an unrelated correction note about IRO-692. Verified against the pre-fix blob `b3a2d5b`: the exact output IRO-693 quotes reproduces verbatim, and `test_green_summary_does_not_claim_a_trailing_tap_is_in_sync` fails against it. So the reported defect is closed; this PR closes what it left behind.

## The residual hole

`TAP_VERDICT` is filled by whichever arm-B branch runs. All four of today's branches fill either it or `STALE` — but nothing *enforces* that. A fifth branch that fills neither still reaches the all-clear, and the empty interpolation reads as a well-formed green:

```
==> Both arms clear: nothing waiting past 240m, and . Tap freshness is within the advertised window.
```

`exit 0`. This is harder to catch than the wrong sentence IRO-693 reported: there is no false claim to disagree with, only a missing one, in the line you read when skimming. The file's own comment asserted `set -u` covered it — it does not, because `TAP_VERDICT` is initialised to `""`.

## Change

- The comment now describes what the code actually does; the empty initialiser is explicitly *not* the enforcement.
- The verdict asserts a non-empty `TAP_VERDICT` before printing, and fails naming which invariant broke.

## Verification

Proven non-vacuous by **mutation**, because no input reaches that state on today's branches: strip the in-branch `TAP_VERDICT=` assignments, run the otherwise-green in-sync fixture.

| guard | mutant result |
|---|---|
| pre-change (`ad9e316`) | prints the empty sentence above, `exit 0` — recorded verbatim in the test |
| this PR | `exit 1`, `arm B finished without recording what it found` |

`_mutant()` refuses to build a copy whose pattern matched nothing, so the test cannot go vacuous if the assignments are renamed.

64 tests under `scripts/tests` green (`ci.yml` runs them via `unittest discover`); `shellcheck` clean.

## Scope

Reporting only, as IRO-693 scoped it. No change to either arm's detection, thresholds, or exit codes. The guard has no write scope and is not a required status check — it gates nothing.

**Lenses:** none of signing / attestation / required-checks / installer verification are touched. Closest is *fail loud, fail closed*: one more path that used to exit green now exits red.