### PR TITLE
docs: quote the uid `--fix` actually emits, and gate it in CI [IRO-699]

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,12 @@ on:
       - "scripts/check-docs-meta.py"
       - "scripts/check_links.py"
       - "scripts/check-guide-index.py"
+      - "scripts/check-guide-uid.py"
+      # check-guide-uid.py reads `hardenedUID` out of this file, so a change to
+      # the constant has to trigger this workflow too. Without it, moving the
+      # constant would leave 56 guides quoting the old uid and nothing in CI
+      # would ever look: the paths filter, not the check, would be the hole.
+      - "internal/host/scan/remediate.go"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
@@ -30,6 +36,12 @@ on:
       - "scripts/check-docs-meta.py"
       - "scripts/check_links.py"
       - "scripts/check-guide-index.py"
+      - "scripts/check-guide-uid.py"
+      # check-guide-uid.py reads `hardenedUID` out of this file, so a change to
+      # the constant has to trigger this workflow too. Without it, moving the
+      # constant would leave 56 guides quoting the old uid and nothing in CI
+      # would ever look: the paths filter, not the check, would be the hole.
+      - "internal/host/scan/remediate.go"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -88,6 +100,30 @@ jobs:
         # Stdlib only, so it runs before the toolchain install and fails fast.
         # Negative controls: scripts/tests/test_check_guide_index.py (ci.yml).
         run: python3 scripts/check-guide-index.py
+
+      - name: Check the guides quote the uid `--fix` actually emits
+        # Every harden-*.md heads its remediation section "the exact `--fix`
+        # remediation", so the flags under it are a claim about our own tool's
+        # output. Twice that claim was false and both times a human reading the
+        # page caught it, not CI: IRO-698 shipped a guide whose bullet and run
+        # block pinned different uids, and the IRO-699 sweep found 17 guides
+        # quoting a uid --fix never emits (couchdb and neo4j had reused the
+        # image's port number as a uid). A wrong-but-well-formed number inside a
+        # code fence is invisible to check_links.py, check-guide-index.py and
+        # `mkdocs build --strict` alike: none of them read prose, only links,
+        # nav wiring and front-matter.
+        #
+        # The uid is read out of internal/host/scan/remediate.go, so the
+        # assertion follows the constant instead of being a second place to
+        # remember; that file is in this workflow's paths filter for the same
+        # reason. A step in `build` for the same reason as the checks around it:
+        # `build` is the required check on ruleset 17917971 and a new job name
+        # would not be. Stdlib only, so it runs before the toolchain install and
+        # fails fast. Negative controls: scripts/tests/test_check_guide_uid.py
+        # (run by ci.yml script-tests), including the two that assert it stays
+        # silent on haproxy/grafana/prometheus, where the uid is the image's own
+        # and rewriting it would break the container.
+        run: python3 scripts/check-guide-uid.py
 
       - name: Install MkDocs toolchain (hash-pinned)
         # --require-hashes makes pip refuse any wheel whose SHA-256 isn't in the

--- a/docs/blog/harden-cockroachdb-container-isolation.md
+++ b/docs/blog/harden-cockroachdb-container-isolation.md
@@ -43,8 +43,9 @@ and entrench that foothold.
 `ironctl scan my-cockroach --fix` prints one remediation per failed dimension, then one hardened run.
 For `cockroachdb/cockroach:latest`:
 
-- **`--user 1000:1000`** (Non-root user, +15): pin a non-root uid so an escape does not begin as host
-  uid 0. Point `/cockroach/cockroach-data` at a volume this uid owns.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. `--fix` emits 65532, the distroless nonroot uid. Point `/cockroach/cockroach-data`
+  at a volume uid 65532 owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; CockroachDB needs
   none of the default set to serve SQL and its console on high ports.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
@@ -71,7 +72,7 @@ docker run -d --name cockroach cockroachdb/cockroach:latest start-single-node --
 
 # After: 100/100, grade A (single node, co-located app, no network needed)
 docker run -d --name cockroach-hardened \
-  --user 1000:1000 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-couchdb-container-isolation.md
+++ b/docs/blog/harden-couchdb-container-isolation.md
@@ -43,8 +43,9 @@ that foothold.
 `ironctl scan my-couchdb --fix` prints one remediation per failed dimension, then one hardened run. For
 `couchdb:3.4`:
 
-- **`--user 5984:5984`** (Non-root user, +15): pin the non-root `couchdb` uid so an escape does not
-  begin as host uid 0. Point the data directory at a volume this uid owns.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. `--fix` emits 65532, the distroless nonroot uid. Point `/opt/couchdb/data` at a volume
+  uid 65532 owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; CouchDB needs none of
   the default set to serve its HTTP API on a high port.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
@@ -71,7 +72,7 @@ docker run -d --name couchdb couchdb:3.4
 
 # After: 100/100, grade A (co-located store, no network needed)
 docker run -d --name couchdb-hardened \
-  --user 5984:5984 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-dgraph-container-isolation.md
+++ b/docs/blog/harden-dgraph-container-isolation.md
@@ -40,8 +40,8 @@ friends, on a filesystem it can rewrite to persist.
 `ironctl scan my-dgraph --fix` prints one remediation per failed dimension, then one hardened run.
 For `dgraph/dgraph:v24.0.5`:
 
-- **`--user 1000:1000`** (Non-root, +15): run the process as an unprivileged uid. Point the data
-  directory at a volume that uid owns.
+- **`--user 65532:65532`** (Non-root, +15): run the process as an unprivileged uid. `--fix` emits
+  65532, the distroless nonroot uid. Point the data directory at a volume uid 65532 owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
   the workload provably needs. Dgraph needs none of the defaults.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
@@ -58,7 +58,7 @@ docker run -d --name dgraph dgraph/dgraph:v24.0.5
 
 # After: 100/100, grade A
 docker run -d --name dgraph-hardened \
-  --user 1000:1000 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-envoy-container-isolation.md
+++ b/docs/blog/harden-envoy-container-isolation.md
@@ -41,8 +41,8 @@ rewrite to persist.
 `ironctl scan my-envoy --fix` prints one remediation per failed dimension, then one hardened run.
 For `envoyproxy/envoy:v1.32-latest`:
 
-- **`--user 1000:1000`** (Non-root, +15): run the process as an unprivileged uid. Envoy binds
-  unprivileged ports fine as a non-root user.
+- **`--user 65532:65532`** (Non-root, +15): run the process as an unprivileged uid; `--fix` emits
+  65532, the distroless nonroot uid. Envoy binds unprivileged ports fine as a non-root user.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
   the workload provably needs. Envoy needs none of the defaults for a standard listen on an
   unprivileged port.
@@ -62,7 +62,7 @@ docker run -d --name envoy envoyproxy/envoy:v1.32-latest
 
 # After: 89/100, grade B (scoped private mesh network)
 docker run -d --name envoy-hardened \
-  --user 1000:1000 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-gitea-container-isolation.md
+++ b/docs/blog/harden-gitea-container-isolation.md
@@ -43,8 +43,9 @@ connections.
 `ironctl scan my-gitea --fix` prints one remediation per failed dimension, then one hardened run. For
 `gitea:1.22`:
 
-- **`--user 1000:1000`** (Non-root user, +15): pin the non-root `git` uid so an escape does not begin
-  as host uid 0. Point the data directory at a volume this uid owns.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. `--fix` emits 65532, the distroless nonroot uid. Point the data directory at a volume
+  uid 65532 owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Gitea needs none of the
   default set to serve HTTP and SSH on high ports.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
@@ -62,7 +63,7 @@ docker run -d --name gitea gitea/gitea:1.22
 
 # After: 89/100, grade B (scoped private network for proxy and clients)
 docker run -d --name gitea-hardened \
-  --user 1000:1000 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-immich-server-container-isolation.md
+++ b/docs/blog/harden-immich-server-container-isolation.md
@@ -45,8 +45,9 @@ durable.
 `ironctl scan my-immich --fix` prints one remediation per failed dimension, then one hardened run.
 For `immich-server`:
 
-- **`--user 1000:1000`** (Non-root user, +15): run as a non-root uid that owns the upload volume so an
-  escape does not begin as host uid 0.
+- **`--user 65532:65532`** (Non-root user, +15): run as a non-root uid so an escape does not begin as
+  host uid 0. `--fix` emits 65532, the distroless nonroot uid, so give uid 65532 ownership of the
+  upload volume.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; the server binds a
   high port and needs none of the default set.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
@@ -68,7 +69,7 @@ docker run -d --name immich-server \
 
 # After: 89/100, grade B (scoped private network for its clients and helpers)
 docker run -d --name immich-hardened \
-  --user 1000:1000 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \
@@ -82,7 +83,7 @@ flags. Proven directly on the hardened config with `ironctl scan --compose`:
 
 ```
 score:   89/100  grade B  (solid, minor gaps)
-Non-root user (uid != 0)    [+] PASS  15/15  runs as 1000:1000 (uid != 0)
+Non-root user (uid != 0)    [+] PASS  15/15  runs as 65532:65532 (uid != 0)
 Dropped capabilities        [+] PASS  20/20  all capabilities dropped, none added back
 Read-only root filesystem   [+] PASS  10/10  root filesystem is read-only
 Network isolation / egress  [~] WARN  4/15   network=bridge: outbound egress is possible

--- a/docs/blog/harden-influxdb-container-isolation.md
+++ b/docs/blog/harden-influxdb-container-isolation.md
@@ -43,8 +43,9 @@ rootfs widen and entrench that foothold.
 `ironctl scan my-influxdb --fix` prints one remediation per failed dimension, then one hardened run.
 For `influxdb:2.7`:
 
-- **`--user 1000:1000`** (Non-root user, +15): pin a non-root uid so an escape does not begin as host
-  uid 0. Point the data and config directories at a volume this uid owns.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. `--fix` emits 65532, the distroless nonroot uid. Point the data and config directories
+  at a volume uid 65532 owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; InfluxDB needs none
   of the default set to serve its API on a high port.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
@@ -70,7 +71,7 @@ docker run -d --name influxdb influxdb:2.7
 
 # After: 100/100, grade A (co-located store, no network needed)
 docker run -d --name influxdb-hardened \
-  --user 1000:1000 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-jenkins-container-isolation.md
+++ b/docs/blog/harden-jenkins-container-isolation.md
@@ -45,8 +45,9 @@ writable rootfs widen and entrench any foothold.
 `ironctl scan my-jenkins --fix` prints one remediation per failed dimension, then one hardened run.
 For `jenkins/jenkins:lts`:
 
-- **`--user 1000:1000`** (Non-root user, +15): pin the non-root `jenkins` uid so an escape does not
-  begin as host uid 0. Point `JENKINS_HOME` at a volume this uid owns.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. `--fix` emits 65532, the distroless nonroot uid. Point `JENKINS_HOME` at a volume uid
+  65532 owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; the Jenkins
   controller serves its UI and agent port on high ports and needs none of the default set.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
@@ -65,7 +66,7 @@ docker run -d --name jenkins jenkins/jenkins:lts
 
 # After: 89/100, grade B (scoped private network for agents and proxy)
 docker run -d --name jenkins-hardened \
-  --user 1000:1000 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-keycloak-container-isolation.md
+++ b/docs/blog/harden-keycloak-container-isolation.md
@@ -44,8 +44,8 @@ server: the value of what it holds is what makes containing it non-negotiable.
 `ironctl scan my-keycloak --fix` prints one remediation per failed dimension, then one hardened run.
 For `quay.io/keycloak/keycloak`:
 
-- **`--user 1000:1000`** (Non-root user, +15): pin the non-root uid the image already ships with so an
-  escape does not begin as host uid 0.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. `--fix` emits 65532, the distroless nonroot uid.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Keycloak serves its
   HTTP and management endpoints on high ports and needs none of the default set.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only. Build a
@@ -65,7 +65,7 @@ docker run -d --name keycloak quay.io/keycloak/keycloak:26.0 start
 
 # After: 89/100, grade B (scoped private network for its database and proxy)
 docker run -d --name keycloak-hardened \
-  --user 1000:1000 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-nats-container-isolation.md
+++ b/docs/blog/harden-nats-container-isolation.md
@@ -61,7 +61,7 @@ docker run -d --name nats nats:2.10-alpine
 
 # After: 89/100, grade B (scoped private network for clients and peers)
 docker run -d --name nats-hardened \
-  --user 65532:65532 \
+  --user 1000:1000 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-nats-container-isolation.md
+++ b/docs/blog/harden-nats-container-isolation.md
@@ -61,7 +61,7 @@ docker run -d --name nats nats:2.10-alpine
 
 # After: 89/100, grade B (scoped private network for clients and peers)
 docker run -d --name nats-hardened \
-  --user 1000:1000 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-neo4j-container-isolation.md
+++ b/docs/blog/harden-neo4j-container-isolation.md
@@ -43,8 +43,9 @@ entrench that foothold.
 `ironctl scan my-neo4j --fix` prints one remediation per failed dimension, then one hardened run. For
 `neo4j:5`:
 
-- **`--user 7474:7474`** (Non-root user, +15): pin the non-root `neo4j` uid so an escape does not
-  begin as host uid 0. Point the data and logs directories at a volume this uid owns.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. `--fix` emits 65532, the distroless nonroot uid. Point the data and logs directories
+  at volumes uid 65532 owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Neo4j needs none of
   the default set to serve Bolt and HTTP on high ports.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
@@ -71,7 +72,7 @@ docker run -d --name neo4j neo4j:5
 
 # After: 100/100, grade A (co-located store, no network needed)
 docker run -d --name neo4j-hardened \
-  --user 7474:7474 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-pgadmin4-container-isolation.md
+++ b/docs/blog/harden-pgadmin4-container-isolation.md
@@ -80,7 +80,7 @@ Proven directly on the hardened config with `ironctl scan --compose`:
 
 ```
 score:   89/100  grade B  (solid, minor gaps)
-Non-root user (uid != 0)    [+] PASS  15/15  runs as 1000:1000 (uid != 0)
+Non-root user (uid != 0)    [+] PASS  15/15  runs as pgadmin (uid != 0)
 Dropped capabilities        [+] PASS  20/20  all capabilities dropped, none added back
 Read-only root filesystem   [+] PASS  10/10  root filesystem is read-only
 Network isolation / egress  [~] WARN  4/15   network=bridge: outbound egress is possible

--- a/docs/blog/harden-questdb-container-isolation.md
+++ b/docs/blog/harden-questdb-container-isolation.md
@@ -43,8 +43,9 @@ rootfs widen and entrench that foothold.
 `ironctl scan my-questdb --fix` prints one remediation per failed dimension, then one hardened run. For
 `questdb:8.2.1`:
 
-- **`--user 10001:10001`** (Non-root user, +15): pin a non-root uid so an escape does not begin as host
-  uid 0. Point the data root at a volume this uid owns.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. `--fix` emits 65532, the distroless nonroot uid. Point the data root at a volume uid
+  65532 owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; QuestDB needs none of
   the default set to serve its HTTP, PostgreSQL-wire, and InfluxDB-line ports.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
@@ -70,7 +71,7 @@ docker run -d --name questdb questdb/questdb:8.2.1
 
 # After: 100/100, grade A (co-located store, no network needed)
 docker run -d --name questdb-hardened \
-  --user 10001:10001 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-sonarqube-container-isolation.md
+++ b/docs/blog/harden-sonarqube-container-isolation.md
@@ -44,8 +44,9 @@ only SonarQube talks to it.
 `ironctl scan my-sonarqube --fix` prints one remediation per failed dimension, then one hardened run.
 For `sonarqube`:
 
-- **`--user 1000:1000`** (Non-root user, +15): pin the non-root `sonarqube` uid so an escape does not
-  begin as host uid 0. Point the data, logs, and extensions directories at volumes this uid owns.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. `--fix` emits 65532, the distroless nonroot uid. Point the data, logs, and extensions
+  directories at volumes uid 65532 owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; SonarQube serves its
   UI and API on a high port and needs none of the default set.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
@@ -64,7 +65,7 @@ docker run -d --name sonarqube sonarqube:community
 
 # After: 89/100, grade B (scoped private network for CI and its database)
 docker run -d --name sonarqube-hardened \
-  --user 1000:1000 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-timescaledb-container-isolation.md
+++ b/docs/blog/harden-timescaledb-container-isolation.md
@@ -43,8 +43,9 @@ and entrench that foothold.
 `ironctl scan my-timescaledb --fix` prints one remediation per failed dimension, then one hardened
 run. For `timescale/timescaledb:2.17.2-pg17`:
 
-- **`--user 999:999`** (Non-root user, +15): pin the non-root `postgres` uid so an escape does not
-  begin as host uid 0. Point `/var/lib/postgresql/data` at a volume this uid owns.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. `--fix` emits 65532, the distroless nonroot uid. Point `/var/lib/postgresql/data` at a
+  volume uid 65532 owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Postgres needs none
   of the default set to serve on its port.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
@@ -70,7 +71,7 @@ docker run -d --name timescaledb -e POSTGRES_PASSWORD=x timescale/timescaledb:2.
 
 # After: 100/100, grade A (co-located app, no network needed)
 docker run -d --name timescaledb-hardened \
-  --user 999:999 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-typesense-container-isolation.md
+++ b/docs/blog/harden-typesense-container-isolation.md
@@ -42,8 +42,9 @@ capability set widens that foothold and the writable rootfs makes it durable.
 `ironctl scan my-typesense --fix` prints one remediation per failed dimension, then one hardened run.
 For `typesense`:
 
-- **`--user 1000:1000`** (Non-root user, +15): run as a non-root uid so an escape does not begin as
-  host uid 0. Point `--data-dir` at a volume this uid owns.
+- **`--user 65532:65532`** (Non-root user, +15): run as a non-root uid so an escape does not begin as
+  host uid 0. `--fix` emits 65532, the distroless nonroot uid. Point `--data-dir` at a volume uid
+  65532 owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Typesense serves its
   API on a high port and needs none of the default set.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
@@ -63,7 +64,7 @@ docker run -d --name typesense \
 
 # After: 89/100, grade B (scoped private network for its clients)
 docker run -d --name typesense-hardened \
-  --user 1000:1000 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \
@@ -78,7 +79,7 @@ flags. Proven directly on the hardened config with `ironctl scan --compose`:
 
 ```
 score:   89/100  grade B  (solid, minor gaps)
-Non-root user (uid != 0)    [+] PASS  15/15  runs as 1000:1000 (uid != 0)
+Non-root user (uid != 0)    [+] PASS  15/15  runs as 65532:65532 (uid != 0)
 Dropped capabilities        [+] PASS  20/20  all capabilities dropped, none added back
 Read-only root filesystem   [+] PASS  10/10  root filesystem is read-only
 Network isolation / egress  [~] WARN  4/15   network=bridge: outbound egress is possible

--- a/docs/blog/harden-valkey-container-isolation.md
+++ b/docs/blog/harden-valkey-container-isolation.md
@@ -43,8 +43,9 @@ execution. The default capability set and writable rootfs widen and entrench tha
 `ironctl scan my-valkey --fix` prints one remediation per failed dimension, then one hardened run. For
 `valkey/valkey:8`:
 
-- **`--user 999:999`** (Non-root user, +15): pin the non-root `valkey` uid so an escape does not begin
-  as host uid 0. Point `/data` at a volume this uid owns if you persist an RDB/AOF snapshot.
+- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
+  host uid 0. `--fix` emits 65532, the distroless nonroot uid. Point `/data` at a volume uid 65532
+  owns if you persist an RDB/AOF snapshot.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Valkey needs none of
   the default set to serve on its port.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
@@ -70,7 +71,7 @@ docker run -d --name valkey valkey/valkey:8
 
 # After: 100/100, grade A (co-located app on loopback, no network needed)
 docker run -d --name valkey-hardened \
-  --user 999:999 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-weaviate-container-isolation.md
+++ b/docs/blog/harden-weaviate-container-isolation.md
@@ -40,8 +40,8 @@ filesystem it can rewrite to persist its embeddings-poisoning payload.
 `ironctl scan my-weaviate --fix` prints one remediation per failed dimension, then one hardened run.
 For `semitechnologies/weaviate:1.28.1`:
 
-- **`--user 1000:1000`** (Non-root, +15): run the process as an unprivileged uid. Point the
-  persistence path at a volume that uid owns.
+- **`--user 65532:65532`** (Non-root, +15): run the process as an unprivileged uid. `--fix` emits
+  65532, the distroless nonroot uid. Point the persistence path at a volume uid 65532 owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; add back only what
   the workload provably needs. Weaviate needs none of the defaults.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and
@@ -58,7 +58,7 @@ docker run -d --name weaviate semitechnologies/weaviate:1.28.1
 
 # After: 100/100, grade A
 docker run -d --name weaviate-hardened \
-  --user 1000:1000 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \

--- a/docs/blog/harden-yugabyte-container-isolation.md
+++ b/docs/blog/harden-yugabyte-container-isolation.md
@@ -42,8 +42,9 @@ durable.
 `ironctl scan my-yugabyte --fix` prints one remediation per failed dimension, then one hardened run.
 For `yugabyte`:
 
-- **`--user 1000:1000`** (Non-root user, +15): run as a non-root uid so an escape does not begin as
-  host uid 0. Point the data directory at a volume this uid owns.
+- **`--user 65532:65532`** (Non-root user, +15): run as a non-root uid so an escape does not begin as
+  host uid 0. `--fix` emits 65532, the distroless nonroot uid. Point the data directory at a volume
+  uid 65532 owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +20): drop every Linux capability; the SQL and RPC
   listeners bind high ports and need none of the default set.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
@@ -64,7 +65,7 @@ docker run -d --name yugabyte \
 
 # After: 100/100, grade A (single node, only its app connects)
 docker run -d --name yugabyte-hardened \
-  --user 1000:1000 \
+  --user 65532:65532 \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
   --read-only --tmpfs /tmp \
@@ -79,7 +80,7 @@ flags. Proven directly on the hardened config with `ironctl scan --compose`:
 
 ```
 score:   100/100  grade A  (hardened)
-Non-root user (uid != 0)    [+] PASS  15/15  runs as 1000:1000 (uid != 0)
+Non-root user (uid != 0)    [+] PASS  15/15  runs as 65532:65532 (uid != 0)
 Dropped capabilities        [+] PASS  20/20  all capabilities dropped, none added back
 Read-only root filesystem   [+] PASS  10/10  root filesystem is read-only
 Network isolation / egress  [+] PASS  15/15  network=none: no NIC but loopback, no egress

--- a/scripts/check-guide-uid.py
+++ b/scripts/check-guide-uid.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Fail the docs build when a hardening guide misquotes the `--fix` uid.
+
+Every ``docs/blog/harden-*.md`` opens its remediation section with the words
+"Harden it: the exact ``--fix`` remediation". That heading is a claim about our
+own tool's output, so the flags under it have to *be* that output. Twice now
+they were not, and both times a human reading the page caught it rather than
+CI: IRO-698 shipped a guide whose bullet and run block pinned different uids,
+and the IRO-699 sweep that followed found 17 guides quoting a uid ``--fix``
+never emits, two of them (couchdb ``5984``, neo4j ``7474``) reusing the image's
+own port number.
+
+Nothing else in CI can see this. ``check_links.py`` and ``mkdocs build
+--strict`` only follow links; ``check-guide-index.py`` only checks nav wiring;
+``check-docs-meta.py`` only reads front-matter. A wrong-but-well-formed number
+in a code fence is invisible to all three.
+
+Two properties are asserted, and the split matters:
+
+1. **Attribution.** ``hardenedUID`` in ``internal/host/scan/remediate.go`` is a
+   compile-time constant with no image input, so ``--fix`` emits the same uid
+   for every image. In a guide whose *own* default-scan table reports FAIL on
+   the non-root dimension, ``--fix`` genuinely remediates that dimension, so
+   every ``--user`` in the page must be that constant.
+
+   The uid is read out of the Go source, never hardcoded here, so changing the
+   constant moves the assertion with it instead of turning this check into a
+   second thing to remember.
+
+2. **Internal consistency.** A pasted "after" scan block is the output of the
+   hardened ``docker run`` above it, so its ``runs as`` detail has to match
+   what that block actually sets: the block's ``--user`` when it has one, and
+   otherwise the user from the guide's own default-scan table, because a run
+   with no ``--user`` does not change who the image runs as. This is the check
+   that catches a bullet and a run block disagreeing, and it is what resolved
+   pgadmin4, whose hardened block sets no ``--user`` at all yet claimed an
+   "after" uid that nothing in the guide set.
+
+Guides whose default table already PASSes non-root are deliberately exempt from
+(1). There ``--fix`` emits no user remediation, and the guide is pinning the
+image's *own* uid: haproxy ``99:99``, grafana ``472:472``, prometheus
+``nobody``. Rewriting those to 65532 would replace a true statement with a
+false one and break the container besides, since the data volume is owned by
+the image's uid. They stay under (2).
+
+Also out of scope: ``docs/scores/**``. ``1000:1000`` there is real scan output
+for an image that really does run as uid 1000, not a ``--fix`` recommendation.
+This check never reads that tree.
+
+Usage:
+
+    python3 scripts/check-guide-uid.py [repo-root]
+
+Exits 0 when every guide agrees with the Go constant and with itself, 1 on any
+mismatch, and 2 on a usage/IO error or on anything that would make the run
+vacuous. Negative controls: scripts/tests/test_check_guide_uid.py.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+BLOG_DIR = Path("docs/blog")
+GUIDE_GLOB = "harden-*.md"
+
+# The single source of truth for the uid. Read, never hardcoded.
+REMEDIATE_GO = Path("internal/host/scan/remediate.go")
+HARDENED_UID_RE = re.compile(r'^const\s+hardenedUID\s*=\s*"([^"]+)"', re.MULTILINE)
+
+# `| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as pgadmin (uid != 0) |`
+TABLE_ROW_RE = re.compile(
+    r"^\|\s*Non-root user \(uid != 0\)\s*\|[^|]*?\b(PASS|FAIL|WARN)\b[^|]*\|"
+    r"[^|]*\|\s*(.*?)\s*\|\s*$",
+    re.MULTILINE,
+)
+
+# `Non-root user (uid != 0)    [+] PASS  15/15  runs as 65532:65532 (uid != 0)`
+# inside a pasted scan-output fence.
+OUTPUT_ROW_RE = re.compile(
+    r"^Non-root user \(uid != 0\)\s+\[.\]\s+(PASS|FAIL|WARN)\s+\S+\s+(.*?)\s*$",
+    re.MULTILINE,
+)
+
+# `runs as <user> (uid != 0)` -- the scorer's PASS detail (score.go).
+RUNS_AS_RE = re.compile(r"runs as (\S+) \(uid != 0\)")
+
+# A `--user` flag, in a bullet (`--user 65532:65532`) or a run block.
+USER_FLAG_RE = re.compile(r"--user\s+`?([^\s`\\]+)")
+
+# The hardened `docker run`: the fenced block introduced by a `# After:` comment.
+AFTER_BLOCK_RE = re.compile(r"^# After:.*?(?=^```|\Z)", re.MULTILINE | re.DOTALL)
+
+
+def read_hardened_uid(root: Path) -> str:
+    path = root / REMEDIATE_GO
+    text = path.read_text(encoding="utf-8")
+    match = HARDENED_UID_RE.search(text)
+    if match is None:
+        # The constant moving or being renamed must break loudly. Silently
+        # skipping the assertion would leave a green check over an unchecked
+        # docs tree, which is the failure mode this whole file exists to stop.
+        raise LookupError(f"no `const hardenedUID = \"...\"` in {REMEDIATE_GO}")
+    return match.group(1)
+
+
+def check_guide(path: Path, text: str, hardened_uid: str) -> tuple[list[str], int, int]:
+    """Return (failures, user_flags_asserted, output_rows_asserted)."""
+    failures: list[str] = []
+    rel = BLOG_DIR / path.name
+
+    table = TABLE_ROW_RE.search(text)
+    if table is None:
+        failures.append(
+            f"::error file={rel}::no `| Non-root user (uid != 0) | ... |` row in the "
+            "default-scan table, so this guide's uid claims cannot be checked; "
+            "keep the table row or this guide ships unguarded"
+        )
+        return failures, 0, 0
+    default_verdict, default_detail = table.group(1), table.group(2)
+
+    user_flags = [
+        (m.group(1), text.count("\n", 0, m.start()) + 1)
+        for m in USER_FLAG_RE.finditer(text)
+    ]
+
+    asserted_flags = 0
+    if default_verdict == "FAIL":
+        # `--fix` remediates the non-root dimension here, so every uid on the
+        # page is a claim about what it emits.
+        for value, line in user_flags:
+            asserted_flags += 1
+            if value != hardened_uid:
+                failures.append(
+                    f"::error file={rel},line={line}::`--user {value}` is attributed to "
+                    f"`ironctl scan --fix`, but --fix emits `--user {hardened_uid}` "
+                    f"(hardenedUID in {REMEDIATE_GO}). This guide's own scan table "
+                    "reports FAIL on the non-root dimension, so --fix does remediate "
+                    f"it; use {hardened_uid} or correct the table."
+                )
+
+    # What the hardened run block actually sets. No `--user` means the container
+    # keeps the image's own user, which the default table already names.
+    after = AFTER_BLOCK_RE.search(text)
+    after_user = None
+    if after is not None:
+        flag = USER_FLAG_RE.search(after.group(0))
+        if flag is not None:
+            after_user = flag.group(1)
+
+    expected = after_user
+    if expected is None:
+        seen = RUNS_AS_RE.search(default_detail)
+        expected = seen.group(1) if seen is not None else None
+
+    asserted_rows = 0
+    for match in OUTPUT_ROW_RE.finditer(text):
+        detail = match.group(2)
+        seen = RUNS_AS_RE.search(detail)
+        if seen is None:
+            continue
+        line = text.count("\n", 0, match.start()) + 1
+        if expected is None:
+            failures.append(
+                f"::error file={rel},line={line}::pasted scan output claims "
+                f"`runs as {seen.group(1)}`, but neither the hardened run block nor "
+                "the default-scan table names a user to compare it against"
+            )
+            continue
+        asserted_rows += 1
+        if seen.group(1) != expected:
+            source = (
+                f"the hardened run block sets `--user {after_user}`"
+                if after_user is not None
+                else f"the hardened run block sets no `--user`, and the default-scan "
+                f"table reports `runs as {expected}`"
+            )
+            failures.append(
+                f"::error file={rel},line={line}::pasted scan output claims "
+                f"`runs as {seen.group(1)}`, but {source}. A reader copying the block "
+                "above does not get this output; make them agree."
+            )
+
+    return failures, asserted_flags, asserted_rows
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 2:
+        print(f"usage: {argv[0]} [repo-root]", file=sys.stderr)
+        return 2
+    root = Path(argv[1]) if len(argv) == 2 else Path.cwd()
+
+    blog = root / BLOG_DIR
+    if not blog.is_dir():
+        print(f"::error::{blog} is not a directory", file=sys.stderr)
+        return 2
+
+    try:
+        hardened_uid = read_hardened_uid(root)
+    except (OSError, LookupError) as exc:
+        print(f"::error::cannot read the hardened uid: {exc}", file=sys.stderr)
+        return 2
+
+    guides = sorted(blog.glob(GUIDE_GLOB))
+    if not guides:
+        print(
+            f"::error::no {GUIDE_GLOB} guides under {blog}; this check would pass "
+            "vacuously",
+            file=sys.stderr,
+        )
+        return 2
+
+    failures: list[str] = []
+    total_flags = 0
+    total_rows = 0
+    for path in guides:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"::error::cannot read {path}: {exc}", file=sys.stderr)
+            return 2
+        found, flags, rows = check_guide(path, text, hardened_uid)
+        failures.extend(found)
+        total_flags += flags
+        total_rows += rows
+
+    # A green run has to mean "the assertions ran and held", not "there was
+    # nothing to assert". Every count below was non-zero when this check was
+    # written; a zero means the guides' shape drifted out from under the
+    # parser and the check is no longer looking at anything.
+    if not failures:
+        if total_flags == 0:
+            print(
+                "::error::matched 0 `--user` flags in any guide whose non-root "
+                "dimension FAILs by default; the parser has drifted and this check "
+                "is asserting nothing",
+                file=sys.stderr,
+            )
+            return 2
+        if total_rows == 0:
+            print(
+                "::error::matched 0 pasted scan-output rows to compare against a "
+                "hardened run block; the parser has drifted and this check is "
+                "asserting nothing",
+                file=sys.stderr,
+            )
+            return 2
+
+    if failures:
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        print(
+            f"\n{len(failures)} uid mismatch(es) across {len(guides)} guide(s).",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Name what was actually enumerated: "no failures" and "nothing was checked"
+    # have to be distinguishable in the log.
+    print(
+        f"ok: {len(guides)} hardening guides; {total_flags} `--user` flag(s) match "
+        f"hardenedUID={hardened_uid} from {REMEDIATE_GO}; {total_rows} pasted "
+        "scan-output row(s) match their hardened run block"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/tests/test_check_guide_uid.py
+++ b/scripts/tests/test_check_guide_uid.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check-guide-uid.py (IRO-699).
+
+This checker's passing output is "exit 0", which is also what a checker that
+enumerates nothing produces, so the tests below are negative controls: each
+builds a tree carrying a real defect and asserts the checker names it, or
+builds a degenerate tree and asserts the checker refuses to call it green.
+
+Three specific defects are pinned, all of them real:
+
+* the IRO-698 shape, a bullet and a run block in one guide pinning different
+  uids, which shipped to `main` in PR #643;
+* the IRO-699 shape, a uid attributed to `--fix` that `--fix` does not emit;
+* the pgadmin4 shape, a pasted "after" scan block naming a uid that nothing in
+  the guide sets.
+
+Equally important is what must NOT fire. haproxy, grafana and prometheus
+already PASS non-root by default, so their `--user` pins the image's own uid
+rather than quoting `--fix`. A checker that "fixed" those would replace a true
+statement with a false one, so test_image_own_uid_is_not_flagged holds that
+line.
+
+Run:
+    python3 -m unittest discover -s scripts/tests -v
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import tempfile
+import unittest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / 'check-guide-uid.py'
+REPO_ROOT = SCRIPT.parent.parent
+
+UID = '65532:65532'
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location('check_guide_uid', SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run(root: pathlib.Path):
+    """Run the checker against `root`, returning (exit code, stderr+stdout)."""
+    module = load_module()
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        code = module.main(['check-guide-uid.py', str(root)])
+    return code, out.getvalue() + err.getvalue()
+
+
+def guide(
+    *,
+    default_verdict='FAIL',
+    default_detail='runs as root (uid 0); a container escape starts with host-uid 0',
+    bullet_uid=UID,
+    run_uid=UID,
+    after_detail=None,
+):
+    """Render a guide with the same shape as the real ones.
+
+    `run_uid=None` omits the `--user` line from the hardened run block, which is
+    how pgadmin4 is actually written. `after_detail=None` omits the pasted scan
+    output, which most guides do not carry.
+    """
+    bullet = (
+        f'- **`--user {bullet_uid}`** (Non-root user, +15): pin a non-root uid.\n'
+        if bullet_uid is not None
+        else ''
+    )
+    user_line = f'  --user {run_uid} \\\n' if run_uid is not None else ''
+    after = (
+        '\n```\nscore:   89/100  grade B  (solid, minor gaps)\n'
+        f'Non-root user (uid != 0)    [+] PASS  15/15  {after_detail}\n```\n'
+        if after_detail is not None
+        else ''
+    )
+    return (
+        '# How to harden a thing\n\n'
+        '| Dimension | Verdict | Score | What the scan found |\n'
+        '|-----------|:-------:|------:|---------------------|\n'
+        f'| Non-root user (uid != 0) | x {default_verdict} | 0/15 | {default_detail} |\n'
+        '\n## Harden it: the exact `--fix` remediation\n\n'
+        f'{bullet}'
+        '\n## Before and after\n\n'
+        '```bash\n'
+        '# Before: 63/100, grade C\n'
+        'docker run -d --name thing thing:1\n'
+        '\n# After: 100/100, grade A\n'
+        'docker run -d --name thing-hardened \\\n'
+        f'{user_line}'
+        '  --cap-drop=ALL \\\n'
+        '  thing:1\n'
+        '```\n'
+        f'{after}'
+    )
+
+
+# A correct guide carrying both of the shapes the checker asserts on: a
+# remediated `--user` and a pasted "after" block. Most fixtures include it so
+# the run is non-vacuous, leaving the guide under test as the only variable.
+# Tests that are specifically about the vacuity gate opt out with baseline=False.
+BASELINE = 'harden-baseline-container-isolation.md'
+
+
+def build_tree(
+    root: pathlib.Path,
+    guides: dict,
+    hardened_uid: str = UID,
+    baseline: bool = True,
+):
+    """Write a minimal repo: docs/blog guides plus the Go file holding the uid."""
+    blog = root / 'docs' / 'blog'
+    blog.mkdir(parents=True)
+    if baseline:
+        (blog / BASELINE).write_text(
+            guide(
+                bullet_uid=hardened_uid,
+                run_uid=hardened_uid,
+                after_detail=f'runs as {hardened_uid} (uid != 0)',
+            ),
+            encoding='utf-8',
+        )
+    for name, text in guides.items():
+        (blog / name).write_text(text, encoding='utf-8')
+    go = root / 'internal' / 'host' / 'scan'
+    go.mkdir(parents=True)
+    (go / 'remediate.go').write_text(
+        'package scan\n\n'
+        f'const hardenedUID = "{hardened_uid}"\n',
+        encoding='utf-8',
+    )
+    return root
+
+
+class CheckGuideUidTest(unittest.TestCase):
+    @contextlib.contextmanager
+    def tree(self, guides, **kwargs):
+        with tempfile.TemporaryDirectory() as tmp:
+            yield build_tree(pathlib.Path(tmp), guides, **kwargs)
+
+    def test_clean_tree_passes_and_names_its_counts(self):
+        with self.tree(
+            {'harden-a-container-isolation.md': guide(
+                after_detail=f'runs as {UID} (uid != 0)')}
+        ) as root:
+            code, output = run(root)
+        self.assertEqual(code, 0, output)
+        # A green that cannot distinguish "held" from "checked nothing" is the
+        # bug these two lines exist to prevent: two guides, each with a bullet
+        # and a run-block flag, each with one pasted output row.
+        self.assertIn('4 `--user` flag(s) match', output)
+        self.assertIn('2 pasted scan-output row(s)', output)
+
+    def test_wrong_uid_attributed_to_fix_is_caught(self):
+        """The IRO-699 defect: a uid `--fix` does not emit, under its heading."""
+        with self.tree(
+            {'harden-a-container-isolation.md': guide(
+                bullet_uid='1000:1000', run_uid='1000:1000')}
+        ) as root:
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        self.assertIn('--user 1000:1000', output)
+        self.assertIn('--fix emits `--user 65532:65532`', output)
+
+    def test_invented_image_uid_is_caught(self):
+        """couchdb quoted 5984, its own port number, as `--fix` output."""
+        with self.tree(
+            {'harden-a-container-isolation.md': guide(
+                bullet_uid='5984:5984', run_uid='5984:5984')}
+        ) as root:
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        self.assertIn('--user 5984:5984', output)
+
+    def test_bullet_and_run_block_disagreeing_is_caught(self):
+        """The IRO-698 defect that shipped in PR #643: half-applied fix."""
+        with self.tree(
+            {'harden-a-container-isolation.md': guide(
+                bullet_uid=UID, run_uid='1000:1000')}
+        ) as root:
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        self.assertIn('--user 1000:1000', output)
+
+    def test_after_scan_disagreeing_with_run_block_is_caught(self):
+        with self.tree(
+            {'harden-a-container-isolation.md': guide(
+                after_detail='runs as 1000:1000 (uid != 0)')}
+        ) as root:
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        self.assertIn('runs as 1000:1000', output)
+        self.assertIn(f'sets `--user {UID}`', output)
+
+    def test_after_scan_uid_nothing_sets_is_caught(self):
+        """The pgadmin4 defect: PASS by default, no `--user`, yet claims one."""
+        with self.tree(
+            {'harden-a-container-isolation.md': guide(
+                default_verdict='PASS',
+                default_detail='runs as pgadmin (uid != 0)',
+                bullet_uid=None,
+                run_uid=None,
+                after_detail='runs as 1000:1000 (uid != 0)')}
+        ) as root:
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        self.assertIn('runs as 1000:1000', output)
+        self.assertIn('sets no `--user`', output)
+
+    def test_image_own_uid_is_not_flagged(self):
+        """haproxy/grafana/prometheus: already non-root, so 472 is not a lie.
+
+        Rewriting these to the hardened uid would break the container, whose
+        data volume the image's own uid owns. The checker must leave them be.
+        """
+        with self.tree(
+            {'harden-a-container-isolation.md': guide(
+                default_verdict='PASS',
+                default_detail='runs as 472 (uid != 0)',
+                bullet_uid=None,
+                run_uid='472:472',
+                after_detail='runs as 472:472 (uid != 0)')}
+        ) as root:
+            code, output = run(root)
+        self.assertEqual(code, 0, output)
+
+    def test_uid_is_read_from_go_not_hardcoded(self):
+        """Move the constant and the assertion must move with it."""
+        with self.tree(
+            {'harden-a-container-isolation.md': guide(
+                bullet_uid='4242:4242', run_uid='4242:4242')},
+            hardened_uid='4242:4242',
+        ) as root:
+            code, output = run(root)
+        self.assertEqual(code, 0, output)
+        # And the old value is now the failure, not the pass.
+        with self.tree(
+            {'harden-a-container-isolation.md': guide()},
+            hardened_uid='4242:4242',
+        ) as root:
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        self.assertIn('4242:4242', output)
+
+    def test_missing_go_constant_is_an_error_not_a_pass(self):
+        with self.tree({'harden-a-container-isolation.md': guide()}) as root:
+            (root / 'internal' / 'host' / 'scan' / 'remediate.go').write_text(
+                'package scan\n', encoding='utf-8'
+            )
+            code, output = run(root)
+        self.assertEqual(code, 2, output)
+        self.assertIn('hardenedUID', output)
+
+    def test_no_guides_is_an_error_not_a_pass(self):
+        with self.tree({}, baseline=False) as root:
+            code, output = run(root)
+        self.assertEqual(code, 2, output)
+        self.assertIn('vacuously', output)
+
+    def test_guide_without_a_scan_table_is_caught(self):
+        """A guide whose table drifted is unguarded, so it fails loudly."""
+        with self.tree(
+            {'harden-a-container-isolation.md': '# no table here\n'}
+        ) as root:
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        self.assertIn('default-scan table', output)
+
+    def test_parser_drift_is_an_error_not_a_green(self):
+        """Every guide PASSing by default means rule 1 asserted nothing."""
+        with self.tree(
+            {'harden-a-container-isolation.md': guide(
+                default_verdict='PASS',
+                default_detail='runs as nobody (uid != 0)',
+                bullet_uid=None,
+                run_uid=None)},
+            baseline=False,
+        ) as root:
+            code, output = run(root)
+        self.assertEqual(code, 2, output)
+        self.assertIn('asserting nothing', output)
+
+    def test_real_repo_is_clean(self):
+        """The committed tree must satisfy the checker it ships with."""
+        code, output = run(REPO_ROOT)
+        self.assertEqual(code, 0, output)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes IRO-699.

Every `docs/blog/harden-*.md` opens its remediation section with **"Harden it: the exact `--fix` remediation"**. That heading is a claim about our own tool's output, so the flags under it have to *be* that output. They were not.

## What `--fix` actually emits, proven against live containers

`hardenedUID` in `internal/host/scan/remediate.go` is a compile-time `const` with no image input. Rather than take the constant's word for it, `ironctl` was built from `main` and run against real containers under podman/crun:

| container | default non-root verdict | `--fix` emitted |
|---|---|---|
| `influxdb:latest` | FAIL 0/15, runs as root | `fix: --user 65532:65532` |
| `postgres` | FAIL 0/15, runs as root | `fix: --user 65532:65532` |

Two different images, same uid. It is not image-dependent, so the brief's escalation trigger did not fire.

## Scope: 5 guides beyond the itemization

The IRO-699 itemization came from `git grep '1000:1000'`, which by construction could only find the one wrong value it already knew about. Grepping the *shape* instead (any `--user` under that heading) found five more guides quoting a uid `--fix` never emits, two of them reusing the image's own **port number**:

| guide | claimed | note |
|---|---|---|
| couchdb | `5984:5984` | 5984 is CouchDB's port |
| neo4j | `7474:7474` | 7474 is Neo4j's HTTP port |
| questdb | `10001:10001` | |
| timescaledb | `999:999` | |
| valkey | `999:999` | |

All five default to **FAIL 0/15, runs as root**, so `--fix` does remediate the dimension for them and does emit 65532. Same heading, same false claim, same defect class. They are corrected here rather than deferred: splitting them out would mean landing a CI guard that ships green over five known live violations, which is the hardcoded-branch failure mode from IRO-690.

## Prose, not just numbers

Several bullets also named a uid the image does not run as: *"pin the non-root `git` uid"*, *"the non-root `jenkins` uid"*, *"the uid the image already ships with"*. All 17 of these images scan **FAIL 0/15 as root** by default, so that prose was false independently of the number. Rewritten to name 65532 in the volume-ownership sentence, per the brief.

## pgadmin4, resolved by a real scan

Its hardened block sets **no `--user`** and the image already runs non-root, so the pasted "after" output could not have come from the block above it. A real hardened container was built and scanned:

```
IronClaw containment scan
  target:  pgadmin-hardened (podman)
  score:   89/100  grade B  (solid, minor gaps)
Non-root user (uid != 0)    [+] PASS  15/15  runs as pgadmin (uid != 0)
```

`runs as pgadmin`, not `1000:1000`. The guide's stated 63/100 C default and 89/100 B hardened both reproduced exactly, so this is a uid correction, not the content rewrite the brief flagged as an escalation. Line 83 now matches line 29.

## Deliberately not touched

| guide | uid | why it stays |
|---|---|---|
| haproxy | `99:99` | bullet reads "already **+15**"; image PASSes non-root by default |
| grafana | `472:472` | PASSes by default, no `--user` bullet at all |
| prometheus | `nobody` | PASSes by default, no `--user` bullet at all |

In all three the uid is the **image's own**, not a `--fix` emission. Rewriting them to 65532 would replace a true statement with a false one, and would break the container besides, since the data volume is owned by the image's uid.

`docs/scores/` is untouched. `1000:1000` there is real scan data for `groovy`, an image that genuinely runs as uid 1000. `git diff --stat origin/main` lists no file under `docs/scores/`.

## The CI guard

`scripts/check-guide-uid.py`, wired as a **step in `docs.yml`'s `build`** (not a new job: `build` is the required check on ruleset 17917971, a new job name would not be). Asserts two things:

1. **Attribution.** In a guide whose *own* default-scan table reports FAIL on the non-root dimension, every `--user` must equal `hardenedUID`. The uid is **read out of the Go source**, never hardcoded, so moving the constant moves the assertion.
2. **Internal consistency.** A pasted "after" block must match what the hardened run above it sets, or the image's own user when it sets no `--user`. This is the half that catches the IRO-698 bullet-vs-run-block split, and the half that caught pgadmin4.

`internal/host/scan/remediate.go` was added to `docs.yml`'s paths filter. Without it, a Go-only PR moving the constant would leave all 56 guides stale with the gate never running, and the **paths filter, not the check**, would be the hole.

### Proven red against the real pre-fix tree

Not against a synthetic bad value. Run against `origin/main`'s `docs/blog` at `b799553`, it reports **36 mismatches**: exactly the 17 guides (2 flags each) + NATS's remaining run block + pgadmin4's output row. It stays silent on all three image-own-uid guides. Sample:

```
::error file=docs/blog/harden-neo4j-container-isolation.md,line=46::`--user 7474:7474` is
attributed to `ironctl scan --fix`, but --fix emits `--user 65532:65532` (hardenedUID in
internal/host/scan/remediate.go). This guide's own scan table reports FAIL on the non-root
dimension, so --fix does remediate it; use 65532:65532 or correct the table.

::error file=docs/blog/harden-pgadmin4-container-isolation.md,line=83::pasted scan output
claims `runs as 1000:1000`, but the hardened run block sets no `--user`, and the default-scan
table reports `runs as pgadmin`. A reader copying the block above does not get this output.
```

A CI-side red proof on a scratch commit follows in the next comment, then reverts.

### A green must mean the assertions ran

Zero guides, zero matched `--user` flags, zero matched output rows, and a missing/renamed Go constant are all **exit 2**, not exit 0. The passing line names its counts: `56 hardening guides; 82 --user flag(s) match hardenedUID=65532:65532; 5 pasted scan-output row(s) match their hardened run block`.

13 negative controls in `scripts/tests/test_check_guide_uid.py` (run by `ci.yml` `script-tests`), including two that hold the line on haproxy/grafana/prometheus not being flagged.

## Verification

- `python3 -m unittest discover -s scripts/tests` — 76 tests, OK
- `check-guide-uid.py`, `check-guide-index.py`, `check_links.py` — all green
- `git grep -n '1000:1000' -- docs/` returns **only** the two `docs/scores/` lines
- No em-dashes added

No Go source changed; `remediate.go` is read, not edited.

## Review

This touches `.github/workflows/docs.yml`, so it is reviewer-bot gated. Per `docs/pr-review-process.md` it needs a non-author approval dispatched through `reviewer-approve.yml` with a `review_of_record` from the board. I am not minting my own. Squash merge.