### PR TITLE
docs(sched): land the n=6 sub-hourly cron distribution and the regime rule [IRO-702]

### DIFF
--- a/.github/workflows/brew-bump-waiting.yml
+++ b/.github/workflows/brew-bump-waiting.yml
@@ -79,6 +79,15 @@ on:
     # deliver next, so still do not turn one into a promise. Against the 240 min staleness
     # threshold the worst observed hourly gap of 180.8 min leaves 59.2 min of headroom.
     #
+    # Those figures are a DATED SNAPSHOT, not a live mirror. The script queries recent runs
+    # over the API, so re-running it later legitimately reports a larger n and shifted
+    # min/p50 as new intervals land -- that is the measurement continuing, not a
+    # contradiction, and it is why the timestamp above is quoted with the numbers. Compare
+    # a re-run's CONCLUSIONS (every interval overshoots its period; the max; the headroom
+    # against 240), not its min/p50. Re-checked 2026-07-30T21:42Z: the backstop had gained
+    # a 7th interval (n=7, min +63 / p50 +78) with max +117 and every conclusion here
+    # unchanged. Only re-edit these numbers if a conclusion moves.
+    #
     # An interval only counts against the cron that DELIVERED it. A change to the cron
     # LINE invalidates every interval spanning it; a change to this comment block does
     # not, and the file having a commit in it is not by itself grounds to exclude

--- a/.github/workflows/brew-bump-waiting.yml
+++ b/.github/workflows/brew-bump-waiting.yml
@@ -59,21 +59,36 @@ on:
     # DO NOT write a detection-latency bound here. An earlier version claimed "<= 60 min"
     # off the cron expression (IRO-679), a later one claimed "~135 min" by carrying the
     # daily/weekly overshoot onto a 60 min period. The second is also wrong, and this
-    # workflow is the experiment that showed it. Measured 2026-07-30T11:47Z with
-    # `scripts/measure-cron-latency.py`:
+    # workflow is the experiment that showed it. Measured 2026-07-30T20:57Z with
+    # `scripts/measure-cron-latency.py`, excess over the period each cron asked for:
     #
-    #   - Daily+weekly pooled, 57 intervals: p50 -8 / p90 +36 / p95 +51 / max +75 min
-    #     excess over the period asked for. Cadence roughly holds at those frequencies.
-    #   - THIS workflow, 1 interval: +121 min excess -- a 181 min gap against the 60 min
-    #     it asked for, i.e. GitHub delivered 2 of the 7 due slots and dropped 5. Live
-    #     silence hit 2.0x its period with nothing queued.
-    #   - `fork-ci-approval-backstop` (`13,43 * * * *`), the repo's other sub-hourly cron:
-    #     +113 min excess, live silence 3.5x. Same behaviour, independently.
+    #   - Daily+weekly pooled, 57 intervals: p50 -8 / p90 +36 / p95 +51 / max +75 min.
+    #     Cadence roughly holds at those frequencies.
+    #   - THIS workflow (`23 * * * *`, asks 60 min), n=6 intervals, every one of them
+    #     under the cron below: min +47 / p50 +79 / max +121 min. The worst gap was
+    #     180.8 min, 3.0x the period it asked for.
+    #   - `fork-ci-approval-backstop` (`13,43 * * * *`, asks 30 min), the repo's other
+    #     sub-hourly cron, n=6 intervals under THAT expression: min +74 / p50 +83 /
+    #     max +117 min. The worst gap was 146.6 min, 4.9x its period.
     #
-    # So hourly IS in GitHub's dropped bucket, which settles the open question this
-    # paragraph used to carry. One interval is not a distribution, so there is no bound to
-    # state -- and 181 min against a 240 min threshold leaves ~59 min of headroom, not the
-    # ~105 min previously claimed. IRO-680 re-runs the measurement with more intervals.
+    # So hourly IS in GitHub's dropped bucket, and the backstop says the same thing
+    # independently. It is a second witness for SUB-HOURLY crons being dropped, not a
+    # second witness for the hourly bound: "excess" and "Nx" are period-relative and the
+    # two crons ask for different periods, so their numbers are not poolable. n=6 each is
+    # a distribution and not a bound -- neither max is a ceiling on what the scheduler may
+    # deliver next, so still do not turn one into a promise. Against the 240 min staleness
+    # threshold the worst observed hourly gap of 180.8 min leaves 59.2 min of headroom.
+    #
+    # An interval only counts against the cron that DELIVERED it. A change to the cron
+    # LINE invalidates every interval spanning it; a change to this comment block does
+    # not, and the file having a commit in it is not by itself grounds to exclude
+    # anything. Check the line: `git show <sha> -- <file> | grep -E '^[+-].*cron:'`.
+    # `scripts/measure-cron-latency.py` applies exactly this rule (`_cron_landed_at()`)
+    # and prints what it excluded. It is why the backstop's 328.8 min gap of
+    # 02:12Z -> 07:41Z is NOT in the numbers above and is NOT a 240 min breach: it
+    # straddles the 04:49Z `*/30` -> `13,43` change in f81aed31 and belongs to neither
+    # regime. Every interval of THIS workflow is in-regime -- `- cron: "23 * * * *"` has
+    # not been touched since the file was created at 2026-07-30T03:32:47Z (c669409e).
     #
     # Why the guard's design survives that anyway: BOTH arms fire on a LEVEL, not an edge.
     # An open bump PR stays open and a stale formula stays stale, so a dropped run delays

--- a/.github/workflows/fork-ci-approval-backstop.yml
+++ b/.github/workflows/fork-ci-approval-backstop.yml
@@ -81,21 +81,31 @@ on:
     # was dropping this one -- consistent with GitHub's documented deprioritisation of
     # high-frequency schedules.
     #
-    # n=2 cannot prove that on its own, so do not lean on those two gaps. The load-bearing
-    # number is the script's LIVE SILENCE column, which needs no sample at all: re-measured
-    # 2026-07-30 06:08Z, this cron had been silent 236 minutes against a 30-minute period
-    # (7.9x) while `state: active` with nothing queued, and over the 7h40m since its
-    # first-ever scheduled run the scheduler delivered 3 runs where a 30-minute cron
-    # predicts ~15. Every daily/weekly cron in the repo sat at 0.0x-0.9x of its period in
-    # that same table, so the metric is not just flagging everything it looks at.
+    # That was n=2 and could not prove it on its own. It no longer has to: re-measured
+    # 2026-07-30T20:57Z, the `13,43` form below now has n=6 intervals of its own, all of
+    # them delivered under it, at min +74 / p50 +83 / max +117 minutes of excess. The
+    # worst gap was 146.6 minutes, 4.9x the 30 minutes asked for, and the BEST interval
+    # still overshot by 74. Every interval measured exceeds the period. That is a
+    # distribution and still not a ceiling, so there is no bound to write here. The
+    # script's LIVE SILENCE column is the negative control on all of it: in that same run
+    # this cron sat at 2.3x its period, `state: active` with nothing queued, while every
+    # daily and weekly cron in the repo sat at 0.5x-0.6x of its own.
+    #
+    # An interval only counts against the cron that DELIVERED it. The 02:12Z -> 07:41Z gap
+    # of 328.8 minutes straddles the 04:49Z `*/30` -> `13,43` change (f81aed31) and is
+    # excluded for that reason -- it is NOT a breach of the 240-minute threshold the brew
+    # guard uses and must not be reported as one. A change to the cron LINE voids the
+    # intervals spanning it; a change to a comment in this block does not. Check the line:
+    # `git show <sha> -- <file> | grep -E '^[+-].*cron:'`. The script applies this rule
+    # (`_cron_landed_at()`) and prints what it excluded.
     #
     # The minutes are offset off :00/:30 as a cheap, strictly-dominating experiment: same
     # 30-minute cadence and the same promise, but off the two most congested minutes of
-    # the hour. It costs nothing if it does not help. It is still NOT known to help, and
-    # the early read is that it has not: in the 79 minutes after the offset landed on main
-    # the scheduler delivered 0 runs where `13,43` predicts 2. That is n=0 and settles
-    # nothing on its own -- do not write a latency number off it either way. Re-run the
-    # script before anyone does.
+    # the hour. With n=6 under `13,43` the answer is that it did NOT help. Keep it -- it
+    # costs nothing -- but minute-of-hour is not the lever. `brew-bump-waiting` asks for
+    # 60 minutes at `23 * * * *`, equally off-peak, and is dropped on every interval too;
+    # the deprioritisation is about frequency. Note its numbers are NOT poolable with
+    # these: excess and Nx are relative to the period each cron asked for.
     #
     # If a real latency bound is ever needed here, it needs an event-driven trigger, and
     # that is a trust-model decision (a run entering `action_required` is contributor-

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -472,7 +472,7 @@ the cron expression alone. That was not measured, and it is not true.
 
 [`scripts/measure-cron-latency.py`](https://github.com/IronSecCo/ironclaw/blob/main/scripts/measure-cron-latency.py)
 measures it. Run it before writing any latency number here. Re-measured
-2026-07-30 **11:47Z**, over **57 intervals** of this repo's daily and weekly crons:
+2026-07-30 **20:57Z**, over **57 intervals** of this repo's daily and weekly crons:
 
 | quantity | measured |
 |---|---|
@@ -495,41 +495,55 @@ Caveats, because this is the part that is easy to overstate:
   used to read "the hourly cadence is unmeasured", with a projected worst case of
   ~135 min (60 nominal + the 75 min daily/weekly overshoot) and ~105 min of
   headroom against the 240 min threshold. The hourly guard was made the experiment
-  that settles it, and it has now returned data that kills the projection:
+  that settles it, and each sub-hourly cron now has **n=6 intervals** behind it,
+  every one of them delivered under the expression it is scored against:
 
-  | cron | period asked | delivered gap | excess | live silence |
+  | cron | period asked | intervals | excess over period | worst gap |
   |---|---|---|---|---|
-  | `brew-bump-waiting` `23 * * * *` | 60 min | **181 min** | **+121** | 122 min = **2.0x**, nothing queued |
-  | `fork-ci-approval-backstop` `13,43 * * * *` | 30 min | 143 min | **+113** | 104 min = **3.5x**, nothing queued |
+  | `brew-bump-waiting` `23 * * * *` | 60 min | 6 | min **+47**, p50 **+79**, max **+121** | **180.8 min** = 3.0x the period |
+  | `fork-ci-approval-backstop` `13,43 * * * *` | 30 min | 6 | min **+74**, p50 **+83**, max **+117** | **146.6 min** = 4.9x the period |
 
-  GitHub delivered **2 of the 7 slots due** to the brew guard and dropped five.
-  Both sub-hourly crons in the repo now exceed their own period, independently,
-  which matches GitHub's documented deprioritisation of high-frequency schedules.
-  One interval is not a distribution, so do not turn 181 min into a bound either —
-  it is a floor on what has been observed, not a ceiling. IRO-680 re-runs the
-  measurement once there are more intervals.
-- **The 240 min threshold survives, with less headroom than claimed.** 181 min
-  against 240 leaves ~59 min, not ~105. The design still holds for a reason
-  independent of the numbers: **both arms fire on a level, not an edge.** An open
-  bump PR stays open and a stale formula stays stale, so a dropped run delays
-  detection and never loses it. Only time-to-notice degrades.
-- **Quote the silence, not the gap count.** Two intervals cannot carry that
-  conclusion on their own. What carries it is the script's second table: **live
-  silence**, the still-open interval since the last scheduled run. Re-measured
-  2026-07-30 06:08Z, the backstop had been silent **236 min against a 30 min
-  period (7.9x)** while `state: active` with nothing queued — and across the
-  7h40m since its first-ever scheduled run, a 30-min cron predicts ~15 runs
-  where the scheduler delivered **3**. That is one direct observation with no
-  sample-size caveat attached. In the same table every daily/weekly cron in the
-  repo sat at **0.0x–0.9x** of its period, so the metric is not merely flagging
-  everything it looks at.
+  Both sub-hourly crons in the repo exceed their own period on **every** interval
+  measured, independently of each other, which matches GitHub's documented
+  deprioritisation of high-frequency schedules. Read the second row as a second
+  witness that **sub-hourly** crons get dropped, and nothing more: "excess" and
+  "Nx" are period-relative, the two crons ask for different periods, and pooling
+  them would manufacture a number neither one measured. n=6 is a distribution, not
+  a ceiling — do not turn 180.8 min into a promise to a contributor.
+- **The 240 min threshold survives, with less headroom than once claimed.** The
+  worst hourly gap measured, 180.8 min, leaves **59.2 min** against 240 — a real
+  margin, and not the ~105 min the projection claimed. Do not lower the threshold
+  to buy margin; it would only make the guard noisier. The design holds for a
+  reason independent of the numbers anyway: **both arms fire on a level, not an
+  edge.** An open bump PR stays open and a stale formula stays stale, so a dropped
+  run delays detection and never loses it. Only time-to-notice degrades.
+- **The silence column is the negative control.** The script's second table reports
+  **live silence**, the still-open interval since the last scheduled run, and it is
+  what keeps the gap tables from being a story about the measurement. In the same
+  20:57Z run the backstop sat at **2.3x** its period with `state: active` and
+  nothing queued, while every daily and weekly cron in the repo sat at **0.5x–0.6x**
+  of its own. The metric is not merely flagging everything it looks at.
+- **An interval belongs to the cron that delivered it.** Two different things can
+  happen to a workflow file and only one of them invalidates data. If the **cron
+  line** changed, every interval spanning the change is void — the old schedule's
+  gaps say nothing about the new expression. If the file changed but the cron line
+  did not (a comment edit, a step added), the interval is **valid and counts**.
+  Check the line, not the file: `git show <sha> -- <file> | grep -E '^[+-].*cron:'`.
+  `scripts/measure-cron-latency.py` implements exactly this (`_cron_landed_at()`)
+  and prints what it excluded rather than dropping it silently. This is load-bearing
+  in both directions here. The backstop's 02:12Z → 07:41Z gap of **328.8 min**
+  straddles the 04:49Z `*/30` → `13,43` change and is therefore **excluded** — it is
+  *not* a 240 min breach and must never be reported as one. In the other direction,
+  `b3a2d5b1` (13:09Z) edited this workflow's comments and left `- cron: "23 * * * *"`
+  alone, so the 12:07Z → 14:37Z interval it sits inside stays in the hourly sample.
 - **The `13,43` offset did not help.** It was a free experiment — same cadence,
-  off the two most congested minutes of the hour. It now has a post-offset sample
-  and the answer is no: under `13,43`, the backstop delivered 2 runs with a 143 min
-  gap against a 30 min period, and sat at 3.5x live silence. Keep the offset (it
-  costs nothing and n=1 gap is thin), but stop treating minute-of-hour as the lever.
-  The brew guard's own `23 * * * *` is off-peak too and is dropped just as hard, so
-  the deprioritisation is about frequency, not about which minute you ask for.
+  off the two most congested minutes of the hour. With n=6 under the new expression
+  the answer is no: the backstop's worst gap is 146.6 min against a 30 min period
+  and its *best* interval still overshoots by 74 min. Keep the offset (it costs
+  nothing), but stop treating minute-of-hour as the lever. The brew guard's own
+  `23 * * * *` is off-peak too and is dropped on every interval as well, so the
+  deprioritisation is about frequency, not about which minute you ask for. The
+  lever, if one is needed, is leaving the high-frequency bucket entirely.
 - **A cron is the wrong tool for a hard latency bound.** Getting a real one
   needs an event-driven trigger, and for the approval backstop that is a
   trust-model change, not a scheduling tweak: the safety net must stay

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -510,6 +510,16 @@ Caveats, because this is the part that is easy to overstate:
   "Nx" are period-relative, the two crons ask for different periods, and pooling
   them would manufacture a number neither one measured. n=6 is a distribution, not
   a ceiling — do not turn 180.8 min into a promise to a contributor.
+
+  The table is a **dated snapshot, not a live mirror**. The script queries recent
+  runs over the API, so re-running it later legitimately reports a larger `n` and
+  shifted min/p50 as new intervals land — that is the measurement continuing, not
+  a contradiction with this table, and it is why the 20:57Z timestamp is quoted
+  alongside the numbers. Compare a re-run's **conclusions** (every interval
+  overshoots its period; the worst gap; the headroom against 240), not its
+  min/p50. Re-checked 2026-07-30 **21:42Z**: the backstop had gained a 7th
+  interval (n=7, min +63, p50 +78) with max +117 and every conclusion below
+  unchanged. Only re-edit the table if a conclusion moves.
 - **The 240 min threshold survives, with less headroom than once claimed.** The
   worst hourly gap measured, 180.8 min, leaves **59.2 min** against 240 — a real
   margin, and not the ~105 min the projection claimed. Do not lower the threshold


### PR DESCRIPTION
Comments only. No cron line, no step, no `permissions:`, no product code.

## What landed

Both sub-hourly crons now carry a distribution instead of a single interval.
Measured 2026-07-30T20:57Z with `scripts/measure-cron-latency.py`, excess over
the period each cron asked for:

| cron | period asked | n | excess | worst gap |
|---|---|---|---|---|
| `brew-bump-waiting` `23 * * * *` | 60 min | 6 | min +47 / p50 +79 / max +121 | 180.8 min = 3.0x |
| `fork-ci-approval-backstop` `13,43 * * * *` | 30 min | 6 | min +74 / p50 +83 / max +117 | 146.6 min = 4.9x |

Every interval of either cron overshoots its own period. **The 240 min staleness
threshold is not breached**: 180.8 against 240 leaves 59.2 min of headroom, so the
threshold and the guard's design are unchanged. No contributor-facing latency
promise is added -- n=6 is a distribution, not a ceiling.

Each figure is labelled with the expression *and* the period it was measured
under, and the two crons are marked non-poolable: excess and Nx are
period-relative, so the 30 min backstop is a second witness that **sub-hourly**
crons get dropped, not a second witness for the **hourly** bound.

The regime rule is now stated wherever the methodology is, in both directions: a
change to the cron **line** voids the intervals spanning it, a comment-only change
does not, and a commit touching the file is not by itself grounds to exclude
anything. That is why the backstop's 328.8 min gap (02:12Z -> 07:41Z) is excluded
-- it straddles the 04:49Z `*/30` -> `13,43` change in `f81aed31` and is **not** a
240 min breach -- and why the 12:07Z -> 14:37Z hourly interval stays in, `b3a2d5b1`
having touched only comments.

## One correction to the brief

IRO-702 asked me to fix `+113 min / 3.5x` in `brew-bump-waiting.yml` as a figure
measured on the `*/30` form and misattributed in print to `13,43`. **That premise
does not hold; the figure was correctly attributed.** Evidence:

- `+113` / `3.5x` first appear in `b3a2d5b1` (2026-07-30T13:09Z) and nowhere earlier
  (`git log -S`), carrying the stamp "measured 11:47Z".
- The cron-regime filter (`_cron_landed_at`) landed at `56459ab` **08:54Z**, before
  that measurement, so the 11:47Z run was already scoped to `13,43`.
- The `*/30` data cannot produce `+113` under any scoping. Backstop scheduled runs
  are 22:28, 23:33, 02:12, 07:41, 10:04, ...; `*/30`-only gaps give a max excess of
  +129, and unfiltered gives +299. `+113` is 07:41 -> 10:04 = 142.7 min, which is
  post-change data.

So the defect was **n=1, not misattribution**. The fix is the same either way
(replace with the n=6 in-regime distribution), and the files now say so -- but the
repo does not claim a misattribution that did not happen.

## Also updated

`fork-ci-approval-backstop.yml` still said the offset was "NOT known to help,
n=0 ... re-run the script before anyone does". It has n=6 now, so the deferral is
replaced with the measured answer (it did not help; frequency is the lever, not
minute-of-hour). Its labelled `*/30` history stays, correctly labelled.

## Verification

- `scripts/measure-cron-latency.py` re-run after the edits: exit 0, both workflows
  still parsed, every figure in either file matches its output.
- `actionlint` clean on both workflows.
- `mkdocs build --strict` green in a `--require-hashes` venv; `scripts/check-docs-meta.py _site`
  passed on 436 built pages.
- Worst-gap minutes recomputed from the raw `gh api .../runs?event=schedule`
  timestamps, independent of the tables in the issue.

## Review

This touches `.github/workflows/**`, so it is reviewer-bot gated. It needs a
non-author approval dispatched through `reviewer-approve.yml` with a
`review_of_record` from the board. I am not minting my own. Squash merge.