### PR TITLE
ci(scorecard): scope `actions: write` to the job that uses it [IRO-704]

### DIFF
--- a/.github/workflows/fork-ci-approval-backstop.yml
+++ b/.github/workflows/fork-ci-approval-backstop.yml
@@ -118,15 +118,13 @@ on:
         type: boolean
         default: false
 
-# Least-privilege (Scorecard Token-Permissions). `actions: write` is required by the
-# "Approve a workflow run for a fork pull request" endpoint and is the only elevated
-# scope here.
+# Least-privilege (Scorecard Token-Permissions). Nothing elevated at workflow scope: the
+# one elevated scope this workflow needs is declared on the one job that uses it, below.
+# Scorecard scores ANY top-level write as a hard zero on Token-Permissions no matter how
+# narrow it is, while the same write at job scope only reduces the check -- so keep this
+# block read-only and grant downward. IRO-704.
 permissions:
   contents: read
-  actions: write
-  pull-requests: read
-  # Read-only, and only so the CLA gate can read the `license/cla` commit status.
-  statuses: read
 
 concurrency:
   group: fork-ci-approval-backstop
@@ -135,6 +133,24 @@ concurrency:
 jobs:
   approve-stalled-fork-runs:
     runs-on: ubuntu-latest
+    # A job-level `permissions:` REPLACES the top-level set outright, it does not merge
+    # with it, so every scope this job touches has to be listed here -- dropping one that
+    # only appears above would fail the job, not inherit.
+    #
+    # This workflow has exactly ONE job, so the effective privilege of the run is entirely
+    # determined by this block and is identical to the top-level block it replaced. That is
+    # deliberate: a scoping change for Scorecard, not a capability change. If a second job
+    # is ever added here, it gets its OWN block -- do not promote this one back up.
+    permissions:
+      # `actions/checkout`, so the invariant scanner below reads the default-branch tree.
+      contents: read
+      # The only elevated scope. Required by the "Approve a workflow run for a fork pull
+      # request" endpoint, and it also covers listing a head SHA's `action_required` runs.
+      actions: write
+      # Read-only, to drive the loop from the open pull requests via `gh pr list`.
+      pull-requests: read
+      # Read-only, and only so the CLA gate can read the `license/cla` commit status.
+      statuses: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
Raises the public OpenSSF Scorecard **Token-Permissions** check, currently a hard **0**, by clearing the repo's single top-level token-permission violation. Closes IRO-704.

## Effective privilege is unchanged — this is a scoping change, not a capability change

Scorecard scores *any* top-level write as a zero on Token-Permissions no matter how narrow it is; the same write at **job** scope only reduces the check. So the fix is purely where the block is declared.

`fork-ci-approval-backstop.yml` has **exactly one job**, `approve-stalled-fork-runs`. A job-level `permissions:` **replaces** the top-level set rather than merging with it, so the full set is restated on the job. With a single job, the effective privilege of the run is therefore identical. Resolved mechanically from both trees:

| | `actions` | `contents` | `pull-requests` | `statuses` |
|---|---|---|---|---|
| **before** (top-level) | `write` | `read` | `read` | `read` |
| **after** (job-level) | `write` | `read` | `read` | `read` |

Top-level after the move is `contents: read` only — **no write value**.

Nothing gains a scope, nothing loses one, and no step changes. The comment explaining *why* `actions: write` exists (the "Approve a workflow run for a fork pull request" endpoint requires it) moves down with the block rather than being deleted, plus a note not to promote it back up if a second job is ever added.

## Verification

This workflow approves untrusted fork CI runs, so it is a security boundary and a YAML restructure is exactly the input its own fail-closed scanner exists to catch.

1. **The workflow's own invariant scanner, run against the edited tree** — extracted verbatim from the edited file (not a transcribed copy) and executed from the repo root:

   `invariant holds across 22 workflows (12 pull_request-triggered): no pull_request_target, no non-GITHUB_TOKEN secrets, no secrets: inherit`

   Non-vacuous by its own guards: it scanned 22 workflows and saw 12 `pull_request`-triggered ones, so neither vacuity guard was the thing that passed it.

2. **Negative control** — a green from a scanner is only worth what a red proves. Re-ran the same scanner against a copy of the tree with the *new job block* deliberately mis-indented. It went **red**, correctly, on `unparseable, cannot prove it is safe`. The green in (1) is therefore load-bearing.

3. **Guardrails held** — the diff contains no `on:`, `schedule`, `cron`, `pull_request`, or scanner line. Trigger surface and fail-closed logic are untouched, and no scope was broadened.

4. **`actionlint`** clean.

5. **Live dry-run dispatch on this branch** (`-f dry_run=true`) to prove the `actions: write` API call still has scope at job level — a green *parse* is not proof. Result reported in a comment below.

## Scope note, checked and deliberately not acted on

A raw YAML sweep of all 22 workflows finds a *second* top-level write: `scan-scorecard.yml:37` `pull-requests: write`. It is **not** a Scorecard finding and is intentionally left alone — the live report's own `Token-Permissions` details enumerate every `topLevel` permission it evaluated and that line appears **nowhere**, not even as `Info`, because `pull-requests` is not one of the permissions Scorecard scores. `fork-ci-approval-backstop.yml:126` is the only `Warn: topLevel ... write` in the report and thus the whole gap. Flagging so nobody later "fixes" a non-finding.

## Expected outcome

Token-Permissions `0` → high single digits. Scorecard re-runs on a schedule, so **the badge will lag this merge by up to a week** — an unchanged badge immediately after merge is not a failure. Verify by re-fetching `api.securityscorecards.dev` and comparing the `Token-Permissions` **check** score, not the total.

## Review

`.github/workflows/**` is reviewer-gated and I cannot self-approve. @omerzamir — pinging you for the approving review once checks are green, per the issue.