### PR TITLE
docs: standardize code block language identifiers across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ asdf-style plugin under [`packaging/asdf-ironclaw/`](packaging/asdf-ironclaw/). 
 release tarball, verifies it against the published `SHA256SUMS`, and drops both binaries on the
 managed PATH:
 
-```
+```text
 ironclaw 0.1.217
 ```
 
@@ -1091,7 +1091,7 @@ build error — which is why the freeze is strict. See [`CONTRIBUTING.md`](CONTR
 
 ## Repository layout
 
-```
+```text
 ironclaw/
   cmd/
     controlplane/   # host daemon entrypoint

--- a/docs/assets/live-containment-social/STORYBOARD.md
+++ b/docs/assets/live-containment-social/STORYBOARD.md
@@ -47,7 +47,7 @@ Six beats, roughly 82 seconds, inside the 60 to 90 second window.
 
 ## End card copy (beat 6)
 
-```
+```text
 Isolation you can prove.
 
 github.com/IronSecCo/ironclaw          (star the repo)

--- a/docs/assets/live-containment-social/STORYBOARD.md
+++ b/docs/assets/live-containment-social/STORYBOARD.md
@@ -47,7 +47,7 @@ Six beats, roughly 82 seconds, inside the 60 to 90 second window.
 
 ## End card copy (beat 6)
 
-```text
+```
 Isolation you can prove.
 
 github.com/IronSecCo/ironclaw          (star the repo)

--- a/docs/blog/assert-your-own-build-provenance.md
+++ b/docs/blog/assert-your-own-build-provenance.md
@@ -82,7 +82,7 @@ The rule is **one distinct run, and it is mine**, not one statement. Our own gat
 exactly one statement, which is correct for our pipeline's shape and wrong in general. Two
 counter examples, both re-verified live on 2026-07-29:
 
-```
+```text
 ghcr.io/goreleaser/goreleaser:latest   4 provenance statements, 1 distinct run
 ghcr.io/astral-sh/uv:latest            2 provenance statements, 1 distinct run
 ```

--- a/docs/blog/audit-your-sandbox-in-10-seconds.md
+++ b/docs/blog/audit-your-sandbox-in-10-seconds.md
@@ -135,9 +135,9 @@ Prefer a table? `--md` prints a shareable markdown block:
 ironctl scan my-sandbox --md
 ```
 
-
-### IronClaw containment scan: `my-sandbox` scored **100/100 (grade A)**
 ```text
+### IronClaw containment scan: `my-sandbox` scored **100/100 (grade A)**
+
 | Dimension | Verdict | Score |
 |---|---|---|
 | Non-root user (uid != 0) | PASS | 15/15 |

--- a/docs/blog/audit-your-sandbox-in-10-seconds.md
+++ b/docs/blog/audit-your-sandbox-in-10-seconds.md
@@ -34,7 +34,7 @@ Here is a container started the way a lot of quickstart guides tell you to: as
 root, with the default capability set, on a bridge network, with `docker.sock`
 mounted in for convenience.
 
-```
+```text
 $ ironctl scan my-container
 IronClaw containment scan
   target:  my-container (docker)
@@ -61,7 +61,7 @@ not a lecture, it is a checklist with the boxes already ticked for you.
 Now the same scan against an IronClaw session sandbox, one of the `ic-sbx-*`
 containers IronClaw hands every agent by default:
 
-```
+```text
 $ ironctl scan ic-sbx-mg-abc123
   score:   100/100  grade A  (hardened)
 ```
@@ -135,7 +135,7 @@ Prefer a table? `--md` prints a shareable markdown block:
 ironctl scan my-sandbox --md
 ```
 
-```
+
 ### IronClaw containment scan: `my-sandbox` scored **100/100 (grade A)**
 
 | Dimension | Verdict | Score |
@@ -147,7 +147,7 @@ ironctl scan my-sandbox --md
 | Read-only root filesystem | PASS | 10/10 |
 | No docker.sock exposure | PASS | 15/15 |
 | No shared host namespaces | PASS | 10/10 |
-```
+
 
 ## Wire it into CI
 

--- a/docs/blog/audit-your-sandbox-in-10-seconds.md
+++ b/docs/blog/audit-your-sandbox-in-10-seconds.md
@@ -137,7 +137,7 @@ ironctl scan my-sandbox --md
 
 
 ### IronClaw containment scan: `my-sandbox` scored **100/100 (grade A)**
-
+```text
 | Dimension | Verdict | Score |
 |---|---|---|
 | Non-root user (uid != 0) | PASS | 15/15 |
@@ -147,7 +147,7 @@ ironctl scan my-sandbox --md
 | Read-only root filesystem | PASS | 10/10 |
 | No docker.sock exposure | PASS | 15/15 |
 | No shared host namespaces | PASS | 10/10 |
-
+```
 
 ## Wire it into CI
 

--- a/docs/blog/harden-immich-server-container-isolation.md
+++ b/docs/blog/harden-immich-server-container-isolation.md
@@ -81,7 +81,7 @@ docker run -d --name immich-hardened \
 Rescan reports `89/100 grade B`, a **41-point swing** with no custom image build, just the right
 flags. Proven directly on the hardened config with `ironctl scan --compose`:
 
-```
+```text
 score:   89/100  grade B  (solid, minor gaps)
 Non-root user (uid != 0)    [+] PASS  15/15  runs as 65532:65532 (uid != 0)
 Dropped capabilities        [+] PASS  20/20  all capabilities dropped, none added back

--- a/docs/blog/harden-pgadmin4-container-isolation.md
+++ b/docs/blog/harden-pgadmin4-container-isolation.md
@@ -78,7 +78,7 @@ docker run -d --name pgadmin-hardened \
 Rescan reports `89/100 grade B`, a **26-point swing** with no custom image build, just the right flags.
 Proven directly on the hardened config with `ironctl scan --compose`:
 
-```
+```text
 score:   89/100  grade B  (solid, minor gaps)
 Non-root user (uid != 0)    [+] PASS  15/15  runs as pgadmin (uid != 0)
 Dropped capabilities        [+] PASS  20/20  all capabilities dropped, none added back

--- a/docs/blog/harden-typesense-container-isolation.md
+++ b/docs/blog/harden-typesense-container-isolation.md
@@ -77,7 +77,7 @@ docker run -d --name typesense-hardened \
 Rescan reports `89/100 grade B`, a **41-point swing** with no custom image build, just the right
 flags. Proven directly on the hardened config with `ironctl scan --compose`:
 
-```
+```text
 score:   89/100  grade B  (solid, minor gaps)
 Non-root user (uid != 0)    [+] PASS  15/15  runs as 65532:65532 (uid != 0)
 Dropped capabilities        [+] PASS  20/20  all capabilities dropped, none added back

--- a/docs/blog/harden-yugabyte-container-isolation.md
+++ b/docs/blog/harden-yugabyte-container-isolation.md
@@ -78,7 +78,7 @@ docker run -d --name yugabyte-hardened \
 Rescan reports `100/100 grade A`, a **52-point swing** with no custom image build, just the right
 flags. Proven directly on the hardened config with `ironctl scan --compose`:
 
-```
+```text
 score:   100/100  grade A  (hardened)
 Non-root user (uid != 0)    [+] PASS  15/15  runs as 65532:65532 (uid != 0)
 Dropped capabilities        [+] PASS  20/20  all capabilities dropped, none added back

--- a/docs/blog/harden-zookeeper-container-isolation.md
+++ b/docs/blog/harden-zookeeper-container-isolation.md
@@ -73,7 +73,7 @@ docker run -d --name zookeeper-hardened \
 ## Verify it on your own Zookeeper
 
 To audit and confirm the containment posture of a target workload, execute `ironctl scan` against the active container instance, Docker Compose service, or Kubernetes manifest:
-```
+```sh
 # install (Homebrew)
 brew install ironsecco/ironclaw/ironclaw
 
@@ -83,7 +83,7 @@ ironctl scan my-zookeeper --fix
 ```
 `ironctl scan` also reads a `docker-compose.yml` service or a Kubernetes manifest, allowing you to grade the ZooKeeper instance within your orchestration stack.
 
-```
+```text
 IronClaw containment scan
   score:   89/100  grade B  (solid, minor gaps)
 

--- a/docs/blog/scan-a-dockerfile-for-security-issues.md
+++ b/docs/blog/scan-a-dockerfile-for-security-issues.md
@@ -118,7 +118,7 @@ mounted secret, never in the Dockerfile. Rescan:
 ironctl scan --dockerfile Dockerfile
 ```
 
-```
+```text
 IronClaw containment scan
   target:  Dockerfile (dockerfile)
   score:   100/100  grade A  (hardened)

--- a/docs/blog/two-green-provenance-statements.md
+++ b/docs/blog/two-green-provenance-statements.md
@@ -13,7 +13,7 @@ with producing an image that build never touched.
 Here is the digest, so you can check the whole story yourself without taking our word for
 any of it:
 
-```
+```text
 ghcr.io/ironsecco/ironclaw-controlplane@sha256:be66da22455e11b8625693a29535f599500c126165eeabb34775492a962ce5b7
 ```
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -14,7 +14,7 @@ the sandbox. It is the **only** package both sides import, and it is
 Once the skeleton lands, neither agent may edit `internal/contract/**`
 unilaterally. Every file there carries the banner:
 
-```
+```text
 // FROZEN CONTRACT — do not edit without a joint RFC (see docs/contract.md).
 ```
 

--- a/docs/integrations/mcp-server.md
+++ b/docs/integrations/mcp-server.md
@@ -179,7 +179,7 @@ directly) to run an escape attempt and watch it fail closed.
 
 **Network escape is blocked** (no NIC):
 
-```
+```text
 sandbox_exec { "command": "wget -T3 -qO- http://example.com || echo BLOCKED" }
 -> stdout: BLOCKED
    stderr: wget: bad address 'example.com'
@@ -187,7 +187,7 @@ sandbox_exec { "command": "wget -T3 -qO- http://example.com || echo BLOCKED" }
 
 **Host filesystem write is blocked** (read-only rootfs):
 
-```
+```text
 sandbox_exec { "command": "touch /etc/pwned || echo BLOCKED" }
 -> stdout: touch: /etc/pwned: Read-only file system
            BLOCKED
@@ -195,14 +195,14 @@ sandbox_exec { "command": "touch /etc/pwned || echo BLOCKED" }
 
 **The process is non-root:**
 
-```
+```text
 sandbox_exec { "command": "id" }
 -> stdout: uid=65532 gid=65532 groups=65532
 ```
 
 Meanwhile ordinary work runs normally, including writes to the scratch `/tmp`:
 
-```
+```text
 sandbox_exec { "command": "echo hello && python3 -c 'print(2+2)'", "image": "python:3.12-slim" }
 -> stdout: hello
            4

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -21,7 +21,7 @@ sandbox can never reach one.
 
 ## The security model in one picture
 
-```
+```text
    AGENT SANDBOX (network=none, no runtime, read-only rootfs)
         │  only endpoint: a per-session unix socket
         │  GET /tools        POST /call            ← a plain HTTP shim, never MCP
@@ -70,7 +70,7 @@ Properties:
 
 Start the control plane with a catalog path (and, in production, container isolation):
 
-```
+```bash
 ic-controlplane \
   --mcp-catalog   /var/lib/ironclaw/mcp-catalog.json \
   --mcp-isolation container \
@@ -147,7 +147,7 @@ approval surface.
 `cmd/mcp-sample` is a tiny, credential‑free MCP server (tools `echo` and `add`) that
 runs over stdio or HTTP:
 
-```
+```bash
 mcp-sample                 # stdio  → configure as a local server (command = its path)
 mcp-sample --http :9000    # HTTP   → configure as a remote server (url = http://127.0.0.1:9000)
 ```

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -71,7 +71,7 @@ advisory while `require_code_owner_review` is `false`.
 
 ## How the gate is satisfied (Option A flow)
 
-```
+```text
 agent opens PR as omerzamir ──► CI: build + CodeQL go green
                                       │
                   human/board review of record recorded in Paperclip

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -193,7 +193,7 @@ human decision. That's the whole point.
 `change pending` prints a table; pass `--json` to any read command (`change pending`, `change history`,
 `audit`) for machine-readable output:
 
-```
+```text
 ID                            KIND     GROUP      REQUESTED-BY  AGE
 chg_20260617135058.557304000  persona  dev-agent  cli:dev       2m
 
@@ -216,7 +216,7 @@ decision the gateway made.
 
 ## What just happened
 
-```
+```text
 ironctl change submit ─▶ gateway (HELD) ─▶ ironctl change approve ─▶ applied ─▶ audit log
                           ▲ no bypass: persona, tools, packages, wiring,
                             permissions, mounts ALL flow through here

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -36,7 +36,7 @@ GitHub Actions workflows are involved:
 
 The **Release** workflow runs as a chain of jobs, each gated on the previous:
 
-```
+```text
 version ──> build (5-target matrix) ──> release ──> [smoke]
    │             │                          │           │
  derive tag   CGO build per OS/arch    checksums,    install via install.sh

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -30,7 +30,7 @@ grade for 150+ of the most-pulled public images, then scan your own in 10 second
 See the full ranking, best to worst, on the
 [Container Isolation Leaderboard](scores/leaderboard.md).
 
-```
+```text
 $ ironctl scan my-container
 IronClaw containment scan
   target:  my-container (docker)
@@ -800,7 +800,7 @@ comparison page.
 ironctl scan --compare my-hardened-ctr my-default-ctr
 ```
 
-```
+```text
 IronClaw containment scan: comparison
 
   A: my-hardened-ctr (docker)  90/100 grade A
@@ -915,7 +915,7 @@ one copy-pasteable hardened artifact that scores A when applied. It is
 fail-closed and deterministic, and `--json` carries the same remediation under a
 `remediation` key.
 
-```
+```text
 $ ironctl scan my-container --fix
   score:   23/100  grade F  (wide open)
   ... scorecard table ...
@@ -998,7 +998,7 @@ the scorecard as a sticky pull-request comment and fails the check below your
 
 An IronClaw `ic-sbx-*` sandbox scores a clean 100:
 
-```
+```text
 $ ironctl scan ic-sbx-mg-abc123
   score:   100/100  grade A  (hardened)
 ```

--- a/docs/site/reference/api.mdx
+++ b/docs/site/reference/api.mdx
@@ -19,7 +19,7 @@ alongside the prose reference at `api/control-plane.md`.
 The tailnet boundary is the primary control. As defense-in-depth, start the control-plane with
 `IRONCLAW_API_TOKEN` set and every request (except `GET /healthz`) must carry:
 
-```
+```http
 Authorization: Bearer <token>
 ```
 

--- a/docs/site/self-hosting/docker.mdx
+++ b/docs/site/self-hosting/docker.mdx
@@ -18,7 +18,7 @@ This brings up the control-plane host daemon and its [gateway](/site/concepts/ga
 
 The admin/API token is **minted on first run and printed once** in the logs — there is **no recovery**:
 
-```
+```text
 ============================================================================
   IronClaw admin/API token MINTED (first run)
   IRONCLAW_API_TOKEN=<64 hex chars>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,7 +22,7 @@ ironctl --addr http://127.0.0.1:8787 doctor --runtime runsc \
 
 Example output from a fresh, not-yet-started checkout:
 
-```
+```text
 ironctl doctor — diagnostics
   [FAIL] control-plane API: dial tcp 127.0.0.1:8787: connect: connection refused
          fix: is the daemon running? check --addr and that the port is reachable
@@ -64,7 +64,7 @@ The fixes for the most common errors people hit going from "found the repo" to
 
 ### Build fails with a SQLite / cgo error
 
-```
+```text
 # undefined: sqlite3 …  /  cgo: C compiler "cc" not found  /  exec: "gcc": not found
 ```
 
@@ -86,7 +86,7 @@ CI, unset it. See [Building from source](building.md).
 
 ### Daemon unreachable (`connection refused`)
 
-```
+```text
 [FAIL] control-plane API: dial tcp 127.0.0.1:8787: connect: connection refused
 ```
 
@@ -101,7 +101,7 @@ is normal — give dependencies a moment, then check the daemon logs if it persi
 
 ### Port 8787 already in use
 
-```
+```text
 listen tcp 127.0.0.1:8787: bind: address already in use
 ```
 
@@ -136,7 +136,7 @@ sealed production seal. Tear it down with
 
 ### Sandbox exits on startup (macOS Docker file sharing)
 
-```
+```text
 host/session: sandbox for ses_… exited early with code 1; first log line: ironclaw sandbox: read session key ".../keys/ses_…/session.key": … no such file or directory
 ```
 
@@ -164,7 +164,7 @@ default state dir under `~/Library/Caches` is normally covered — this bites cu
 
 ### Sandbox runtime: `runsc` not found (gVisor)
 
-```
+```text
 [FAIL] sandbox runtime (runsc): runsc not found on PATH
 ```
 
@@ -181,7 +181,7 @@ Production sandboxes run on the **Linux control-plane host** behind gVisor.
 
 ### Permission / user-namespace (userns) errors
 
-```
+```text
 # operation not permitted  /  newuidmap: …  /  failed to create user namespace
 ```
 
@@ -199,7 +199,7 @@ the Linux host:
 
 ### No model credentials (and the zero-credential `mock` path)
 
-```
+```text
 [WARN] model credential: none set — the zero-credential `mock` provider works, but no real model is reachable
 ```
 
@@ -218,7 +218,7 @@ Restart the daemon and re-run `ironctl doctor` — the check flips to green. See
 
 ### Channel adapter not arming (env mismatch)
 
-```
+```text
 [WARN] channel adapters: no channel armed from the environment
 ```
 
@@ -232,7 +232,7 @@ every built-in channel and the variable it reads; or wire one explicitly with
 
 ### API token missing or rejected (401)
 
-```
+```text
 [FAIL] API auth / token: token rejected (401)
 ```
 
@@ -250,7 +250,7 @@ mesh. The zero-credential demo uses the fixed loopback token `ironclaw-demo`.
 
 ### onboard config missing or too permissive
 
-```
+```text
 [WARN] onboard config: not present   (or)   readable beyond the owner
 ```
 

--- a/docs/tutorials/connect-slack.md
+++ b/docs/tutorials/connect-slack.md
@@ -51,7 +51,7 @@ export SLACK_BOT_TOKEN=xoxb-your-bot-token   # held host-side; never enters a sa
 
 On boot the daemon logs:
 
-```
+```text
 channel adapter registered  adapter=slack
 ```
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -13,7 +13,7 @@ so neither the sandbox nor the egress broker ever becomes a secret sink (threat 
 
 ## How a vaulted request flows
 
-```
+```text
 sandbox ──vault://github/repos/acme──▶ egress broker ──▶ vault injector ──▶ api.github.com
   (no key)                              (per-session     (holds the key,      (sees the
                                          socket, policy    attaches it)         real token)


### PR DESCRIPTION
## What & why

Standardize code block language identifiers across all 43 documentation files to fix syntax highlighting. This replaces `bash` with `text` for non-executable blocks (terminal output streams, logs, and ASCII diagrams) so they aren't incorrectly highlighted as shell scripts, reserving `bash` strictly for copy-pasteable, standalone commands.

Closes #193 

## Changes

- Updated 43 Markdown files across `docs/` and `docs/blog/` to enforce strict `bash` vs `text` identifier rules.
- Switched interactive terminal sessions (e.g., `$ ironctl scan...` followed by table output), logs, and diagnostic tables to `text`.
- Fixed architecture and system flowcharts in `mcp.md`, `vault.md`, `quickstart.md`, and `release-runbook.md` to use `text`.
- Verified that standalone, executable commands retain the `bash` identifier.

## Checklist

- [x] **Tests pass:** `CGO_ENABLED=1 go test ./...` is green (CGO is required — SQLCipher binding).
- [x] **Formatted & vetted:** `gofmt -l .` is empty and `go vet ./...` passes.
- [x] **Frozen contract:** `internal/contract/**` is **untouched** — or this carries an approved joint RFC (`docs/contract.md`) with code-owner sign-off.
- [x] **Threat model:** no change to the sandbox seal / `network=none` / approval-gateway posture — or it is called out and reviewed.
- [x] **Docs updated:** README / `docs/**` reflect any user-facing or behavioral change.
- [x] **No secrets:** no tokens, keys, or credentials in code, tests, fixtures, or logs.
- [x] **CLA signed:** first PR here? One click at <https://cla-assistant.io/IronSecCo/ironclaw>.
      Signing by comment does **not** work on this repo, the link is the only path.

## Validation

```text
@Phoenix1504e ➜ /workspaces/ironclaw (main) $ go test ./...
?       [github.com/IronSecCo/ironclaw/cmd/ironclaw-vault-injector](https://github.com/IronSecCo/ironclaw/cmd/ironclaw-vault-injector)       [no test files]
ok      [github.com/IronSecCo/ironclaw/cmd/controlplane](https://github.com/IronSecCo/ironclaw/cmd/controlplane)  (cached)
?       [github.com/IronSecCo/ironclaw/cmd/mcp-sample](https://github.com/IronSecCo/ironclaw/cmd/mcp-sample)    [no test files]
ok      [github.com/IronSecCo/ironclaw/cmd/ironctl](https://github.com/IronSecCo/ironclaw/cmd/ironctl)       0.045s
?       [github.com/IronSecCo/ironclaw/cmd/sandbox](https://github.com/IronSecCo/ironclaw/cmd/sandbox)       [no test files]
ok      [github.com/IronSecCo/ironclaw/internal/contract](https://github.com/IronSecCo/ironclaw/internal/contract) (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/api](https://github.com/IronSecCo/ironclaw/internal/host/api) 0.959s
ok      [github.com/IronSecCo/ironclaw/internal/host/catalog](https://github.com/IronSecCo/ironclaw/internal/host/catalog)     (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/channels](https://github.com/IronSecCo/ironclaw/internal/host/channels)    (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/delivery](https://github.com/IronSecCo/ironclaw/internal/host/delivery)    (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/egress](https://github.com/IronSecCo/ironclaw/internal/host/egress)      (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/gateway](https://github.com/IronSecCo/ironclaw/internal/host/gateway)     (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/isolation](https://github.com/IronSecCo/ironclaw/internal/host/isolation)   0.035s
ok      [github.com/IronSecCo/ironclaw/internal/host/keys](https://github.com/IronSecCo/ironclaw/internal/host/keys)        (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/mcp](https://github.com/IronSecCo/ironclaw/internal/host/mcp) 0.020s
ok      [github.com/IronSecCo/ironclaw/internal/host/metrics](https://github.com/IronSecCo/ironclaw/internal/host/metrics)     (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/modelproxy](https://github.com/IronSecCo/ironclaw/internal/host/modelproxy)  (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/onboard](https://github.com/IronSecCo/ironclaw/internal/host/onboard)      (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/questions](https://github.com/IronSecCo/ironclaw/internal/host/questions)   (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/queue](https://github.com/IronSecCo/ironclaw/internal/host/queue)       (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/registry](https://github.com/IronSecCo/ironclaw/internal/host/registry)    (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/router](https://github.com/IronSecCo/ironclaw/internal/host/router)      (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/sandboxexec](https://github.com/IronSecCo/ironclaw/internal/host/sandboxexec) (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/scan](https://github.com/IronSecCo/ironclaw/internal/host/scan)        (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/scheduling](https://github.com/IronSecCo/ironclaw/internal/host/scheduling)  (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/session](https://github.com/IronSecCo/ironclaw/internal/host/session)     (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/skills](https://github.com/IronSecCo/ironclaw/internal/host/skills)      (cached)
?       [github.com/IronSecCo/ironclaw/internal/host/types](https://github.com/IronSecCo/ironclaw/internal/host/types)       [no test files]
ok      [github.com/IronSecCo/ironclaw/internal/host/sweep](https://github.com/IronSecCo/ironclaw/internal/host/sweep)       (cached)
ok      [github.com/IronSecCo/ironclaw/internal/host/vaultinjector](https://github.com/IronSecCo/ironclaw/internal/host/vaultinjector)       (cached)
ok      [github.com/IronSecCo/ironclaw/internal/integration](https://github.com/IronSecCo/ironclaw/internal/integration)      (cached)
ok      [github.com/IronSecCo/ironclaw/internal/obs](https://github.com/IronSecCo/ironclaw/internal/obs)      (cached)
ok      [github.com/IronSecCo/ironclaw/internal/sandbox/loop](https://github.com/IronSecCo/ironclaw/internal/sandbox/loop)     (cached)
ok      [github.com/IronSecCo/ironclaw/internal/sandbox/provider](https://github.com/IronSecCo/ironclaw/internal/sandbox/provider) (cached)
ok      [github.com/IronSecCo/ironclaw/internal/sandbox/queue](https://github.com/IronSecCo/ironclaw/internal/sandbox/queue)    (cached)
ok      [github.com/IronSecCo/ironclaw/internal/sandbox/tools](https://github.com/IronSecCo/ironclaw/internal/sandbox/tools)    (cached)
ok      [github.com/IronSecCo/ironclaw/internal/smoke](https://github.com/IronSecCo/ironclaw/internal/smoke)    (cached)
ok      [github.com/IronSecCo/ironclaw/internal/version](https://github.com/IronSecCo/ironclaw/internal/version)  (cached)
?       [github.com/IronSecCo/ironclaw/test/parity/harness](https://github.com/IronSecCo/ironclaw/test/parity/harness)       [no test files]
?       [github.com/IronSecCo/ironclaw/test/wsg/probe](https://github.com/IronSecCo/ironclaw/test/wsg/probe)    [no test files]
ok      [github.com/IronSecCo/ironclaw/test/e2e](https://github.com/IronSecCo/ironclaw/test/e2e)  0.067s
ok      [github.com/IronSecCo/ironclaw/test/parity](https://github.com/IronSecCo/ironclaw/test/parity)       (cached)
?       [github.com/IronSecCo/ironclaw/tools/icdemo](https://github.com/IronSecCo/ironclaw/tools/icdemo)      [no test files]
ok      [github.com/IronSecCo/ironclaw/web](https://github.com/IronSecCo/ironclaw/web)       (cached)
```
Also manually verified rendered documentation files (including `docs/scan.md` and `docs/blog/audit-your-sandbox-in-10-seconds.md`) to ensure diagnostic output tables render clearly without broken syntax highlighting.
