### PR TITLE
ci(docs): catch a deleted markdown code fence, which balance alone cannot [IRO-707]

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ on:
       - "scripts/check_links.py"
       - "scripts/check-guide-index.py"
       - "scripts/check-guide-uid.py"
+      - "scripts/check-md-fences.py"
       # check-guide-uid.py reads `hardenedUID` out of this file, so a change to
       # the constant has to trigger this workflow too. Without it, moving the
       # constant would leave 56 guides quoting the old uid and nothing in CI
@@ -37,6 +38,7 @@ on:
       - "scripts/check_links.py"
       - "scripts/check-guide-index.py"
       - "scripts/check-guide-uid.py"
+      - "scripts/check-md-fences.py"
       # check-guide-uid.py reads `hardenedUID` out of this file, so a change to
       # the constant has to trigger this workflow too. Without it, moving the
       # constant would leave 56 guides quoting the old uid and nothing in CI
@@ -67,6 +69,25 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+
+      - name: Check markdown code fences are intact
+        # Nothing else in CI reads markdown *structure*. PR #656 proved the cost:
+        # it deleted the two fences wrapping the sample `ironctl scan --md`
+        # output in docs/blog/audit-your-sandbox-in-10-seconds.md, and all 17
+        # checks went green while the page started rendering that literal sample
+        # as a real `###` heading (which entered the nav) and a real table.
+        # `mkdocs build --strict` does not care, and neither does anything below.
+        #
+        # Two rules: an unclosed fence, and -- the one that actually catches
+        # #656, which left the file perfectly balanced -- a two-blank run outside
+        # a fenced block, which is the trace a *deleted* fence leaves behind.
+        # A step in `build` for the same reason as the checks around it: `build`
+        # is the required check on ruleset 17917971 and a new job name would not
+        # be. Stdlib only, so it runs before the toolchain install and fails
+        # fast. Negative controls: scripts/tests/test_check_md_fences.py (run by
+        # ci.yml script-tests), including a fixture of #656's exact pre-fix bytes
+        # and an assertion that a balance-only guard is green on it. See IRO-707.
+        run: python3 scripts/check-md-fences.py
 
       - name: Check root Markdown links and anchor fragments
         # Root Markdown (README.md, CONTRIBUTING.md, SECURITY.md, ...) is not part

--- a/docs/bring-your-own-model.md
+++ b/docs/bring-your-own-model.md
@@ -13,7 +13,6 @@ IronClaw speaks the OpenAI-compatible API shape, so the model is a config choice
 
 > IronClaw ships more backends than the three below. Eleven are registered today: Anthropic, OpenAI, OpenRouter, Codex, Gemini, Vertex AI, AWS Bedrock, Azure OpenAI, Ollama, a generic OpenAI-compatible `local` endpoint, and a credential-free `mock` provider. For the full list with an auth-and-streaming comparison and a short decision guide, see [Choose your model provider](providers/index.md).
 
-
 And because of how the runtime is built, **your model key never enters the agent sandbox**. Model calls are
 brokered host-side. Bringing your own model doesn't mean trusting the box with your credential.
 

--- a/scripts/check-md-fences.py
+++ b/scripts/check-md-fences.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Fail the docs build when a markdown code fence is broken.
+
+Nothing in CI reads markdown *structure*. PR #656 ("standardize code block
+language identifiers") proved what that costs: it annotated 44 fences correctly
+and, in ``docs/blog/audit-your-sandbox-in-10-seconds.md``, *deleted* the two
+that wrapped the sample ``ironctl scan --md`` output instead of annotating them.
+All 17 checks went green -- CodeQL, build, race, fuzz, wsg-verify,
+sandbox-containment -- while the page silently started rendering the literal
+sample text as a real ``###`` heading (which entered the page nav) and a real
+table. A human reading the diff caught it. See IRO-707.
+
+Two rules, and the second one is the interesting one:
+
+``unclosed fence``
+    An opening fence with no matching close before EOF. The textbook breakage,
+    and the one every "fence guard" gets right. It is also the one that would
+    *not* have caught #656: both fences were removed, so the file stayed
+    perfectly balanced.
+
+``stray blank line``
+    Two or more consecutive blank lines outside a fenced block. This is the rule
+    that catches a *deleted* fence. A fence line is conventionally preceded (if
+    opening) or followed (if closing) by a blank line, so blanking one out --
+    exactly what a botched fence edit does -- merges it into its neighbour and
+    leaves a two-blank run where a fence used to be. On #656's head this fires
+    on precisely the two damaged lines, 138 and 151, and nowhere else in the
+    repo. It is deliberately a whitespace rule in service of a structural one:
+    a deleted line leaves no other trace to assert on.
+
+Known limitation: a fence indented inside a list item is often written with no
+blank line around it, so deleting *that* kind of fence leaves no double-blank
+and this check cannot see it. Requiring blank lines around every fence would
+flag six legitimate list-embedded fences in docs/providers/ollama.md and
+docs/pr-review-process.md, and a check that pressures authors into breaking
+valid list markup is worse than a documented gap.
+
+Not asserted here, on purpose: *bare* (untagged) opening fences. That is a good
+invariant and would be a third rule, but ``main`` carries 48 of them today; #656
+is the PR that tags 45. Turning it on now would mean either failing on main or
+shipping a suppression list. It becomes enforceable in a follow-up once #656
+lands and the last three sites are tagged. See IRO-707.
+
+``CODE_OF_CONDUCT.md`` is excluded: it is a verbatim copy of the Contributor
+Covenant, third-party licensed text we do not get to reformat, and it carries
+seven double-blank runs of its own.
+
+Usage:
+
+    python3 scripts/check-md-fences.py [repo-root]
+
+Exits 0 when every scanned file is clean, 1 on any finding, and 2 on a
+usage/IO/vacuity error. Negative controls: scripts/tests/test_check_md_fences.py.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Every markdown surface a reader can reach. docs/site/**.mdx and
+# docs/assets/**/*.md are excluded from the MkDocs build by `exclude_docs`, but
+# a broken fence there is still a broken fence, so they are scanned too.
+PATTERNS = ("docs/**/*.md", "docs/**/*.mdx", "*.md")
+
+# Verbatim third-party licensed text; reformatting it is not ours to do.
+EXCLUDED = frozenset({Path("CODE_OF_CONDUCT.md")})
+
+# CommonMark: a fence is 3+ backticks or tildes, indented by at most 3 spaces.
+FENCE = re.compile(r"^ {0,3}(?P<delim>`{3,}|~{3,})(?P<info>.*)$")
+
+
+class Finding:
+    """One rule violation, carrying the file:line it must be reported at."""
+
+    def __init__(self, path: Path, line: int, message: str) -> None:
+        self.path = path
+        self.line = line
+        self.message = message
+
+
+def check_text(rel: Path, text: str) -> tuple[list[Finding], int]:
+    """Apply both rules to one file, returning findings and the fences seen."""
+    lines = text.split("\n")
+    # split() on a trailing newline yields a phantom final "" that is EOF, not a
+    # line. Dropping it keeps line numbers honest and stops every well-formed
+    # file from reporting a trailing blank.
+    if lines and lines[-1] == "":
+        lines.pop()
+
+    findings: list[Finding] = []
+    fences = 0
+    open_delim: str | None = None
+    open_line = 0
+    prev_blank = True  # start-of-file behaves like a blank for run detection
+
+    for lineno, line in enumerate(lines, start=1):
+        match = FENCE.match(line)
+        if match:
+            delim = match.group("delim")
+            info = match.group("info").strip()
+            if open_delim is None:
+                # A backtick fence's info string may not contain a backtick, so
+                # this is an inline code span (`` ```x`` ``), not a fence.
+                if delim[0] == "`" and "`" in info:
+                    prev_blank = False
+                    continue
+                open_delim, open_line = delim, lineno
+                fences += 1
+                prev_blank = False
+                continue
+            # A closing fence matches the opening delimiter, is at least as
+            # long, and carries no info string. Anything else is block content.
+            if delim[0] == open_delim[0] and len(delim) >= len(open_delim) and not info:
+                open_delim = None
+                prev_blank = False
+                continue
+
+        if open_delim is not None:
+            # Inside a fenced block: blank lines are content (Go and Python both
+            # use double blanks between declarations), so no rule applies.
+            continue
+
+        blank = line.strip() == ""
+        if blank and prev_blank and lineno > 1:
+            findings.append(
+                Finding(
+                    rel,
+                    lineno,
+                    "stray blank line: two consecutive blank lines outside a code "
+                    "block. A deleted fence leaves exactly this signature -- check "
+                    "whether a ``` opening or closing this block was removed",
+                )
+            )
+        prev_blank = blank
+
+    if open_delim is not None:
+        findings.append(
+            Finding(
+                rel,
+                open_line,
+                f"unclosed code fence: `{open_delim}` opens a block that never "
+                "closes before end of file. If this block's closing fence was "
+                "given a language tag, remove the tag -- a closing fence takes no "
+                "info string and is read as a new opening fence",
+            )
+        )
+
+    return findings, fences
+
+
+def collect(root: Path) -> list[Path]:
+    """Every in-scope markdown path, relative to the repo root, deduplicated."""
+    seen: set[Path] = set()
+    for pattern in PATTERNS:
+        for path in root.glob(pattern):
+            rel = path.relative_to(root)
+            if rel not in EXCLUDED and path.is_file():
+                seen.add(rel)
+    return sorted(seen)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 2:
+        print(f"usage: {argv[0]} [repo-root]", file=sys.stderr)
+        return 2
+    root = Path(argv[1]) if len(argv) == 2 else Path.cwd()
+
+    if not (root / "docs").is_dir():
+        print(f"::error::{root / 'docs'} is not a directory", file=sys.stderr)
+        return 2
+
+    paths = collect(root)
+    # A glob that matched nothing would report a green "all fences balanced"
+    # over an empty set. Refuse to be that check.
+    if not paths:
+        print(
+            f"::error::no markdown matched {' '.join(PATTERNS)} under {root}; "
+            "this check would pass vacuously",
+            file=sys.stderr,
+        )
+        return 2
+
+    findings: list[Finding] = []
+    fences = 0
+    for rel in paths:
+        try:
+            text = (root / rel).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"::error::cannot read {rel}: {exc}", file=sys.stderr)
+            return 2
+        file_findings, file_fences = check_text(rel, text)
+        findings.extend(file_findings)
+        fences += file_fences
+
+    if findings:
+        for finding in findings:
+            print(
+                f"::error file={finding.path},line={finding.line}::"
+                f"{finding.path}:{finding.line}: {finding.message}",
+                file=sys.stderr,
+            )
+        print(
+            f"\n{len(findings)} finding(s) across {len(paths)} markdown file(s).",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Name what was actually enumerated: "no failures" and "nothing was checked"
+    # have to be distinguishable in the log.
+    print(
+        f"ok: {len(paths)} markdown files, {fences} fenced blocks, "
+        "every block closed and no stray blank lines"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/tests/test_check_md_fences.py
+++ b/scripts/tests/test_check_md_fences.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check-md-fences.py (IRO-707).
+
+This checker's passing output is "exit 0", which is also what a checker that
+enumerates nothing produces. So most of what follows are negative controls: each
+builds a tree with a real fence defect and asserts the checker names the
+file:line, or builds a degenerate tree and asserts the checker refuses to call
+it green.
+
+The specific defect being pinned is the one IRO-707 was filed for: PR #656
+deleted the opening and closing fence around the sample `ironctl scan --md`
+output in docs/blog/audit-your-sandbox-in-10-seconds.md, leaving the file
+perfectly *balanced* while the literal sample text started rendering as a real
+heading and a real table. All 17 checks passed. The exact pre-fix byte pattern
+is reproduced in test_deleted_fence_pair_is_caught -- a balance-only guard
+passes on it, which is why the stray-blank-line rule exists.
+
+Run:
+    python3 -m unittest discover -s scripts/tests -v
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import tempfile
+import unittest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / 'check-md-fences.py'
+REPO_ROOT = SCRIPT.parent.parent
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location('check_md_fences', SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run(root: pathlib.Path):
+    """Run the checker against `root`, returning (exit code, stderr+stdout)."""
+    module = load_module()
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        code = module.main(['check-md-fences.py', str(root)])
+    return code, out.getvalue() + err.getvalue()
+
+
+def write(root: pathlib.Path, rel: str, body: str):
+    """Write one markdown file under `root`, creating parent directories."""
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding='utf-8')
+    return path
+
+
+def build_tree(root: pathlib.Path, body: str, rel: str = 'docs/page.md'):
+    """A minimal repo root: a docs/ directory holding one markdown file."""
+    (root / 'docs').mkdir(parents=True, exist_ok=True)
+    write(root, rel, body)
+
+
+# The bytes PR #656 produced, reduced to the two lines it damaged. Note that the
+# fence count is even and every remaining block closes: this is what a
+# balance-only checker sees as clean.
+DELETED_FENCE_PAIR = """# Audit your sandbox
+
+Prefer a table? `--md` prints a shareable markdown block:
+
+```bash
+ironctl scan my-sandbox --md
+```
+
+
+### IronClaw containment scan: `my-sandbox` scored **100/100 (grade A)**
+
+| Dimension | Verdict | Score |
+| --- | --- | --- |
+| Runs as non-root | PASS | 15/15 |
+
+
+## Wire it into CI
+"""
+
+# The same page with the two fences restored, exactly as the fix to #656 does.
+INTACT_FENCE_PAIR = DELETED_FENCE_PAIR.replace(
+    '```\n\n\n### IronClaw', '```\n\n```text\n### IronClaw'
+).replace('| PASS | 15/15 |\n\n\n## Wire', '| PASS | 15/15 |\n```\n\n## Wire')
+
+
+class DeletedFenceTest(unittest.TestCase):
+    """The IRO-707 defect itself: a *balanced* file with two fences removed."""
+
+    def test_deleted_fence_pair_is_caught(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, DELETED_FENCE_PAIR, 'docs/blog/audit.md')
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        # Both damaged sites, each named with its own line number.
+        self.assertIn('docs/blog/audit.md:9:', output)
+        self.assertIn('docs/blog/audit.md:16:', output)
+
+    def test_balance_alone_would_not_catch_it(self):
+        """Pins *why* the second rule exists, not just that it fires.
+
+        If this ever fails, the fixture stopped reproducing #656 and the test
+        above would be passing for the wrong reason.
+        """
+        module = load_module()
+        opens = 0
+        for line in DELETED_FENCE_PAIR.split('\n'):
+            if module.FENCE.match(line):
+                opens += 1
+        self.assertEqual(opens % 2, 0, 'fixture must be fence-balanced')
+
+    def test_restoring_the_fences_passes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, INTACT_FENCE_PAIR, 'docs/blog/audit.md')
+            code, output = run(root)
+        self.assertEqual(code, 0, output)
+
+
+class UnclosedFenceTest(unittest.TestCase):
+    def test_unclosed_fence_is_caught_at_the_opening_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\n```bash\nls\n\nand then some prose.\n')
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        self.assertIn('docs/page.md:3:', output)
+        self.assertIn('unclosed code fence', output)
+
+    def test_tagged_closing_fence_is_caught(self):
+        """A "standardize the fences" edit that tags the *closing* fence too.
+
+        ```text ... ```text reads as two openings, so the block never closes.
+        This is the sibling mistake to the one #656 made.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\n```text\nout\n```text\n\ndone.\n')
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        self.assertIn('unclosed code fence', output)
+
+    def test_tilde_fence_closes_a_tilde_fence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\n~~~text\nout\n~~~\n\ndone.\n')
+            code, output = run(root)
+        self.assertEqual(code, 0, output)
+
+    def test_longer_fence_nests_shorter_ones(self):
+        """A ````markdown block quoting ``` fences must not be misread."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(
+                root, '# t\n\n````markdown\n```bash\nls\n```\n````\n\ndone.\n'
+            )
+            code, output = run(root)
+        self.assertEqual(code, 0, output)
+
+
+class FalsePositiveTest(unittest.TestCase):
+    """The shapes a noisy version of this check would flag. All are legal."""
+
+    def test_blank_lines_inside_a_fence_are_content(self):
+        """Go and Python both put double blanks between declarations."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\n```go\nfunc a() {}\n\n\nfunc b() {}\n```\n')
+            code, output = run(root)
+        self.assertEqual(code, 0, output)
+
+    def test_inline_triple_backtick_span_is_not_a_fence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\nWrite ```` ``` ```` to open a block.\n')
+            code, output = run(root)
+        self.assertEqual(code, 0, output)
+
+    def test_bare_opening_fence_is_not_flagged_yet(self):
+        """Rule 3 is deliberately not shipped; main carries 48 bare fences.
+
+        This pins the decision so that turning it on is a visible change to this
+        test rather than a silent one. See the module docstring of the checker.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\n```\nsome output\n```\n')
+            code, output = run(root)
+        self.assertEqual(code, 0, output)
+
+    def test_single_trailing_newline_is_not_a_stray_blank(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\nprose.\n')
+            code, output = run(root)
+        self.assertEqual(code, 0, output)
+
+    def test_code_of_conduct_is_excluded(self):
+        """Verbatim Contributor Covenant text, seven double-blanks of its own."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\nprose.\n')
+            write(root, 'CODE_OF_CONDUCT.md', '# CoC\n\n\n## Scope\n\n\ntext.\n')
+            code, output = run(root)
+        self.assertEqual(code, 0, output)
+
+
+class ScopeTest(unittest.TestCase):
+    def test_root_readme_is_in_scope(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\nprose.\n')
+            write(root, 'README.md', '# r\n\n```bash\nls\n\nprose.\n')
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        self.assertIn('README.md:3:', output)
+
+    def test_mdx_under_docs_is_in_scope(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\nprose.\n')
+            write(root, 'docs/site/quickstart.mdx', '# q\n\n\nprose.\n')
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        self.assertIn('docs/site/quickstart.mdx:3:', output)
+
+    def test_empty_docs_tree_is_not_green(self):
+        """A glob that matches nothing must not report "all fences balanced"."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            (root / 'docs').mkdir()
+            code, output = run(root)
+        self.assertEqual(code, 2, output)
+        self.assertIn('vacuously', output)
+
+    def test_missing_docs_dir_is_a_usage_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            code, output = run(pathlib.Path(tmp))
+        self.assertEqual(code, 2, output)
+
+
+class RealRepoTest(unittest.TestCase):
+    def test_repo_is_clean(self):
+        """Acceptance criterion 1: the guard passes on the tree it ships in."""
+        code, output = run(REPO_ROOT)
+        self.assertEqual(code, 0, output)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Nothing in CI read markdown *structure*. PR #656 ("standardize code block language identifiers") is the proof: it annotated 44 fences correctly and, in `docs/blog/audit-your-sandbox-in-10-seconds.md`, **deleted** the pair wrapping the sample `ironctl scan --md` output instead of annotating them. All 17 checks went green - CodeQL, build, race, fuzz, wsg-verify, sandbox-containment - while the page silently began rendering that literal sample as a real `###` heading (which entered the page nav) and a real table. A human reading the diff caught it, not CI.

## The obvious rule does not catch it

Both fences were removed, so the file stayed perfectly **balanced**. An odd-delimiter-count check is green on #656 - measured, not assumed: `main` has 1351 fenced blocks and #656's head has 1350, with zero unclosed blocks on either side.

The rule that does catch it is a **stray blank line**. A fence is conventionally preceded (if opening) or followed (if closing) by a blank line, so blanking one out merges it into its neighbour and leaves a two-blank run where the fence used to be. On #656's head that fires on exactly lines 138 and 151 of that file and nowhere else in the repo.

## What is asserted

`scripts/check-md-fences.py`, over `docs/**/*.{md,mdx}` and root `*.md`:

1. **unclosed fence** - an opening fence with no matching close before EOF, reported at the *opening* line. The message calls out the closing-fence-was-tagged case by name, since ` ```text ... ```text ` is the sibling mistake to #656's.
2. **stray blank line** - two or more consecutive blank lines outside a fenced block. Blank lines *inside* a fence are content (Go and Python both put double blanks between declarations), so the rule is suppressed there.

Failures are `file:line` with a GitHub `::error file=,line=` annotation, so they land on the diff.

## Verification: all four arms run, not reasoned about

| tree | expected | result |
| --- | --- | --- |
| `main` + this PR | pass | `ok: 471 markdown files, 1351 fenced blocks` (exit 0) |
| merged `main` + **#656** | fail, naming the file | exit 1, exactly 2 findings: `audit-your-sandbox-in-10-seconds.md:138` and `:151` |
| merged `main` + #656, lines 138/150 restored to ` ```text ` / ` ``` ` | pass | exit 0 |
| merged `main` + #568 / #569 / #574 | pass | exit 0 on all three |

The last row is the false-positive control against older, unrelated open PRs - every open PR in the repo was swept, and only #656 goes red. The three merges are real `git merge` results, not `pull_request.base.sha` diffs (IRO-673): the guard scans *all* of `docs/`, so it has no base-ref to get wrong.

Runtime is 0.5s wall for the full 471-file scan.

## Deliberately not asserted: bare opening fences

A bare, untagged ` ``` ` opening fence is a good invariant and would be a natural third rule, but **`main` carries 48 of them** and #656 is the PR that tags 45. Turning it on now would mean either failing on `main` or shipping a suppression list. It becomes enforceable in a follow-up once #656 lands and the last three sites are tagged (`docs/assets/live-containment-social/STORYBOARD.md:50`, `docs/blog/scan-a-dockerfile-for-security-issues.md:51`, `docs/site/quickstart.mdx:101`). A test pins that decision so switching it on is a visible edit rather than a silent one.

Worth recording: the bare-fence rule would **not** have caught #656 either. On that head, `audit-your-sandbox-in-10-seconds.md` has zero bare opening fences - all three of its bare fences were correctly tagged, and the two that broke were *deleted*.

## Known gap, documented rather than papered over

A fence indented inside a list item is usually written with no blank line around it, so deleting one of *those* leaves no double-blank and this guard cannot see it. Requiring blanks around every fence would flag six legitimate list-embedded fences in `docs/providers/ollama.md` and `docs/pr-review-process.md`, and a check that pressures authors into breaking valid list markup is worse than a documented gap.

## Scope notes

- `CODE_OF_CONDUCT.md` is excluded: verbatim Contributor Covenant, third-party licensed text we do not get to reformat, and it carries seven double-blank runs of its own.
- The **one** genuine pre-existing finding on `main` was a single stray blank line in `docs/bring-your-own-model.md:16`. It is fixed here, in one line. That is the whole pre-existing backlog - stated rather than silently absorbed.
- `docs/blog/audit-your-sandbox-in-10-seconds.md` is **not** touched. #656 owns those lines.

## Wiring

A **step** in the docs `build` job, next to `check_links.py`, `check-guide-index.py` and `check-guide-uid.py`, for the reason they are all steps rather than jobs: `build` is the required status check on ruleset 17917971 and a new job name would not be. No ruleset or branch-protection change. Stdlib only, so it runs before the toolchain install and fails fast.

Because a new step does not change the job name, an already-open PR can show `build` green having never run it. That is why the step list was diffed against `main` and the guard was run against the **merged** trees above rather than trusted from a green check.

Negative controls in `scripts/tests/test_check_md_fences.py` (17 tests, run by `ci.yml` `script-tests`) include #656's exact pre-fix bytes **plus an assertion that a balance-only guard is green on that fixture**, so the positive control cannot rot into a test that passes for the wrong reason.