### PR TITLE
ci(docs): turn on the bare-opening-fence rule, held back since IRO-707 [IRO-710]

### DIFF
--- a/docs/assets/live-containment-social/STORYBOARD.md
+++ b/docs/assets/live-containment-social/STORYBOARD.md
@@ -47,7 +47,7 @@ Six beats, roughly 82 seconds, inside the 60 to 90 second window.
 
 ## End card copy (beat 6)
 
-```
+```text
 Isolation you can prove.
 
 github.com/IronSecCo/ironclaw          (star the repo)

--- a/docs/blog/scan-a-dockerfile-for-security-issues.md
+++ b/docs/blog/scan-a-dockerfile-for-security-issues.md
@@ -48,7 +48,7 @@ Scan it:
 ironctl scan --dockerfile Dockerfile
 ```
 
-```
+```text
 IronClaw containment scan
   target:  Dockerfile (dockerfile)
   score:   5/100  grade F  (wide open)

--- a/docs/site/quickstart.mdx
+++ b/docs/site/quickstart.mdx
@@ -98,7 +98,7 @@ decision the gateway made.
 
 ## What just happened
 
-```
+```text
 ironctl change submit ─▶ gateway (HELD) ─▶ ironctl change approve ─▶ applied ─▶ audit log
                           ▲ no bypass: persona, tools, packages, wiring,
                             permissions, mounts ALL flow through here

--- a/scripts/check-md-fences.py
+++ b/scripts/check-md-fences.py
@@ -10,7 +10,7 @@ sandbox-containment -- while the page silently started rendering the literal
 sample text as a real ``###`` heading (which entered the page nav) and a real
 table. A human reading the diff caught it. See IRO-707.
 
-Two rules, and the second one is the interesting one:
+Three rules, and the second one is the interesting one:
 
 ``unclosed fence``
     An opening fence with no matching close before EOF. The textbook breakage,
@@ -28,18 +28,40 @@ Two rules, and the second one is the interesting one:
     repo. It is deliberately a whitespace rule in service of a structural one:
     a deleted line leaves no other trace to assert on.
 
-Known limitation: a fence indented inside a list item is often written with no
-blank line around it, so deleting *that* kind of fence leaves no double-blank
-and this check cannot see it. Requiring blank lines around every fence would
-flag six legitimate list-embedded fences in docs/providers/ollama.md and
-docs/pr-review-process.md, and a check that pressures authors into breaking
-valid list markup is worse than a documented gap.
+``bare opening fence``
+    An opening fence with an empty info string. Untagged blocks lose syntax
+    highlighting, and they are also what a careless "standardize the fences"
+    sweep leaves behind, so the corpus staying tagged is what keeps the two
+    rules above reading a consistent shape.
 
-Not asserted here, on purpose: *bare* (untagged) opening fences. That is a good
-invariant and would be a third rule, but ``main`` carries 48 of them today; #656
-is the PR that tags 45. Turning it on now would mean either failing on main or
-shipping a suppression list. It becomes enforceable in a follow-up once #656
-lands and the last three sites are tagged. See IRO-707.
+    This rule is live, on by default, with no suppression list -- but it could
+    not ship with IRO-707. Immediately before #656 (``8c384e5``) the in-scope
+    corpus carried 48 bare openers, so turning it on then would have meant
+    either failing on main or shipping exactly the suppression list this rule
+    now does without. #656 tagged 45 of them across 22 files; the last three
+    (docs/assets/live-containment-social/STORYBOARD.md,
+    docs/blog/scan-a-dockerfile-for-security-issues.md, docs/site/quickstart.mdx)
+    were tagged in the commit that enabled this rule. See IRO-709 / IRO-710.
+
+    Only *opening* fences are checked. A bare ``` inside a longer ```` block is
+    block content, and the closing fence of any block is required to be bare --
+    both fall out of the parser below rather than needing a special case.
+
+Known limitation of the stray-blank-line rule: a fence indented inside a list
+item is often written with no blank line around it, so deleting *that* kind of
+fence leaves no double-blank and this check cannot see it. Requiring blank lines
+around every fence would flag six legitimate list-embedded fences in
+docs/providers/ollama.md and docs/pr-review-process.md, and a check that
+pressures authors into breaking valid list markup is worse than a documented
+gap.
+
+``PATTERNS`` is deliberately narrower than the repo. 540 markdown files exist;
+471 are in scope. The other 69 carry 33 bare openers of their own (20 under
+examples/integrations, 9 under community/, plus api/, packaging/, runbooks/).
+Widening the scope is a real proposal with a real diff attached, not a drive-by
+edit to the tuple below -- the rules here are only as trustworthy as the
+green they produce, and quietly growing the corpus is how a check starts
+getting suppressed.
 
 ``CODE_OF_CONDUCT.md`` is excluded: it is a verbatim copy of the Contributor
 Covenant, third-party licensed text we do not get to reformat, and it carries
@@ -81,7 +103,7 @@ class Finding:
 
 
 def check_text(rel: Path, text: str) -> tuple[list[Finding], int]:
-    """Apply both rules to one file, returning findings and the fences seen."""
+    """Apply all three rules to one file, returning findings and fences seen."""
     lines = text.split("\n")
     # split() on a trailing newline yields a phantom final "" that is EOF, not a
     # line. Dropping it keeps line numbers honest and stops every well-formed
@@ -109,6 +131,18 @@ def check_text(rel: Path, text: str) -> tuple[list[Finding], int]:
                 open_delim, open_line = delim, lineno
                 fences += 1
                 prev_blank = False
+                if not info:
+                    findings.append(
+                        Finding(
+                            rel,
+                            lineno,
+                            "bare opening code fence: this block opens with no "
+                            "language tag. Add one so the block is highlighted "
+                            "and reads as deliberate -- ```text for literal "
+                            "command output, ```bash for commands to run. The "
+                            "closing fence stays bare",
+                        )
+                    )
                 continue
             # A closing fence matches the opening delimiter, is at least as
             # long, and carries no info string. Anything else is block content.
@@ -211,7 +245,7 @@ def main(argv: list[str]) -> int:
     # have to be distinguishable in the log.
     print(
         f"ok: {len(paths)} markdown files, {fences} fenced blocks, "
-        "every block closed and no stray blank lines"
+        "every block opened with a language tag, closed, and no stray blank lines"
     )
     return 0
 

--- a/scripts/tests/test_check_md_fences.py
+++ b/scripts/tests/test_check_md_fences.py
@@ -15,6 +15,10 @@ heading and a real table. All 17 checks passed. The exact pre-fix byte pattern
 is reproduced in test_deleted_fence_pair_is_caught -- a balance-only guard
 passes on it, which is why the stray-blank-line rule exists.
 
+The bare-opening-fence rule (IRO-709) landed later, once #656 had tagged the
+corpus it would otherwise have failed on. Its controls are in
+BareOpeningFenceTest.
+
 Run:
     python3 -m unittest discover -s scripts/tests -v
 """
@@ -183,18 +187,6 @@ class FalsePositiveTest(unittest.TestCase):
             code, output = run(root)
         self.assertEqual(code, 0, output)
 
-    def test_bare_opening_fence_is_not_flagged_yet(self):
-        """Rule 3 is deliberately not shipped; main carries 48 bare fences.
-
-        This pins the decision so that turning it on is a visible change to this
-        test rather than a silent one. See the module docstring of the checker.
-        """
-        with tempfile.TemporaryDirectory() as tmp:
-            root = pathlib.Path(tmp)
-            build_tree(root, '# t\n\n```\nsome output\n```\n')
-            code, output = run(root)
-        self.assertEqual(code, 0, output)
-
     def test_single_trailing_newline_is_not_a_stray_blank(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = pathlib.Path(tmp)
@@ -210,6 +202,65 @@ class FalsePositiveTest(unittest.TestCase):
             write(root, 'CODE_OF_CONDUCT.md', '# CoC\n\n\n## Scope\n\n\ntext.\n')
             code, output = run(root)
         self.assertEqual(code, 0, output)
+
+
+class BareOpeningFenceTest(unittest.TestCase):
+    """Rule 3 (IRO-709). Held back from IRO-707 until #656 tagged the corpus.
+
+    The negative control and its inverse are deliberately adjacent: the rule is
+    only worth anything if it fires on an untagged block *and* stays quiet on a
+    tagged one. The remaining cases pin the two shapes a naive version of this
+    rule gets wrong -- a bare closing fence, which is required to be bare, and a
+    bare fence quoted inside a longer block, which is content.
+    """
+
+    def test_bare_opening_fence_is_flagged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\n```\nsome output\n```\n')
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        self.assertIn('docs/page.md:3:', output)
+        self.assertIn('bare opening code fence', output)
+
+    def test_tagged_opening_fence_is_green(self):
+        """The inverse control: the rule must not fire on the fixed shape."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\n```text\nsome output\n```\n')
+            code, output = run(root)
+        self.assertEqual(code, 0, output)
+
+    def test_closing_fence_is_not_reported_as_bare(self):
+        """A closing fence takes no info string, so it must never be a finding.
+
+        Asserts the count, not just the exit code: a rule that fired on both
+        ends of every block would still exit 1 on the test above.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\n```\nout\n```\n\n```\nmore\n```\n')
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        self.assertEqual(output.count('bare opening code fence'), 2, output)
+        self.assertIn('docs/page.md:3:', output)
+        self.assertIn('docs/page.md:7:', output)
+
+    def test_bare_fence_quoted_inside_a_longer_block_is_content(self):
+        """A ``` inside a ````markdown block is sample text, not an opening."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\n````markdown\n```\nls\n```\n````\n')
+            code, output = run(root)
+        self.assertEqual(code, 0, output)
+
+    def test_bare_tilde_fence_is_flagged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_tree(root, '# t\n\n~~~\nout\n~~~\n')
+            code, output = run(root)
+        self.assertEqual(code, 1, output)
+        self.assertIn('bare opening code fence', output)
 
 
 class ScopeTest(unittest.TestCase):


### PR DESCRIPTION
`scripts/check-md-fences.py` shipped (IRO-707, #657) with two rules and a documented hole: *bare* (untagged) opening fences were a good invariant that could not be enforced, because `main` carried 48 of them. Enabling it then meant either failing on main or shipping a suppression list.

#656 tagged 45 across 22 files. This tags the last three and turns the rule on — **on by default, no suppression list**.

## What changed

| file | change |
|---|---|
| `docs/assets/live-containment-social/STORYBOARD.md:50` | ` ``` ` → ` ```text ` |
| `docs/blog/scan-a-dockerfile-for-security-issues.md:51` | ` ``` ` → ` ```text ` |
| `docs/site/quickstart.mdx:101` | ` ``` ` → ` ```text ` |
| `scripts/check-md-fences.py` | third rule + docstring rewritten from "deferred" to live |
| `scripts/tests/test_check_md_fences.py` | `BareOpeningFenceTest` (5 controls), replaces the "not shipped yet" pin |

All three sites are literal command output, so `text` is the tag — the same call #656 made everywhere else.

## Numbers, measured not assumed

| tree | bare openers in scope |
|---|---|
| `8c384e5` (pre-#656) | **48** — re-derived by running this rule against that tree |
| `85c2b769` (post-#656, this PR's base) | **3** |
| this PR | **0**; `check-md-fences.py .` exits 0 over 471 files / 1351 fenced blocks |

`PATTERNS` is **unchanged on purpose**. Repo-wide there are 36 bare openers, not 3 — the other 33 are outside the linter's scope (20 under `examples/integrations`, 9 under `community/`, plus `api/`, `packaging/`, `runbooks/`). Widening scope is a separate proposal; the docstring now records the boundary so it does not get widened by drive-by.

## Verification

- **Red control** — the rule fires on all 3 sites on untouched `85c2b769` and exits 1.
- **Per-site control** — re-baring any *one* of the three alone exits 1 with exactly one finding at that `file:line`; green with all three tagged.
- **Non-vacuity** — the 5 new tests were run against the *pre-rule* checker blob (`85c2b769:scripts/check-md-fences.py`): 3 fail. The 2 that pass are the inverse controls that must be green on both.
- **Count, not just exit code** — the closing-fence test asserts the finding *count* is 2 over a two-block fixture. A rule that fired on every fence (opening *and* closing) would still pass a naive exit-1 control.
- **Strip-and-compare on the docs diff**, not by eye and not by counting (counting passed a broken revision of #656): deleting the changed line from both trees leaves byte-identical remainders in all three files. Only delta is ` ``` ` → ` ```text `.
- `python3 -m unittest discover -s scripts/tests` — 98 tests, OK.

## Notes for review

- No `.github/workflows` diff. `docs.yml` already runs `python3 scripts/check-md-fences.py`, so the check name and command are unchanged and no new check context appears.
- Per our own history, a guard added as a **step in an existing job** never ran on any PR opened before it. After merge I will confirm this step actually executed on a real older PR rather than trusting a green tick here.

Closes IRO-709. Tracked as IRO-710.