### PR TITLE
docs: say which guide indexes are exhaustive and which are curated [IRO-711]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,14 +205,21 @@ into the nav and the hub, and CI is satisfied — `check-guide-index.py` fails t
 build if either is missing, and that is the whole contract.
 
 **Do not add your guide to `docs/blog/index.md` or `README.md`, and do not treat
-its absence there as a bug to fix.** Both are curated prose: each entry carries a
-hand-written summary quoting that guide's real before/after scores. Neither page
-claims to list every guide — both link the hub, which does. Making them
-exhaustive would mean inventing a summary and a score line per guide, and a rule
-that pressures an author into fabricating numbers is worse than no rule. Most
-guides are intentionally absent from both. Whether a particular guide earns a
-spot on the landing page is an editorial call a maintainer makes case by case, so
-please leave it to review rather than backfilling it in a PR.
+its absence there as a bug to fix.** Neither page claims to list every guide, and
+most guides are deliberately absent from both — both link the hub, which is the
+exhaustive one. They are curated for different reasons:
+
+- `docs/blog/index.md` gives every entry a hand-written summary quoting that
+  guide's real before/after scores ("scores 48 of 100 (D) … the honest hardened
+  ceiling is 89 of 100 (B)"). Making it exhaustive would mean inventing a summary
+  and a score line per guide, and a rule that pressures an author into
+  fabricating numbers is worse than no rule.
+- `README.md` carries a short, representative selection of guides as a link list.
+  It is the project's front door, not a catalog, and it stays short on purpose.
+
+Whether a particular guide earns a spot on either is an editorial call a
+maintainer makes case by case, so please leave it to review rather than
+backfilling it in a PR.
 
 The same reasoning, from the enforcing side, is in the module docstring of
 [`scripts/check-guide-index.py`](scripts/check-guide-index.py).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,36 @@ then `mkdocs build --strict`). The assembler fails the build loudly if a
 fragment points at a missing page, so a typo can never silently drop a page.
 See the top of [`docs/hooks.py`](docs/hooks.py) for the fragment format.
 
+### Adding a hardening guide: which indexes are exhaustive
+
+Hardening guides (`docs/blog/harden-*.md`) are listed on four surfaces, and only
+two of them are meant to list *every* guide. The split is deliberate, so knowing
+which is which saves you a round of review:
+
+| Surface | Exhaustive? | Enforced by |
+|---------|-------------|-------------|
+| [`docs/blog/.nav.yml`](docs/blog/.nav.yml) — the blog nav | **Yes, every guide** | `scripts/check-guide-index.py` in CI |
+| [`docs/blog/hardening-guides.md`](docs/blog/hardening-guides.md) — the hub | **Yes, every guide** | `scripts/check-guide-index.py` in CI |
+| [`docs/blog/index.md`](docs/blog/index.md) — the blog landing page | No, curated | maintainer, case by case |
+| [`README.md`](README.md) | No, curated | maintainer, case by case |
+
+**Adding a guide requires the first two and nothing else.** Wire your new guide
+into the nav and the hub, and CI is satisfied — `check-guide-index.py` fails the
+build if either is missing, and that is the whole contract.
+
+**Do not add your guide to `docs/blog/index.md` or `README.md`, and do not treat
+its absence there as a bug to fix.** Both are curated prose: each entry carries a
+hand-written summary quoting that guide's real before/after scores. Neither page
+claims to list every guide — both link the hub, which does. Making them
+exhaustive would mean inventing a summary and a score line per guide, and a rule
+that pressures an author into fabricating numbers is worse than no rule. Most
+guides are intentionally absent from both. Whether a particular guide earns a
+spot on the landing page is an editorial call a maintainer makes case by case, so
+please leave it to review rather than backfilling it in a PR.
+
+The same reasoning, from the enforcing side, is in the module docstring of
+[`scripts/check-guide-index.py`](scripts/check-guide-index.py).
+
 ## Pull requests
 
 - Branch from `main`, make your change, and open a PR against `main`.

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -9,6 +9,15 @@ Long-form writing on running autonomous AI agents safely. Every post links its c
 shipped code, a versioned threat model, or a benchmark you can re-run yourself. No
 adjectives standing in for numbers.
 
+<!--
+  This page is CURATED, not exhaustive. Adding a hardening guide does NOT require
+  an entry here: the exhaustive, CI-enforced surfaces are docs/blog/.nav.yml and
+  docs/blog/hardening-guides.md (see scripts/check-guide-index.py). Entries below
+  carry hand-written summaries quoting real scores, so they are added editorially
+  by a maintainer, not backfilled. See CONTRIBUTING.md, "Adding a hardening
+  guide: which indexes are exhaustive".
+-->
+
 ## Posts
 
 - [One of our container images carries two green provenance statements. Only one of them is true.](two-green-provenance-statements.md) -

--- a/scripts/check-guide-index.py
+++ b/scripts/check-guide-index.py
@@ -14,12 +14,17 @@ Two surfaces are required to be exhaustive, and this asserts both:
 * ``docs/blog/hardening-guides.md`` -- the hub page, which opens with the words
   "Every guide below", so an omission there makes the page's own claim false.
 
-``docs/blog/index.md`` and ``README.md`` are deliberately *not* checked. Both are
-curated prose with a hand-written, per-guide summary quoting real before/after
-scores, so "every guide appears" is not a property either one claims or should
-claim; both instead link the hub, which is exhaustive. Enforcing presence there
-would demand a fabricated summary per guide, and a check that pressures an
-author into inventing scores is worse than no check.
+``docs/blog/index.md`` and ``README.md`` are deliberately *not* checked. Neither
+claims, or should claim, that every guide appears; both instead link the hub,
+which is exhaustive. ``index.md`` gives each entry a hand-written summary quoting
+real before/after scores, so enforcing presence there would demand a fabricated
+summary per guide, and a check that pressures an author into inventing scores is
+worse than no check. ``README.md`` carries a short, representative link list: it
+is the front door, not a catalog, and it stays short on purpose.
+
+The contributor-facing statement of this rule is in CONTRIBUTING.md, under
+"Adding a hardening guide: which indexes are exhaustive" (IRO-711). Keep the two
+in sync.
 
 Usage:
 


### PR DESCRIPTION
Closes the docs half of IRO-711.

## Why

`scripts/check-guide-index.py` enforces that every `docs/blog/harden-*.md` guide is wired into `docs/blog/.nav.yml` and `docs/blog/hardening-guides.md`. It deliberately does **not** check `docs/blog/index.md` or `README.md`, which are curated. That decision was recorded only in the checker's module docstring.

Nobody reads a checker docstring before opening a PR, so the gap in `index.md` (16 of 56 guides listed) keeps reading as an omission rather than a decision. Two people in a row have now made that call: the contributor on #661, and a maintainer reviewing them.

## What

**Commit 1** — `CONTRIBUTING.md`, under `## Documentation`: a table of the four surfaces marking which two are exhaustive and CI-enforced, an explicit statement that wiring the nav and the hub is the whole contract, and that a guide's absence from the landing page or the README is not a bug to backfill. `docs/blog/index.md` also gets a non-rendering HTML comment with the same rule, because that file is what someone has open at the moment they are about to make this mistake.

**Commit 2** — an accuracy fix found by checking the claim against the files rather than against the docstring. The first pass said both curated pages carry per-guide summaries quoting real scores. Only `index.md` does (16 of 56, each with a line like *"scores 48 of 100 (D) … ceiling 89 of 100 (B)"*). `README.md` references 24 of 56 as a plain comma-separated link list, no summaries, no scores. So the fabricated-numbers argument is the right reason for `index.md` and the wrong reason for the README, and a contributor who spotted the mismatch would be right to push back. Each surface now gets its actual reason. The same overclaim was in the checker's docstring, which is where it came from, so it is fixed at the source too and cross-referenced.

Docs plus one docstring. No scoring, behaviour, or CI change; `SURFACES` in the checker is untouched and no surface is widened.

## Verification

Run with the same invocations `docs.yml` uses:

| Gate | Result |
|---|---|
| `check-guide-index.py` | pass, 56 guides |
| `scripts/tests/test_check_guide_index.py` | 6 passed |
| `check-md-fences.py` | pass, 471 files / 1351 blocks |
| `check-guide-uid.py` | pass, 56 guides |
| `check_links.py` | pass, 110 links / 10 root files |
| `mkdocs build --strict --site-dir _site` | built clean |
| `check-docs-meta.py _site` | pass, 436 pages |

Non-vacuity: `check_links.py` reports 105 relative links on pristine `main` and 110 here, so all five new links are in scope; typo'ing one is reported as a broken link. (The first attempt at that control silently no-op'd and "passed" — caught on the link count and redone.) The `index.md` comment was confirmed absent from the rendered HTML after stripping comments, with the `## Posts` heading intact.

Counts stated in the change were verified directly rather than taken from the brief: 56 guides on disk, 56 in the hub and nav, 16 in `index.md`, 24 in `README.md`.

Note `check-docs-meta.py` must be pointed at `_site` as CI does. Run against the repo root it also walks `overrides/`, `web/` and a stray `site/`, and reports 4 unrelated failures.