### PR TITLE
docs(scores): the provenance line said image inspect with no workload; a container is started [IRO-713]

### DIFF
--- a/docs/scores/act_runner.md
+++ b/docs/scores/act_runner.md
@@ -7,7 +7,7 @@ description: "How isolated is act_runner:0.2.11 by default? IronClaw scores its 
 
 Run with plain `docker run gitea/act_runner:0.2.11` defaults, no hardening flags, the **act_runner** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `gitea/act_runner:0.2.11` at digest `sha256:c57233403eff970945cfb8b13f0e622d2124f4dbc623af3e2c74f061d05e8f60`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `gitea/act_runner:0.2.11` at digest `sha256:c57233403eff970945cfb8b13f0e622d2124f4dbc623af3e2c74f061d05e8f60` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/actions-runner.md
+++ b/docs/scores/actions-runner.md
@@ -7,7 +7,7 @@ description: "How isolated is actions-runner:2.321.0 by default? IronClaw scores
 
 Run with plain `docker run ghcr.io/actions/actions-runner:2.321.0` defaults, no hardening flags, the **actions runner** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ghcr.io/actions/actions-runner:2.321.0` at digest `sha256:27f3f74ec6f88026491d761270525ccf630a53ce9cd5db1d5f44cd2470abe380`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ghcr.io/actions/actions-runner:2.321.0` at digest `sha256:27f3f74ec6f88026491d761270525ccf630a53ce9cd5db1d5f44cd2470abe380` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/activemq-artemis.md
+++ b/docs/scores/activemq-artemis.md
@@ -7,7 +7,7 @@ description: "How isolated is activemq-artemis:2.38.0 by default? IronClaw score
 
 Run with plain `docker run apache/activemq-artemis:2.38.0` defaults, no hardening flags, the **activemq artemis** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `apache/activemq-artemis:2.38.0` at digest `sha256:fc17d2b82112d87c0a17a38874f3464eb162249f1e289ca25386b7b900047bd0`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `apache/activemq-artemis:2.38.0` at digest `sha256:fc17d2b82112d87c0a17a38874f3464eb162249f1e289ca25386b7b900047bd0` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/actual-server.md
+++ b/docs/scores/actual-server.md
@@ -7,7 +7,7 @@ description: "How isolated is actual-server:24.12.0 by default? IronClaw scores 
 
 Run with plain `docker run actualbudget/actual-server:24.12.0` defaults, no hardening flags, the **actual server** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `actualbudget/actual-server:24.12.0` at digest `sha256:0cf0300ed4905045ed87e8892c26fbd83cd08e8499bb81dc28deef6afeb162fb`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `actualbudget/actual-server:24.12.0` at digest `sha256:0cf0300ed4905045ed87e8892c26fbd83cd08e8499bb81dc28deef6afeb162fb` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/adguardhome.md
+++ b/docs/scores/adguardhome.md
@@ -7,7 +7,7 @@ description: "How isolated is adguardhome:latest by default? IronClaw scores its
 
 Run with plain `docker run adguard/adguardhome:latest` defaults, no hardening flags, the **adguardhome** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `adguard/adguardhome:latest` at digest `sha256:1ea34eafe5dc691007946e8eaab7bf46b0de9412f39213d8c06e48b53bf9a6c5`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `adguard/adguardhome:latest` at digest `sha256:1ea34eafe5dc691007946e8eaab7bf46b0de9412f39213d8c06e48b53bf9a6c5` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/adminer.md
+++ b/docs/scores/adminer.md
@@ -7,7 +7,7 @@ description: "How isolated is adminer:4.8.1 by default? IronClaw scores its sand
 
 Run with plain `docker run adminer:4.8.1` defaults, no hardening flags, the **adminer** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `adminer:4.8.1` at digest `sha256:34d37131366c5aa84e1693dbed48593ed6f95fb450b576c1a7a59d3a9c9e8802`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `adminer:4.8.1` at digest `sha256:34d37131366c5aa84e1693dbed48593ed6f95fb450b576c1a7a59d3a9c9e8802` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/aerospike-server.md
+++ b/docs/scores/aerospike-server.md
@@ -7,7 +7,7 @@ description: "How isolated is aerospike-server:7.2.0.1 by default? IronClaw scor
 
 Run with plain `docker run aerospike/aerospike-server:7.2.0.1` defaults, no hardening flags, the **aerospike server** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `aerospike/aerospike-server:7.2.0.1` at digest `sha256:200067011b2c73ce2809d93e16de2f2581333a0109303dcbc1b9534c1875b483`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `aerospike/aerospike-server:7.2.0.1` at digest `sha256:200067011b2c73ce2809d93e16de2f2581333a0109303dcbc1b9534c1875b483` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/airflow.md
+++ b/docs/scores/airflow.md
@@ -7,7 +7,7 @@ description: "How isolated is airflow:2.10.4 by default? IronClaw scores its san
 
 Run with plain `docker run apache/airflow:2.10.4` defaults, no hardening flags, the **airflow** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `apache/airflow:2.10.4` at digest `sha256:04e7fba174eb5c77057f59ef18c1215179181cd5dd7189afbc39b1146f54540f`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `apache/airflow:2.10.4` at digest `sha256:04e7fba174eb5c77057f59ef18c1215179181cd5dd7189afbc39b1146f54540f` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/alertmanager.md
+++ b/docs/scores/alertmanager.md
@@ -7,7 +7,7 @@ description: "How isolated is alertmanager:v0.28.0 by default? IronClaw scores i
 
 Run with plain `docker run prom/alertmanager:v0.28.0` defaults, no hardening flags, the **alertmanager** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `prom/alertmanager:v0.28.0` at digest `sha256:d5155cfac40a6d9250ffc97c19db2c5e190c7bc57c6b67125c94903358f8c7d8`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `prom/alertmanager:v0.28.0` at digest `sha256:d5155cfac40a6d9250ffc97c19db2c5e190c7bc57c6b67125c94903358f8c7d8` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/alloy.md
+++ b/docs/scores/alloy.md
@@ -7,7 +7,7 @@ description: "How isolated is alloy:latest by default? IronClaw scores its sandb
 
 Run with plain `docker run grafana/alloy:latest` defaults, no hardening flags, the **alloy** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `grafana/alloy:latest` at digest `sha256:491b0578c04983fd54fe99b587b6fab4404dc46d0dc16677bd6b00cc1140b308`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `grafana/alloy:latest` at digest `sha256:491b0578c04983fd54fe99b587b6fab4404dc46d0dc16677bd6b00cc1140b308` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/almalinux.md
+++ b/docs/scores/almalinux.md
@@ -7,7 +7,7 @@ description: "How isolated is almalinux:9 by default? IronClaw scores its sandbo
 
 Run with plain `docker run almalinux:9` defaults, no hardening flags, the **almalinux** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `almalinux:9` at digest `sha256:d2515c769e7b73f95c4fde38c0a505336ff38f14990c0b7253b77060a049a743`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `almalinux:9` at digest `sha256:d2515c769e7b73f95c4fde38c0a505336ff38f14990c0b7253b77060a049a743` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/alpine.md
+++ b/docs/scores/alpine.md
@@ -7,7 +7,7 @@ description: "How isolated is alpine:3.21 by default? IronClaw scores its sandbo
 
 Run with plain `docker run alpine:3.21` defaults, no hardening flags, the **alpine** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `alpine:3.21` at digest `sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `alpine:3.21` at digest `sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/amazoncorretto.md
+++ b/docs/scores/amazoncorretto.md
@@ -7,7 +7,7 @@ description: "How isolated is amazoncorretto:21 by default? IronClaw scores its 
 
 Run with plain `docker run amazoncorretto:21` defaults, no hardening flags, the **amazoncorretto** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `amazoncorretto:21` at digest `sha256:540708337af29fda537479f2205d2d219a3780c3f07be5f42be96501789f610b`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `amazoncorretto:21` at digest `sha256:540708337af29fda537479f2205d2d219a3780c3f07be5f42be96501789f610b` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/amazonlinux.md
+++ b/docs/scores/amazonlinux.md
@@ -7,7 +7,7 @@ description: "How isolated is amazonlinux:2023 by default? IronClaw scores its s
 
 Run with plain `docker run amazonlinux:2023` defaults, no hardening flags, the **amazonlinux** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `amazonlinux:2023` at digest `sha256:0c74e9fbba754003cfa179fd5cc65be7790d7248443276948704b8a858b298e5`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `amazonlinux:2023` at digest `sha256:0c74e9fbba754003cfa179fd5cc65be7790d7248443276948704b8a858b298e5` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/anaconda3.md
+++ b/docs/scores/anaconda3.md
@@ -7,7 +7,7 @@ description: "How isolated is anaconda3:2024.10-1 by default? IronClaw scores it
 
 Run with plain `docker run continuumio/anaconda3:2024.10-1` defaults, no hardening flags, the **anaconda3** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `continuumio/anaconda3:2024.10-1` at digest `sha256:b2c5350cc4e2338a1705c15dcca4fff520b1728f49752d390d92aaec02cf8c3a`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `continuumio/anaconda3:2024.10-1` at digest `sha256:b2c5350cc4e2338a1705c15dcca4fff520b1728f49752d390d92aaec02cf8c3a` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/appwrite.md
+++ b/docs/scores/appwrite.md
@@ -7,7 +7,7 @@ description: "How isolated is appwrite:1.6.0 by default? IronClaw scores its san
 
 Run with plain `docker run appwrite/appwrite:1.6.0` defaults, no hardening flags, the **appwrite** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `appwrite/appwrite:1.6.0` at digest `sha256:269f8953594890a62f015e29c6343f7f2119468180d0dcecdfdc331bcbadf845`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `appwrite/appwrite:1.6.0` at digest `sha256:269f8953594890a62f015e29c6343f7f2119468180d0dcecdfdc331bcbadf845` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/arangodb.md
+++ b/docs/scores/arangodb.md
@@ -7,7 +7,7 @@ description: "How isolated is arangodb:3.12 by default? IronClaw scores its sand
 
 Run with plain `docker run arangodb:3.12` defaults, no hardening flags, the **arangodb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `arangodb:3.12` at digest `sha256:bf5eabc0fb3a16a13d0d4de00cddfbf2209e3d25630e5331832efb206519ff8f`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `arangodb:3.12` at digest `sha256:bf5eabc0fb3a16a13d0d4de00cddfbf2209e3d25630e5331832efb206519ff8f` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/archlinux.md
+++ b/docs/scores/archlinux.md
@@ -7,7 +7,7 @@ description: "How isolated is archlinux:latest by default? IronClaw scores its s
 
 Run with plain `docker run archlinux:latest` defaults, no hardening flags, the **archlinux** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `archlinux:latest` at digest `sha256:592e11bd99ab579f933a0cb77a8f66e2f3ae57f5eafacf13aea44a6e98ef21ae`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `archlinux:latest` at digest `sha256:592e11bd99ab579f933a0cb77a8f66e2f3ae57f5eafacf13aea44a6e98ef21ae` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/argocd.md
+++ b/docs/scores/argocd.md
@@ -7,7 +7,7 @@ description: "How isolated is argocd:v2.13.2 by default? IronClaw scores its san
 
 Run with plain `docker run quay.io/argoproj/argocd:v2.13.2` defaults, no hardening flags, the **argocd** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `quay.io/argoproj/argocd:v2.13.2` at digest `sha256:1322e91b758b9d44db3af44f457c298831c57a8e1d635118910d35e71f822646`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `quay.io/argoproj/argocd:v2.13.2` at digest `sha256:1322e91b758b9d44db3af44f457c298831c57a8e1d635118910d35e71f822646` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/aspnet.md
+++ b/docs/scores/aspnet.md
@@ -7,7 +7,7 @@ description: "How isolated is aspnet:9.0 by default? IronClaw scores its sandbox
 
 Run with plain `docker run mcr.microsoft.com/dotnet/aspnet:9.0` defaults, no hardening flags, the **aspnet** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `mcr.microsoft.com/dotnet/aspnet:9.0` at digest `sha256:86085bc68dde4a8cdfd8c2342acc3bf843eade855092879a85e3f3adb56e55c7`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `mcr.microsoft.com/dotnet/aspnet:9.0` at digest `sha256:86085bc68dde4a8cdfd8c2342acc3bf843eade855092879a85e3f3adb56e55c7` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/audiobookshelf.md
+++ b/docs/scores/audiobookshelf.md
@@ -7,7 +7,7 @@ description: "How isolated is audiobookshelf:2.17.5 by default? IronClaw scores 
 
 Run with plain `docker run ghcr.io/advplyr/audiobookshelf:2.17.5` defaults, no hardening flags, the **audiobookshelf** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ghcr.io/advplyr/audiobookshelf:2.17.5` at digest `sha256:aa88c9f4652872a2a72043511a87d17ec743b60f53e8024e9868ebec5aae59bd`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ghcr.io/advplyr/audiobookshelf:2.17.5` at digest `sha256:aa88c9f4652872a2a72043511a87d17ec743b60f53e8024e9868ebec5aae59bd` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/authelia.md
+++ b/docs/scores/authelia.md
@@ -7,7 +7,7 @@ description: "How isolated is authelia:4.38 by default? IronClaw scores its sand
 
 Run with plain `docker run authelia/authelia:4.38` defaults, no hardening flags, the **authelia** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `authelia/authelia:4.38` at digest `sha256:46021dc20efdcc5cdc38a29e3050b8835429a155ae6215388ed3b793a02eb0ab`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `authelia/authelia:4.38` at digest `sha256:46021dc20efdcc5cdc38a29e3050b8835429a155ae6215388ed3b793a02eb0ab` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/base-notebook.md
+++ b/docs/scores/base-notebook.md
@@ -7,7 +7,7 @@ description: "How isolated is base-notebook:latest by default? IronClaw scores i
 
 Run with plain `docker run quay.io/jupyter/base-notebook:latest` defaults, no hardening flags, the **base notebook** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `quay.io/jupyter/base-notebook:latest` at digest `sha256:50d8c29bb555af7ba18e956c97734c31ada26ee12d7e6dc77927608cb730d108`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `quay.io/jupyter/base-notebook:latest` at digest `sha256:50d8c29bb555af7ba18e956c97734c31ada26ee12d7e6dc77927608cb730d108` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/baserow.md
+++ b/docs/scores/baserow.md
@@ -7,7 +7,7 @@ description: "How isolated is baserow:1.30.1 by default? IronClaw scores its san
 
 Run with plain `docker run baserow/baserow:1.30.1` defaults, no hardening flags, the **baserow** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `baserow/baserow:1.30.1` at digest `sha256:df0c42eb67e86a5b3f3e608e904f18db98650aaa701098d1d437ef5170979a8e`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `baserow/baserow:1.30.1` at digest `sha256:df0c42eb67e86a5b3f3e608e904f18db98650aaa701098d1d437ef5170979a8e` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/blackbox-exporter.md
+++ b/docs/scores/blackbox-exporter.md
@@ -7,7 +7,7 @@ description: "How isolated is blackbox-exporter:v0.25.0 by default? IronClaw sco
 
 Run with plain `docker run prom/blackbox-exporter:v0.25.0` defaults, no hardening flags, the **blackbox exporter** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `prom/blackbox-exporter:v0.25.0` at digest `sha256:b04a9fef4fa086a02fc7fcd8dcdbc4b7b35cc30cdee860fdc6a19dd8b208d63e`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `prom/blackbox-exporter:v0.25.0` at digest `sha256:b04a9fef4fa086a02fc7fcd8dcdbc4b7b35cc30cdee860fdc6a19dd8b208d63e` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/bun.md
+++ b/docs/scores/bun.md
@@ -7,7 +7,7 @@ description: "How isolated is bun:1.1 by default? IronClaw scores its sandbox po
 
 Run with plain `docker run oven/bun:1.1` defaults, no hardening flags, the **bun** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `oven/bun:1.1` at digest `sha256:d6ad4d3280d3e7e92b793a924105d68766d60b1f36709f4cee11bc8737782621`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `oven/bun:1.1` at digest `sha256:d6ad4d3280d3e7e92b793a924105d68766d60b1f36709f4cee11bc8737782621` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/busybox.md
+++ b/docs/scores/busybox.md
@@ -7,7 +7,7 @@ description: "How isolated is busybox:1.37 by default? IronClaw scores its sandb
 
 Run with plain `docker run busybox:1.37` defaults, no hardening flags, the **busybox** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `busybox:1.37` at digest `sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `busybox:1.37` at digest `sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/caddy.md
+++ b/docs/scores/caddy.md
@@ -7,7 +7,7 @@ description: "How isolated is caddy:2-alpine by default? IronClaw scores its san
 
 Run with plain `docker run caddy:2-alpine` defaults, no hardening flags, the **caddy** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `caddy:2-alpine` at digest `sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `caddy:2-alpine` at digest `sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/cadvisor.md
+++ b/docs/scores/cadvisor.md
@@ -7,7 +7,7 @@ description: "How isolated is cadvisor:v0.52.1 by default? IronClaw scores its s
 
 Run with plain `docker run gcr.io/cadvisor/cadvisor:v0.52.1` defaults, no hardening flags, the **cadvisor** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `gcr.io/cadvisor/cadvisor:v0.52.1` at digest `sha256:f40e65878e25c2e78ea037f73a449527a0fb994e303dc3e34cb6b187b4b91435`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `gcr.io/cadvisor/cadvisor:v0.52.1` at digest `sha256:f40e65878e25c2e78ea037f73a449527a0fb994e303dc3e34cb6b187b4b91435` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/cassandra.md
+++ b/docs/scores/cassandra.md
@@ -7,7 +7,7 @@ description: "How isolated is cassandra:5.0 by default? IronClaw scores its sand
 
 Run with plain `docker run cassandra:5.0` defaults, no hardening flags, the **cassandra** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `cassandra:5.0` at digest `sha256:e52bb93c21f69cc5c2f5eb9e7d9736b10a047ad38bc7776480c7dbbf7d4e0ba7`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `cassandra:5.0` at digest `sha256:e52bb93c21f69cc5c2f5eb9e7d9736b10a047ad38bc7776480c7dbbf7d4e0ba7` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/centrifugo.md
+++ b/docs/scores/centrifugo.md
@@ -7,7 +7,7 @@ description: "How isolated is centrifugo:v5.4.7 by default? IronClaw scores its 
 
 Run with plain `docker run centrifugo/centrifugo:v5.4.7` defaults, no hardening flags, the **centrifugo** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `centrifugo/centrifugo:v5.4.7` at digest `sha256:dc3a829ab2e26070df6802138ebfd4ce3929e8fdc970fa56e4fa14b68e321164`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `centrifugo/centrifugo:v5.4.7` at digest `sha256:dc3a829ab2e26070df6802138ebfd4ce3929e8fdc970fa56e4fa14b68e321164` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/ceph.md
+++ b/docs/scores/ceph.md
@@ -7,7 +7,7 @@ description: "How isolated is ceph:v18.2.4 by default? IronClaw scores its sandb
 
 Run with plain `docker run quay.io/ceph/ceph:v18.2.4` defaults, no hardening flags, the **ceph** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `quay.io/ceph/ceph:v18.2.4` at digest `sha256:6ac7f923aa1d23b43248ce0ddec7e1388855ee3d00813b52c3172b0b23b37906`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `quay.io/ceph/ceph:v18.2.4` at digest `sha256:6ac7f923aa1d23b43248ce0ddec7e1388855ee3d00813b52c3172b0b23b37906` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/chroma.md
+++ b/docs/scores/chroma.md
@@ -7,7 +7,7 @@ description: "How isolated is chroma:0.5.23 by default? IronClaw scores its sand
 
 Run with plain `docker run chromadb/chroma:0.5.23` defaults, no hardening flags, the **chroma** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `chromadb/chroma:0.5.23` at digest `sha256:18e67eecc172abbcd9413d751bde64983b3d167fe497c98f979083eb24c0c942`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `chromadb/chroma:0.5.23` at digest `sha256:18e67eecc172abbcd9413d751bde64983b3d167fe497c98f979083eb24c0c942` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/chronograf.md
+++ b/docs/scores/chronograf.md
@@ -7,7 +7,7 @@ description: "How isolated is chronograf:1.10 by default? IronClaw scores its sa
 
 Run with plain `docker run chronograf:1.10` defaults, no hardening flags, the **chronograf** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `chronograf:1.10` at digest `sha256:0df4b54d28c2cb2bd23670f13f32404f01ff00dc4eca6eb94347a86ab686b39e`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `chronograf:1.10` at digest `sha256:0df4b54d28c2cb2bd23670f13f32404f01ff00dc4eca6eb94347a86ab686b39e` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/clickhouse.md
+++ b/docs/scores/clickhouse.md
@@ -7,7 +7,7 @@ description: "How isolated is clickhouse:24.8 by default? IronClaw scores its sa
 
 Run with plain `docker run clickhouse:24.8` defaults, no hardening flags, the **clickhouse** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `clickhouse:24.8` at digest `sha256:9eb59796efe815711207122267e407dd3b42efd90d01537e1c80118bfc642a11`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `clickhouse:24.8` at digest `sha256:9eb59796efe815711207122267e407dd3b42efd90d01537e1c80118bfc642a11` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/clojure.md
+++ b/docs/scores/clojure.md
@@ -7,7 +7,7 @@ description: "How isolated is clojure:temurin-21-tools-deps by default? IronClaw
 
 Run with plain `docker run clojure:temurin-21-tools-deps` defaults, no hardening flags, the **clojure** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `clojure:temurin-21-tools-deps` at digest `sha256:db77923e67984d00cbf55a4e44cfacdefed5a8fcf1499469086ba1b569f9d937`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `clojure:temurin-21-tools-deps` at digest `sha256:db77923e67984d00cbf55a4e44cfacdefed5a8fcf1499469086ba1b569f9d937` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/cockroach.md
+++ b/docs/scores/cockroach.md
@@ -7,7 +7,7 @@ description: "How isolated is cockroach:latest by default? IronClaw scores its s
 
 Run with plain `docker run cockroachdb/cockroach:latest` defaults, no hardening flags, the **cockroach** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `cockroachdb/cockroach:latest` at digest `sha256:85417da0fd2f57e4f1b01ae8a4125402c977a38a56b43d0902db93dc2669ab09`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `cockroachdb/cockroach:latest` at digest `sha256:85417da0fd2f57e4f1b01ae8a4125402c977a38a56b43d0902db93dc2669ab09` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/concourse.md
+++ b/docs/scores/concourse.md
@@ -7,7 +7,7 @@ description: "How isolated is concourse:7.12.0 by default? IronClaw scores its s
 
 Run with plain `docker run concourse/concourse:7.12.0` defaults, no hardening flags, the **concourse** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `concourse/concourse:7.12.0` at digest `sha256:3a432faa505de02f6d6592f4b727a1e2683a7adbf42e4fcc052e30f0a144efc6`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `concourse/concourse:7.12.0` at digest `sha256:3a432faa505de02f6d6592f4b727a1e2683a7adbf42e4fcc052e30f0a144efc6` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/consul.md
+++ b/docs/scores/consul.md
@@ -7,7 +7,7 @@ description: "How isolated is consul:1.20 by default? IronClaw scores its sandbo
 
 Run with plain `docker run hashicorp/consul:1.20` defaults, no hardening flags, the **consul** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `hashicorp/consul:1.20` at digest `sha256:200471c74bc0965cd20c81eacc31a209873d5d9e599fe637ceb856b0cbbc518d`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `hashicorp/consul:1.20` at digest `sha256:200471c74bc0965cd20c81eacc31a209873d5d9e599fe637ceb856b0cbbc518d` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/cortex.md
+++ b/docs/scores/cortex.md
@@ -7,7 +7,7 @@ description: "How isolated is cortex:v1.18.1 by default? IronClaw scores its san
 
 Run with plain `docker run quay.io/cortexproject/cortex:v1.18.1` defaults, no hardening flags, the **cortex** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `quay.io/cortexproject/cortex:v1.18.1` at digest `sha256:b2c37512c56294f6f648eabd9833adbbfd37b453aaae4390b7f5334bc57f136e`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `quay.io/cortexproject/cortex:v1.18.1` at digest `sha256:b2c37512c56294f6f648eabd9833adbbfd37b453aaae4390b7f5334bc57f136e` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/couchdb.md
+++ b/docs/scores/couchdb.md
@@ -7,7 +7,7 @@ description: "How isolated is couchdb:3.4 by default? IronClaw scores its sandbo
 
 Run with plain `docker run couchdb:3.4` defaults, no hardening flags, the **couchdb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `couchdb:3.4` at digest `sha256:d603d4086836b1e20f1ec35d2d38e49359639c2eb56a54c8ba0ddbdff0f3dabe`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `couchdb:3.4` at digest `sha256:d603d4086836b1e20f1ec35d2d38e49359639c2eb56a54c8ba0ddbdff0f3dabe` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/cp-kafka.md
+++ b/docs/scores/cp-kafka.md
@@ -7,7 +7,7 @@ description: "How isolated is cp-kafka:7.8.0 by default? IronClaw scores its san
 
 Run with plain `docker run confluentinc/cp-kafka:7.8.0` defaults, no hardening flags, the **cp kafka** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `confluentinc/cp-kafka:7.8.0` at digest `sha256:adc392d28a1e99e8c9a1ec7f087e9e91041837b35b8b7cc8b8a691b82dd581b0`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `confluentinc/cp-kafka:7.8.0` at digest `sha256:adc392d28a1e99e8c9a1ec7f087e9e91041837b35b8b7cc8b8a691b82dd581b0` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/crystal.md
+++ b/docs/scores/crystal.md
@@ -7,7 +7,7 @@ description: "How isolated is crystal:1.14.1 by default? IronClaw scores its san
 
 Run with plain `docker run crystallang/crystal:1.14.1` defaults, no hardening flags, the **crystal** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `crystallang/crystal:1.14.1` at digest `sha256:e1356b557c098ae5b7956ed58edb6d0c081c3c4d588c56cec11f6bbb7caeea2c`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `crystallang/crystal:1.14.1` at digest `sha256:e1356b557c098ae5b7956ed58edb6d0c081c3c4d588c56cec11f6bbb7caeea2c` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/dart.md
+++ b/docs/scores/dart.md
@@ -7,7 +7,7 @@ description: "How isolated is dart:3.6 by default? IronClaw scores its sandbox p
 
 Run with plain `docker run dart:3.6` defaults, no hardening flags, the **dart** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `dart:3.6` at digest `sha256:7a6a4ad2560e46cb6979bd73f46edec0fa7bc092146f5fafefdf3c6568a77e75`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `dart:3.6` at digest `sha256:7a6a4ad2560e46cb6979bd73f46edec0fa7bc092146f5fafefdf3c6568a77e75` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/dashy.md
+++ b/docs/scores/dashy.md
@@ -7,7 +7,7 @@ description: "How isolated is dashy:3.1.0 by default? IronClaw scores its sandbo
 
 Run with plain `docker run lissy93/dashy:3.1.0` defaults, no hardening flags, the **dashy** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `lissy93/dashy:3.1.0` at digest `sha256:e0e4d344f9be6d6f0061bb4f5368efd5034e8f2cec886d8afefc89a76be830d4`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `lissy93/dashy:3.1.0` at digest `sha256:e0e4d344f9be6d6f0061bb4f5368efd5034e8f2cec886d8afefc89a76be830d4` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/debian.md
+++ b/docs/scores/debian.md
@@ -7,7 +7,7 @@ description: "How isolated is debian:12-slim by default? IronClaw scores its san
 
 Run with plain `docker run debian:12-slim` defaults, no hardening flags, the **debian** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `debian:12-slim` at digest `sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `debian:12-slim` at digest `sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/deno.md
+++ b/docs/scores/deno.md
@@ -7,7 +7,7 @@ description: "How isolated is deno:2.1.4 by default? IronClaw scores its sandbox
 
 Run with plain `docker run denoland/deno:2.1.4` defaults, no hardening flags, the **deno** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `denoland/deno:2.1.4` at digest `sha256:3bf75873714baa410dcf7fabaf76d806d20f0ac8a7579df11577b4ed97416e34`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `denoland/deno:2.1.4` at digest `sha256:3bf75873714baa410dcf7fabaf76d806d20f0ac8a7579df11577b4ed97416e34` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/dex.md
+++ b/docs/scores/dex.md
@@ -7,7 +7,7 @@ description: "How isolated is dex:v2.41.1 by default? IronClaw scores its sandbo
 
 Run with plain `docker run dexidp/dex:v2.41.1` defaults, no hardening flags, the **dex** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `dexidp/dex:v2.41.1` at digest `sha256:bc7cfce7c17f52864e2bb2a4dc1d2f86a41e3019f6d42e81d92a301fad0c8a1d`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `dexidp/dex:v2.41.1` at digest `sha256:bc7cfce7c17f52864e2bb2a4dc1d2f86a41e3019f6d42e81d92a301fad0c8a1d` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/dgraph.md
+++ b/docs/scores/dgraph.md
@@ -7,7 +7,7 @@ description: "How isolated is dgraph:v24.0.5 by default? IronClaw scores its san
 
 Run with plain `docker run dgraph/dgraph:v24.0.5` defaults, no hardening flags, the **dgraph** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `dgraph/dgraph:v24.0.5` at digest `sha256:73db2307831ef1229c6b2aaa432ba8cbc0f525002318713d4e3392bf56199c3a`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `dgraph/dgraph:v24.0.5` at digest `sha256:73db2307831ef1229c6b2aaa432ba8cbc0f525002318713d4e3392bf56199c3a` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/directus.md
+++ b/docs/scores/directus.md
@@ -7,7 +7,7 @@ description: "How isolated is directus:11.3.5 by default? IronClaw scores its sa
 
 Run with plain `docker run directus/directus:11.3.5` defaults, no hardening flags, the **directus** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `directus/directus:11.3.5` at digest `sha256:6bc79ef2f0daa224d84b4da22ea3831e60697d399589d54067cb3681c2f94514`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `directus/directus:11.3.5` at digest `sha256:6bc79ef2f0daa224d84b4da22ea3831e60697d399589d54067cb3681c2f94514` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/docker.md
+++ b/docs/scores/docker.md
@@ -7,7 +7,7 @@ description: "How isolated is docker:27-dind by default? IronClaw scores its san
 
 Run with plain `docker run docker:27-dind` defaults, no hardening flags, the **docker** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `docker:27-dind` at digest `sha256:aa3df78ecf320f5fafdce71c659f1629e96e9de0968305fe1de670e0ca9176ce`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `docker:27-dind` at digest `sha256:aa3df78ecf320f5fafdce71c659f1629e96e9de0968305fe1de670e0ca9176ce` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/dragonfly.md
+++ b/docs/scores/dragonfly.md
@@ -7,7 +7,7 @@ description: "How isolated is dragonfly:latest by default? IronClaw scores its s
 
 Run with plain `docker run docker.dragonflydb.io/dragonflydb/dragonfly:latest` defaults, no hardening flags, the **dragonfly** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `docker.dragonflydb.io/dragonflydb/dragonfly:latest` at digest `sha256:0fa01a2b929e704c7a9300d23e7f52002ebd39e90996fb8bb63826aed92fa06f`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `docker.dragonflydb.io/dragonflydb/dragonfly:latest` at digest `sha256:0fa01a2b929e704c7a9300d23e7f52002ebd39e90996fb8bb63826aed92fa06f` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/drone.md
+++ b/docs/scores/drone.md
@@ -7,7 +7,7 @@ description: "How isolated is drone:2 by default? IronClaw scores its sandbox po
 
 Run with plain `docker run drone/drone:2` defaults, no hardening flags, the **drone** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `drone/drone:2` at digest `sha256:55897c8fb22ddc5dff6be4c85b7fbc3ce07c34fe1f03d7cf2cbbfd095833fca6`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `drone/drone:2` at digest `sha256:55897c8fb22ddc5dff6be4c85b7fbc3ce07c34fe1f03d7cf2cbbfd095833fca6` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/druid.md
+++ b/docs/scores/druid.md
@@ -7,7 +7,7 @@ description: "How isolated is druid:31.0.0 by default? IronClaw scores its sandb
 
 Run with plain `docker run apache/druid:31.0.0` defaults, no hardening flags, the **druid** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `apache/druid:31.0.0` at digest `sha256:738d6e8f5d543483c56fca98d7a4c465e2a5f123953c26d2d684f19ee2af14fc`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `apache/druid:31.0.0` at digest `sha256:738d6e8f5d543483c56fca98d7a4c465e2a5f123953c26d2d684f19ee2af14fc` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/drupal.md
+++ b/docs/scores/drupal.md
@@ -7,7 +7,7 @@ description: "How isolated is drupal:11-apache by default? IronClaw scores its s
 
 Run with plain `docker run drupal:11-apache` defaults, no hardening flags, the **drupal** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `drupal:11-apache` at digest `sha256:7a93ee9c8bec6a780cc25ec4e1610ae6dde483368db3d5aa0ac477567a645d6b`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `drupal:11-apache` at digest `sha256:7a93ee9c8bec6a780cc25ec4e1610ae6dde483368db3d5aa0ac477567a645d6b` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/duplicati.md
+++ b/docs/scores/duplicati.md
@@ -7,7 +7,7 @@ description: "How isolated is duplicati:2.1.0 by default? IronClaw scores its sa
 
 Run with plain `docker run lscr.io/linuxserver/duplicati:2.1.0` defaults, no hardening flags, the **duplicati** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `lscr.io/linuxserver/duplicati:2.1.0` at digest `sha256:ea0fc5050e0369e3d6736ac4633c65a977668889aed949aaa312ba4c73c8c772`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `lscr.io/linuxserver/duplicati:2.1.0` at digest `sha256:ea0fc5050e0369e3d6736ac4633c65a977668889aed949aaa312ba4c73c8c772` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/eclipse-mosquitto.md
+++ b/docs/scores/eclipse-mosquitto.md
@@ -7,7 +7,7 @@ description: "How isolated is eclipse-mosquitto:2 by default? IronClaw scores it
 
 Run with plain `docker run eclipse-mosquitto:2` defaults, no hardening flags, the **eclipse mosquitto** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `eclipse-mosquitto:2` at digest `sha256:6f8d8a947c506f8a2290ec65cd4bd2bc7cb4d43fb5f6271f861cb013e2ef9797`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `eclipse-mosquitto:2` at digest `sha256:6f8d8a947c506f8a2290ec65cd4bd2bc7cb4d43fb5f6271f861cb013e2ef9797` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/eclipse-temurin.md
+++ b/docs/scores/eclipse-temurin.md
@@ -7,7 +7,7 @@ description: "How isolated is eclipse-temurin:21-jre-alpine by default? IronClaw
 
 Run with plain `docker run eclipse-temurin:21-jre-alpine` defaults, no hardening flags, the **eclipse temurin** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `eclipse-temurin:21-jre-alpine` at digest `sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `eclipse-temurin:21-jre-alpine` at digest `sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/elasticsearch.md
+++ b/docs/scores/elasticsearch.md
@@ -7,7 +7,7 @@ description: "How isolated is elasticsearch:8.16.1 by default? IronClaw scores i
 
 Run with plain `docker run elasticsearch:8.16.1` defaults, no hardening flags, the **elasticsearch** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `elasticsearch:8.16.1` at digest `sha256:e5ee5f8dacbf18fa3ab59a098cc7d4d69f73e61637eb45f1c029e74b1cb200a1`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `elasticsearch:8.16.1` at digest `sha256:e5ee5f8dacbf18fa3ab59a098cc7d4d69f73e61637eb45f1c029e74b1cb200a1` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/elixir.md
+++ b/docs/scores/elixir.md
@@ -7,7 +7,7 @@ description: "How isolated is elixir:1.18-alpine by default? IronClaw scores its
 
 Run with plain `docker run elixir:1.18-alpine` defaults, no hardening flags, the **elixir** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `elixir:1.18-alpine` at digest `sha256:768e2c3c1831e221c7fb60ec11b8bf02cc8f6bb1db6ffe8715a4935c0aba235c`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `elixir:1.18-alpine` at digest `sha256:768e2c3c1831e221c7fb60ec11b8bf02cc8f6bb1db6ffe8715a4935c0aba235c` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/emqx.md
+++ b/docs/scores/emqx.md
@@ -7,7 +7,7 @@ description: "How isolated is emqx:5 by default? IronClaw scores its sandbox pos
 
 Run with plain `docker run emqx:5` defaults, no hardening flags, the **emqx** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `emqx:5` at digest `sha256:45b79cdae22e896f07285cdff744bbca06413ac1c334bd6e6f594a0b63823432`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `emqx:5` at digest `sha256:45b79cdae22e896f07285cdff744bbca06413ac1c334bd6e6f594a0b63823432` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/envoy.md
+++ b/docs/scores/envoy.md
@@ -7,7 +7,7 @@ description: "How isolated is envoy:v1.32-latest by default? IronClaw scores its
 
 Run with plain `docker run envoyproxy/envoy:v1.32-latest` defaults, no hardening flags, the **envoy** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `envoyproxy/envoy:v1.32-latest` at digest `sha256:6bf0d37dd5e8eac4b37effe89a1aec4760f7f2ce860d1fd6af22147eb87a5058`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `envoyproxy/envoy:v1.32-latest` at digest `sha256:6bf0d37dd5e8eac4b37effe89a1aec4760f7f2ce860d1fd6af22147eb87a5058` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/erlang.md
+++ b/docs/scores/erlang.md
@@ -7,7 +7,7 @@ description: "How isolated is erlang:27-alpine by default? IronClaw scores its s
 
 Run with plain `docker run erlang:27-alpine` defaults, no hardening flags, the **erlang** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `erlang:27-alpine` at digest `sha256:068162a593db370cea47991df530effda4cf2e24e26a05541835f1c1cd2a6daa`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `erlang:27-alpine` at digest `sha256:068162a593db370cea47991df530effda4cf2e24e26a05541835f1c1cd2a6daa` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/fedora.md
+++ b/docs/scores/fedora.md
@@ -7,7 +7,7 @@ description: "How isolated is fedora:41 by default? IronClaw scores its sandbox 
 
 Run with plain `docker run fedora:41` defaults, no hardening flags, the **fedora** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `fedora:41` at digest `sha256:f1a3fab47bcb3c3ddf3135d5ee7ba8b7b25f2e809a47440936212a3a50957f3d`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `fedora:41` at digest `sha256:f1a3fab47bcb3c3ddf3135d5ee7ba8b7b25f2e809a47440936212a3a50957f3d` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/firebird.md
+++ b/docs/scores/firebird.md
@@ -7,7 +7,7 @@ description: "How isolated is firebird:5.0.1 by default? IronClaw scores its san
 
 Run with plain `docker run firebirdsql/firebird:5.0.1` defaults, no hardening flags, the **firebird** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `firebirdsql/firebird:5.0.1` at digest `sha256:b89818b7017398ac1808ede3985685b95f936a8d884a786425faa774505d5a03`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `firebirdsql/firebird:5.0.1` at digest `sha256:b89818b7017398ac1808ede3985685b95f936a8d884a786425faa774505d5a03` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/flink.md
+++ b/docs/scores/flink.md
@@ -7,7 +7,7 @@ description: "How isolated is flink:1.20 by default? IronClaw scores its sandbox
 
 Run with plain `docker run flink:1.20` defaults, no hardening flags, the **flink** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `flink:1.20` at digest `sha256:35d8399ac4ad5cfd73adb674c77e5f83541f4faf96221e116421542fb63ee8f0`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `flink:1.20` at digest `sha256:35d8399ac4ad5cfd73adb674c77e5f83541f4faf96221e116421542fb63ee8f0` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/fluentd.md
+++ b/docs/scores/fluentd.md
@@ -7,7 +7,7 @@ description: "How isolated is fluentd:v1.17 by default? IronClaw scores its sand
 
 Run with plain `docker run fluent/fluentd:v1.17` defaults, no hardening flags, the **fluentd** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `fluent/fluentd:v1.17` at digest `sha256:c795c1bf9918c77a5415e2fda5825f9341f2dd0645d9adfb91f8cae3a3e6b240`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `fluent/fluentd:v1.17` at digest `sha256:c795c1bf9918c77a5415e2fda5825f9341f2dd0645d9adfb91f8cae3a3e6b240` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/forgejo.md
+++ b/docs/scores/forgejo.md
@@ -7,7 +7,7 @@ description: "How isolated is forgejo:9 by default? IronClaw scores its sandbox 
 
 Run with plain `docker run codeberg.org/forgejo/forgejo:9` defaults, no hardening flags, the **forgejo** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `codeberg.org/forgejo/forgejo:9` at digest `sha256:3c34f11fe8b9983096eef3f8f25c2d2c21c4ae7504960cb203f0b075d1d8ed73`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `codeberg.org/forgejo/forgejo:9` at digest `sha256:3c34f11fe8b9983096eef3f8f25c2d2c21c4ae7504960cb203f0b075d1d8ed73` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/freshrss.md
+++ b/docs/scores/freshrss.md
@@ -7,7 +7,7 @@ description: "How isolated is freshrss:1.24.3 by default? IronClaw scores its sa
 
 Run with plain `docker run freshrss/freshrss:1.24.3` defaults, no hardening flags, the **freshrss** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `freshrss/freshrss:1.24.3` at digest `sha256:baedf173d60b63c72f93fdb8480ee002d4622cd34103aac6510f45fdff41effe`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `freshrss/freshrss:1.24.3` at digest `sha256:baedf173d60b63c72f93fdb8480ee002d4622cd34103aac6510f45fdff41effe` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/gcc.md
+++ b/docs/scores/gcc.md
@@ -7,7 +7,7 @@ description: "How isolated is gcc:14 by default? IronClaw scores its sandbox pos
 
 Run with plain `docker run gcc:14` defaults, no hardening flags, the **gcc** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `gcc:14` at digest `sha256:1ea81e094f614fd2ed066316651dbac8eecb4d36add2ddd8a26151374c85c52c`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `gcc:14` at digest `sha256:1ea81e094f614fd2ed066316651dbac8eecb4d36add2ddd8a26151374c85c52c` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/ghost.md
+++ b/docs/scores/ghost.md
@@ -7,7 +7,7 @@ description: "How isolated is ghost:5-alpine by default? IronClaw scores its san
 
 Run with plain `docker run ghost:5-alpine` defaults, no hardening flags, the **ghost** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ghost:5-alpine` at digest `sha256:a0506f3f05f5bdc6c950c5113cdcdb1e1f96fbf15f6dc0a39fc093c25348bdb5`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ghost:5-alpine` at digest `sha256:a0506f3f05f5bdc6c950c5113cdcdb1e1f96fbf15f6dc0a39fc093c25348bdb5` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/gitea.md
+++ b/docs/scores/gitea.md
@@ -7,7 +7,7 @@ description: "How isolated is gitea:1.22 by default? IronClaw scores its sandbox
 
 Run with plain `docker run gitea/gitea:1.22` defaults, no hardening flags, the **gitea** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `gitea/gitea:1.22` at digest `sha256:538658de667c5d098a274f2f63aa6ec891d88f670cdd5282cf27221ba747dda4`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `gitea/gitea:1.22` at digest `sha256:538658de667c5d098a274f2f63aa6ec891d88f670cdd5282cf27221ba747dda4` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/gitlab-ce.md
+++ b/docs/scores/gitlab-ce.md
@@ -7,7 +7,7 @@ description: "How isolated is gitlab-ce:17.7.0-ce.0 by default? IronClaw scores 
 
 Run with plain `docker run gitlab/gitlab-ce:17.7.0-ce.0` defaults, no hardening flags, the **gitlab ce** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `gitlab/gitlab-ce:17.7.0-ce.0` at digest `sha256:8a464787956c4b9c13f33b69f9db9b928aa354770f6d2b5dd1dbe5040dc3c076`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `gitlab/gitlab-ce:17.7.0-ce.0` at digest `sha256:8a464787956c4b9c13f33b69f9db9b928aa354770f6d2b5dd1dbe5040dc3c076` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/gitlab-runner.md
+++ b/docs/scores/gitlab-runner.md
@@ -7,7 +7,7 @@ description: "How isolated is gitlab-runner:v17.7.0 by default? IronClaw scores 
 
 Run with plain `docker run gitlab/gitlab-runner:v17.7.0` defaults, no hardening flags, the **gitlab runner** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `gitlab/gitlab-runner:v17.7.0` at digest `sha256:11e3a44e7df21a32691a6975c7824c682787f742776d705ce89a74a780e3809f`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `gitlab/gitlab-runner:v17.7.0` at digest `sha256:11e3a44e7df21a32691a6975c7824c682787f742776d705ce89a74a780e3809f` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/gogs.md
+++ b/docs/scores/gogs.md
@@ -7,7 +7,7 @@ description: "How isolated is gogs:0.13 by default? IronClaw scores its sandbox 
 
 Run with plain `docker run gogs/gogs:0.13` defaults, no hardening flags, the **gogs** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `gogs/gogs:0.13` at digest `sha256:2fed2f7ce8dcf7bfdde3e6c309d934254ae8eb1cf8053a3f394baa184461dbfa`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `gogs/gogs:0.13` at digest `sha256:2fed2f7ce8dcf7bfdde3e6c309d934254ae8eb1cf8053a3f394baa184461dbfa` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/golang.md
+++ b/docs/scores/golang.md
@@ -7,7 +7,7 @@ description: "How isolated is golang:1.23-alpine by default? IronClaw scores its
 
 Run with plain `docker run golang:1.23-alpine` defaults, no hardening flags, the **golang** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `golang:1.23-alpine` at digest `sha256:383395b794dffa5b53012a212365d40c8e37109a626ca30d6151c8348d380b5f`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `golang:1.23-alpine` at digest `sha256:383395b794dffa5b53012a212365d40c8e37109a626ca30d6151c8348d380b5f` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/graalvm-community.md
+++ b/docs/scores/graalvm-community.md
@@ -7,7 +7,7 @@ description: "How isolated is graalvm-community:21 by default? IronClaw scores i
 
 Run with plain `docker run ghcr.io/graalvm/graalvm-community:21` defaults, no hardening flags, the **graalvm community** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ghcr.io/graalvm/graalvm-community:21` at digest `sha256:6e46c711c90bdbc24e23ccdb6e3fba837d660e68dd4ffeb87abbd3d08e115653`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ghcr.io/graalvm/graalvm-community:21` at digest `sha256:6e46c711c90bdbc24e23ccdb6e3fba837d660e68dd4ffeb87abbd3d08e115653` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/gradle.md
+++ b/docs/scores/gradle.md
@@ -7,7 +7,7 @@ description: "How isolated is gradle:8-jdk21 by default? IronClaw scores its san
 
 Run with plain `docker run gradle:8-jdk21` defaults, no hardening flags, the **gradle** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `gradle:8-jdk21` at digest `sha256:dae150d9066fc04a791ec7f0adc1a0eb4e867f11d76d03063ee0a60e5da56149`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `gradle:8-jdk21` at digest `sha256:dae150d9066fc04a791ec7f0adc1a0eb4e867f11d76d03063ee0a60e5da56149` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/grafana.md
+++ b/docs/scores/grafana.md
@@ -7,7 +7,7 @@ description: "How isolated is grafana:11.4.0 by default? IronClaw scores its san
 
 Run with plain `docker run grafana/grafana:11.4.0` defaults, no hardening flags, the **grafana** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `grafana/grafana:11.4.0` at digest `sha256:d8ea37798ccc41061a62ab080f2676dda6bf7815558499f901bdb0f533a456fb`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `grafana/grafana:11.4.0` at digest `sha256:d8ea37798ccc41061a62ab080f2676dda6bf7815558499f901bdb0f533a456fb` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/graphql-engine.md
+++ b/docs/scores/graphql-engine.md
@@ -7,7 +7,7 @@ description: "How isolated is graphql-engine:v2.44.0 by default? IronClaw scores
 
 Run with plain `docker run hasura/graphql-engine:v2.44.0` defaults, no hardening flags, the **graphql engine** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `hasura/graphql-engine:v2.44.0` at digest `sha256:4d34476840601fa0c372bce9b1ed15aac6ffc3f0a0db677e81062764c08e1dc5`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `hasura/graphql-engine:v2.44.0` at digest `sha256:4d34476840601fa0c372bce9b1ed15aac6ffc3f0a0db677e81062764c08e1dc5` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/graylog.md
+++ b/docs/scores/graylog.md
@@ -7,7 +7,7 @@ description: "How isolated is graylog:6.1 by default? IronClaw scores its sandbo
 
 Run with plain `docker run graylog/graylog:6.1` defaults, no hardening flags, the **graylog** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `graylog/graylog:6.1` at digest `sha256:c43d68d0af1d4decc7fa63effe0a065d04f1eca4b7b13d160ac8c501452cf3fe`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `graylog/graylog:6.1` at digest `sha256:c43d68d0af1d4decc7fa63effe0a065d04f1eca4b7b13d160ac8c501452cf3fe` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/groovy.md
+++ b/docs/scores/groovy.md
@@ -7,7 +7,7 @@ description: "How isolated is groovy:4 by default? IronClaw scores its sandbox p
 
 Run with plain `docker run groovy:4` defaults, no hardening flags, the **groovy** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `groovy:4` at digest `sha256:ae895be0ed7584713f2316a5b619dc14477c61f5509117bf01bcffa4b718adfb`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `groovy:4` at digest `sha256:ae895be0ed7584713f2316a5b619dc14477c61f5509117bf01bcffa4b718adfb` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/haproxy.md
+++ b/docs/scores/haproxy.md
@@ -7,7 +7,7 @@ description: "How isolated is haproxy:3.1-alpine by default? IronClaw scores its
 
 Run with plain `docker run haproxy:3.1-alpine` defaults, no hardening flags, the **haproxy** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `haproxy:3.1-alpine` at digest `sha256:475863a372c92c3dab3d59eafbbf8019dceebcd0c456594551b160ecdba4bdb9`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `haproxy:3.1-alpine` at digest `sha256:475863a372c92c3dab3d59eafbbf8019dceebcd0c456594551b160ecdba4bdb9` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/harbor-core.md
+++ b/docs/scores/harbor-core.md
@@ -7,7 +7,7 @@ description: "How isolated is harbor-core:v2.12.0 by default? IronClaw scores it
 
 Run with plain `docker run goharbor/harbor-core:v2.12.0` defaults, no hardening flags, the **harbor core** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `goharbor/harbor-core:v2.12.0` at digest `sha256:0d5499810373c66674bf7f83310bff2224fbae73bba731a807ecadb3b9aa0c2b`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `goharbor/harbor-core:v2.12.0` at digest `sha256:0d5499810373c66674bf7f83310bff2224fbae73bba731a807ecadb3b9aa0c2b` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/haskell.md
+++ b/docs/scores/haskell.md
@@ -7,7 +7,7 @@ description: "How isolated is haskell:9.8 by default? IronClaw scores its sandbo
 
 Run with plain `docker run haskell:9.8` defaults, no hardening flags, the **haskell** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `haskell:9.8` at digest `sha256:e2f16cad64d6271ecc44e6465ff461ef0bf95742edbe94fdfe489f17f8bf2f83`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `haskell:9.8` at digest `sha256:e2f16cad64d6271ecc44e6465ff461ef0bf95742edbe94fdfe489f17f8bf2f83` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/hazelcast.md
+++ b/docs/scores/hazelcast.md
@@ -7,7 +7,7 @@ description: "How isolated is hazelcast:5.5.0 by default? IronClaw scores its sa
 
 Run with plain `docker run hazelcast/hazelcast:5.5.0` defaults, no hardening flags, the **hazelcast** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `hazelcast/hazelcast:5.5.0` at digest `sha256:5dd5d31c7a0685d832f02eba03556898689ce85796c6b030132e93b7c0d77bd9`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `hazelcast/hazelcast:5.5.0` at digest `sha256:5dd5d31c7a0685d832f02eba03556898689ce85796c6b030132e93b7c0d77bd9` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/heimdall.md
+++ b/docs/scores/heimdall.md
@@ -7,7 +7,7 @@ description: "How isolated is heimdall:2.6.3 by default? IronClaw scores its san
 
 Run with plain `docker run lscr.io/linuxserver/heimdall:2.6.3` defaults, no hardening flags, the **heimdall** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `lscr.io/linuxserver/heimdall:2.6.3` at digest `sha256:71597f4461e4f01350bc9cd257ccf23e0041e666ff31bcb7c1671b5eac20b279`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `lscr.io/linuxserver/heimdall:2.6.3` at digest `sha256:71597f4461e4f01350bc9cd257ccf23e0041e666ff31bcb7c1671b5eac20b279` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/home-assistant.md
+++ b/docs/scores/home-assistant.md
@@ -7,7 +7,7 @@ description: "How isolated is home-assistant:2024.12 by default? IronClaw scores
 
 Run with plain `docker run ghcr.io/home-assistant/home-assistant:2024.12` defaults, no hardening flags, the **home assistant** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ghcr.io/home-assistant/home-assistant:2024.12` at digest `sha256:132ef461504be5c5ebd6e34e5d3fb3d7958bb6758a5136107eea9f84c299254a`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ghcr.io/home-assistant/home-assistant:2024.12` at digest `sha256:132ef461504be5c5ebd6e34e5d3fb3d7958bb6758a5136107eea9f84c299254a` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/homepage.md
+++ b/docs/scores/homepage.md
@@ -7,7 +7,7 @@ description: "How isolated is homepage:v0.10.9 by default? IronClaw scores its s
 
 Run with plain `docker run ghcr.io/gethomepage/homepage:v0.10.9` defaults, no hardening flags, the **homepage** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ghcr.io/gethomepage/homepage:v0.10.9` at digest `sha256:b6d732817572f9af99ec168b10641b8f7820f30cfa5a5cc5c68f1e291804bec8`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ghcr.io/gethomepage/homepage:v0.10.9` at digest `sha256:b6d732817572f9af99ec168b10641b8f7820f30cfa5a5cc5c68f1e291804bec8` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/httpd.md
+++ b/docs/scores/httpd.md
@@ -7,7 +7,7 @@ description: "How isolated is httpd:2.4-alpine by default? IronClaw scores its s
 
 Run with plain `docker run httpd:2.4-alpine` defaults, no hardening flags, the **httpd** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `httpd:2.4-alpine` at digest `sha256:1b766f17b84026429b7cb243317b142921b24432336e798bc881c43f45ed9567`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `httpd:2.4-alpine` at digest `sha256:1b766f17b84026429b7cb243317b142921b24432336e798bc881c43f45ed9567` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/hydra.md
+++ b/docs/scores/hydra.md
@@ -7,7 +7,7 @@ description: "How isolated is hydra:v2.2.0 by default? IronClaw scores its sandb
 
 Run with plain `docker run oryd/hydra:v2.2.0` defaults, no hardening flags, the **hydra** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `oryd/hydra:v2.2.0` at digest `sha256:2c93beb5e5f260cb5ed5ab579d8a1c133b0ec503c933244370522a2a53695ce7`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `oryd/hydra:v2.2.0` at digest `sha256:2c93beb5e5f260cb5ed5ab579d8a1c133b0ec503c933244370522a2a53695ce7` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/ibmjava.md
+++ b/docs/scores/ibmjava.md
@@ -7,7 +7,7 @@ description: "How isolated is ibmjava:8-jre by default? IronClaw scores its sand
 
 Run with plain `docker run ibmjava:8-jre` defaults, no hardening flags, the **ibmjava** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ibmjava:8-jre` at digest `sha256:c15361471b31ad587358bb3c388242b2d84d8f1ce17f6cb56f81e72ef84163cf`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ibmjava:8-jre` at digest `sha256:c15361471b31ad587358bb3c388242b2d84d8f1ce17f6cb56f81e72ef84163cf` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/ignite.md
+++ b/docs/scores/ignite.md
@@ -7,7 +7,7 @@ description: "How isolated is ignite:2.16.0 by default? IronClaw scores its sand
 
 Run with plain `docker run apacheignite/ignite:2.16.0` defaults, no hardening flags, the **ignite** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `apacheignite/ignite:2.16.0` at digest `sha256:9f32983b771957be8956e1855cfd7a649bbb137a6b011702088480f3e37b3aa9`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `apacheignite/ignite:2.16.0` at digest `sha256:9f32983b771957be8956e1855cfd7a649bbb137a6b011702088480f3e37b3aa9` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/immich-server.md
+++ b/docs/scores/immich-server.md
@@ -7,7 +7,7 @@ description: "How isolated is immich-server:v1.123.0 by default? IronClaw scores
 
 Run with plain `docker run ghcr.io/immich-app/immich-server:v1.123.0` defaults, no hardening flags, the **immich server** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ghcr.io/immich-app/immich-server:v1.123.0` at digest `sha256:666ce77995230ff7327da5d285c861895576977237de08564e3c3ddf842877eb`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ghcr.io/immich-app/immich-server:v1.123.0` at digest `sha256:666ce77995230ff7327da5d285c861895576977237de08564e3c3ddf842877eb` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/influxdb.md
+++ b/docs/scores/influxdb.md
@@ -7,7 +7,7 @@ description: "How isolated is influxdb:2.7-alpine by default? IronClaw scores it
 
 Run with plain `docker run influxdb:2.7-alpine` defaults, no hardening flags, the **influxdb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `influxdb:2.7-alpine` at digest `sha256:991673dc2d237bd79b15d6627410d72de111387e7dac673dbb92cf3333ffcc8c`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `influxdb:2.7-alpine` at digest `sha256:991673dc2d237bd79b15d6627410d72de111387e7dac673dbb92cf3333ffcc8c` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/jaeger.md
+++ b/docs/scores/jaeger.md
@@ -7,7 +7,7 @@ description: "How isolated is jaeger:2.1.0 by default? IronClaw scores its sandb
 
 Run with plain `docker run jaegertracing/jaeger:2.1.0` defaults, no hardening flags, the **jaeger** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `jaegertracing/jaeger:2.1.0` at digest `sha256:778b0f45d1cb4f94abcfdb86e5ad83155e16c0bce86d5fc2b6bb1cbd5b7386bc`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `jaegertracing/jaeger:2.1.0` at digest `sha256:778b0f45d1cb4f94abcfdb86e5ad83155e16c0bce86d5fc2b6bb1cbd5b7386bc` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/jellyfin.md
+++ b/docs/scores/jellyfin.md
@@ -7,7 +7,7 @@ description: "How isolated is jellyfin:10.10.3 by default? IronClaw scores its s
 
 Run with plain `docker run jellyfin/jellyfin:10.10.3` defaults, no hardening flags, the **jellyfin** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `jellyfin/jellyfin:10.10.3` at digest `sha256:17c3a8d9dddb97789b5f37112840ebf96566442c14d4754193a6c2eb154bc221`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `jellyfin/jellyfin:10.10.3` at digest `sha256:17c3a8d9dddb97789b5f37112840ebf96566442c14d4754193a6c2eb154bc221` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/jenkins.md
+++ b/docs/scores/jenkins.md
@@ -7,7 +7,7 @@ description: "How isolated is jenkins:lts by default? IronClaw scores its sandbo
 
 Run with plain `docker run jenkins/jenkins:lts` defaults, no hardening flags, the **jenkins** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `jenkins/jenkins:lts` at digest `sha256:f4f65e6cd1405cd889b7f5ac33f9d5cdc2a099de6b87fe8a3933b9c5d53d1d02`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `jenkins/jenkins:lts` at digest `sha256:f4f65e6cd1405cd889b7f5ac33f9d5cdc2a099de6b87fe8a3933b9c5d53d1d02` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/jetty.md
+++ b/docs/scores/jetty.md
@@ -7,7 +7,7 @@ description: "How isolated is jetty:12-jre21 by default? IronClaw scores its san
 
 Run with plain `docker run jetty:12-jre21` defaults, no hardening flags, the **jetty** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `jetty:12-jre21` at digest `sha256:cfd57c89498e1c90d99102a4f3ef67ba2f1d959be7c49c6378fa175e474bf7a1`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `jetty:12-jre21` at digest `sha256:cfd57c89498e1c90d99102a4f3ef67ba2f1d959be7c49c6378fa175e474bf7a1` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/joomla.md
+++ b/docs/scores/joomla.md
@@ -7,7 +7,7 @@ description: "How isolated is joomla:5-apache by default? IronClaw scores its sa
 
 Run with plain `docker run joomla:5-apache` defaults, no hardening flags, the **joomla** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `joomla:5-apache` at digest `sha256:4a6daad09b5897d1319bd066756413d097ecfcda37df571c35d9c2d1ac08e421`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `joomla:5-apache` at digest `sha256:4a6daad09b5897d1319bd066756413d097ecfcda37df571c35d9c2d1ac08e421` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/julia.md
+++ b/docs/scores/julia.md
@@ -7,7 +7,7 @@ description: "How isolated is julia:1.11 by default? IronClaw scores its sandbox
 
 Run with plain `docker run julia:1.11` defaults, no hardening flags, the **julia** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `julia:1.11` at digest `sha256:f2f14ae7fb03084ed759935dbba9c8096dd9a2626dcee607898b3e67b61dfc84`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `julia:1.11` at digest `sha256:f2f14ae7fb03084ed759935dbba9c8096dd9a2626dcee607898b3e67b61dfc84` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/jupyterhub.md
+++ b/docs/scores/jupyterhub.md
@@ -7,7 +7,7 @@ description: "How isolated is jupyterhub:5.2.1 by default? IronClaw scores its s
 
 Run with plain `docker run jupyterhub/jupyterhub:5.2.1` defaults, no hardening flags, the **jupyterhub** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `jupyterhub/jupyterhub:5.2.1` at digest `sha256:ed9ab780bb3171883cca1b1492301bf5cbb00d34766149a796b49b0bc5ac3530`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `jupyterhub/jupyterhub:5.2.1` at digest `sha256:ed9ab780bb3171883cca1b1492301bf5cbb00d34766149a796b49b0bc5ac3530` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/k3s.md
+++ b/docs/scores/k3s.md
@@ -7,7 +7,7 @@ description: "How isolated is k3s:v1.31.4-k3s1 by default? IronClaw scores its s
 
 Run with plain `docker run rancher/k3s:v1.31.4-k3s1` defaults, no hardening flags, the **k3s** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `rancher/k3s:v1.31.4-k3s1` at digest `sha256:627fc392e5e7992fb8aa738fb04bc0c9ae9a068999cb4cfbea5858661cd79d04`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `rancher/k3s:v1.31.4-k3s1` at digest `sha256:627fc392e5e7992fb8aa738fb04bc0c9ae9a068999cb4cfbea5858661cd79d04` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/kafka.md
+++ b/docs/scores/kafka.md
@@ -7,7 +7,7 @@ description: "How isolated is kafka:3.9.0 by default? IronClaw scores its sandbo
 
 Run with plain `docker run apache/kafka:3.9.0` defaults, no hardening flags, the **kafka** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `apache/kafka:3.9.0` at digest `sha256:fbc7d7c428e3755cf36518d4976596002477e4c052d1f80b5b9eafd06d0fff2f`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `apache/kafka:3.9.0` at digest `sha256:fbc7d7c428e3755cf36518d4976596002477e4c052d1f80b5b9eafd06d0fff2f` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/kapacitor.md
+++ b/docs/scores/kapacitor.md
@@ -7,7 +7,7 @@ description: "How isolated is kapacitor:1.7 by default? IronClaw scores its sand
 
 Run with plain `docker run kapacitor:1.7` defaults, no hardening flags, the **kapacitor** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `kapacitor:1.7` at digest `sha256:3bf563d0e64ca7180b8dbc49c8036e9a27da10507ad0bfe275475249136874de`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `kapacitor:1.7` at digest `sha256:3bf563d0e64ca7180b8dbc49c8036e9a27da10507ad0bfe275475249136874de` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/keycloak.md
+++ b/docs/scores/keycloak.md
@@ -7,7 +7,7 @@ description: "How isolated is keycloak:26.0.7 by default? IronClaw scores its sa
 
 Run with plain `docker run quay.io/keycloak/keycloak:26.0.7` defaults, no hardening flags, the **keycloak** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `quay.io/keycloak/keycloak:26.0.7` at digest `sha256:4388e2379b7e870a447adbe7b80bd61f5fbf04e925832b19669fda4957f05a81`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `quay.io/keycloak/keycloak:26.0.7` at digest `sha256:4388e2379b7e870a447adbe7b80bd61f5fbf04e925832b19669fda4957f05a81` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/keydb.md
+++ b/docs/scores/keydb.md
@@ -7,7 +7,7 @@ description: "How isolated is keydb:latest by default? IronClaw scores its sandb
 
 Run with plain `docker run eqalpha/keydb:latest` defaults, no hardening flags, the **keydb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `eqalpha/keydb:latest` at digest `sha256:6537505c42355ca1f571276bddf83f5b750f760f07b2a185a676481791e388ac`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `eqalpha/keydb:latest` at digest `sha256:6537505c42355ca1f571276bddf83f5b750f760f07b2a185a676481791e388ac` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/kibana.md
+++ b/docs/scores/kibana.md
@@ -7,7 +7,7 @@ description: "How isolated is kibana:8.16.1 by default? IronClaw scores its sand
 
 Run with plain `docker run kibana:8.16.1` defaults, no hardening flags, the **kibana** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `kibana:8.16.1` at digest `sha256:e18c1f6d92e819b1c577a1af9a02bfcae6e8b63596368eec3b40e9ad98fa3caa`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `kibana:8.16.1` at digest `sha256:e18c1f6d92e819b1c577a1af9a02bfcae6e8b63596368eec3b40e9ad98fa3caa` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/kong.md
+++ b/docs/scores/kong.md
@@ -7,7 +7,7 @@ description: "How isolated is kong:3.8 by default? IronClaw scores its sandbox p
 
 Run with plain `docker run kong:3.8` defaults, no hardening flags, the **kong** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `kong:3.8` at digest `sha256:dd6cd1d94a7aae8c5a4d245ccbee6b81230d41a4312d76d076c4e9c6db65611c`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `kong:3.8` at digest `sha256:dd6cd1d94a7aae8c5a4d245ccbee6b81230d41a4312d76d076c4e9c6db65611c` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/leap.md
+++ b/docs/scores/leap.md
@@ -7,7 +7,7 @@ description: "How isolated is leap:15.6 by default? IronClaw scores its sandbox 
 
 Run with plain `docker run opensuse/leap:15.6` defaults, no hardening flags, the **leap** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `opensuse/leap:15.6` at digest `sha256:79be7751205ea84559990fb76b1bec71e38d6fad41c70a4f6c921b803b58f421`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `opensuse/leap:15.6` at digest `sha256:79be7751205ea84559990fb76b1bec71e38d6fad41c70a4f6c921b803b58f421` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/localstack.md
+++ b/docs/scores/localstack.md
@@ -7,7 +7,7 @@ description: "How isolated is localstack:4 by default? IronClaw scores its sandb
 
 Run with plain `docker run localstack/localstack:4` defaults, no hardening flags, the **localstack** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `localstack/localstack:4` at digest `sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `localstack/localstack:4` at digest `sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/logstash.md
+++ b/docs/scores/logstash.md
@@ -7,7 +7,7 @@ description: "How isolated is logstash:8.16.1 by default? IronClaw scores its sa
 
 Run with plain `docker run logstash:8.16.1` defaults, no hardening flags, the **logstash** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `logstash:8.16.1` at digest `sha256:dca706ef2cf7b0ea326f49bec73647c04270fc763d73eabf93408161955793a0`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `logstash:8.16.1` at digest `sha256:dca706ef2cf7b0ea326f49bec73647c04270fc763d73eabf93408161955793a0` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/loki.md
+++ b/docs/scores/loki.md
@@ -7,7 +7,7 @@ description: "How isolated is loki:3.3.2 by default? IronClaw scores its sandbox
 
 Run with plain `docker run grafana/loki:3.3.2` defaults, no hardening flags, the **loki** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `grafana/loki:3.3.2` at digest `sha256:8af2de1abbdd7aa92b27c9bcc96f0f4140c9096b507c77921ffddf1c6ad6c48f`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `grafana/loki:3.3.2` at digest `sha256:8af2de1abbdd7aa92b27c9bcc96f0f4140c9096b507c77921ffddf1c6ad6c48f` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/lua.md
+++ b/docs/scores/lua.md
@@ -7,7 +7,7 @@ description: "How isolated is lua:5.4 by default? IronClaw scores its sandbox po
 
 Run with plain `docker run nickblah/lua:5.4` defaults, no hardening flags, the **lua** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `nickblah/lua:5.4` at digest `sha256:1f2de2882e50f97bf8fa3cffef666a2e5402d9c447da59bfcb159e38d1587dab`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `nickblah/lua:5.4` at digest `sha256:1f2de2882e50f97bf8fa3cffef666a2e5402d9c447da59bfcb159e38d1587dab` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/mailhog.md
+++ b/docs/scores/mailhog.md
@@ -7,7 +7,7 @@ description: "How isolated is mailhog:v1.0.1 by default? IronClaw scores its san
 
 Run with plain `docker run mailhog/mailhog:v1.0.1` defaults, no hardening flags, the **mailhog** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `mailhog/mailhog:v1.0.1` at digest `sha256:8d76a3d4ffa32a3661311944007a415332c4bb855657f4f6c57996405c009bea`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `mailhog/mailhog:v1.0.1` at digest `sha256:8d76a3d4ffa32a3661311944007a415332c4bb855657f4f6c57996405c009bea` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/mailpit.md
+++ b/docs/scores/mailpit.md
@@ -7,7 +7,7 @@ description: "How isolated is mailpit:latest by default? IronClaw scores its san
 
 Run with plain `docker run axllent/mailpit:latest` defaults, no hardening flags, the **mailpit** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `axllent/mailpit:latest` at digest `sha256:b868afa176bfd6cce2323ea316cd99ccad77915e51e595748f6d786700ecf109`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `axllent/mailpit:latest` at digest `sha256:b868afa176bfd6cce2323ea316cd99ccad77915e51e595748f6d786700ecf109` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/manticore.md
+++ b/docs/scores/manticore.md
@@ -7,7 +7,7 @@ description: "How isolated is manticore:6.3.6 by default? IronClaw scores its sa
 
 Run with plain `docker run manticoresearch/manticore:6.3.6` defaults, no hardening flags, the **manticore** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `manticoresearch/manticore:6.3.6` at digest `sha256:767c48291e48fdff47f08772e1cc0340f389fb008663a60142825b314710121f`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `manticoresearch/manticore:6.3.6` at digest `sha256:767c48291e48fdff47f08772e1cc0340f389fb008663a60142825b314710121f` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/mariadb.md
+++ b/docs/scores/mariadb.md
@@ -7,7 +7,7 @@ description: "How isolated is mariadb:11 by default? IronClaw scores its sandbox
 
 Run with plain `docker run mariadb:11` defaults, no hardening flags, the **mariadb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `mariadb:11` at digest `sha256:efb4959ef2c835cd735dbc388eb9ad6aab0c78dd64febcd51bc17481111890c4`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `mariadb:11` at digest `sha256:efb4959ef2c835cd735dbc388eb9ad6aab0c78dd64febcd51bc17481111890c4` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/matomo.md
+++ b/docs/scores/matomo.md
@@ -7,7 +7,7 @@ description: "How isolated is matomo:5 by default? IronClaw scores its sandbox p
 
 Run with plain `docker run matomo:5` defaults, no hardening flags, the **matomo** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `matomo:5` at digest `sha256:650f4f205b0b8968f430b0fc924e8b37e8ff023948c4db08ea300d154054b257`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `matomo:5` at digest `sha256:650f4f205b0b8968f430b0fc924e8b37e8ff023948c4db08ea300d154054b257` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/mattermost-team-edition.md
+++ b/docs/scores/mattermost-team-edition.md
@@ -7,7 +7,7 @@ description: "How isolated is mattermost-team-edition:10.2 by default? IronClaw 
 
 Run with plain `docker run mattermost/mattermost-team-edition:10.2` defaults, no hardening flags, the **mattermost team edition** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `mattermost/mattermost-team-edition:10.2` at digest `sha256:2dc077d4f2c88dda8a89cc8fd2dd55f65554894c088719a042d7f9ff58cca908`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `mattermost/mattermost-team-edition:10.2` at digest `sha256:2dc077d4f2c88dda8a89cc8fd2dd55f65554894c088719a042d7f9ff58cca908` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/maven.md
+++ b/docs/scores/maven.md
@@ -7,7 +7,7 @@ description: "How isolated is maven:3.9-eclipse-temurin-21 by default? IronClaw 
 
 Run with plain `docker run maven:3.9-eclipse-temurin-21` defaults, no hardening flags, the **maven** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `maven:3.9-eclipse-temurin-21` at digest `sha256:2b4496088e7b80ae10a8c9f74e574ea21380325a006ec684532ad6bad5bc7273`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `maven:3.9-eclipse-temurin-21` at digest `sha256:2b4496088e7b80ae10a8c9f74e574ea21380325a006ec684532ad6bad5bc7273` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/mediawiki.md
+++ b/docs/scores/mediawiki.md
@@ -7,7 +7,7 @@ description: "How isolated is mediawiki:1.43 by default? IronClaw scores its san
 
 Run with plain `docker run mediawiki:1.43` defaults, no hardening flags, the **mediawiki** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `mediawiki:1.43` at digest `sha256:439eda8a1c2a3db2e21ae9817c5ca07fbf8b859465215431405d6412006db803`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `mediawiki:1.43` at digest `sha256:439eda8a1c2a3db2e21ae9817c5ca07fbf8b859465215431405d6412006db803` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/meilisearch.md
+++ b/docs/scores/meilisearch.md
@@ -7,7 +7,7 @@ description: "How isolated is meilisearch:v1.11 by default? IronClaw scores its 
 
 Run with plain `docker run getmeili/meilisearch:v1.11` defaults, no hardening flags, the **meilisearch** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `getmeili/meilisearch:v1.11` at digest `sha256:6f8f1fc29d1ff67b4d8d503bb4e0a69b55c8d42600decafde951344218193a27`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `getmeili/meilisearch:v1.11` at digest `sha256:6f8f1fc29d1ff67b4d8d503bb4e0a69b55c8d42600decafde951344218193a27` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/memcached.md
+++ b/docs/scores/memcached.md
@@ -7,7 +7,7 @@ description: "How isolated is memcached:1.6-alpine by default? IronClaw scores i
 
 Run with plain `docker run memcached:1.6-alpine` defaults, no hardening flags, the **memcached** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `memcached:1.6-alpine` at digest `sha256:dfacdbd93e7a6f1ad63801753a1fc959dc678a5a1d2141ff438d57e6d8793fc3`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `memcached:1.6-alpine` at digest `sha256:dfacdbd93e7a6f1ad63801753a1fc959dc678a5a1d2141ff438d57e6d8793fc3` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/metabase.md
+++ b/docs/scores/metabase.md
@@ -7,7 +7,7 @@ description: "How isolated is metabase:v0.52.4 by default? IronClaw scores its s
 
 Run with plain `docker run metabase/metabase:v0.52.4` defaults, no hardening flags, the **metabase** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `metabase/metabase:v0.52.4` at digest `sha256:ea0229a63116ea625ef09085a84ee0d2618311fd34a6e72cc527ae2eb003a5f9`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `metabase/metabase:v0.52.4` at digest `sha256:ea0229a63116ea625ef09085a84ee0d2618311fd34a6e72cc527ae2eb003a5f9` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/milvus.md
+++ b/docs/scores/milvus.md
@@ -7,7 +7,7 @@ description: "How isolated is milvus:v2.5.1 by default? IronClaw scores its sand
 
 Run with plain `docker run milvusdb/milvus:v2.5.1` defaults, no hardening flags, the **milvus** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `milvusdb/milvus:v2.5.1` at digest `sha256:d86c9d19d4559e6d5481895f3c307193290ac07178499ed108082826f4336387`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `milvusdb/milvus:v2.5.1` at digest `sha256:d86c9d19d4559e6d5481895f3c307193290ac07178499ed108082826f4336387` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/miniflux.md
+++ b/docs/scores/miniflux.md
@@ -7,7 +7,7 @@ description: "How isolated is miniflux:2.2.3 by default? IronClaw scores its san
 
 Run with plain `docker run miniflux/miniflux:2.2.3` defaults, no hardening flags, the **miniflux** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `miniflux/miniflux:2.2.3` at digest `sha256:e21953092096579daaad39ba69729f01b08380b03bae4544a943f549c8e11a67`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `miniflux/miniflux:2.2.3` at digest `sha256:e21953092096579daaad39ba69729f01b08380b03bae4544a943f549c8e11a67` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/minio.md
+++ b/docs/scores/minio.md
@@ -7,7 +7,7 @@ description: "How isolated is minio:latest by default? IronClaw scores its sandb
 
 Run with plain `docker run minio/minio:latest` defaults, no hardening flags, the **minio** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `minio/minio:latest` at digest `sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `minio/minio:latest` at digest `sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/mlflow.md
+++ b/docs/scores/mlflow.md
@@ -7,7 +7,7 @@ description: "How isolated is mlflow:v2.19.0 by default? IronClaw scores its san
 
 Run with plain `docker run ghcr.io/mlflow/mlflow:v2.19.0` defaults, no hardening flags, the **mlflow** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ghcr.io/mlflow/mlflow:v2.19.0` at digest `sha256:e68e3089108faf453681319dc7ae6e746b6f25c28243167dcead391c051871ae`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ghcr.io/mlflow/mlflow:v2.19.0` at digest `sha256:e68e3089108faf453681319dc7ae6e746b6f25c28243167dcead391c051871ae` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/mongo-express.md
+++ b/docs/scores/mongo-express.md
@@ -7,7 +7,7 @@ description: "How isolated is mongo-express:1.0 by default? IronClaw scores its 
 
 Run with plain `docker run mongo-express:1.0` defaults, no hardening flags, the **mongo express** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `mongo-express:1.0` at digest `sha256:1b23d7976f0210dbec74045c209e52fbb26d29b2e873d6c6fa3d3f0ae32c2a64`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `mongo-express:1.0` at digest `sha256:1b23d7976f0210dbec74045c209e52fbb26d29b2e873d6c6fa3d3f0ae32c2a64` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/mongo.md
+++ b/docs/scores/mongo.md
@@ -7,7 +7,7 @@ description: "How isolated is mongo:7 by default? IronClaw scores its sandbox po
 
 Run with plain `docker run mongo:7` defaults, no hardening flags, the **mongo** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `mongo:7` at digest `sha256:d5b3ca8c3f3cdce78d44870dc0871b76d5235e9b2ad4ea6bea5d1fbff8027703`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `mongo:7` at digest `sha256:d5b3ca8c3f3cdce78d44870dc0871b76d5235e9b2ad4ea6bea5d1fbff8027703` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/mono.md
+++ b/docs/scores/mono.md
@@ -7,7 +7,7 @@ description: "How isolated is mono:6.12 by default? IronClaw scores its sandbox 
 
 Run with plain `docker run mono:6.12` defaults, no hardening flags, the **mono** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `mono:6.12` at digest `sha256:34d816779b1248b5cfd095770b64ecbaf1798e2aca693a91c11a018dce9c7ad5`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `mono:6.12` at digest `sha256:34d816779b1248b5cfd095770b64ecbaf1798e2aca693a91c11a018dce9c7ad5` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/mysql.md
+++ b/docs/scores/mysql.md
@@ -7,7 +7,7 @@ description: "How isolated is mysql:8.4 by default? IronClaw scores its sandbox 
 
 Run with plain `docker run mysql:8.4` defaults, no hardening flags, the **mysql** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `mysql:8.4` at digest `sha256:d36d39a64cd12a5c1cc9e6aa2bfb5f8d4c81a2f6586e0a04a9ae13939db02209`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `mysql:8.4` at digest `sha256:d36d39a64cd12a5c1cc9e6aa2bfb5f8d4c81a2f6586e0a04a9ae13939db02209` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/n8n.md
+++ b/docs/scores/n8n.md
@@ -7,7 +7,7 @@ description: "How isolated is n8n:1.71.3 by default? IronClaw scores its sandbox
 
 Run with plain `docker run n8nio/n8n:1.71.3` defaults, no hardening flags, the **n8n** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `n8nio/n8n:1.71.3` at digest `sha256:4846eb2f4b874ab04cde7fc1e249d2ddaec66e9aea64439beb2972cfea88e3c0`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `n8nio/n8n:1.71.3` at digest `sha256:4846eb2f4b874ab04cde7fc1e249d2ddaec66e9aea64439beb2972cfea88e3c0` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/nats.md
+++ b/docs/scores/nats.md
@@ -7,7 +7,7 @@ description: "How isolated is nats:2.10-alpine by default? IronClaw scores its s
 
 Run with plain `docker run nats:2.10-alpine` defaults, no hardening flags, the **nats** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `nats:2.10-alpine` at digest `sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `nats:2.10-alpine` at digest `sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/navidrome.md
+++ b/docs/scores/navidrome.md
@@ -7,7 +7,7 @@ description: "How isolated is navidrome:0.54.3 by default? IronClaw scores its s
 
 Run with plain `docker run deluan/navidrome:0.54.3` defaults, no hardening flags, the **navidrome** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `deluan/navidrome:0.54.3` at digest `sha256:4915ec6ad11ff76167491654184dfb7bbf341042fea498c20b2534af3dde587f`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `deluan/navidrome:0.54.3` at digest `sha256:4915ec6ad11ff76167491654184dfb7bbf341042fea498c20b2534af3dde587f` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/neo4j.md
+++ b/docs/scores/neo4j.md
@@ -7,7 +7,7 @@ description: "How isolated is neo4j:5 by default? IronClaw scores its sandbox po
 
 Run with plain `docker run neo4j:5` defaults, no hardening flags, the **neo4j** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `neo4j:5` at digest `sha256:362542416de6c09a971484d1893878016cc3b5cdec166e54b1c824a220ecd6b9`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `neo4j:5` at digest `sha256:362542416de6c09a971484d1893878016cc3b5cdec166e54b1c824a220ecd6b9` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/netdata.md
+++ b/docs/scores/netdata.md
@@ -7,7 +7,7 @@ description: "How isolated is netdata:stable by default? IronClaw scores its san
 
 Run with plain `docker run netdata/netdata:stable` defaults, no hardening flags, the **netdata** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `netdata/netdata:stable` at digest `sha256:689145f603fed0ca341b4d8a0fb9910cd9d8c0590b0530cd24ae1912a9c7f8f3`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `netdata/netdata:stable` at digest `sha256:689145f603fed0ca341b4d8a0fb9910cd9d8c0590b0530cd24ae1912a9c7f8f3` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/nextcloud.md
+++ b/docs/scores/nextcloud.md
@@ -7,7 +7,7 @@ description: "How isolated is nextcloud:30-apache by default? IronClaw scores it
 
 Run with plain `docker run nextcloud:30-apache` defaults, no hardening flags, the **nextcloud** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `nextcloud:30-apache` at digest `sha256:fb966733647ea03f0446b0c22eac9733c8eb616d37b960caca9d4c3010e14a08`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `nextcloud:30-apache` at digest `sha256:fb966733647ea03f0446b0c22eac9733c8eb616d37b960caca9d4c3010e14a08` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/nexus3.md
+++ b/docs/scores/nexus3.md
@@ -7,7 +7,7 @@ description: "How isolated is nexus3:3.75.0 by default? IronClaw scores its sand
 
 Run with plain `docker run sonatype/nexus3:3.75.0` defaults, no hardening flags, the **nexus3** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `sonatype/nexus3:3.75.0` at digest `sha256:cdf8d3b1d7251183dfe43e208a87060a8b410e0e1b25254ac40a1391caf19c5b`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `sonatype/nexus3:3.75.0` at digest `sha256:cdf8d3b1d7251183dfe43e208a87060a8b410e0e1b25254ac40a1391caf19c5b` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/nginx-proxy-manager.md
+++ b/docs/scores/nginx-proxy-manager.md
@@ -7,7 +7,7 @@ description: "How isolated is nginx-proxy-manager:2.12.1 by default? IronClaw sc
 
 Run with plain `docker run jc21/nginx-proxy-manager:2.12.1` defaults, no hardening flags, the **nginx proxy manager** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `jc21/nginx-proxy-manager:2.12.1` at digest `sha256:b7168e5f6828cbbd3622fa19965007e4611cf42b5f3c603008377ffd45a4fe00`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `jc21/nginx-proxy-manager:2.12.1` at digest `sha256:b7168e5f6828cbbd3622fa19965007e4611cf42b5f3c603008377ffd45a4fe00` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/nginx-proxy.md
+++ b/docs/scores/nginx-proxy.md
@@ -7,7 +7,7 @@ description: "How isolated is nginx-proxy:1.6.4 by default? IronClaw scores its 
 
 Run with plain `docker run nginxproxy/nginx-proxy:1.6.4` defaults, no hardening flags, the **nginx proxy** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `nginxproxy/nginx-proxy:1.6.4` at digest `sha256:5dd14e68ea81f33692b810d096ac8ebe7aa789d75ce91e05f09d56d044ed8ee3`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `nginxproxy/nginx-proxy:1.6.4` at digest `sha256:5dd14e68ea81f33692b810d096ac8ebe7aa789d75ce91e05f09d56d044ed8ee3` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/nginx-unprivileged.md
+++ b/docs/scores/nginx-unprivileged.md
@@ -7,7 +7,7 @@ description: "How isolated is nginx-unprivileged:1.27-alpine by default? IronCla
 
 Run with plain `docker run nginxinc/nginx-unprivileged:1.27-alpine` defaults, no hardening flags, the **nginx unprivileged** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `nginxinc/nginx-unprivileged:1.27-alpine` at digest `sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `nginxinc/nginx-unprivileged:1.27-alpine` at digest `sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/nginx.md
+++ b/docs/scores/nginx.md
@@ -7,7 +7,7 @@ description: "How isolated is nginx:1.27-alpine by default? IronClaw scores its 
 
 Run with plain `docker run nginx:1.27-alpine` defaults, no hardening flags, the **nginx** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `nginx:1.27-alpine` at digest `sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `nginx:1.27-alpine` at digest `sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/nifi.md
+++ b/docs/scores/nifi.md
@@ -7,7 +7,7 @@ description: "How isolated is nifi:2.0.0 by default? IronClaw scores its sandbox
 
 Run with plain `docker run apache/nifi:2.0.0` defaults, no hardening flags, the **nifi** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `apache/nifi:2.0.0` at digest `sha256:cf8f4ce74cf34712766c8aba016c0c5efb8f73d6c2392e2108a809fff242875c`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `apache/nifi:2.0.0` at digest `sha256:cf8f4ce74cf34712766c8aba016c0c5efb8f73d6c2392e2108a809fff242875c` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/nim.md
+++ b/docs/scores/nim.md
@@ -7,7 +7,7 @@ description: "How isolated is nim:2.2.0 by default? IronClaw scores its sandbox 
 
 Run with plain `docker run nimlang/nim:2.2.0` defaults, no hardening flags, the **nim** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `nimlang/nim:2.2.0` at digest `sha256:c918a25a7ef8d96a1d3340cd6ccac9617a7c44e3b3761f0c7ef42126789f7bda`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `nimlang/nim:2.2.0` at digest `sha256:c918a25a7ef8d96a1d3340cd6ccac9617a7c44e3b3761f0c7ef42126789f7bda` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/nocodb.md
+++ b/docs/scores/nocodb.md
@@ -7,7 +7,7 @@ description: "How isolated is nocodb:0.257.2 by default? IronClaw scores its san
 
 Run with plain `docker run nocodb/nocodb:0.257.2` defaults, no hardening flags, the **nocodb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `nocodb/nocodb:0.257.2` at digest `sha256:eef22659895da3fe85e85338c1b3f7fe6a44a1604f40fac8935597ac5b3116e4`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `nocodb/nocodb:0.257.2` at digest `sha256:eef22659895da3fe85e85338c1b3f7fe6a44a1604f40fac8935597ac5b3116e4` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/node-exporter.md
+++ b/docs/scores/node-exporter.md
@@ -7,7 +7,7 @@ description: "How isolated is node-exporter:v1.8.2 by default? IronClaw scores i
 
 Run with plain `docker run prom/node-exporter:v1.8.2` defaults, no hardening flags, the **node exporter** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `prom/node-exporter:v1.8.2` at digest `sha256:4032c6d5bfd752342c3e631c2f1de93ba6b86c41db6b167b9a35372c139e7706`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `prom/node-exporter:v1.8.2` at digest `sha256:4032c6d5bfd752342c3e631c2f1de93ba6b86c41db6b167b9a35372c139e7706` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/node.md
+++ b/docs/scores/node.md
@@ -7,7 +7,7 @@ description: "How isolated is node:22-alpine by default? IronClaw scores its san
 
 Run with plain `docker run node:22-alpine` defaults, no hardening flags, the **node** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `node:22-alpine` at digest `sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `node:22-alpine` at digest `sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/nomad.md
+++ b/docs/scores/nomad.md
@@ -7,7 +7,7 @@ description: "How isolated is nomad:1.9 by default? IronClaw scores its sandbox 
 
 Run with plain `docker run hashicorp/nomad:1.9` defaults, no hardening flags, the **nomad** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `hashicorp/nomad:1.9` at digest `sha256:dc909e89cbace7e45aae811b2fbb1a5810d1bb0620c79513e964f18255aed25b`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `hashicorp/nomad:1.9` at digest `sha256:dc909e89cbace7e45aae811b2fbb1a5810d1bb0620c79513e964f18255aed25b` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/nsq.md
+++ b/docs/scores/nsq.md
@@ -7,7 +7,7 @@ description: "How isolated is nsq:v1.3.0 by default? IronClaw scores its sandbox
 
 Run with plain `docker run nsqio/nsq:v1.3.0` defaults, no hardening flags, the **nsq** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `nsqio/nsq:v1.3.0` at digest `sha256:1a369c146af71bc95c25d54b375a2b98452478c1eaf4e85f8fcb01da20f2c78a`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `nsqio/nsq:v1.3.0` at digest `sha256:1a369c146af71bc95c25d54b375a2b98452478c1eaf4e85f8fcb01da20f2c78a` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/ntfy.md
+++ b/docs/scores/ntfy.md
@@ -7,7 +7,7 @@ description: "How isolated is ntfy:v2.11.0 by default? IronClaw scores its sandb
 
 Run with plain `docker run binwiederhier/ntfy:v2.11.0` defaults, no hardening flags, the **ntfy** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `binwiederhier/ntfy:v2.11.0` at digest `sha256:4a7d0f0adc6d5d9fc36e64ab55ef676e76e124a2bdd50ce115b6d9c1c7430294`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `binwiederhier/ntfy:v2.11.0` at digest `sha256:4a7d0f0adc6d5d9fc36e64ab55ef676e76e124a2bdd50ce115b6d9c1c7430294` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/ollama.md
+++ b/docs/scores/ollama.md
@@ -7,7 +7,7 @@ description: "How isolated is ollama:0.5.4 by default? IronClaw scores its sandb
 
 Run with plain `docker run ollama/ollama:0.5.4` defaults, no hardening flags, the **ollama** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ollama/ollama:0.5.4` at digest `sha256:18bfb1d605604fd53dcad20d0556df4c781e560ebebcd923454d627c994a0e37`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ollama/ollama:0.5.4` at digest `sha256:18bfb1d605604fd53dcad20d0556df4c781e560ebebcd923454d627c994a0e37` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/openresty.md
+++ b/docs/scores/openresty.md
@@ -7,7 +7,7 @@ description: "How isolated is openresty:alpine by default? IronClaw scores its s
 
 Run with plain `docker run openresty/openresty:alpine` defaults, no hardening flags, the **openresty** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `openresty/openresty:alpine` at digest `sha256:99b32fe3e411c98033114dd471440fb702992d0953ce8b6e6b5c016285ac2ab9`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `openresty/openresty:alpine` at digest `sha256:99b32fe3e411c98033114dd471440fb702992d0953ce8b6e6b5c016285ac2ab9` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/opensearch-dashboards.md
+++ b/docs/scores/opensearch-dashboards.md
@@ -7,7 +7,7 @@ description: "How isolated is opensearch-dashboards:2.18.0 by default? IronClaw 
 
 Run with plain `docker run opensearchproject/opensearch-dashboards:2.18.0` defaults, no hardening flags, the **opensearch dashboards** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `opensearchproject/opensearch-dashboards:2.18.0` at digest `sha256:0ecd8444add2926cb6c52e03f910160138b6e331522237561da0b82e159b134f`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `opensearchproject/opensearch-dashboards:2.18.0` at digest `sha256:0ecd8444add2926cb6c52e03f910160138b6e331522237561da0b82e159b134f` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/opensearch.md
+++ b/docs/scores/opensearch.md
@@ -7,7 +7,7 @@ description: "How isolated is opensearch:2 by default? IronClaw scores its sandb
 
 Run with plain `docker run opensearchproject/opensearch:2` defaults, no hardening flags, the **opensearch** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `opensearchproject/opensearch:2` at digest `sha256:8690b204fe914c60ca76d451ac73bc0481e034d32d3779944c8caca56a2b003f`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `opensearchproject/opensearch:2` at digest `sha256:8690b204fe914c60ca76d451ac73bc0481e034d32d3779944c8caca56a2b003f` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/oraclelinux.md
+++ b/docs/scores/oraclelinux.md
@@ -7,7 +7,7 @@ description: "How isolated is oraclelinux:9 by default? IronClaw scores its sand
 
 Run with plain `docker run oraclelinux:9` defaults, no hardening flags, the **oraclelinux** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `oraclelinux:9` at digest `sha256:fe2c9e975c93c1b8c00712e5ad40e0127c0f1982c2d76031f1e09e5307e32aeb`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `oraclelinux:9` at digest `sha256:fe2c9e975c93c1b8c00712e5ad40e0127c0f1982c2d76031f1e09e5307e32aeb` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/orientdb.md
+++ b/docs/scores/orientdb.md
@@ -7,7 +7,7 @@ description: "How isolated is orientdb:3.2.35 by default? IronClaw scores its sa
 
 Run with plain `docker run orientdb:3.2.35` defaults, no hardening flags, the **orientdb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `orientdb:3.2.35` at digest `sha256:c7978496bc63a08b36f65c7c763bfbd1938134dac009fa03fec35ac144e9b431`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `orientdb:3.2.35` at digest `sha256:c7978496bc63a08b36f65c7c763bfbd1938134dac009fa03fec35ac144e9b431` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/outline.md
+++ b/docs/scores/outline.md
@@ -7,7 +7,7 @@ description: "How isolated is outline:0.82.0 by default? IronClaw scores its san
 
 Run with plain `docker run outlinewiki/outline:0.82.0` defaults, no hardening flags, the **outline** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `outlinewiki/outline:0.82.0` at digest `sha256:494dfb9249a6799ca3d38e2bb1bdf3c9f63632634737bd996ce0b3509fe93499`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `outlinewiki/outline:0.82.0` at digest `sha256:494dfb9249a6799ca3d38e2bb1bdf3c9f63632634737bd996ce0b3509fe93499` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/packer.md
+++ b/docs/scores/packer.md
@@ -7,7 +7,7 @@ description: "How isolated is packer:1.11.2 by default? IronClaw scores its sand
 
 Run with plain `docker run hashicorp/packer:1.11.2` defaults, no hardening flags, the **packer** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `hashicorp/packer:1.11.2` at digest `sha256:12c441b8a3994e7df9f0e2692d9298f14c387e70bcc06139420977dbf80a137b`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `hashicorp/packer:1.11.2` at digest `sha256:12c441b8a3994e7df9f0e2692d9298f14c387e70bcc06139420977dbf80a137b` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/paperless-ngx.md
+++ b/docs/scores/paperless-ngx.md
@@ -7,7 +7,7 @@ description: "How isolated is paperless-ngx:2.14.7 by default? IronClaw scores i
 
 Run with plain `docker run ghcr.io/paperless-ngx/paperless-ngx:2.14.7` defaults, no hardening flags, the **paperless ngx** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ghcr.io/paperless-ngx/paperless-ngx:2.14.7` at digest `sha256:2a6d9f6461ad7e8335f5b2123a173b9e6002fda209af8a66483b0c00629569ab`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ghcr.io/paperless-ngx/paperless-ngx:2.14.7` at digest `sha256:2a6d9f6461ad7e8335f5b2123a173b9e6002fda209af8a66483b0c00629569ab` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/percona.md
+++ b/docs/scores/percona.md
@@ -7,7 +7,7 @@ description: "How isolated is percona:8.0 by default? IronClaw scores its sandbo
 
 Run with plain `docker run percona:8.0` defaults, no hardening flags, the **percona** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `percona:8.0` at digest `sha256:2a29b81c1e28d752b854c71565f577414fbc7eb8ce329921d6acc85da890818f`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `percona:8.0` at digest `sha256:2a29b81c1e28d752b854c71565f577414fbc7eb8ce329921d6acc85da890818f` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/perl.md
+++ b/docs/scores/perl.md
@@ -7,7 +7,7 @@ description: "How isolated is perl:5.40-slim by default? IronClaw scores its san
 
 Run with plain `docker run perl:5.40-slim` defaults, no hardening flags, the **perl** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `perl:5.40-slim` at digest `sha256:8d1836c24ebf3ad6523064b20e42878f065fdfbc6ed4fe5861d09aa862889360`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `perl:5.40-slim` at digest `sha256:8d1836c24ebf3ad6523064b20e42878f065fdfbc6ed4fe5861d09aa862889360` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/pgadmin4.md
+++ b/docs/scores/pgadmin4.md
@@ -7,7 +7,7 @@ description: "How isolated is pgadmin4:8 by default? IronClaw scores its sandbox
 
 Run with plain `docker run dpage/pgadmin4:8` defaults, no hardening flags, the **pgadmin4** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `dpage/pgadmin4:8` at digest `sha256:8a68677a97b8c8d1427dc915672a26d2c4a04376916a68256f53d669d6171be7`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `dpage/pgadmin4:8` at digest `sha256:8a68677a97b8c8d1427dc915672a26d2c4a04376916a68256f53d669d6171be7` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/pgvector.md
+++ b/docs/scores/pgvector.md
@@ -7,7 +7,7 @@ description: "How isolated is pgvector:pg17 by default? IronClaw scores its sand
 
 Run with plain `docker run pgvector/pgvector:pg17` defaults, no hardening flags, the **pgvector** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `pgvector/pgvector:pg17` at digest `sha256:d2ef61f42ef767baa5a1475393303cc235bcd92febd9d7014eddb48b41f3bad0`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `pgvector/pgvector:pg17` at digest `sha256:d2ef61f42ef767baa5a1475393303cc235bcd92febd9d7014eddb48b41f3bad0` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/photon.md
+++ b/docs/scores/photon.md
@@ -7,7 +7,7 @@ description: "How isolated is photon:5.0 by default? IronClaw scores its sandbox
 
 Run with plain `docker run photon:5.0` defaults, no hardening flags, the **photon** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `photon:5.0` at digest `sha256:6db86de5ffc11d5c55e59d23790ad526b68e5bca4f030cb6a94e6136280866dd`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `photon:5.0` at digest `sha256:6db86de5ffc11d5c55e59d23790ad526b68e5bca4f030cb6a94e6136280866dd` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/php.md
+++ b/docs/scores/php.md
@@ -7,7 +7,7 @@ description: "How isolated is php:8.4-apache by default? IronClaw scores its san
 
 Run with plain `docker run php:8.4-apache` defaults, no hardening flags, the **php** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `php:8.4-apache` at digest `sha256:ea61837b6dee7f5981cced9fdf6a7773c4ef695bc3237fb9da59d223df638ec2`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `php:8.4-apache` at digest `sha256:ea61837b6dee7f5981cced9fdf6a7773c4ef695bc3237fb9da59d223df638ec2` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/phpmyadmin.md
+++ b/docs/scores/phpmyadmin.md
@@ -7,7 +7,7 @@ description: "How isolated is phpmyadmin:5.2 by default? IronClaw scores its san
 
 Run with plain `docker run phpmyadmin:5.2` defaults, no hardening flags, the **phpmyadmin** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `phpmyadmin:5.2` at digest `sha256:b68f318c5fd85541795ed8eb4ced28ea6908a89910871783b3e479cc6c6d1e1b`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `phpmyadmin:5.2` at digest `sha256:b68f318c5fd85541795ed8eb4ced28ea6908a89910871783b3e479cc6c6d1e1b` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/pihole.md
+++ b/docs/scores/pihole.md
@@ -7,7 +7,7 @@ description: "How isolated is pihole:2024.07.0 by default? IronClaw scores its s
 
 Run with plain `docker run pihole/pihole:2024.07.0` defaults, no hardening flags, the **pihole** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `pihole/pihole:2024.07.0` at digest `sha256:0def896a596e8d45780b6359dbf82fc8c75ef05b97e095452e67a0a4ccc95377`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `pihole/pihole:2024.07.0` at digest `sha256:0def896a596e8d45780b6359dbf82fc8c75ef05b97e095452e67a0a4ccc95377` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/planka.md
+++ b/docs/scores/planka.md
@@ -7,7 +7,7 @@ description: "How isolated is planka:1.24.2 by default? IronClaw scores its sand
 
 Run with plain `docker run ghcr.io/plankanban/planka:1.24.2` defaults, no hardening flags, the **planka** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ghcr.io/plankanban/planka:1.24.2` at digest `sha256:aed25499a1139b3464f924d07f416e257595c3bf83e0dfa28ab22549f1520ee8`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ghcr.io/plankanban/planka:1.24.2` at digest `sha256:aed25499a1139b3464f924d07f416e257595c3bf83e0dfa28ab22549f1520ee8` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/postgis.md
+++ b/docs/scores/postgis.md
@@ -7,7 +7,7 @@ description: "How isolated is postgis:17-3.5 by default? IronClaw scores its san
 
 Run with plain `docker run postgis/postgis:17-3.5` defaults, no hardening flags, the **postgis** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `postgis/postgis:17-3.5` at digest `sha256:77e89c11c4779c394ebeeaac1099dafb77b728abc8cd45dcaf6c4695503a0c37`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `postgis/postgis:17-3.5` at digest `sha256:77e89c11c4779c394ebeeaac1099dafb77b728abc8cd45dcaf6c4695503a0c37` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/postgres.md
+++ b/docs/scores/postgres.md
@@ -7,7 +7,7 @@ description: "How isolated is postgres:17-alpine by default? IronClaw scores its
 
 Run with plain `docker run postgres:17-alpine` defaults, no hardening flags, the **postgres** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `postgres:17-alpine` at digest `sha256:67f624a4ad70edba8d65c82341124fab7054b277b4f7dea4b04be6f939ce2314`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `postgres:17-alpine` at digest `sha256:67f624a4ad70edba8d65c82341124fab7054b277b4f7dea4b04be6f939ce2314` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/prometheus.md
+++ b/docs/scores/prometheus.md
@@ -7,7 +7,7 @@ description: "How isolated is prometheus:v3.1.0 by default? IronClaw scores its 
 
 Run with plain `docker run prom/prometheus:v3.1.0` defaults, no hardening flags, the **prometheus** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `prom/prometheus:v3.1.0` at digest `sha256:6559acbd5d770b15bb3c954629ce190ac3cbbdb2b7f1c30f0385c4e05104e218`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `prom/prometheus:v3.1.0` at digest `sha256:6559acbd5d770b15bb3c954629ce190ac3cbbdb2b7f1c30f0385c4e05104e218` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/promtail.md
+++ b/docs/scores/promtail.md
@@ -7,7 +7,7 @@ description: "How isolated is promtail:3.3.2 by default? IronClaw scores its san
 
 Run with plain `docker run grafana/promtail:3.3.2` defaults, no hardening flags, the **promtail** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `grafana/promtail:3.3.2` at digest `sha256:cb4990801ec58975c5e231057c2bcf204c85fac428eec65ad66e0016c64b9608`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `grafana/promtail:3.3.2` at digest `sha256:cb4990801ec58975c5e231057c2bcf204c85fac428eec65ad66e0016c64b9608` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/pulsar.md
+++ b/docs/scores/pulsar.md
@@ -7,7 +7,7 @@ description: "How isolated is pulsar:3.3.2 by default? IronClaw scores its sandb
 
 Run with plain `docker run apachepulsar/pulsar:3.3.2` defaults, no hardening flags, the **pulsar** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `apachepulsar/pulsar:3.3.2` at digest `sha256:1640b0a6e7dc255820372864016e3892e4cfa04ab7c17e1d11e52e0214793cad`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `apachepulsar/pulsar:3.3.2` at digest `sha256:1640b0a6e7dc255820372864016e3892e4cfa04ab7c17e1d11e52e0214793cad` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/pulumi.md
+++ b/docs/scores/pulumi.md
@@ -7,7 +7,7 @@ description: "How isolated is pulumi:3.144.1 by default? IronClaw scores its san
 
 Run with plain `docker run pulumi/pulumi:3.144.1` defaults, no hardening flags, the **pulumi** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `pulumi/pulumi:3.144.1` at digest `sha256:093f4e36a0b6800e3c08c1ba704c88a0799372095d4afdda83e92ea8db24fe3e`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `pulumi/pulumi:3.144.1` at digest `sha256:093f4e36a0b6800e3c08c1ba704c88a0799372095d4afdda83e92ea8db24fe3e` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/pushgateway.md
+++ b/docs/scores/pushgateway.md
@@ -7,7 +7,7 @@ description: "How isolated is pushgateway:v1.10.0 by default? IronClaw scores it
 
 Run with plain `docker run prom/pushgateway:v1.10.0` defaults, no hardening flags, the **pushgateway** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `prom/pushgateway:v1.10.0` at digest `sha256:7a4d0696a24ef4e8bad62bee5656855a0aff2f26416d8cb32009dc28d6263604`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `prom/pushgateway:v1.10.0` at digest `sha256:7a4d0696a24ef4e8bad62bee5656855a0aff2f26416d8cb32009dc28d6263604` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/pypy.md
+++ b/docs/scores/pypy.md
@@ -7,7 +7,7 @@ description: "How isolated is pypy:3.10-slim by default? IronClaw scores its san
 
 Run with plain `docker run pypy:3.10-slim` defaults, no hardening flags, the **pypy** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `pypy:3.10-slim` at digest `sha256:5d18aa0232059c991ff8d52f1b528a6ff8f55c86154ba248a270a6eb90975f3a`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `pypy:3.10-slim` at digest `sha256:5d18aa0232059c991ff8d52f1b528a6ff8f55c86154ba248a270a6eb90975f3a` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/python.md
+++ b/docs/scores/python.md
@@ -7,7 +7,7 @@ description: "How isolated is python:3.13-alpine by default? IronClaw scores its
 
 Run with plain `docker run python:3.13-alpine` defaults, no hardening flags, the **python** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `python:3.13-alpine` at digest `sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `python:3.13-alpine` at digest `sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/qdrant.md
+++ b/docs/scores/qdrant.md
@@ -7,7 +7,7 @@ description: "How isolated is qdrant:v1.12.4 by default? IronClaw scores its san
 
 Run with plain `docker run qdrant/qdrant:v1.12.4` defaults, no hardening flags, the **qdrant** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `qdrant/qdrant:v1.12.4` at digest `sha256:241edb9d7778327516ef218f8c74e1bd61b5ea42cd4f193cb8d0896199705636`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `qdrant/qdrant:v1.12.4` at digest `sha256:241edb9d7778327516ef218f8c74e1bd61b5ea42cd4f193cb8d0896199705636` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/questdb.md
+++ b/docs/scores/questdb.md
@@ -7,7 +7,7 @@ description: "How isolated is questdb:8.2.1 by default? IronClaw scores its sand
 
 Run with plain `docker run questdb/questdb:8.2.1` defaults, no hardening flags, the **questdb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `questdb/questdb:8.2.1` at digest `sha256:17148f1b0acd4903ee1ad656aa9de9b75d8d179bde2731b5df1d499fa17d978b`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `questdb/questdb:8.2.1` at digest `sha256:17148f1b0acd4903ee1ad656aa9de9b75d8d179bde2731b5df1d499fa17d978b` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/rabbitmq.md
+++ b/docs/scores/rabbitmq.md
@@ -7,7 +7,7 @@ description: "How isolated is rabbitmq:4-alpine by default? IronClaw scores its 
 
 Run with plain `docker run rabbitmq:4-alpine` defaults, no hardening flags, the **rabbitmq** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `rabbitmq:4-alpine` at digest `sha256:835cbc6fabceedef7a3b0ce3195a17adccb753a3ba645bdd61c5557b6e4bf580`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `rabbitmq:4-alpine` at digest `sha256:835cbc6fabceedef7a3b0ce3195a17adccb753a3ba645bdd61c5557b6e4bf580` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/rancher.md
+++ b/docs/scores/rancher.md
@@ -7,7 +7,7 @@ description: "How isolated is rancher:v2.10.1 by default? IronClaw scores its sa
 
 Run with plain `docker run rancher/rancher:v2.10.1` defaults, no hardening flags, the **rancher** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `rancher/rancher:v2.10.1` at digest `sha256:a05127d7084ba04a383bd8896b3fcbe2dcf287b1ae26f785c81c99dceff06d9e`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `rancher/rancher:v2.10.1` at digest `sha256:a05127d7084ba04a383bd8896b3fcbe2dcf287b1ae26f785c81c99dceff06d9e` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/rclone.md
+++ b/docs/scores/rclone.md
@@ -7,7 +7,7 @@ description: "How isolated is rclone:1.68.2 by default? IronClaw scores its sand
 
 Run with plain `docker run rclone/rclone:1.68.2` defaults, no hardening flags, the **rclone** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `rclone/rclone:1.68.2` at digest `sha256:74c51b8817e5431bd6d7ed27cb2a50d8ee78d77f6807b72a41ef6f898845942b`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `rclone/rclone:1.68.2` at digest `sha256:74c51b8817e5431bd6d7ed27cb2a50d8ee78d77f6807b72a41ef6f898845942b` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/redis-stack-server.md
+++ b/docs/scores/redis-stack-server.md
@@ -7,7 +7,7 @@ description: "How isolated is redis-stack-server:7.4.0-v3 by default? IronClaw s
 
 Run with plain `docker run redis/redis-stack-server:7.4.0-v3` defaults, no hardening flags, the **redis stack server** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `redis/redis-stack-server:7.4.0-v3` at digest `sha256:7d8e657d60d525534d6abe96e7645ab30ef1b4f1ffedc6eeb2d4d4283b3a49b9`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `redis/redis-stack-server:7.4.0-v3` at digest `sha256:7d8e657d60d525534d6abe96e7645ab30ef1b4f1ffedc6eeb2d4d4283b3a49b9` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/redis.md
+++ b/docs/scores/redis.md
@@ -7,7 +7,7 @@ description: "How isolated is redis:7-alpine by default? IronClaw scores its san
 
 Run with plain `docker run redis:7-alpine` defaults, no hardening flags, the **redis** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `redis:7-alpine` at digest `sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `redis:7-alpine` at digest `sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/redisinsight.md
+++ b/docs/scores/redisinsight.md
@@ -7,7 +7,7 @@ description: "How isolated is redisinsight:latest by default? IronClaw scores it
 
 Run with plain `docker run redis/redisinsight:latest` defaults, no hardening flags, the **redisinsight** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `redis/redisinsight:latest` at digest `sha256:b5e19ee240abef6edb435871b90ff8a210995422e8e018ab61c0339d318a1f84`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `redis/redisinsight:latest` at digest `sha256:b5e19ee240abef6edb435871b90ff8a210995422e8e018ab61c0339d318a1f84` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/redmine.md
+++ b/docs/scores/redmine.md
@@ -7,7 +7,7 @@ description: "How isolated is redmine:6 by default? IronClaw scores its sandbox 
 
 Run with plain `docker run redmine:6` defaults, no hardening flags, the **redmine** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `redmine:6` at digest `sha256:157c712839fe9787eb5cfe8376c38de45042613c511228f01386e8aeab5cfa21`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `redmine:6` at digest `sha256:157c712839fe9787eb5cfe8376c38de45042613c511228f01386e8aeab5cfa21` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/redpanda.md
+++ b/docs/scores/redpanda.md
@@ -7,7 +7,7 @@ description: "How isolated is redpanda:v24.2.11 by default? IronClaw scores its 
 
 Run with plain `docker run redpandadata/redpanda:v24.2.11` defaults, no hardening flags, the **redpanda** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `redpandadata/redpanda:v24.2.11` at digest `sha256:e51aa0f712861f8d4fc8e37ec5685ef96167434bb687e5ff6907e0b4994c2ce4`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `redpandadata/redpanda:v24.2.11` at digest `sha256:e51aa0f712861f8d4fc8e37ec5685ef96167434bb687e5ff6907e0b4994c2ce4` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/registry.md
+++ b/docs/scores/registry.md
@@ -7,7 +7,7 @@ description: "How isolated is registry:2.8.3 by default? IronClaw scores its san
 
 Run with plain `docker run registry:2.8.3` defaults, no hardening flags, the **registry** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `registry:2.8.3` at digest `sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `registry:2.8.3` at digest `sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/rest-server.md
+++ b/docs/scores/rest-server.md
@@ -7,7 +7,7 @@ description: "How isolated is rest-server:0.13.0 by default? IronClaw scores its
 
 Run with plain `docker run restic/rest-server:0.13.0` defaults, no hardening flags, the **rest server** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `restic/rest-server:0.13.0` at digest `sha256:8668c235a932745585fef5cabbab9eccb501035f90138085a6e74963dcd1a71f`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `restic/rest-server:0.13.0` at digest `sha256:8668c235a932745585fef5cabbab9eccb501035f90138085a6e74963dcd1a71f` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/rethinkdb.md
+++ b/docs/scores/rethinkdb.md
@@ -7,7 +7,7 @@ description: "How isolated is rethinkdb:2.4 by default? IronClaw scores its sand
 
 Run with plain `docker run rethinkdb:2.4` defaults, no hardening flags, the **rethinkdb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `rethinkdb:2.4` at digest `sha256:576a028b0c64eb21defc374395276d669737742bcb79666806a185a512cb7512`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `rethinkdb:2.4` at digest `sha256:576a028b0c64eb21defc374395276d669737742bcb79666806a185a512cb7512` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/rockylinux.md
+++ b/docs/scores/rockylinux.md
@@ -7,7 +7,7 @@ description: "How isolated is rockylinux:9 by default? IronClaw scores its sandb
 
 Run with plain `docker run rockylinux:9` defaults, no hardening flags, the **rockylinux** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `rockylinux:9` at digest `sha256:d7be1c094cc5845ee815d4632fe377514ee6ebcf8efaed6892889657e5ddaaa6`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `rockylinux:9` at digest `sha256:d7be1c094cc5845ee815d4632fe377514ee6ebcf8efaed6892889657e5ddaaa6` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/rstudio.md
+++ b/docs/scores/rstudio.md
@@ -7,7 +7,7 @@ description: "How isolated is rstudio:4.4.2 by default? IronClaw scores its sand
 
 Run with plain `docker run rocker/rstudio:4.4.2` defaults, no hardening flags, the **rstudio** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `rocker/rstudio:4.4.2` at digest `sha256:6bfc87fb66d0072e28d88d684a1f7b3e42a1c20360ee5eca5b43168a4eba3945`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `rocker/rstudio:4.4.2` at digest `sha256:6bfc87fb66d0072e28d88d684a1f7b3e42a1c20360ee5eca5b43168a4eba3945` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/ruby.md
+++ b/docs/scores/ruby.md
@@ -7,7 +7,7 @@ description: "How isolated is ruby:3.4-alpine by default? IronClaw scores its sa
 
 Run with plain `docker run ruby:3.4-alpine` defaults, no hardening flags, the **ruby** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ruby:3.4-alpine` at digest `sha256:c5a5064d190055633011c03aa800170cc36945ff3afb5f6c915329f92d6f1e00`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ruby:3.4-alpine` at digest `sha256:c5a5064d190055633011c03aa800170cc36945ff3afb5f6c915329f92d6f1e00` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/rust.md
+++ b/docs/scores/rust.md
@@ -7,7 +7,7 @@ description: "How isolated is rust:1.83-alpine by default? IronClaw scores its s
 
 Run with plain `docker run rust:1.83-alpine` defaults, no hardening flags, the **rust** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `rust:1.83-alpine` at digest `sha256:0ac946ed7597a9f053a1be2ce38c09aa88b3d7079a91ea491493615294b1f699`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `rust:1.83-alpine` at digest `sha256:0ac946ed7597a9f053a1be2ce38c09aa88b3d7079a91ea491493615294b1f699` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/scala-sbt.md
+++ b/docs/scores/scala-sbt.md
@@ -7,7 +7,7 @@ description: "How isolated is scala-sbt:eclipse-temurin-21.0.5_11_1.10.7_3.6.2 b
 
 Run with plain `docker run sbtscala/scala-sbt:eclipse-temurin-21.0.5_11_1.10.7_3.6.2` defaults, no hardening flags, the **scala sbt** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `sbtscala/scala-sbt:eclipse-temurin-21.0.5_11_1.10.7_3.6.2` at digest `sha256:23d41e6f000835e317e33ab2f44e4aedc0bfb23e96bd1046fbafd21406755496`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `sbtscala/scala-sbt:eclipse-temurin-21.0.5_11_1.10.7_3.6.2` at digest `sha256:23d41e6f000835e317e33ab2f44e4aedc0bfb23e96bd1046fbafd21406755496` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/scylla.md
+++ b/docs/scores/scylla.md
@@ -7,7 +7,7 @@ description: "How isolated is scylla:6.2 by default? IronClaw scores its sandbox
 
 Run with plain `docker run scylladb/scylla:6.2` defaults, no hardening flags, the **scylla** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `scylladb/scylla:6.2` at digest `sha256:a9d904089abe9a4f8b5b893ebb5b5bf8b5a1bd0dc6658921cf05f89d3712289c`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `scylladb/scylla:6.2` at digest `sha256:a9d904089abe9a4f8b5b893ebb5b5bf8b5a1bd0dc6658921cf05f89d3712289c` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/seaweedfs.md
+++ b/docs/scores/seaweedfs.md
@@ -7,7 +7,7 @@ description: "How isolated is seaweedfs:3.80 by default? IronClaw scores its san
 
 Run with plain `docker run chrislusf/seaweedfs:3.80` defaults, no hardening flags, the **seaweedfs** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `chrislusf/seaweedfs:3.80` at digest `sha256:1055999e08eed1789b0ae45d235126e4495e23d3fb9d6396293fd42539b1ae6a`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `chrislusf/seaweedfs:3.80` at digest `sha256:1055999e08eed1789b0ae45d235126e4495e23d3fb9d6396293fd42539b1ae6a` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/server-full.md
+++ b/docs/scores/server-full.md
@@ -7,7 +7,7 @@ description: "How isolated is server-full:6.2024.12 by default? IronClaw scores 
 
 Run with plain `docker run payara/server-full:6.2024.12` defaults, no hardening flags, the **server full** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `payara/server-full:6.2024.12` at digest `sha256:611d9b440cdcb64354999e31258a579ec8ded2a14c89ec73b129f363de8912ce`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `payara/server-full:6.2024.12` at digest `sha256:611d9b440cdcb64354999e31258a579ec8ded2a14c89ec73b129f363de8912ce` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/server.md
+++ b/docs/scores/server.md
@@ -7,7 +7,7 @@ description: "How isolated is server:1.32.7 by default? IronClaw scores its sand
 
 Run with plain `docker run vaultwarden/server:1.32.7` defaults, no hardening flags, the **server** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `vaultwarden/server:1.32.7` at digest `sha256:7a0aa23c0947be3582898deb5170ea4359493ed9a76af2badf60a7eb45ac36af`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `vaultwarden/server:1.32.7` at digest `sha256:7a0aa23c0947be3582898deb5170ea4359493ed9a76af2badf60a7eb45ac36af` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/snipe-it.md
+++ b/docs/scores/snipe-it.md
@@ -7,7 +7,7 @@ description: "How isolated is snipe-it:v7.0.13 by default? IronClaw scores its s
 
 Run with plain `docker run snipe/snipe-it:v7.0.13` defaults, no hardening flags, the **snipe it** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `snipe/snipe-it:v7.0.13` at digest `sha256:076e98033e0beb4dfad6c3d8eef0f5b5f73c1be86ccb0f64e5752c1ebec4fd2a`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `snipe/snipe-it:v7.0.13` at digest `sha256:076e98033e0beb4dfad6c3d8eef0f5b5f73c1be86ccb0f64e5752c1ebec4fd2a` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/solr.md
+++ b/docs/scores/solr.md
@@ -7,7 +7,7 @@ description: "How isolated is solr:9 by default? IronClaw scores its sandbox pos
 
 Run with plain `docker run solr:9` defaults, no hardening flags, the **solr** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `solr:9` at digest `sha256:f4d36b957707a7a8d3876cb45a9f0b4c2bba3aea460e5798f9eeca7d979a66fa`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `solr:9` at digest `sha256:f4d36b957707a7a8d3876cb45a9f0b4c2bba3aea460e5798f9eeca7d979a66fa` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/sonarqube.md
+++ b/docs/scores/sonarqube.md
@@ -7,7 +7,7 @@ description: "How isolated is sonarqube:community by default? IronClaw scores it
 
 Run with plain `docker run sonarqube:community` defaults, no hardening flags, the **sonarqube** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `sonarqube:community` at digest `sha256:160bd2f6a3485bd09b655ef22dd63c02bd1fa7ba82aa5d9973fd010b8bcca0b3`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `sonarqube:community` at digest `sha256:160bd2f6a3485bd09b655ef22dd63c02bd1fa7ba82aa5d9973fd010b8bcca0b3` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/spark.md
+++ b/docs/scores/spark.md
@@ -7,7 +7,7 @@ description: "How isolated is spark:3.5.3 by default? IronClaw scores its sandbo
 
 Run with plain `docker run apache/spark:3.5.3` defaults, no hardening flags, the **spark** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `apache/spark:3.5.3` at digest `sha256:d0f5d63bfbbffdbec08debb4911554ba671a2fa7398374db8db314d80328f576`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `apache/spark:3.5.3` at digest `sha256:d0f5d63bfbbffdbec08debb4911554ba671a2fa7398374db8db314d80328f576` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/standalone-chrome.md
+++ b/docs/scores/standalone-chrome.md
@@ -7,7 +7,7 @@ description: "How isolated is standalone-chrome:4.27.0 by default? IronClaw scor
 
 Run with plain `docker run selenium/standalone-chrome:4.27.0` defaults, no hardening flags, the **standalone chrome** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `selenium/standalone-chrome:4.27.0` at digest `sha256:ee194f1bce288cc17ff02a8b63a2be33ec1185e064586b744cbf5678221e8332`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `selenium/standalone-chrome:4.27.0` at digest `sha256:ee194f1bce288cc17ff02a8b63a2be33ec1185e064586b744cbf5678221e8332` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/statsd.md
+++ b/docs/scores/statsd.md
@@ -7,7 +7,7 @@ description: "How isolated is statsd:v0.10.2 by default? IronClaw scores its san
 
 Run with plain `docker run statsd/statsd:v0.10.2` defaults, no hardening flags, the **statsd** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `statsd/statsd:v0.10.2` at digest `sha256:d8c65ebadf4ec6857314a17673da1d0ab2027865d620512ee17d0910e0d53d50`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `statsd/statsd:v0.10.2` at digest `sha256:d8c65ebadf4ec6857314a17673da1d0ab2027865d620512ee17d0910e0d53d50` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/storm.md
+++ b/docs/scores/storm.md
@@ -7,7 +7,7 @@ description: "How isolated is storm:2.7.1 by default? IronClaw scores its sandbo
 
 Run with plain `docker run storm:2.7.1` defaults, no hardening flags, the **storm** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `storm:2.7.1` at digest `sha256:aaef90ab49ac3615e8c79c87d59ec3c77413a9d331f211d65487fcd3c7471cb7`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `storm:2.7.1` at digest `sha256:aaef90ab49ac3615e8c79c87d59ec3c77413a9d331f211d65487fcd3c7471cb7` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/superset.md
+++ b/docs/scores/superset.md
@@ -7,7 +7,7 @@ description: "How isolated is superset:4.1.1 by default? IronClaw scores its san
 
 Run with plain `docker run apache/superset:4.1.1` defaults, no hardening flags, the **superset** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `apache/superset:4.1.1` at digest `sha256:1d1fdaaeb19ce9cdba71620ee1cc6117d73813b2f3b422ce5a1bf752c247b7c0`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `apache/superset:4.1.1` at digest `sha256:1d1fdaaeb19ce9cdba71620ee1cc6117d73813b2f3b422ce5a1bf752c247b7c0` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/swag.md
+++ b/docs/scores/swag.md
@@ -7,7 +7,7 @@ description: "How isolated is swag:4.1.0 by default? IronClaw scores its sandbox
 
 Run with plain `docker run lscr.io/linuxserver/swag:4.1.0` defaults, no hardening flags, the **swag** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `lscr.io/linuxserver/swag:4.1.0` at digest `sha256:29957b056c5670801b6131d77ec4188dfb6d06a0a8c49cba0e944c88d98abe74`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `lscr.io/linuxserver/swag:4.1.0` at digest `sha256:29957b056c5670801b6131d77ec4188dfb6d06a0a8c49cba0e944c88d98abe74` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/swagger-ui.md
+++ b/docs/scores/swagger-ui.md
@@ -7,7 +7,7 @@ description: "How isolated is swagger-ui:latest by default? IronClaw scores its 
 
 Run with plain `docker run swaggerapi/swagger-ui:latest` defaults, no hardening flags, the **swagger ui** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `swaggerapi/swagger-ui:latest` at digest `sha256:e43eb34b978af58d8cb78e5da9c12d605cf43d113ad3a96b18f9b028d6479d68`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `swaggerapi/swagger-ui:latest` at digest `sha256:e43eb34b978af58d8cb78e5da9c12d605cf43d113ad3a96b18f9b028d6479d68` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/swift.md
+++ b/docs/scores/swift.md
@@ -7,7 +7,7 @@ description: "How isolated is swift:6.0.3 by default? IronClaw scores its sandbo
 
 Run with plain `docker run swift:6.0.3` defaults, no hardening flags, the **swift** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `swift:6.0.3` at digest `sha256:7aaea8cfbebc90f34aeacaabbfb51a905dbef9839fcd2f528621dd515f228128`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `swift:6.0.3` at digest `sha256:7aaea8cfbebc90f34aeacaabbfb51a905dbef9839fcd2f528621dd515f228128` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/synapse.md
+++ b/docs/scores/synapse.md
@@ -7,7 +7,7 @@ description: "How isolated is synapse:v1.121.1 by default? IronClaw scores its s
 
 Run with plain `docker run matrixdotorg/synapse:v1.121.1` defaults, no hardening flags, the **synapse** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `matrixdotorg/synapse:v1.121.1` at digest `sha256:39ac223adee67024d9d5aecd679fdaeacaa1e348a6c4c999cb7270868486cbb5`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `matrixdotorg/synapse:v1.121.1` at digest `sha256:39ac223adee67024d9d5aecd679fdaeacaa1e348a6c4c999cb7270868486cbb5` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/syncthing.md
+++ b/docs/scores/syncthing.md
@@ -7,7 +7,7 @@ description: "How isolated is syncthing:1.28.1 by default? IronClaw scores its s
 
 Run with plain `docker run lscr.io/linuxserver/syncthing:1.28.1` defaults, no hardening flags, the **syncthing** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `lscr.io/linuxserver/syncthing:1.28.1` at digest `sha256:1f55fa811ad3903c4b421129966e0eea4b21d53d2471158288dc4a353e273a0a`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `lscr.io/linuxserver/syncthing:1.28.1` at digest `sha256:1f55fa811ad3903c4b421129966e0eea4b21d53d2471158288dc4a353e273a0a` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/tailscale.md
+++ b/docs/scores/tailscale.md
@@ -7,7 +7,7 @@ description: "How isolated is tailscale:v1.78.3 by default? IronClaw scores its 
 
 Run with plain `docker run tailscale/tailscale:v1.78.3` defaults, no hardening flags, the **tailscale** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `tailscale/tailscale:v1.78.3` at digest `sha256:9d4c17a8451e2d1282c22aee1f08d28dc106979c39c7b5a35ec6313d4682a43e`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `tailscale/tailscale:v1.78.3` at digest `sha256:9d4c17a8451e2d1282c22aee1f08d28dc106979c39c7b5a35ec6313d4682a43e` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/tarantool.md
+++ b/docs/scores/tarantool.md
@@ -7,7 +7,7 @@ description: "How isolated is tarantool:3.3.0 by default? IronClaw scores its sa
 
 Run with plain `docker run tarantool/tarantool:3.3.0` defaults, no hardening flags, the **tarantool** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `tarantool/tarantool:3.3.0` at digest `sha256:f5d064db32692de19adfb7fd4795457b90a480377e1ea107d1516664d66e16c3`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `tarantool/tarantool:3.3.0` at digest `sha256:f5d064db32692de19adfb7fd4795457b90a480377e1ea107d1516664d66e16c3` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/teamcity-server.md
+++ b/docs/scores/teamcity-server.md
@@ -7,7 +7,7 @@ description: "How isolated is teamcity-server:2024.12 by default? IronClaw score
 
 Run with plain `docker run jetbrains/teamcity-server:2024.12` defaults, no hardening flags, the **teamcity server** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `jetbrains/teamcity-server:2024.12` at digest `sha256:2defd16d7b690268483b81df01c6d0cef2ff22eff2258873422e66107af41dfa`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `jetbrains/teamcity-server:2024.12` at digest `sha256:2defd16d7b690268483b81df01c6d0cef2ff22eff2258873422e66107af41dfa` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/telegraf.md
+++ b/docs/scores/telegraf.md
@@ -7,7 +7,7 @@ description: "How isolated is telegraf:1.33-alpine by default? IronClaw scores i
 
 Run with plain `docker run telegraf:1.33-alpine` defaults, no hardening flags, the **telegraf** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `telegraf:1.33-alpine` at digest `sha256:3ea0664bed1cacec5e6b463882dc43da9b33c9742d436ace35f157843aca9e40`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `telegraf:1.33-alpine` at digest `sha256:3ea0664bed1cacec5e6b463882dc43da9b33c9742d436ace35f157843aca9e40` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/tempo.md
+++ b/docs/scores/tempo.md
@@ -7,7 +7,7 @@ description: "How isolated is tempo:2.6.1 by default? IronClaw scores its sandbo
 
 Run with plain `docker run grafana/tempo:2.6.1` defaults, no hardening flags, the **tempo** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `grafana/tempo:2.6.1` at digest `sha256:ef4384fce6e8ad22b95b243d8fc165628cda655376fd50e7850536ad89d71d50`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `grafana/tempo:2.6.1` at digest `sha256:ef4384fce6e8ad22b95b243d8fc165628cda655376fd50e7850536ad89d71d50` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/tensorflow.md
+++ b/docs/scores/tensorflow.md
@@ -7,7 +7,7 @@ description: "How isolated is tensorflow:2.18.0 by default? IronClaw scores its 
 
 Run with plain `docker run tensorflow/tensorflow:2.18.0` defaults, no hardening flags, the **tensorflow** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `tensorflow/tensorflow:2.18.0` at digest `sha256:f3be5db24f080b3b228a23eb24f586058b3bec445d81500f95167c70e5473d4e`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `tensorflow/tensorflow:2.18.0` at digest `sha256:f3be5db24f080b3b228a23eb24f586058b3bec445d81500f95167c70e5473d4e` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/terraform.md
+++ b/docs/scores/terraform.md
@@ -7,7 +7,7 @@ description: "How isolated is terraform:1.10 by default? IronClaw scores its san
 
 Run with plain `docker run hashicorp/terraform:1.10` defaults, no hardening flags, the **terraform** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `hashicorp/terraform:1.10` at digest `sha256:679ac5e095bf550bc726742cd12efa6050f0913080df479fdabfeb202953af28`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `hashicorp/terraform:1.10` at digest `sha256:679ac5e095bf550bc726742cd12efa6050f0913080df479fdabfeb202953af28` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/thanos.md
+++ b/docs/scores/thanos.md
@@ -7,7 +7,7 @@ description: "How isolated is thanos:v0.37.2 by default? IronClaw scores its san
 
 Run with plain `docker run quay.io/thanos/thanos:v0.37.2` defaults, no hardening flags, the **thanos** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `quay.io/thanos/thanos:v0.37.2` at digest `sha256:4ec6df40fdb921de162677b321057caa8fb8324c65f4cfae9568ed55c4469e2c`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `quay.io/thanos/thanos:v0.37.2` at digest `sha256:4ec6df40fdb921de162677b321057caa8fb8324c65f4cfae9568ed55c4469e2c` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/tidb.md
+++ b/docs/scores/tidb.md
@@ -7,7 +7,7 @@ description: "How isolated is tidb:v8.5.0 by default? IronClaw scores its sandbo
 
 Run with plain `docker run pingcap/tidb:v8.5.0` defaults, no hardening flags, the **tidb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `pingcap/tidb:v8.5.0` at digest `sha256:490861bd4a2fa643dbe76b77ffecafcad66e6a42774e580b82f4ec2429a80e57`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `pingcap/tidb:v8.5.0` at digest `sha256:490861bd4a2fa643dbe76b77ffecafcad66e6a42774e580b82f4ec2429a80e57` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/tika.md
+++ b/docs/scores/tika.md
@@ -7,7 +7,7 @@ description: "How isolated is tika:latest by default? IronClaw scores its sandbo
 
 Run with plain `docker run apache/tika:latest` defaults, no hardening flags, the **tika** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `apache/tika:latest` at digest `sha256:90b7fa1dc018434075fce9e1d9b88b1e3d0ea6979d0cf86e116c79a8073ae973`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `apache/tika:latest` at digest `sha256:90b7fa1dc018434075fce9e1d9b88b1e3d0ea6979d0cf86e116c79a8073ae973` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/timescaledb.md
+++ b/docs/scores/timescaledb.md
@@ -7,7 +7,7 @@ description: "How isolated is timescaledb:2.17.2-pg17 by default? IronClaw score
 
 Run with plain `docker run timescale/timescaledb:2.17.2-pg17` defaults, no hardening flags, the **timescaledb** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `timescale/timescaledb:2.17.2-pg17` at digest `sha256:3324f81ca7f84cdc2dc4497863b3798ababa8ce130c5b59d73f0b40e3a34148e`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `timescale/timescaledb:2.17.2-pg17` at digest `sha256:3324f81ca7f84cdc2dc4497863b3798ababa8ce130c5b59d73f0b40e3a34148e` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/tomcat.md
+++ b/docs/scores/tomcat.md
@@ -7,7 +7,7 @@ description: "How isolated is tomcat:10.1-jre21-temurin by default? IronClaw sco
 
 Run with plain `docker run tomcat:10.1-jre21-temurin` defaults, no hardening flags, the **tomcat** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `tomcat:10.1-jre21-temurin` at digest `sha256:f6e69a64d90e3b71b22e77fdfa87b3df9fa86be393cd01912e9bf34d0076b335`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `tomcat:10.1-jre21-temurin` at digest `sha256:f6e69a64d90e3b71b22e77fdfa87b3df9fa86be393cd01912e9bf34d0076b335` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/tomee.md
+++ b/docs/scores/tomee.md
@@ -7,7 +7,7 @@ description: "How isolated is tomee:9.1.3-jre17 by default? IronClaw scores its 
 
 Run with plain `docker run tomee:9.1.3-jre17` defaults, no hardening flags, the **tomee** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `tomee:9.1.3-jre17` at digest `sha256:7dc4d8f661bdee3d782f58ba328f5bd51bde13f9d8d2fa24acd5aa198289e975`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `tomee:9.1.3-jre17` at digest `sha256:7dc4d8f661bdee3d782f58ba328f5bd51bde13f9d8d2fa24acd5aa198289e975` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/traefik.md
+++ b/docs/scores/traefik.md
@@ -7,7 +7,7 @@ description: "How isolated is traefik:v3.2 by default? IronClaw scores its sandb
 
 Run with plain `docker run traefik:v3.2` defaults, no hardening flags, the **traefik** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `traefik:v3.2` at digest `sha256:e561a37f8710d9cf41c78bdf421d822b2c0b48267ec0552e644565fb55466ea9`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `traefik:v3.2` at digest `sha256:e561a37f8710d9cf41c78bdf421d822b2c0b48267ec0552e644565fb55466ea9` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/typesense.md
+++ b/docs/scores/typesense.md
@@ -7,7 +7,7 @@ description: "How isolated is typesense:27.1 by default? IronClaw scores its san
 
 Run with plain `docker run typesense/typesense:27.1` defaults, no hardening flags, the **typesense** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `typesense/typesense:27.1` at digest `sha256:5c12af89130b8ee0be11541321ba8a3a7c7a538d7c6cd95e0409dc2d75ca6455`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `typesense/typesense:27.1` at digest `sha256:5c12af89130b8ee0be11541321ba8a3a7c7a538d7c6cd95e0409dc2d75ca6455` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/ubuntu.md
+++ b/docs/scores/ubuntu.md
@@ -7,7 +7,7 @@ description: "How isolated is ubuntu:24.04 by default? IronClaw scores its sandb
 
 Run with plain `docker run ubuntu:24.04` defaults, no hardening flags, the **ubuntu** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ubuntu:24.04` at digest `sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ubuntu:24.04` at digest `sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/umami.md
+++ b/docs/scores/umami.md
@@ -7,7 +7,7 @@ description: "How isolated is umami:postgresql-v2.14.0 by default? IronClaw scor
 
 Run with plain `docker run ghcr.io/umami-software/umami:postgresql-v2.14.0` defaults, no hardening flags, the **umami** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `ghcr.io/umami-software/umami:postgresql-v2.14.0` at digest `sha256:54ccf9903edf09791889504360e776b52c358ebddf5a5e8662257b2555608f27`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `ghcr.io/umami-software/umami:postgresql-v2.14.0` at digest `sha256:54ccf9903edf09791889504360e776b52c358ebddf5a5e8662257b2555608f27` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/unit.md
+++ b/docs/scores/unit.md
@@ -7,7 +7,7 @@ description: "How isolated is unit:1.34.1-minimal by default? IronClaw scores it
 
 Run with plain `docker run unit:1.34.1-minimal` defaults, no hardening flags, the **unit** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `unit:1.34.1-minimal` at digest `sha256:65727e45ecc51f85b81aacf6621b7362f639419fc1d73541244a6745680a94c1`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `unit:1.34.1-minimal` at digest `sha256:65727e45ecc51f85b81aacf6621b7362f639419fc1d73541244a6745680a94c1` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/uptime-kuma.md
+++ b/docs/scores/uptime-kuma.md
@@ -7,7 +7,7 @@ description: "How isolated is uptime-kuma:1 by default? IronClaw scores its sand
 
 Run with plain `docker run louislam/uptime-kuma:1` defaults, no hardening flags, the **uptime kuma** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `louislam/uptime-kuma:1` at digest `sha256:3d632903e6af34139a37f18055c4f1bfd9b7205ae1138f1e5e8940ddc1d176f9`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `louislam/uptime-kuma:1` at digest `sha256:3d632903e6af34139a37f18055c4f1bfd9b7205ae1138f1e5e8940ddc1d176f9` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/valkey.md
+++ b/docs/scores/valkey.md
@@ -7,7 +7,7 @@ description: "How isolated is valkey:8 by default? IronClaw scores its sandbox p
 
 Run with plain `docker run valkey/valkey:8` defaults, no hardening flags, the **valkey** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `valkey/valkey:8` at digest `sha256:495e4fecdc98ee48a20b207726caa5ab6451e0fac3642a9be10d9e70b3068df6`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `valkey/valkey:8` at digest `sha256:495e4fecdc98ee48a20b207726caa5ab6451e0fac3642a9be10d9e70b3068df6` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/varnish.md
+++ b/docs/scores/varnish.md
@@ -7,7 +7,7 @@ description: "How isolated is varnish:7.6-alpine by default? IronClaw scores its
 
 Run with plain `docker run varnish:7.6-alpine` defaults, no hardening flags, the **varnish** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `varnish:7.6-alpine` at digest `sha256:eb21e9f988be93f33ff9a0025d0a00617d49f3cc0cf59e0f2167bde7724eae6a`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `varnish:7.6-alpine` at digest `sha256:eb21e9f988be93f33ff9a0025d0a00617d49f3cc0cf59e0f2167bde7724eae6a` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/vault.md
+++ b/docs/scores/vault.md
@@ -7,7 +7,7 @@ description: "How isolated is vault:1.18 by default? IronClaw scores its sandbox
 
 Run with plain `docker run hashicorp/vault:1.18` defaults, no hardening flags, the **vault** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `hashicorp/vault:1.18` at digest `sha256:750bb37c1638fa194ab37053a81618c61bb0491ddec6fccac87c07a8e6cd8166`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `hashicorp/vault:1.18` at digest `sha256:750bb37c1638fa194ab37053a81618c61bb0491ddec6fccac87c07a8e6cd8166` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/vector.md
+++ b/docs/scores/vector.md
@@ -7,7 +7,7 @@ description: "How isolated is vector:0.43.0-alpine by default? IronClaw scores i
 
 Run with plain `docker run timberio/vector:0.43.0-alpine` defaults, no hardening flags, the **vector** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `timberio/vector:0.43.0-alpine` at digest `sha256:7bcb75f71f93d312d928182e6a07f6df14a18d030785bb3197ac01128bd287a3`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `timberio/vector:0.43.0-alpine` at digest `sha256:7bcb75f71f93d312d928182e6a07f6df14a18d030785bb3197ac01128bd287a3` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/verdaccio.md
+++ b/docs/scores/verdaccio.md
@@ -7,7 +7,7 @@ description: "How isolated is verdaccio:6 by default? IronClaw scores its sandbo
 
 Run with plain `docker run verdaccio/verdaccio:6` defaults, no hardening flags, the **verdaccio** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `verdaccio/verdaccio:6` at digest `sha256:11e75353c8363650cbf43adf8594b2cd633be6f191056c6e08ba6ff4b1398f62`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `verdaccio/verdaccio:6` at digest `sha256:11e75353c8363650cbf43adf8594b2cd633be6f191056c6e08ba6ff4b1398f62` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/vernemq.md
+++ b/docs/scores/vernemq.md
@@ -7,7 +7,7 @@ description: "How isolated is vernemq:2.0.1 by default? IronClaw scores its sand
 
 Run with plain `docker run vernemq/vernemq:2.0.1` defaults, no hardening flags, the **vernemq** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `vernemq/vernemq:2.0.1` at digest `sha256:f1b7ca7fb68c1cb2d1f459bb6f919d0a5910b49a3d34d2d82f097e4819d3e4c5`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `vernemq/vernemq:2.0.1` at digest `sha256:f1b7ca7fb68c1cb2d1f459bb6f919d0a5910b49a3d34d2d82f097e4819d3e4c5` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/vespa.md
+++ b/docs/scores/vespa.md
@@ -7,7 +7,7 @@ description: "How isolated is vespa:8.453.24 by default? IronClaw scores its san
 
 Run with plain `docker run vespaengine/vespa:8.453.24` defaults, no hardening flags, the **vespa** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `vespaengine/vespa:8.453.24` at digest `sha256:97ad86256424a4f9cc3ebf9ac55f0249935ac30610d9ac5bc6b8356361c9ba24`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `vespaengine/vespa:8.453.24` at digest `sha256:97ad86256424a4f9cc3ebf9ac55f0249935ac30610d9ac5bc6b8356361c9ba24` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/victoria-metrics.md
+++ b/docs/scores/victoria-metrics.md
@@ -7,7 +7,7 @@ description: "How isolated is victoria-metrics:v1.107.0 by default? IronClaw sco
 
 Run with plain `docker run victoriametrics/victoria-metrics:v1.107.0` defaults, no hardening flags, the **victoria metrics** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `victoriametrics/victoria-metrics:v1.107.0` at digest `sha256:b6ea7d78fb46986533439d6131b0ef3f0ddaec39270bb58c6cc2b74b3d9195d0`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `victoriametrics/victoria-metrics:v1.107.0` at digest `sha256:b6ea7d78fb46986533439d6131b0ef3f0ddaec39270bb58c6cc2b74b3d9195d0` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/wallabag.md
+++ b/docs/scores/wallabag.md
@@ -7,7 +7,7 @@ description: "How isolated is wallabag:2.6.10 by default? IronClaw scores its sa
 
 Run with plain `docker run wallabag/wallabag:2.6.10` defaults, no hardening flags, the **wallabag** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `wallabag/wallabag:2.6.10` at digest `sha256:8854765d299d8e93f962d4be02ceb5703ed2ee24ec6c884f870bb7a18de41378`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `wallabag/wallabag:2.6.10` at digest `sha256:8854765d299d8e93f962d4be02ceb5703ed2ee24ec6c884f870bb7a18de41378` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/weaviate.md
+++ b/docs/scores/weaviate.md
@@ -7,7 +7,7 @@ description: "How isolated is weaviate:1.28.1 by default? IronClaw scores its sa
 
 Run with plain `docker run semitechnologies/weaviate:1.28.1` defaults, no hardening flags, the **weaviate** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `semitechnologies/weaviate:1.28.1` at digest `sha256:f78e60524c759dffa41ccfce54ebc58072078f0c9d6f6138fbb139f340837bf0`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `semitechnologies/weaviate:1.28.1` at digest `sha256:f78e60524c759dffa41ccfce54ebc58072078f0c9d6f6138fbb139f340837bf0` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/wekan.md
+++ b/docs/scores/wekan.md
@@ -7,7 +7,7 @@ description: "How isolated is wekan:v7.72 by default? IronClaw scores its sandbo
 
 Run with plain `docker run wekanteam/wekan:v7.72` defaults, no hardening flags, the **wekan** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `wekanteam/wekan:v7.72` at digest `sha256:20a60935337393b4c6d3a60661f84d72a0cce4c808c80e1fe6ef11dd77c43cf2`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `wekanteam/wekan:v7.72` at digest `sha256:20a60935337393b4c6d3a60661f84d72a0cce4c808c80e1fe6ef11dd77c43cf2` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/wiki.md
+++ b/docs/scores/wiki.md
@@ -7,7 +7,7 @@ description: "How isolated is wiki:2 by default? IronClaw scores its sandbox pos
 
 Run with plain `docker run requarks/wiki:2` defaults, no hardening flags, the **wiki** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `requarks/wiki:2` at digest `sha256:68f0d1848261ae76492ba358e30a96a76fed5d97a3fff381656082bf90f70d7e`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `requarks/wiki:2` at digest `sha256:68f0d1848261ae76492ba358e30a96a76fed5d97a3fff381656082bf90f70d7e` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/wireguard.md
+++ b/docs/scores/wireguard.md
@@ -7,7 +7,7 @@ description: "How isolated is wireguard:1.0.20210914 by default? IronClaw scores
 
 Run with plain `docker run lscr.io/linuxserver/wireguard:1.0.20210914` defaults, no hardening flags, the **wireguard** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `lscr.io/linuxserver/wireguard:1.0.20210914` at digest `sha256:ee2db24277b43ec4e7529e93967dc3cea00a02bf81b749c680b2b102a6e4aa5b`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `lscr.io/linuxserver/wireguard:1.0.20210914` at digest `sha256:ee2db24277b43ec4e7529e93967dc3cea00a02bf81b749c680b2b102a6e4aa5b` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/wordpress.md
+++ b/docs/scores/wordpress.md
@@ -7,7 +7,7 @@ description: "How isolated is wordpress:6-php8.3-apache by default? IronClaw sco
 
 Run with plain `docker run wordpress:6-php8.3-apache` defaults, no hardening flags, the **wordpress** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `wordpress:6-php8.3-apache` at digest `sha256:5d2c212561c4b5442ebc4d98933a9cbadcf3dee8888ed3fd9ed44667c27cc905`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `wordpress:6-php8.3-apache` at digest `sha256:5d2c212561c4b5442ebc4d98933a9cbadcf3dee8888ed3fd9ed44667c27cc905` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/yugabyte.md
+++ b/docs/scores/yugabyte.md
@@ -7,7 +7,7 @@ description: "How isolated is yugabyte:2.23.0.0-b710 by default? IronClaw scores
 
 Run with plain `docker run yugabytedb/yugabyte:2.23.0.0-b710` defaults, no hardening flags, the **yugabyte** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `yugabytedb/yugabyte:2.23.0.0-b710` at digest `sha256:1d743191e0ab021b4d955b882bce18df4758b621d44e72bd3d0d35e2d4327564`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `yugabytedb/yugabyte:2.23.0.0-b710` at digest `sha256:1d743191e0ab021b4d955b882bce18df4758b621d44e72bd3d0d35e2d4327564` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/zeppelin.md
+++ b/docs/scores/zeppelin.md
@@ -7,7 +7,7 @@ description: "How isolated is zeppelin:0.11.2 by default? IronClaw scores its sa
 
 Run with plain `docker run apache/zeppelin:0.11.2` defaults, no hardening flags, the **zeppelin** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `apache/zeppelin:0.11.2` at digest `sha256:42abb8a82ca074c5a419beb69b4f714dc15dfefedb4c4f2a9fa5eb26377a1c30`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `apache/zeppelin:0.11.2` at digest `sha256:42abb8a82ca074c5a419beb69b4f714dc15dfefedb4c4f2a9fa5eb26377a1c30` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/zipkin.md
+++ b/docs/scores/zipkin.md
@@ -7,7 +7,7 @@ description: "How isolated is zipkin:3.4.4 by default? IronClaw scores its sandb
 
 Run with plain `docker run openzipkin/zipkin:3.4.4` defaults, no hardening flags, the **zipkin** image scores **63/100, grade C (partial)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `openzipkin/zipkin:3.4.4` at digest `sha256:966cf6ba77938e3f40922964b47513bec7d10b617f96aea4921e1a887989c6f9`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `openzipkin/zipkin:3.4.4` at digest `sha256:966cf6ba77938e3f40922964b47513bec7d10b617f96aea4921e1a887989c6f9` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/zookeeper.md
+++ b/docs/scores/zookeeper.md
@@ -7,7 +7,7 @@ description: "How isolated is zookeeper:3.9 by default? IronClaw scores its sand
 
 Run with plain `docker run zookeeper:3.9` defaults, no hardening flags, the **zookeeper** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `zookeeper:3.9` at digest `sha256:4c6f15fbd5491a3e01b0108c046891125553329a4956848ba3014cedff5386ee`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `zookeeper:3.9` at digest `sha256:4c6f15fbd5491a3e01b0108c046891125553329a4956848ba3014cedff5386ee` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/docs/scores/zulu-openjdk.md
+++ b/docs/scores/zulu-openjdk.md
@@ -7,7 +7,7 @@ description: "How isolated is zulu-openjdk:21 by default? IronClaw scores its sa
 
 Run with plain `docker run azul/zulu-openjdk:21` defaults, no hardening flags, the **zulu openjdk** image scores **48/100, grade D (porous)** on IronClaw's seven-dimension container containment scale. Higher is safer. This is what you get straight out of a copy-pasted `docker run`; the fixes below close the gap.
 
-> Graded from a read-only `docker inspect` of `azul/zulu-openjdk:21` at digest `sha256:df4952073643ebaecf1415ee04d9f0c07a72ec99f9a12a98cff1928ef6a7c49d`. No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from `azul/zulu-openjdk:21` at digest `sha256:df4952073643ebaecf1415ee04d9f0c07a72ec99f9a12a98cff1928ef6a7c49d` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result. [How scoring works &rarr;](../scan.md)
 
 ## How it scores, dimension by dimension
 

--- a/examples/isolation-survey/gen_scorecards.py
+++ b/examples/isolation-survey/gen_scorecards.py
@@ -271,9 +271,18 @@ def render_page(scn: dict) -> str:
              f"straight out of a copy-pasted `docker run`; the fixes below close the gap.")
     L.append("")
     if digest:
-        L.append(f"> Graded from a read-only `docker inspect` of "
-                 f"`{image.split('@')[0]}` at digest `{digest}`. No workload is "
-                 f"executed. [How scoring works &rarr;](../scan.md)")
+        # The grading procedure starts a container and inspects it; only the
+        # *scan* is read-only. Saying "docker inspect of <image>" described the
+        # image-ref path, which scores differently (IRO-711) and had readers
+        # reproducing a number this page never showed (IRO-713).
+        L.append(f"> Graded from a read-only inspect of a **running container** "
+                 f"started from `{image.split('@')[0]}` at digest `{digest}` "
+                 f"with plain `docker run` defaults, its entrypoint overridden "
+                 f"with `sleep` purely to keep it alive. The scan itself "
+                 f"executes nothing inside the container. Scoring an image "
+                 f"reference instead of a running container yields a different, "
+                 f"non-comparable result. "
+                 f"[How scoring works &rarr;](../scan.md)")
         L.append("")
 
     # Per-dimension table.


### PR DESCRIPTION
Fixes IRO-713.

## What was wrong

Every per-image scorecard opened with:

> Graded from a read-only `docker inspect` of `haproxy:3.1-alpine` at digest `sha256:475863a3...`. No workload is executed.

`examples/isolation-survey/survey.sh:187` is what produced those numbers:

```sh
"$DOCKER" run -d --name "$cname" $flags --entrypoint sleep "$runref" 86400
```

Both halves of the sentence are wrong about the grading procedure. A container is started and left running, then inspected, so `sleep 86400` is a workload and only the *scan* is read-only. And "`docker inspect` of `<image>`" describes the image-**reference** path, which per IRO-711 scores differently from the container path (59 vs 63 for haproxy). A reader following the stated methodology reproduces a number the page does not show, which is the likely origin of the rescore in PR #661.

Worth noting: `survey.sh`'s own header (lines 19-21) already describes this accurately. The scorecard one-liner compressed an honest description into a false claim.

## The new line

> Graded from a read-only inspect of a **running container** started from `haproxy:3.1-alpine` at digest `sha256:475863a3...` with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. Scoring an image reference instead of a running container yields a different, non-comparable result.

It states a container was started, keeps the true read-only-scan claim rather than dropping it, preserves the digest pin, and forecloses the image-ref misreading rather than being merely not-false.

## Generator, not just output

**There is a generator: `examples/isolation-survey/gen_scorecards.py:274`.** It is the single emission site for this line, and it is fixed in the first commit; the second commit is its mechanical output.

I confirmed the corpus really is generator-produced rather than hand-maintained: *before* editing anything, a fresh run of the generator into a scratch directory was **byte-identical** to committed `docs/scores/`, differing only by the two hand-maintained `.nav.yml` files. So regeneration cannot revert this fix.

## Count, by direct enumeration

Enumerated from the tree, not code search. `docs/scores/` holds **269 markdown files**, of which **252** are per-image scorecards that carried the line. The other 17 never had it: `index.md`, `leaderboard.md`, and 15 `collections/*.md`. The generator emits exactly 252 scorecards, matching.

The code-search figure of 321 is not an exact-phrase count and does not survive contact with the tree, as the issue predicted. I also checked for variant phrasings rather than only the exact string; `docker inspect` appears in `docs/scores/` only inside this one line.

## No score, grade, or digest moved (checked, not asserted)

Diff-wide, mechanical:

- 252 files changed, exactly **252 insertions and 252 deletions** (one line per file).
- Every deleted line matched the old provenance pattern and every added line the new one (0 exceptions each), so no other line in the corpus changed.
- **Strip-and-compare:** with the provenance line removed, all 252 files are byte-identical to their `HEAD` blobs.
- Every `sha256:` digest is unchanged, per file.
- Both checks were shown **non-vacuous** by injecting a `63/100` to `64/100` score change and a digest change into one page and confirming each check fired.

No page's numbers looked wrong, so there is nothing to escalate on that front.

## Green

`mkdocs build --strict`, plus all five docs checkers: `check-md-fences` (471 files, 1351 blocks), `check_links`, `check-guide-index` (56 guides), `check-guide-uid`, `check-docs-meta` (436 built pages).

## Two things for the reporter, out of scope here

1. **The same false claim exists in 58 files outside `docs/scores/`**: 56 `docs/blog/harden-*.md` guides, `docs/blog/hardening-guides.md`, and `docs/blog/run-untrusted-nodejs-code-safely.md`. Example, `harden-haproxy-container-isolation.md:16`: "Every number here comes from a read-only `docker inspect` of `haproxy:3.1-alpine` ... No workload is executed." The issue scoped me to `docs/scores/**` and flagged Forge as holding six `docs/blog/harden-*.md` under IRO-712, so I did not touch any of them. The real blast radius there is 58, not six. Left untouched pending your call on who takes it.
2. **`examples/isolation-survey/gen_scorecards.py` is not in `docs.yml`'s `paths:` filter.** A generator-only change would not trigger the docs checks. `docs.yml` already reasons about exactly this hole for `internal/host/scan/remediate.go`. I did not add it, because editing `.github/workflows/**` would put this PR behind the reviewer-bot gate; it wants its own ticket.

Normal review path: this needs a non-author approving review.
