### PR TITLE
scan: stop grading an image reference as if it were a container [IRO-712]

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -502,10 +502,28 @@ func cmdScan(args []string) error {
 			return fmt.Errorf("scan grades one target at a time; got %d: %s", len(positional), strings.Join(positional, " "))
 		}
 		bins := runtimeBins{docker: *dockerBin, podman: *podmanBin, nerdctl: *nerdctlBin}
-		spec, err = containerSpec(*runtime, bins, positional[0])
+		spec, err = targetSpec(*runtime, bins, positional[0])
 	}
 	if err != nil {
 		return err
+	}
+
+	// An image reference has no composite score (IRO-712), so every output that
+	// presupposes one is rejected BEFORE anything is emitted: a non-zero exit and
+	// an explanation, never a grade or a placeholder.
+	if spec.Mode == scan.ModeImage {
+		if err := rejectScoreBearingOutputs(spec.Target, map[string]bool{
+			"--badge":      *badge != "",
+			"--badge-json": *badgeJSON != "",
+			"--badge-md":   *badgeMd != "",
+			"--md":         *md,
+			"--share":      *share,
+			"--sarif":      *sarif != "",
+			"--min-score":  *minScore > 0,
+			"--fix":        *fix || *remediate,
+		}); err != nil {
+			return err
+		}
 	}
 
 	report := scan.Score(spec)
@@ -595,10 +613,11 @@ type compareArgs struct {
 }
 
 // runCompare grades exactly two live containers and prints a side-by-side diff.
-// It reuses containerSpec (the same docker/podman/nerdctl adapters as a single
+// It reuses targetSpec (the same docker/podman/nerdctl adapters as a single
 // scan) and scan.Score, then defers to the comparison renderers. It fails closed:
 // if either target cannot be inspected, the whole compare errors rather than
-// printing a half diff.
+// printing a half diff, and an image reference on either side is rejected because
+// a comparison is a score delta and an image has no score (IRO-712).
 func runCompare(a compareArgs) error {
 	if len(a.targets) != 2 {
 		scanUsage(os.Stderr)
@@ -610,9 +629,12 @@ func runCompare(a compareArgs) error {
 
 	reports := make([]scan.Report, 2)
 	for i, target := range a.targets {
-		spec, err := containerSpec(a.runtime, a.bins, target)
+		spec, err := targetSpec(a.runtime, a.bins, target)
 		if err != nil {
 			return fmt.Errorf("scan target %q: %w", target, err)
+		}
+		if spec.Mode == scan.ModeImage {
+			return scan.UnsupportedForImageRef("--compare", target)
 		}
 		r := scan.Score(spec)
 		r.Version = version.String()
@@ -2984,10 +3006,44 @@ func writeSARIF(path string, r scan.Report, s scan.Spec, opts scan.SARIFOptions)
 // runtimeBins carries the resolved binary name for each supported runtime.
 type runtimeBins struct{ docker, podman, nerdctl string }
 
-// containerSpec inspects a running container with the selected (or auto-detected)
-// OCI runtime and parses the result into a Spec. It fails closed: an unknown or
-// unreachable runtime returns a clear error rather than a silent empty scan.
-func containerSpec(runtime string, bins runtimeBins, target string) (scan.Spec, error) {
+// scoreBearingFlags is the ordered list of flags whose output is a composite
+// score or a gate on one. Ordered so the error names the same flag every run.
+var scoreBearingFlags = []string{
+	"--badge", "--badge-json", "--badge-md", "--md", "--share", "--sarif", "--min-score", "--fix",
+}
+
+// rejectScoreBearingOutputs fails the run when any score-bearing output was
+// requested for an image-mode target. Image mode supports the default table and
+// --json only; everything else here would have to invent a number.
+func rejectScoreBearingOutputs(target string, requested map[string]bool) error {
+	for _, f := range scoreBearingFlags {
+		if requested[f] {
+			return scan.UnsupportedForImageRef(f, target)
+		}
+	}
+	return nil
+}
+
+// targetSpec resolves a positional scan target with the selected (or
+// auto-detected) OCI runtime and parses the result into a Spec.
+//
+// MODE DETECTION IS EXPLICIT (IRO-712). docker/podman/nerdctl resolve containers
+// AND images out of a single namespace, so a bare `<bin> inspect <ref>` answers
+// for either one and the caller cannot tell which it got. That is how an image
+// reference used to land in the CONTAINER adapter and get graded as if a
+// container existed, awarding 40 points of PASS on postures nothing had observed
+// (IRO-711). So we ask two separate, unambiguous questions:
+//
+//	<bin> container inspect <target>   -> container mode
+//	<bin> image inspect <target>       -> image mode
+//
+// Containers win a name collision, matching the bare `inspect` precedence. There
+// is no ref heuristic and no inference from which fields came back: the mode is
+// whichever explicit subcommand answered, and it is stamped onto the Spec.
+//
+// It fails closed: an unknown or unreachable runtime, or a target that is neither
+// a container nor an image, returns a clear error rather than a silent empty scan.
+func targetSpec(runtime string, bins runtimeBins, target string) (scan.Spec, error) {
 	rt := strings.ToLower(strings.TrimSpace(runtime))
 	if rt == "" || rt == "auto" {
 		detected, err := detectRuntime(bins)
@@ -2997,28 +3053,38 @@ func containerSpec(runtime string, bins runtimeBins, target string) (scan.Spec, 
 		rt = detected
 	}
 
+	var bin string
 	switch rt {
 	case "docker":
-		out, err := runInspect(bins.docker, "docker", target)
-		if err != nil {
-			return scan.Spec{}, err
-		}
-		return scan.SpecFromDockerInspect(out)
+		bin = bins.docker
 	case "podman":
-		out, err := runInspect(bins.podman, "podman", target)
-		if err != nil {
-			return scan.Spec{}, err
-		}
-		return scan.SpecFromPodmanInspect(out, podmanRootless(bins.podman))
+		bin = bins.podman
 	case "nerdctl":
-		out, err := runInspect(bins.nerdctl, "nerdctl", target)
-		if err != nil {
-			return scan.Spec{}, err
-		}
-		return scan.SpecFromNerdctlInspect(out)
+		bin = bins.nerdctl
 	default:
 		return scan.Spec{}, fmt.Errorf("unknown --runtime %q: expected auto|docker|podman|nerdctl", runtime)
 	}
+
+	out, cerr := runInspect(bin, rt, "container", target)
+	if cerr == nil {
+		switch rt {
+		case "docker":
+			return scan.SpecFromDockerInspect(out)
+		case "podman":
+			return scan.SpecFromPodmanInspect(out, podmanRootless(bins.podman))
+		default:
+			return scan.SpecFromNerdctlInspect(out)
+		}
+	}
+
+	// Not a container. Ask the image question separately, so a hit here is a
+	// POSITIVE image-mode determination rather than a guess.
+	iout, ierr := runInspect(bin, rt, "image", target)
+	if ierr == nil {
+		return scan.SpecFromImageInspect(iout, rt, target)
+	}
+
+	return scan.Spec{}, fmt.Errorf("%q is neither a container nor an image known to %s:\n  %v\n  %v", target, rt, cerr, ierr)
 }
 
 // detectRuntime picks the first runtime whose CLI is on PATH, preferring docker,
@@ -3037,22 +3103,25 @@ func detectRuntime(bins runtimeBins) (string, error) {
 	return "", fmt.Errorf("no container runtime found (looked for docker, podman, nerdctl on PATH); install one or pass --runtime and the matching --<runtime>-bin")
 }
 
-// runInspect runs `<bin> inspect <target>` and returns its stdout, surfacing the
-// runtime's own stderr on failure.
-func runInspect(bin, runtime, target string) ([]byte, error) {
+// runInspect runs `<bin> <kind> inspect <target>` (kind is "container" or
+// "image") and returns its stdout, surfacing the runtime's own stderr on failure.
+//
+// The kind subcommand is NOT optional: a bare `<bin> inspect` resolves both
+// namespaces and is exactly the ambiguity IRO-712 removes.
+func runInspect(bin, runtime, kind, target string) ([]byte, error) {
 	if _, err := exec.LookPath(bin); err != nil {
 		return nil, fmt.Errorf("%s runtime selected but %q is not on PATH: %w", runtime, bin, err)
 	}
-	out, err := exec.Command(bin, "inspect", target).Output()
+	out, err := exec.Command(bin, kind, "inspect", target).Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
 			msg := strings.TrimSpace(string(ee.Stderr))
 			if msg == "" {
 				msg = err.Error()
 			}
-			return nil, fmt.Errorf("%s inspect %s: %s", runtime, target, msg)
+			return nil, fmt.Errorf("%s %s inspect %s: %s", runtime, kind, target, msg)
 		}
-		return nil, fmt.Errorf("run %s inspect: %w (is %s running and the container up?)", bin, err, runtime)
+		return nil, fmt.Errorf("run %s %s inspect: %w (is %s running?)", bin, kind, err, runtime)
 	}
 	return out, nil
 }
@@ -3080,6 +3149,7 @@ func scanUsage(w *os.File) {
 
 USAGE:
   ironctl scan <container>                    grade a running container (docker|podman|nerdctl)
+  ironctl scan <image-ref>                    report the image USER finding only; NO score (see IMAGE REFERENCES)
   ironctl scan --compose FILE [--service N]   grade a docker-compose service
   ironctl scan --k8s FILE                     grade a Kubernetes pod/workload manifest
   ironctl scan --k8s-admission FILE            grade the workload in a Kubernetes AdmissionReview JSON (webhook backend; '-' = stdin)
@@ -3132,6 +3202,18 @@ IRO-429 scoring stays runtime-agnostic (no points for a runtime name).
 Dimensions graded: non-root user, dropped capabilities, seccomp, network
 isolation, read-only rootfs, docker.sock exposure, shared host namespaces.
 Unknown postures are graded fail-closed (as insecure).
+
+IMAGE REFERENCES:
+A positional target is resolved with an explicit `+"`<runtime> container inspect`"+`
+first, then `+"`<runtime> image inspect`"+`; containers win a name collision. An IMAGE
+gets NO containment score and NO grade. Six of the seven dimensions (capabilities,
+seccomp, network, read-only rootfs, control-socket exposure, host namespaces) are
+set at `+"`docker run`"+` time and simply do not exist in an image, so they report
+N/A rather than a graded verdict. Only the image USER finding is real. Image mode
+supports the default table and --json; --badge, --badge-json, --badge-md, --md,
+--share, --sarif, --min-score, --fix and --compare all need a composite score and
+exit non-zero instead of inventing one. To grade a workload, run it and scan the
+container; to grade the image build, use --dockerfile.
 
 --helm renders a chart locally with `+"`helm template`"+` (no cluster, daemon-free) and
 grades the rendered workloads with the same k8s dimension set. The chart grade is

--- a/cmd/ironctl/scan_test.go
+++ b/cmd/ironctl/scan_test.go
@@ -109,3 +109,51 @@ func TestCmdScan_DockerfileNoPath(t *testing.T) {
 		t.Error("expected an error when --dockerfile is given no path")
 	}
 }
+
+// Every score-bearing output must fail LOUDLY on an image reference rather than
+// emit a grade or a placeholder (IRO-712). This exercises the gate directly, so
+// it runs with no container runtime present.
+func TestRejectScoreBearingOutputs_ImageMode(t *testing.T) {
+	const ref = "docker.io/library/haproxy:latest"
+	for _, flag := range scoreBearingFlags {
+		err := rejectScoreBearingOutputs(ref, map[string]bool{flag: true})
+		if err == nil {
+			t.Errorf("%s was allowed on an image reference; it needs a composite score", flag)
+			continue
+		}
+		msg := err.Error()
+		for _, want := range []string{flag, ref, "--dockerfile", "image reference"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("%s error missing %q: %v", flag, want, msg)
+			}
+		}
+	}
+	// The default table and --json request none of these, so they stay allowed:
+	// image mode still reports the USER finding and the N/A dimensions.
+	if err := rejectScoreBearingOutputs(ref, nil); err != nil {
+		t.Errorf("a plain image scan must be allowed: %v", err)
+	}
+}
+
+// scoreBearingFlags must stay in sync with the flags runScan actually feeds it;
+// a flag that emits a grade but is missing from the list is a silent hole.
+func TestScoreBearingFlagsCoverGradeEmittingOutputs(t *testing.T) {
+	want := map[string]bool{
+		"--badge": true, "--badge-json": true, "--badge-md": true, "--md": true,
+		"--share": true, "--sarif": true, "--min-score": true, "--fix": true,
+	}
+	got := map[string]bool{}
+	for _, f := range scoreBearingFlags {
+		got[f] = true
+	}
+	for f := range want {
+		if !got[f] {
+			t.Errorf("%s emits or gates on a score but is not in scoreBearingFlags", f)
+		}
+	}
+	for f := range got {
+		if !want[f] {
+			t.Errorf("scoreBearingFlags has an unexpected entry %q", f)
+		}
+	}
+}

--- a/docs/blog/alpine-vs-debian-vs-ubuntu-container-isolation.md
+++ b/docs/blog/alpine-vs-debian-vs-ubuntu-container-isolation.md
@@ -98,8 +98,10 @@ category, and grab a copy-paste score badge for your own repo at the
 **[Container Isolation Scores explorer](https://nivardsec.com/scores)**. The
 [leaderboard](../scores/leaderboard.md) refreshes weekly.
 
-Scan the image you actually run in about ten seconds:
+Scan the container you actually run in about ten seconds, with the flags you
+actually pass, because those flags are most of the score:
 
 ```bash
-ironctl scan your-image:tag
+docker run -d --name my-app your-image:tag
+ironctl scan my-app
 ```

--- a/docs/blog/container-isolation-leaderboard-what-151-images-scored.md
+++ b/docs/blog/container-isolation-leaderboard-what-151-images-scored.md
@@ -24,15 +24,18 @@ handful of `docker run` flags.
 
 ## How the grade works
 
-`ironctl scan` inspects a container or image and scores seven containment
+`ironctl scan` inspects a running container and scores seven containment
 dimensions: dropped capabilities, non-root user, read-only root filesystem,
 network isolation and egress, seccomp profile, no privileged mode, and no
 dangerous host mounts. Each failing dimension names the exact hole and the flag
-that closes it. No account, no cloud, no agent to install. You can run the same
-scan on your own images in about ten seconds:
+that closes it. No account, no cloud, no agent to install. Six of the seven
+dimensions are set by the `docker run` invocation rather than baked into the
+image, so the scan grades a container, not an image reference. You can run the
+same scan on your own images in about ten seconds:
 
 ```bash
-ironctl scan nginx:latest
+docker run -d --name nginx-scan nginx:latest
+ironctl scan nginx-scan
 ```
 
 Every number below comes from that scan, run over the pinned image manifest in
@@ -102,8 +105,10 @@ image links to a per-dimension scorecard with the precise hardening flags. The
 [scores directory](../scores/index.md) live in the docs and refresh weekly.
 
 If the image you run is not in the survey yet, scan it in ten seconds and see
-your own number:
+your own number. Start the container the way you actually run it, because the
+flags you pass are most of the score:
 
 ```bash
-ironctl scan your-image:tag
+docker run -d --name my-app your-image:tag
+ironctl scan my-app
 ```

--- a/docs/blog/docker-default-vs-hardened-container-isolation.md
+++ b/docs/blog/docker-default-vs-hardened-container-isolation.md
@@ -99,6 +99,7 @@ score badge for your repo at the
 **[Container Isolation Scores explorer](https://nivardsec.com/scores)**.
 
 ```bash
-ironctl scan your-image:tag        # see your default score
-ironctl scan your-image:tag --fix  # get the hardened command
+docker run -d --name my-app your-image:tag  # run it the way you actually run it
+ironctl scan my-app                         # see your default score
+ironctl scan my-app --fix                   # get the hardened command
 ```

--- a/docs/blog/gvisor-vs-runc-container-isolation-compared.md
+++ b/docs/blog/gvisor-vs-runc-container-isolation-compared.md
@@ -94,7 +94,8 @@ and check the block rates against this post. And whatever runtime you land on, s
 your container's configuration so the flags you *do* control are not the weak link:
 
 ```bash
-ironctl scan your-image:tag
+docker run -d --name my-app your-image:tag
+ironctl scan my-app
 ```
 
 Browse the full 151-image isolation ranking and grab a score badge for your repo at

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -75,9 +75,9 @@ inspect data, so probe-masking from inside the container cannot change the score
 
 | Runtime | How it is graded | Notes |
 |---|---|---|
-| `docker` | `docker inspect` | the default; also covers Docker-compatible engines |
-| `podman` | `podman inspect` | rootless is detected and credited (see below) |
-| `nerdctl` / containerd | `nerdctl inspect` | Docker-compatible schema; containerd runtime handlers (for example `io.containerd.runsc.v1`) are recognized |
+| `docker` | `docker container inspect` | the default; also covers Docker-compatible engines |
+| `podman` | `podman container inspect` | rootless is detected and credited (see below) |
+| `nerdctl` / containerd | `nerdctl container inspect` | Docker-compatible schema; containerd runtime handlers (for example `io.containerd.runsc.v1`) are recognized |
 | compose | `--compose FILE` | grades a service from the file, no runtime needed |
 | Kubernetes | `--k8s FILE` | grades a pod or workload manifest, no runtime needed |
 | Helm | `--helm CHART` | renders a chart with `helm template` and grades its workloads, no cluster needed |
@@ -101,6 +101,55 @@ is not on your PATH or cannot reach a running container, the scan errors with a
 clear message instead of returning a misleadingly clean report. `--docker-bin`,
 `--podman-bin`, and `--nerdctl-bin` (or the `DOCKER`, `PODMAN`, `NERDCTL`
 environment variables) point at a non-default binary.
+
+### An image reference is not a container
+
+A positional target is resolved with an explicit `container inspect` first and
+then `image inspect`, two separate questions. A container wins a name collision.
+
+**An image reference gets no containment score and no grade.** Six of the seven
+graded dimensions (dropped capabilities, seccomp, network isolation, read-only
+rootfs, control-socket exposure, shared host namespaces) are set by the
+`docker run` invocation and are simply not present in an image, so they report
+`N/A` rather than a verdict. Only the image `USER` finding is real:
+
+```bash
+ironctl scan haproxy:latest
+```
+
+```text
+IronClaw containment scan
+  target:  haproxy:latest (docker)
+  mode:    image reference (static image config; no container is running)
+  score:   not reported for an image reference. See the notes below.
+
+DIMENSION                   VERDICT   SCORE  DETAIL
+Non-root user (uid != 0)    [+] PASS  -      image config sets USER haproxy (uid != 0); ...
+Dropped capabilities        [-] N/A   -      not observable from an image reference: ...
+...
+```
+
+Scoring an image out of the observable total would be worse, not better: with one
+observable dimension, an image that sets `USER` scores 15 out of 15 and every
+badge renderer normalizes that to 100 percent, grade A, on an otherwise
+unhardened image. Nor is the image result a bound in either direction. The same
+image run as a container ranges from 15/100 with hostile flags to 100/100
+hardened, so an image number would predict neither.
+
+Image mode supports the default table and `--json`. Everything that needs a
+composite score (`--badge`, `--badge-json`, `--badge-md`, `--md`, `--share`,
+`--sarif`, `--min-score`, `--fix`, `--compare`) exits non-zero with an
+explanation rather than inventing a number. Scan a workload or a Dockerfile
+instead:
+
+```bash
+# grade the workload you actually run
+docker run -d --name app haproxy:latest
+ironctl scan app
+
+# grade the image build itself
+ironctl scan --dockerfile Dockerfile
+```
 
 ### Rootless Podman is credited
 
@@ -750,7 +799,7 @@ which gates the three container images it ships at `--min-score=80`.
 | Flag | What you get |
 |---|---|
 | (default) | a human-readable scorecard table |
-| `--json` | the full report as JSON (schemaVersion 1.0), for pipelines and dashboards |
+| `--json` | the full report as JSON (schemaVersion 1.1), for pipelines and dashboards |
 | `--fix` | print the concrete remediation for every failed dimension, plus a copy-pasteable hardened config (`--remediate` is an alias) |
 | `--badge scan.svg` | a self-contained SVG badge you can drop into a README |
 | `--badge-json badge.json` | a [shields.io endpoint](https://shields.io/badges/endpoint-badge) JSON file for a live, self-updating README badge |
@@ -760,6 +809,24 @@ which gates the three container images it ships at `--min-score=80`.
 | `--share` | a shareable scan receipt: a grade badge, the per-dimension breakdown, a link to a hosted receipt page, and an install CTA (offline; no network) |
 | `--compare A B` | grade two containers and print a side-by-side isolation-posture diff |
 | `--min-score N` | exit non-zero when the score is below N (a CI gate) |
+
+### JSON schema 1.1
+
+`--json` carries `"schemaVersion": "1.1"`. Two things changed from `1.0`:
+
+- **`mode` is new and always present**, one of `"container"`, `"image"`, or
+  `"dockerfile"`. Switch on it. Never detect the mode from a missing key: before
+  1.1 the only machine-readable tell that a scan had hit an image was that
+  `runtime` was absent, and an absent key is indistinguishable from a zero at the
+  call site.
+- **In `"image"` mode the top-level `score`, `grade` and `max` keys are absent**,
+  because an image reference has no composite. Every dimension then carries
+  `"score": 0, "max": 0`, so summing the dimensions yields 0 out of 0 rather than
+  a plausible-looking total, and the six unobservable dimensions carry
+  `"verdict": "N/A"`.
+
+Container-mode reports are otherwise unchanged from `1.0`: same dimensions, same
+scores, same grade bands.
 
 ## Share a scan receipt
 

--- a/internal/host/scan/dockerfile_score.go
+++ b/internal/host/scan/dockerfile_score.go
@@ -52,6 +52,9 @@ const staticCeilingNote = "static Dockerfile scan grades AUTHORING-TIME posture 
 // (table/json/md/badge/sarif) works unchanged.
 func ScoreDockerfile(s DockerfileSpec) Report {
 	r := Report{
+		// Its own mode: this composite is over the BUILD-time dimension set, not
+		// the run-time one, so a consumer must not compare it to a container score.
+		Mode:   ModeDockerfile,
 		Source: s.Source,
 		Target: s.Target,
 		Max:    TotalWeight,

--- a/internal/host/scan/image.go
+++ b/internal/host/scan/image.go
@@ -1,0 +1,123 @@
+package scan
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// --------------------------------------------------------------------------- //
+// Image adapter (IRO-712).
+//
+// An IMAGE is not a container. It carries the build-time config (USER, ENV, CMD,
+// ports, labels) and nothing else: no capability set, no seccomp profile, no
+// network mode, no mounts, no namespaces. Six of the seven graded containment
+// dimensions are decided at `docker run` time and are simply not present in an
+// image manifest.
+//
+// This adapter therefore does NOT reuse specFromDockerLike. That function is
+// correct for containers and load-bearing precisely because it resolves absence
+// to a concrete value (no seccomp SecurityOpt on a RUNNING container really does
+// mean the default profile is active; an empty Mounts list really does mean no
+// docker.sock). Feeding image data through it is what produced IRO-711: it
+// overwrote the fail-closed Unknown tristate with an affirmative "hardened" claim
+// on six dimensions, awarding 40 points of PASS about a container that never
+// existed. The only safe split is a separate adapter that leaves every
+// unobservable posture at Unknown and a mode that says so out loud.
+// --------------------------------------------------------------------------- //
+
+// imageInspect is the subset of `docker image inspect` / `podman image inspect` /
+// `nerdctl image inspect` we can grade. All three emit an OCI image config under
+// Config; only User is a containment posture. The rest of the schema is
+// deliberately not modelled: there is nothing else in an image config that
+// decides a containment dimension, and parsing more would invite exactly the
+// "looks like enough to grade" mistake this adapter exists to prevent.
+type imageInspect struct {
+	ID          string   `json:"Id"`
+	RepoTags    []string `json:"RepoTags"`
+	RepoDigests []string `json:"RepoDigests"`
+	Config      struct {
+		User string `json:"User"`
+	} `json:"Config"`
+}
+
+// SpecFromImageInspect parses `<runtime> image inspect <ref>` output into a Spec
+// in ModeImage. source is the runtime label ("docker"|"podman"|"nerdctl") and ref
+// is the reference the caller asked for, used as the report target so the output
+// names what the user typed rather than a resolved digest.
+//
+// Every run-time posture is left at Unknown ON PURPOSE. The scorer reports those
+// dimensions as N/A rather than grading them, so this adapter can never claim a
+// boundary holds on an artifact that does not have that boundary.
+func SpecFromImageInspect(raw []byte, source, ref string) (Spec, error) {
+	var arr []imageInspect
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		// Tolerate a single (non-array) object too, as the container adapters do.
+		var one imageInspect
+		if err2 := json.Unmarshal(raw, &one); err2 != nil {
+			return Spec{}, fmt.Errorf("parse image inspect: %w", err)
+		}
+		arr = []imageInspect{one}
+	}
+	if len(arr) == 0 {
+		return Spec{}, fmt.Errorf("image inspect returned no images")
+	}
+	img := arr[0]
+
+	s := Spec{
+		Mode:   ModeImage,
+		Source: source,
+		Target: imageTarget(ref, img),
+		Image:  imageTarget(ref, img),
+	}
+
+	// --- user / uid ---------------------------------------------------------
+	// The ONLY containment posture an image config carries. An absent USER is a
+	// determinable fact about the image (it declares no user, so a container
+	// started from it defaults to uid 0), not a missing field.
+	u := strings.TrimSpace(img.Config.User)
+	s.User = u
+	switch {
+	case u == "":
+		s.RunAsNonRoot = No
+		s.User = "0 (no USER instruction)"
+	case u == "0" || strings.HasPrefix(u, "0:") || u == "root" || strings.HasPrefix(u, "root:"):
+		s.RunAsNonRoot = No
+	default:
+		s.RunAsNonRoot = Yes
+	}
+
+	// Everything else stays at its zero value (Unknown / "") deliberately: see
+	// the package comment above. Do not "fill these in" from an image inspect.
+	return s, nil
+}
+
+// UnsupportedForImageRef builds the error every score-bearing output path returns
+// when the target resolved to an image reference. Those paths (badges, the
+// markdown/share blocks, the --min-score CI gate, SARIF, remediation) all
+// presuppose a composite score, and image mode deliberately has none. They must
+// fail LOUDLY with a non-zero exit rather than emit a grade or a placeholder: a
+// badge that says "0/100 F" or "15/15 A" for an image is the exact wrong number
+// sitting next to a real one (IRO-712).
+func UnsupportedForImageRef(what, target string) error {
+	return fmt.Errorf(`%s needs a containment score, and %q is an image reference, which has none.
+An image carries no run-time configuration, so six of the seven graded dimensions do not exist for it.
+  to score a workload:      docker run -d --name app %s   then   ironctl scan app
+  to score the image build: ironctl scan --dockerfile Dockerfile
+  (plain "ironctl scan %s" still reports the image USER finding and the N/A dimensions)`,
+		what, target, target, target)
+}
+
+// imageTarget picks the most useful display reference: what the caller asked for,
+// else the first repo tag, else a short image id.
+func imageTarget(ref string, img imageInspect) string {
+	if r := strings.TrimSpace(ref); r != "" {
+		return r
+	}
+	for _, t := range img.RepoTags {
+		if t = strings.TrimSpace(t); t != "" && t != "<none>:<none>" {
+			return t
+		}
+	}
+	return shortID(strings.TrimPrefix(img.ID, "sha256:"))
+}

--- a/internal/host/scan/image_test.go
+++ b/internal/host/scan/image_test.go
@@ -1,0 +1,310 @@
+package scan
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// haproxyImageInspect is a trimmed but FAITHFUL `podman image inspect
+// docker.io/library/haproxy:latest` blob: the real key set, with the long
+// History/RootFS/GraphDriver arrays dropped. What matters is what is NOT here.
+// An image inspect has no HostConfig, no Mounts, no Name and no NetworkSettings,
+// which is precisely why the container adapter must never be fed one.
+const haproxyImageInspect = `[{
+  "Id": "sha256:78b71716647e884d0a58c0a111053a8dd151b71907746b8a39d37abf613578e8",
+  "RepoTags": ["docker.io/library/haproxy:latest"],
+  "RepoDigests": ["docker.io/library/haproxy@sha256:0f0a1cf1e0a5ba7d2a2e4d1c2b3a49586d3b9b1c8f2e5a7c9d0b1e2f3a4b5c6d"],
+  "Architecture": "arm64",
+  "Os": "linux",
+  "Config": {
+    "User": "haproxy",
+    "Env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "HAPROXY_VERSION=3.2.7"],
+    "Cmd": ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"],
+    "Entrypoint": ["docker-entrypoint.sh"],
+    "WorkingDir": "/",
+    "StopSignal": "SIGUSR1"
+  }
+}]`
+
+// rootImageInspect is an image that declares no USER at all: the common case, and
+// the one real finding image mode can make.
+const rootImageInspect = `[{
+  "Id": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "RepoTags": ["docker.io/library/nginx:latest"],
+  "Config": { "Cmd": ["nginx", "-g", "daemon off;"] }
+}]`
+
+// The image adapter must leave EVERY run-time posture at Unknown. This is the
+// property that makes image mode honest: the scorer can then report those
+// dimensions as N/A instead of inventing a verdict for them.
+func TestSpecFromImageInspect_LeavesRuntimePosturesUnknown(t *testing.T) {
+	s, err := SpecFromImageInspect([]byte(haproxyImageInspect), "podman", "docker.io/library/haproxy:latest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Mode != ModeImage {
+		t.Fatalf("mode=%v, want ModeImage", s.Mode)
+	}
+	if s.Target != "docker.io/library/haproxy:latest" {
+		t.Errorf("target=%q, want the reference the caller asked for", s.Target)
+	}
+	if s.RunAsNonRoot != Yes || s.User != "haproxy" {
+		t.Errorf("USER haproxy should grade non-root; got RunAsNonRoot=%v user=%q", s.RunAsNonRoot, s.User)
+	}
+	for _, c := range []struct {
+		name string
+		got  Tristate
+	}{
+		{"CapDropAll", s.CapDropAll},
+		{"DockerSock", s.DockerSock},
+		{"ReadonlyRoot", s.ReadonlyRoot},
+		{"HostPID", s.HostPID},
+		{"HostIPC", s.HostIPC},
+		{"HostNetwork", s.HostNetwork},
+		{"Privileged", s.Privileged},
+	} {
+		if c.got != Unknown {
+			t.Errorf("%s = %v from an IMAGE inspect; an image carries no such posture, it must stay Unknown", c.name, c.got)
+		}
+	}
+	if s.Seccomp != "" {
+		t.Errorf("Seccomp = %q from an IMAGE inspect; want \"\" (unknown)", s.Seccomp)
+	}
+	if s.NetworkMode != "" {
+		t.Errorf("NetworkMode = %q from an IMAGE inspect; want \"\" (unknown)", s.NetworkMode)
+	}
+	if s.Runtime != "" {
+		t.Errorf("Runtime = %q from an IMAGE inspect; an image has no runtime", s.Runtime)
+	}
+}
+
+func TestSpecFromImageInspect_NoUserGradesRoot(t *testing.T) {
+	s, err := SpecFromImageInspect([]byte(rootImageInspect), "docker", "nginx:latest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.RunAsNonRoot != No {
+		t.Errorf("an image with no USER instruction must grade as root, got %v", s.RunAsNonRoot)
+	}
+	if d := dimByKey(Score(s), "user.nonroot"); d.Verdict != VerdictFail {
+		t.Errorf("user.nonroot verdict = %s, want FAIL", d.Verdict)
+	}
+}
+
+func TestSpecFromImageInspect_Errors(t *testing.T) {
+	if _, err := SpecFromImageInspect([]byte("not json"), "docker", "x"); err == nil {
+		t.Error("expected parse error")
+	}
+	if _, err := SpecFromImageInspect([]byte("[]"), "docker", "x"); err == nil {
+		t.Error("expected empty-array error")
+	}
+	// A single object (not wrapped in an array) is tolerated, as elsewhere.
+	if _, err := SpecFromImageInspect([]byte(`{"Id":"sha256:aa","Config":{"User":"1000"}}`), "docker", "x"); err != nil {
+		t.Errorf("single object should parse: %v", err)
+	}
+}
+
+// --------------------------------------------------------------------------- //
+// THE SEAM REGRESSION (IRO-711 / IRO-712).
+//
+// The defect never lived in the scorer. score_test.go asserts Score(Spec{}) is
+// fail-closed and passes, but the container adapter NEVER produces a Spec{}:
+// specFromDockerLike resolves absence to a concrete value BEFORE the scorer runs.
+// That is correct for a container and wrong for an image, so the guarantee has to
+// be tested at the adapter seam, not one layer below it.
+// --------------------------------------------------------------------------- //
+
+// The hazard pin / negative control. Routing an IMAGE inspect blob through the
+// CONTAINER adapter is the original bug, and this test asserts it still produces
+// the affirmative false claims. It is deliberately an assertion about BROKEN
+// behaviour: it documents why the two adapters must stay separate, and it stops
+// anyone "simplifying" the split away on the theory that specFromDockerLike
+// handles an image fine. If this test ever needs changing, the mode split is
+// being dismantled.
+func TestSpecFromDockerLike_OverwritesUnknownWithAffirmativeClaims(t *testing.T) {
+	// An image inspect reduces to empty docker-like fields: no HostConfig, no
+	// Mounts, no Name.
+	s := specFromDockerLike(dockerLikeFields{user: "haproxy"}, "podman")
+
+	if s.Seccomp != "confined" {
+		t.Fatalf("Seccomp=%q: the container adapter is expected to assert the default profile", s.Seccomp)
+	}
+	if s.DockerSock != No || s.CapDropAll != No || s.ReadonlyRoot != No {
+		t.Fatalf("the container adapter is expected to resolve absence to a concrete value; got sock=%v caps=%v ro=%v",
+			s.DockerSock, s.CapDropAll, s.ReadonlyRoot)
+	}
+	if s.HostPID != No || s.HostIPC != No || s.HostNetwork != No {
+		t.Fatalf("the container adapter is expected to resolve namespaces concretely; got pid=%v ipc=%v net=%v",
+			s.HostPID, s.HostIPC, s.HostNetwork)
+	}
+
+	// Those overwrites are worth 40 points of affirmative PASS about postures
+	// nothing observed. THIS is the fail-open, and it is why image data must not
+	// reach here.
+	r := Score(s)
+	var falsePass int
+	for _, key := range []string{"seccomp", "docker.sock", "namespaces.host"} {
+		d := dimByKey(r, key)
+		if d.Verdict == VerdictPass {
+			falsePass += d.Score
+		}
+	}
+	if falsePass != 40 {
+		t.Fatalf("expected the documented 40 points of unobserved PASS through this seam, got %d", falsePass)
+	}
+
+	// The load-bearing guarantee: whatever it grades, this adapter ALWAYS declares
+	// container mode. It has no way to represent an image, so an image must never
+	// be routed through it.
+	if s.Mode != ModeContainer {
+		t.Fatalf("specFromDockerLike mode=%v, want ModeContainer", s.Mode)
+	}
+}
+
+// The positive control: the same image data through the IMAGE adapter makes none
+// of those claims and yields no composite.
+func TestScoreImage_NoCompositeAndNoUnobservedClaims(t *testing.T) {
+	s, err := SpecFromImageInspect([]byte(haproxyImageInspect), "podman", "docker.io/library/haproxy:latest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := Score(s)
+
+	if r.Mode != ModeImage {
+		t.Fatalf("report mode=%v, want ModeImage", r.Mode)
+	}
+	if r.Scored() {
+		t.Fatal("an image report must not claim to be scored")
+	}
+	if r.Score != 0 || r.Grade != "" || r.Max != 0 {
+		t.Fatalf("image report carries a composite: score=%d grade=%q max=%d", r.Score, r.Grade, r.Max)
+	}
+
+	// The one real finding survives.
+	if d := dimByKey(r, "user.nonroot"); d.Verdict != VerdictPass || !strings.Contains(d.Detail, "haproxy") {
+		t.Errorf("image USER finding lost: %+v", d)
+	}
+
+	// Every run-time dimension reports N/A, with no points in either direction.
+	for _, key := range []string{"caps.dropped", "seccomp", "network.isolated", "rootfs.readonly", "docker.sock", "namespaces.host"} {
+		d := dimByKey(r, key)
+		if d.Verdict != VerdictNA {
+			t.Errorf("%s verdict = %s, want N/A", key, d.Verdict)
+		}
+		if d.Score != 0 || d.Max != 0 {
+			t.Errorf("%s carries points %d/%d; an unobservable dimension must carry none", key, d.Score, d.Max)
+		}
+		if !strings.Contains(d.Detail, "not observable from an image reference") {
+			t.Errorf("%s detail = %q, want the N/A explanation", key, d.Detail)
+		}
+	}
+
+	// Summing the dimensions must not produce a plausible-looking total.
+	sum, max := 0, 0
+	for _, d := range r.Dimensions {
+		sum += d.Score
+		max += d.Max
+	}
+	if sum != 0 || max != 0 {
+		t.Errorf("dimension totals = %d/%d, want 0/0 so a summing consumer cannot fabricate a score", sum, max)
+	}
+}
+
+// The single highest-value line of this change: an image scan must never print
+// "no docker.sock / OCI control socket mounted", nor a grade.
+func TestRenderTable_ImageModeEmitsNoGradeAndNoFalsePass(t *testing.T) {
+	s, _ := SpecFromImageInspect([]byte(haproxyImageInspect), "podman", "docker.io/library/haproxy:latest")
+	var b bytes.Buffer
+	RenderTable(&b, Score(s))
+	out := b.String()
+
+	for _, forbidden := range []string{
+		"no docker.sock / OCI control socket mounted",
+		"seccomp profile active",
+		"no host PID/IPC/network namespace sharing",
+		"grade A", "grade B", "grade C", "grade D", "grade F",
+		"(hardened)", "(wide open)", "(weak, fix the FAILs)",
+		"15/15",
+		"/100",
+	} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("image-mode table contains %q:\n%s", forbidden, out)
+		}
+	}
+	for _, want := range []string{"N/A", "image reference", "--dockerfile", "USER haproxy"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("image-mode table missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// Schema 1.1: mode is positive in BOTH modes; the composite keys are absent only
+// in image mode.
+func TestRenderJSON_ImageModeOmitsCompositeCarriesMode(t *testing.T) {
+	s, _ := SpecFromImageInspect([]byte(haproxyImageInspect), "podman", "docker.io/library/haproxy:latest")
+	var b bytes.Buffer
+	if err := RenderJSON(&b, Score(s)); err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b.Bytes(), &m); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if m["schemaVersion"] != "1.1" {
+		t.Errorf("schemaVersion=%v, want 1.1", m["schemaVersion"])
+	}
+	if m["mode"] != "image" {
+		t.Errorf("mode=%v, want image", m["mode"])
+	}
+	for _, k := range []string{"score", "grade", "max"} {
+		if _, ok := m[k]; ok {
+			t.Errorf("image-mode JSON carries %q=%v; an image has no composite", k, m[k])
+		}
+	}
+	// runtime is legitimately absent (an image has no runtime), which is exactly
+	// why it can never be the mode signal.
+	if _, ok := m["runtime"]; ok {
+		t.Errorf("image-mode JSON carries runtime=%v", m["runtime"])
+	}
+}
+
+// ScanMode round-trips by NAME, and an unrecognized mode is an error rather than
+// a silent fallback to "container".
+func TestScanModeJSONRoundTrip(t *testing.T) {
+	for _, m := range []ScanMode{ModeContainer, ModeImage, ModeDockerfile} {
+		b, err := json.Marshal(m)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got ScanMode
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Fatalf("unmarshal %s: %v", b, err)
+		}
+		if got != m {
+			t.Errorf("round-trip %s -> %v", b, got)
+		}
+	}
+	var m ScanMode
+	if err := json.Unmarshal([]byte(`"sandbox"`), &m); err == nil {
+		t.Error("an unknown mode must be an error, not a silent fallback to container")
+	}
+}
+
+// Every other adapter keeps declaring container mode, so the JSON gains "mode"
+// without any of them changing meaning.
+func TestNonImageAdaptersDeclareContainerMode(t *testing.T) {
+	for name, raw := range map[string]string{"docker": weakInspect, "hardened": hardenedInspect} {
+		s, err := SpecFromDockerInspect([]byte(raw))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if s.Mode != ModeContainer || Score(s).Mode != ModeContainer {
+			t.Errorf("%s: mode=%v, want ModeContainer", name, s.Mode)
+		}
+		if !Score(s).Scored() {
+			t.Errorf("%s: a container report must be scored", name)
+		}
+	}
+}

--- a/internal/host/scan/render.go
+++ b/internal/host/scan/render.go
@@ -25,11 +25,25 @@ func RenderTable(w io.Writer, r Report) {
 	if r.HardenedRuntime != "" {
 		fmt.Fprintf(w, "  isolation: %s (hardened runtime; informational, no score bonus)\n", r.HardenedRuntime)
 	}
-	fmt.Fprintf(w, "  score:   %d/%d  grade %s  %s\n\n", r.Score, r.Max, r.Grade, gradeBanner(r.Grade))
+	// Image mode has no composite (IRO-712). Say so where the score would be,
+	// rather than printing a zero or a placeholder grade.
+	if !r.Scored() {
+		fmt.Fprintf(w, "  mode:    image reference (static image config; no container is running)\n")
+		fmt.Fprintf(w, "  score:   not reported for an image reference. See the notes below.\n\n")
+	} else {
+		fmt.Fprintf(w, "  score:   %d/%d  grade %s  %s\n\n", r.Score, r.Max, r.Grade, gradeBanner(r.Grade))
+	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "DIMENSION\tVERDICT\tSCORE\tDETAIL")
 	for _, d := range r.Dimensions {
+		if !r.Scored() {
+			// No points are available in either direction; "0/15" would read as a
+			// failed dimension and "15/15" as a passed one, and neither was graded.
+			fmt.Fprintf(tw, "%s\t%s %s\t%s\t%s\n",
+				d.Title, verdictGlyph(d.Verdict), d.Verdict, "-", d.Detail)
+			continue
+		}
 		fmt.Fprintf(tw, "%s\t%s %s\t%d/%d\t%s\n",
 			d.Title, verdictGlyph(d.Verdict), d.Verdict, d.Score, d.Max, d.Detail)
 	}
@@ -65,15 +79,31 @@ func verdictGlyph(v Verdict) string {
 		return "[+]"
 	case VerdictWarn:
 		return "[~]"
+	case VerdictNA:
+		// Not graded, so neither a tick nor a cross: both would be a claim.
+		return "[-]"
 	default: // FAIL / UNKNOWN
 		return "[x]"
 	}
 }
 
-// RenderJSON writes the machine-readable report (schemaVersion 1.0). When a
+// RenderJSON writes the machine-readable report (schemaVersion 1.1). When a
 // non-nil RemediationPlan is passed (from `--fix`), it is spliced in under the
 // "remediation" key so the JSON carries the prescriptive fixes too — fail-closed
 // parity with the human output.
+//
+// SCHEMA 1.1 (IRO-712) moved the contract in two ways:
+//
+//   - "mode" is a new, ALWAYS-PRESENT string: "container" | "image" |
+//     "dockerfile". Switch on it. Never detect the mode from an absent key.
+//   - When mode is "image", the top-level "score", "grade" and "max" keys are
+//     ABSENT, because an image reference has no composite (see scoreImage). Every
+//     dimension then carries score 0 / max 0, so a consumer that sums the
+//     dimensions gets 0/0 rather than a plausible-looking total, and the six
+//     run-time dimensions carry verdict "N/A".
+//
+// The version bump is what lets a consumer pinned to "1.0" notice that the
+// contract moved instead of discovering it as a missing key at runtime.
 func RenderJSON(w io.Writer, r Report, plan ...*RemediationPlan) error {
 	// json does not honour ",inline"; marshal the report and splice fields in.
 	b, err := json.Marshal(r)
@@ -84,8 +114,14 @@ func RenderJSON(w io.Writer, r Report, plan ...*RemediationPlan) error {
 	if err := json.Unmarshal(b, &m); err != nil {
 		return err
 	}
-	m["schemaVersion"] = "1.0"
+	m["schemaVersion"] = "1.1"
 	m["report"] = "ironclaw-containment-scan"
+	if !r.Scored() {
+		// Emit no composite at all rather than a zero that reads as an F.
+		delete(m, "score")
+		delete(m, "grade")
+		delete(m, "max")
+	}
 	if len(plan) > 0 && plan[0] != nil {
 		m["remediation"] = plan[0]
 	}
@@ -117,6 +153,8 @@ func mdGlyph(v Verdict) string {
 		return "✅"
 	case VerdictWarn:
 		return "⚠️"
+	case VerdictNA:
+		return "—"
 	default:
 		return "❌"
 	}

--- a/internal/host/scan/render_test.go
+++ b/internal/host/scan/render_test.go
@@ -36,8 +36,13 @@ func TestRenderJSON(t *testing.T) {
 	if err := json.Unmarshal(b.Bytes(), &m); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
-	if m["schemaVersion"] != "1.0" {
+	if m["schemaVersion"] != "1.1" {
 		t.Errorf("schemaVersion=%v", m["schemaVersion"])
+	}
+	// mode is a POSITIVE assertion present in EVERY mode (IRO-712): a consumer
+	// must never have to detect image mode by an absent key.
+	if m["mode"] != "container" {
+		t.Errorf("mode=%v, want container", m["mode"])
 	}
 	if m["score"].(float64) != 100 {
 		t.Errorf("score=%v", m["score"])

--- a/internal/host/scan/score.go
+++ b/internal/host/scan/score.go
@@ -14,6 +14,14 @@ const (
 	VerdictUnknown Verdict = "UNKNOWN" // could not determine — scored as FAIL (fail-closed)
 	VerdictWarn    Verdict = "WARN"    // partial / weakened posture
 	VerdictPass    Verdict = "PASS"    // hardened posture observed
+	// VerdictNA means the dimension is NOT OBSERVABLE from the artifact that was
+	// scanned, so it is not graded at all and carries no points in either
+	// direction. It is categorically different from UNKNOWN: UNKNOWN says "this
+	// container has a posture and we could not read it", so it is scored
+	// fail-closed as insecure; N/A says "the artifact has no such posture to
+	// read". Grading a run-time control on an image would be a claim about a
+	// container that does not exist (IRO-712), in either direction.
+	VerdictNA Verdict = "N/A"
 )
 
 // Dimension is one graded containment axis.
@@ -27,10 +35,18 @@ type Dimension struct {
 }
 
 // Report is the full scorecard for one Spec.
+//
+// Score/Grade/Max are meaningful only when Scored() is true. In ModeImage there
+// is no composite at all and the JSON renderer omits those keys outright rather
+// than emitting a zero that reads as "failed" (IRO-712). Mode is the positive
+// assertion a consumer switches on; never infer the mode from an absent key.
 type Report struct {
-	Source  string `json:"source"`
-	Target  string `json:"target"`
-	Runtime string `json:"runtime,omitempty"`
+	// Mode says what was inspected: "container" | "image" | "dockerfile".
+	// ALWAYS present in the JSON, in every mode.
+	Mode    ScanMode `json:"mode"`
+	Source  string   `json:"source"`
+	Target  string   `json:"target"`
+	Runtime string   `json:"runtime,omitempty"`
 	// HardenedRuntime names a recognized strong-isolation runtime (gVisor, Kata,
 	// Firecracker) when one is detected. Informational ONLY: scoring stays
 	// runtime-agnostic (IRO-429), so this awards no points; it surfaces the fact
@@ -73,10 +89,24 @@ var scorers = []scorer{
 // TotalWeight is the maximum achievable score (100 by construction).
 const TotalWeight = 100
 
+// Scored reports whether the report carries a meaningful composite score and
+// grade. It is false in ModeImage, where six of the seven dimensions are not
+// observable and no composite is emitted. Check this before reading Score/Grade
+// or rendering a badge: a zero Score in image mode is the ABSENCE of a score,
+// not an F.
+func (r Report) Scored() bool { return r.Mode != ModeImage }
+
 // Score grades a Spec across every dimension and returns the full Report. It is
 // pure: no I/O, no clock, deterministic for a given Spec.
+//
+// An image-mode Spec is routed to scoreImage, which grades ONLY the dimension an
+// image can actually answer and reports the rest as N/A with no composite.
 func Score(s Spec) Report {
+	if s.Mode == ModeImage {
+		return scoreImage(s)
+	}
 	r := Report{
+		Mode:    s.Mode,
 		Source:  s.Source,
 		Target:  s.Target,
 		Runtime: s.Runtime,
@@ -111,6 +141,71 @@ func Score(s Spec) Report {
 			name))
 	}
 	return r
+}
+
+// --------------------------------------------------------------------------- //
+// Image mode (IRO-712).
+// --------------------------------------------------------------------------- //
+
+// imageObservableDim is the only graded dimension an image reference can answer:
+// the OCI image config's USER. Everything else in the dimension set is decided by
+// the `docker run` invocation.
+const imageObservableDim = "user.nonroot"
+
+// naFromImage is the detail every unobservable dimension carries in image mode.
+const naFromImage = "not observable from an image reference: this is run-time configuration and no container exists"
+
+// scoreImage builds the report for an IMAGE reference. It emits NO composite
+// score and NO grade, on purpose:
+//
+//   - Only user.nonroot (15 of 100 points) is observable from an image config, so
+//     any composite would be a number computed almost entirely from things that
+//     were not looked at.
+//   - Scoring out of the observable total is worse, not better: with one
+//     observable dimension it collapses to two values and renders `USER nobody`
+//     on an otherwise unhardened image as 15/15, which every badge normalizes to
+//     100% / grade A.
+//   - The image number is not a bound in either direction. The same image scanned
+//     as a container ranges from 15/100 (hostile flags) to 100/100 (hardened),
+//     so no wording may call image mode a floor or a ceiling.
+//
+// The one real finding is kept, and the six run-time dimensions report N/A with
+// zero points available so a consumer that sums the dimensions gets 0/0 rather
+// than a plausible-looking total.
+func scoreImage(s Spec) Report {
+	r := Report{
+		Mode:   ModeImage,
+		Source: s.Source,
+		Target: s.Target,
+		Notes:  append([]string(nil), s.Notes...),
+	}
+	for _, sc := range scorers {
+		d := Dimension{Key: sc.key, Title: sc.title, Verdict: VerdictNA, Detail: naFromImage}
+		if sc.key == imageObservableDim {
+			d.Verdict, d.Detail = gradeImageUser(s)
+		}
+		r.Dimensions = append(r.Dimensions, d)
+	}
+	r.Notes = append(r.Notes,
+		"image mode: no containment score or grade is reported. Six of the seven graded dimensions (capabilities, seccomp, network, read-only rootfs, control-socket exposure, host namespaces) are run-time configuration that an image does not carry, so grading them either way would be a claim about a container that does not exist.",
+		"to grade a workload's containment, scan the RUNNING container: `docker run -d --name app <image>` then `ironctl scan app`.",
+		"to grade the image build itself (base pinning, USER, baked secrets, ADD, world-writable paths), use the purpose-built static scorer: `ironctl scan --dockerfile Dockerfile`.",
+	)
+	return r
+}
+
+// gradeImageUser grades the image config's USER. It is the image-mode dual of
+// gradeNonRoot and awards no points: image mode has no composite. Fail-closed is
+// preserved (an unreadable user is UNKNOWN, never a pass).
+func gradeImageUser(s Spec) (Verdict, string) {
+	switch s.RunAsNonRoot {
+	case Yes:
+		return VerdictPass, fmt.Sprintf("image config sets USER %s (uid != 0); a container started from it defaults to a non-root uid", nz(s.User, "non-root"))
+	case No:
+		return VerdictFail, fmt.Sprintf("image config runs as root (USER %s); a container started from it is uid 0 unless the run command overrides it", nz(s.User, "0"))
+	default:
+		return VerdictUnknown, "image config user not reported; assuming root (fail-closed)"
+	}
 }
 
 // StrongIsolationRuntime classifies an OCI runtime identifier (a docker

--- a/internal/host/scan/spec.go
+++ b/internal/host/scan/spec.go
@@ -18,6 +18,78 @@
 // boundary holds.
 package scan
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ScanMode names WHAT the report actually inspected. It exists because the
+// docker-family CLIs resolve containers and images out of a SINGLE namespace, so
+// `docker inspect <ref>` silently answers for either one (IRO-711): an image ref
+// landed in the container adapter and was graded as if a container existed. The
+// mode is therefore decided by which explicit inspect subcommand succeeded, never
+// inferred from which fields came back.
+//
+// It is a POSITIVE assertion, always emitted. A consumer must never have to
+// detect image mode by an absent key: an absent key and a zero value are
+// indistinguishable at the call site, which is the exact failure this field
+// exists to close.
+type ScanMode int
+
+const (
+	// ModeContainer is the zero value: the report grades the run-time
+	// configuration of a container, either a live one (docker/podman/nerdctl
+	// `container inspect`) or one declared by a manifest (compose, k8s, ECS,
+	// Terraform, …). Every dimension is observable, so the report carries a
+	// composite score and grade.
+	ModeContainer ScanMode = iota
+	// ModeImage means only an IMAGE was inspected. An image manifest carries no
+	// run-time configuration, so six of the seven graded dimensions are not
+	// observable at all and the report deliberately carries NO composite score
+	// and NO grade. Scoring them either way would be a claim about a container
+	// that does not exist.
+	ModeImage
+	// ModeDockerfile means a Dockerfile was graded statically against the
+	// build-time dimension set (dockerfile_score.go). It has its own composite
+	// over its own dimensions.
+	ModeDockerfile
+)
+
+func (m ScanMode) String() string {
+	switch m {
+	case ModeImage:
+		return "image"
+	case ModeDockerfile:
+		return "dockerfile"
+	default:
+		return "container"
+	}
+}
+
+// MarshalJSON emits the mode as its stable string name.
+func (m ScanMode) MarshalJSON() ([]byte, error) { return json.Marshal(m.String()) }
+
+// UnmarshalJSON accepts the stable string names. An unrecognized mode is an
+// error rather than a silent fallback to "container", which would re-create the
+// fail-open the mode field exists to prevent.
+func (m *ScanMode) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "container":
+		*m = ModeContainer
+	case "image":
+		*m = ModeImage
+	case "dockerfile":
+		*m = ModeDockerfile
+	default:
+		return fmt.Errorf("unknown scan mode %q", s)
+	}
+	return nil
+}
+
 // Tristate is a three-valued boolean used for every security posture that a
 // source may or may not report. Unlike a plain bool (or *bool), it makes the
 // "we could not determine this" case a first-class, non-optional value so the
@@ -60,6 +132,11 @@ func boolTri(b bool) Tristate {
 // Fields left at their zero value (Unknown / "" / nil) are treated as unknown
 // and graded fail-closed.
 type Spec struct {
+	// Mode records what was inspected. It is set by the ADAPTER, which is the
+	// only layer that knows: the container adapters leave it at ModeContainer,
+	// SpecFromImageInspect sets ModeImage. The scorers read it and refuse to
+	// grade run-time dimensions that the inspected artifact cannot carry.
+	Mode ScanMode
 	// Source identity (informational; shown in the report header).
 	Source string // "docker" | "compose" | "k8s"
 	Target string // container name/id, compose service, or pod name


### PR DESCRIPTION
## What

`ironctl scan <image-ref>` used to grade an image as if it were a container. On
`haproxy:latest` that produced **59/100 grade C**, of which **40 points were
affirmative PASS about postures nothing had observed**:

- `PASS 15/15  seccomp profile active (syscall surface filtered)`
- `PASS 15/15  no docker.sock / OCI control socket mounted`
- `PASS 10/10  no host PID/IPC/network namespace sharing`

There is no container. Those three lines are the important half of this fix; the
missing composite is the smaller half.

Implements IRO-712 (option **(c)-strengthened**, as ruled). Parent: IRO-711.

## Why it happened

Two causes, neither of them in the scorer:

1. **No mode detection existed anywhere.** `docker`/`podman`/`nerdctl` resolve
   containers *and* images from one namespace, so a bare `<bin> inspect <ref>`
   answered for either and the caller could not tell which it got.
2. **`specFromDockerLike` resolves absence to a concrete value** before
   `score.go` ever runs: `Seccomp = "confined"`, `DockerSock = No`,
   `CapDropAll = No`, `ReadonlyRoot = No`, `HostPID/IPC/Network = No`. That is
   *correct* for a container (no seccomp `SecurityOpt` on a running container
   really does mean the default profile is active) and false for an image. Six of
   the seven fail-closed branches were therefore unreachable through this
   adapter, which is why `network` was the only dimension that ever surfaced as
   `UNKNOWN`.

## What changed

**Explicit mode detection.** `<bin> container inspect` then `<bin> image inspect`
as two separate calls. Containers win a name collision. No ref heuristic, no
inference from which fields came back. The adapter stamps the mode on the `Spec`.

**No composite in image mode.** Scoring out of the observable total is worse, not
better: only `user.nonroot` (15 of 100) is observable, so an image that sets
`USER` scores 15/15 and every badge renderer normalizes that to 100% grade A on
an unhardened image. The image result is also not a bound in either direction:
the same image as a container ranges from 15/100 (hostile flags) to 100/100
(hardened). Nothing in the code or docs calls it a floor or a ceiling.

**Six dimensions report `N/A`** with zero points available in either direction,
so a consumer summing the dimensions gets 0/0 rather than a plausible total. The
one real finding (image `USER`) is kept, and the output points at
`scan --dockerfile`.

**Schema 1.1.**
- `mode` (`"container"` | `"image"` | `"dockerfile"`) is new and **always
  present**. Before this, the only machine-readable tell that a scan had hit an
  image was that `runtime` was *missing*, and an absent key is indistinguishable
  from a zero at the call site.
- In image mode the top-level `score`/`grade`/`max` keys are absent, so the
  version bump is what lets a consumer pinned to `"1.0"` notice the contract
  moved rather than discovering it as a `KeyError`.
- I extended the ruling by one value: `"dockerfile"`. `Report` is shared by every
  source, and `--dockerfile` grades a *build-time* dimension set with its own
  composite, so labelling it `"container"` would have been false and omitting the
  key would have re-created the absent-key problem. Flagging it explicitly as the
  one place I went beyond the decision.

**Score-bearing outputs exit non-zero on an image ref** rather than emitting a
grade or a placeholder: `--badge`, `--badge-json`, `--badge-md`, `--md`,
`--share`, `--sarif`, `--min-score`, `--fix`, `--compare`. The default table and
`--json` still work.

**Regression coverage at the `specFromDockerLike` seam.** `score_test.go:206-218`
asserts `Score(Spec{})` is fail-closed and passes, while the adapter it is meant
to protect never produces a `Spec{}`. The new test is a *hazard pin*: it asserts
the container adapter still awards the documented 40 points of unobserved PASS on
empty fields, so the two adapters cannot be quietly re-merged on the theory that
one handles both. A companion test asserts the image adapter leaves every
run-time posture `Unknown`.

**The six doc lines and the usage text**, in this PR as agreed.

## Verified by RUNNING the tool

- `ironctl scan --runtime podman docker.io/library/haproxy:latest` emits no score
  or grade, six `N/A` rows, and keeps `PASS ... image config sets USER haproxy`.
  The `no docker.sock` line is gone.
- **Container-mode table output is byte-identical to `origin/main`** (`diff`, not
  reasoning) for the default container (63/100 C), a fully hardened one
  (100/100 A), a hostile `--privileged --network=host --pid=host` one (15/100 F),
  and for `--fix`, `--md`, `--share`, `--compare`, `--compose`, `--k8s` and
  `--dockerfile`. `--badge`/`--badge-json`/`--badge-md` artifacts are byte-identical.
- Container/compose/k8s/dockerfile `--json` diff vs `origin/main` is exactly the
  two intended additive changes (`+mode`, `1.0`->`1.1`) and nothing else.
- All nine rejection paths exit 1 and write no artifact.
- The seam regression test was proven non-vacuous: temporarily routing the image
  adapter back through `specFromDockerLike` turns it red on all eight overwritten
  postures, then reverted.
- `mkdocs build --strict` clean; `scripts/check-md-fences.py` ok across 471 files.
- `CGO_ENABLED=1 go build ./...`, `go vet`, and the full `go test ./...` are green.

## Verified by READING the code

- `docs/integrations/ci.md:87`'s `schemaVersion 1.0` names the containment-report
  artifact from the escape harness, not `ironctl scan --json`, so it is
  deliberately untouched. Traced through the action's `report-path` output.
- `nerdctl` supports `container inspect` / `image inspect`; I have no nerdctl
  host to exercise, so that adapter's mode split is code-read only. docker (via
  the local Podman-backed client) and podman were both exercised live.

## No published score or badge moves

Re-confirmed independently rather than inherited: `examples/isolation-survey/survey.sh:187`
does `run -d --name "$cname"` and then scans `"$cname"`, a container name, which
still takes the `container inspect` path. Zero `UNKNOWN` verdicts and zero
occurrences of the image-mode fingerprint `network mode not reported` across the
254 pages in `docs/scores/`. `render.py` reads `score`/`grade`/`version`, all of
which are unchanged in container mode; it never reads `schemaVersion`. Nothing to
retract.

Out of scope as instructed: PR #661, `internal/contract/**` (untouched; the scan
`Report` does not live there), and the `docs/scores/*` "No workload is executed"
provenance line.

Closes IRO-712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
