### PR TITLE
ci(docs): gate the scores generator, which shipped ungated onto 252 pages [IRO-715]

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,11 +21,17 @@ on:
       - "scripts/check-guide-index.py"
       - "scripts/check-guide-uid.py"
       - "scripts/check-md-fences.py"
+      - "scripts/check-scores-drift.py"
       # check-guide-uid.py reads `hardenedUID` out of this file, so a change to
       # the constant has to trigger this workflow too. Without it, moving the
       # constant would leave 56 guides quoting the old uid and nothing in CI
       # would ever look: the paths filter, not the check, would be the hole.
       - "internal/host/scan/remediate.go"
+      # Every page under docs/scores/ is emitted from this directory
+      # (gen_scorecards.py + results.json), so a change here changes published
+      # docs without touching docs/**. Omitting it meant a generator-only PR ran
+      # no Docs build at all -- see IRO-715 and check-scores-drift.py below.
+      - "examples/isolation-survey/**"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
@@ -39,11 +45,17 @@ on:
       - "scripts/check-guide-index.py"
       - "scripts/check-guide-uid.py"
       - "scripts/check-md-fences.py"
+      - "scripts/check-scores-drift.py"
       # check-guide-uid.py reads `hardenedUID` out of this file, so a change to
       # the constant has to trigger this workflow too. Without it, moving the
       # constant would leave 56 guides quoting the old uid and nothing in CI
       # would ever look: the paths filter, not the check, would be the hole.
       - "internal/host/scan/remediate.go"
+      # Every page under docs/scores/ is emitted from this directory
+      # (gen_scorecards.py + results.json), so a change here changes published
+      # docs without touching docs/**. Omitting it meant a generator-only PR ran
+      # no Docs build at all -- see IRO-715 and check-scores-drift.py below.
+      - "examples/isolation-survey/**"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -145,6 +157,28 @@ jobs:
         # silent on haproxy/grafana/prometheus, where the uid is the image's own
         # and rewriting it would break the container.
         run: python3 scripts/check-guide-uid.py
+
+      - name: Check docs/scores/ still matches its generator
+        # docs/scores/ is not hand-written: all 270 files under it are emitted by
+        # examples/isolation-survey/gen_scorecards.py from results.json, and
+        # committed so the site builds without re-running the survey. Committed
+        # bytes and generator can therefore disagree, and nothing else here would
+        # see it -- the pages build fine, link fine and carry front-matter fine
+        # whether or not they match what the generator would emit today.
+        #
+        # The damage is deferred, which is why it needs a gate: scores-refresh.yml
+        # re-runs the generator weekly and force-opens a rolling PR, so a template
+        # change that landed without re-emitting gets rewritten across all 252
+        # published scorecards inside a diff already full of legitimate score
+        # movement. Catch it on the PR that changed the generator instead.
+        # A step in `build` for the same reason as the checks around it: `build`
+        # is the required check on ruleset 17917971 and a new job name would not
+        # be. Stdlib only, so it runs before the toolchain install and fails fast
+        # (~1s). Negative controls: scripts/tests/test_check_scores_drift.py (run
+        # by ci.yml script-tests), including the two carve-outs a naive `diff -r`
+        # gets wrong -- hand-maintained .nav.yml files, and the generator's
+        # routine stderr warnings. See IRO-715.
+        run: python3 scripts/check-scores-drift.py
 
       - name: Install MkDocs toolchain (hash-pinned)
         # --require-hashes makes pip refuse any wheel whose SHA-256 isn't in the

--- a/scripts/check-scores-drift.py
+++ b/scripts/check-scores-drift.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Fail the docs build when committed ``docs/scores/`` drifts from its generator.
+
+Every page under ``docs/scores/`` -- 252 scorecards plus index.md,
+leaderboard.md, index.json and the collection pages -- is *emitted* by
+``examples/isolation-survey/gen_scorecards.py`` from
+``examples/isolation-survey/results.json``. The tree is committed so the docs
+site builds without re-running the survey, which means the committed bytes and
+the generator can disagree and nothing notices.
+
+Two ways that hurts, both of them quiet:
+
+* A hand-edit of a generated page looks like a normal docs change, passes every
+  other check here, and is silently reverted by the next refresh.
+* ``.github/workflows/scores-refresh.yml`` re-runs the generator weekly and
+  force-opens a rolling PR. A generator change that landed without re-emitting
+  is picked up there and rewritten across all 252 published pages, inside a diff
+  that is already full of legitimate score movement -- a broken template is at
+  its least visible exactly where it does the most damage (IRO-715).
+
+So this regenerates into a scratch directory and compares byte-for-byte against
+what is committed. The generator is deterministic (pages keyed by image slug,
+rows sorted by ``(score, slug)``), so a clean tree compares equal every time.
+
+Two deliberate carve-outs:
+
+* ``docs/scores/.nav.yml`` and ``docs/scores/collections/.nav.yml`` are
+  hand-maintained -- the generator never emits them -- so any file named
+  ``.nav.yml`` is excluded. A naive ``diff -r`` reports them and fails.
+* The generator prints ``warning: no family mapping for slug ...`` to stderr on
+  a perfectly clean run. Only its exit status is read; stderr is not failure.
+
+Usage:
+
+    python3 scripts/check-scores-drift.py [repo-root]
+
+Exits 0 when every generated file matches, 1 on drift, and 2 on a usage/IO error
+or a generator that will not run. Negative controls:
+scripts/tests/test_check_scores_drift.py.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+GENERATOR = Path("examples/isolation-survey/gen_scorecards.py")
+RESULTS = Path("examples/isolation-survey/results.json")
+SCORES_DIR = Path("docs/scores")
+
+# Hand-maintained, never emitted by the generator. Matched on basename, which
+# covers both docs/scores/.nav.yml and docs/scores/collections/.nav.yml.
+EXCLUDED_NAMES = {".nav.yml"}
+
+
+def generated_files(root: Path) -> dict[str, str]:
+    """Map repo-relative-to-`root` path -> sha256, skipping the excluded names."""
+    digests = {}
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.name in EXCLUDED_NAMES:
+            continue
+        digests[str(path.relative_to(root))] = hashlib.sha256(
+            path.read_bytes()
+        ).hexdigest()
+    return digests
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 2:
+        print(f"usage: {argv[0]} [repo-root]", file=sys.stderr)
+        return 2
+    root = Path(argv[1]) if len(argv) == 2 else Path(__file__).resolve().parent.parent
+
+    generator, results, committed_dir = root / GENERATOR, root / RESULTS, root / SCORES_DIR
+    for label, path in (("generator", generator), ("results", results)):
+        if not path.is_file():
+            print(f"::error::{label} not found at {path}", file=sys.stderr)
+            return 2
+    if not committed_dir.is_dir():
+        print(f"::error::no committed scores tree at {committed_dir}", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out_dir = Path(tmp) / "scores"
+        proc = subprocess.run(
+            [sys.executable, str(generator), str(results), str(out_dir)],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            # A generator that cannot run is a failure of this check, not a pass.
+            print(
+                f"::error file={GENERATOR}::generator exited {proc.returncode}; "
+                f"docs/scores/ cannot be re-derived",
+                file=sys.stderr,
+            )
+            print(proc.stdout + proc.stderr, file=sys.stderr)
+            return 2
+
+        fresh = generated_files(out_dir)
+        committed = generated_files(committed_dir)
+
+    # "Nothing differs" and "nothing was compared" must not look alike.
+    if not fresh:
+        print(
+            f"::error file={GENERATOR}::generator emitted no files; nothing was compared",
+            file=sys.stderr,
+        )
+        return 2
+
+    missing = sorted(set(fresh) - set(committed))
+    extra = sorted(set(committed) - set(fresh))
+    changed = sorted(
+        rel for rel in set(fresh) & set(committed) if fresh[rel] != committed[rel]
+    )
+
+    for rel in missing:
+        print(
+            f"::error file={SCORES_DIR / rel}::the generator emits this file but it "
+            f"is not committed; re-run the generator and commit the result",
+            file=sys.stderr,
+        )
+    for rel in extra:
+        print(
+            f"::error file={SCORES_DIR / rel}::committed but the generator does not "
+            f"emit it; it is either stale or a hand-edit that the next "
+            f"scores-refresh run will delete",
+            file=sys.stderr,
+        )
+    for rel in changed:
+        print(
+            f"::error file={SCORES_DIR / rel}::committed bytes differ from what the "
+            f"generator emits; re-run the generator and commit the result",
+            file=sys.stderr,
+        )
+
+    if missing or extra or changed:
+        print(
+            f"\n{len(missing) + len(extra) + len(changed)} drifted file(s) "
+            f"({len(missing)} uncommitted, {len(extra)} stale, {len(changed)} "
+            f"modified) out of {len(fresh)} generated. Regenerate with:\n"
+            f"  python3 {GENERATOR} {RESULTS} {SCORES_DIR}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Name the count that was actually compared: a green run has to be
+    # distinguishable from a run that enumerated nothing.
+    print(
+        f"ok: {len(fresh)} generated files under {SCORES_DIR} are byte-identical to "
+        f"{GENERATOR} output (excluding hand-maintained "
+        f"{', '.join(sorted(EXCLUDED_NAMES))})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/tests/test_check_scores_drift.py
+++ b/scripts/tests/test_check_scores_drift.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check-scores-drift.py (IRO-715).
+
+This checker's passing output is "exit 0", which is also what a checker that
+compared nothing produces -- and on a clean tree it is green by construction, so
+a green run proves very little on its own. Every test below is therefore a
+negative control: each builds a tree that IS drifted (or degenerate) and asserts
+the checker refuses to call it green.
+
+Two of them pin the specific traps called out on IRO-715, both of which a naive
+`diff -r docs/scores <regen>` gets wrong:
+
+* test_hand_maintained_nav_is_not_drift -- `.nav.yml` is hand-maintained and the
+  generator never emits it, so a plain `diff -r` reports it and fails on a
+  perfectly clean tree.
+* test_generator_stderr_is_not_failure -- the real generator prints `warning: no
+  family mapping for slug ...` to stderr on a clean run; treating stderr as
+  failure would make this check red on `main` from day one.
+
+test_real_repo_is_clean is the non-vacuity anchor in the other direction: it runs
+against the actual committed tree, so if the fake-tree tests ever passed for the
+wrong reason (a stub that does not resemble the generator), this one still holds
+the checker to real bytes.
+
+Run:
+    python3 -m unittest discover -s scripts/tests -v
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import tempfile
+import unittest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / 'check-scores-drift.py'
+REPO_ROOT = SCRIPT.parent.parent
+
+# A stub standing in for gen_scorecards.py: same contract (argv = results.json,
+# out_dir), writing a deterministic two-file tree. Keeps the tests to
+# milliseconds instead of re-emitting 252 real pages per case.
+STUB_GENERATOR = '''\
+import json, os, sys
+results, out_dir = sys.argv[1], sys.argv[2]
+data = json.load(open(results))
+os.makedirs(os.path.join(out_dir, "collections"), exist_ok=True)
+for name, body in data["pages"].items():
+    with open(os.path.join(out_dir, name), "w") as f:
+        f.write(body)
+'''
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location('check_scores_drift', SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run(root: pathlib.Path):
+    """Run the checker against `root`, returning (exit code, stdout+stderr)."""
+    module = load_module()
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        code = module.main(['check-scores-drift.py', str(root)])
+    return code, out.getvalue() + err.getvalue()
+
+
+def build_tree(root: pathlib.Path, pages, committed=None, generator=STUB_GENERATOR):
+    """Write a fake repo: a stub generator, its results.json, and docs/scores/.
+
+    `pages` is what the generator will emit; `committed` is what lands in
+    docs/scores/ (defaults to `pages`, i.e. a clean tree).
+    """
+    survey = root / 'examples' / 'isolation-survey'
+    survey.mkdir(parents=True, exist_ok=True)
+    (survey / 'gen_scorecards.py').write_text(generator, encoding='utf-8')
+    (survey / 'results.json').write_text(
+        __import__('json').dumps({'pages': pages}), encoding='utf-8'
+    )
+    scores = root / 'docs' / 'scores'
+    (scores / 'collections').mkdir(parents=True, exist_ok=True)
+    for name, body in (pages if committed is None else committed).items():
+        (scores / name).write_text(body, encoding='utf-8')
+    return root
+
+
+@contextlib.contextmanager
+def temp_root():
+    with tempfile.TemporaryDirectory() as tmp:
+        yield pathlib.Path(tmp)
+
+
+class CheckScoresDriftTest(unittest.TestCase):
+    def test_clean_tree_passes(self):
+        with temp_root() as root:
+            build_tree(root, {'nginx.md': 'score 41\n', 'index.md': 'directory\n'})
+            code, output = run(root)
+            self.assertEqual(code, 0, output)
+            # The green line must name what it compared, so "nothing differed"
+            # and "nothing was compared" stay distinguishable in the log.
+            self.assertIn('2 generated files', output)
+
+    def test_hand_edited_page_is_caught(self):
+        """The quiet case: a generated page edited by hand, reverted next refresh."""
+        with temp_root() as root:
+            pages = {'nginx.md': 'score 41\n', 'index.md': 'directory\n'}
+            build_tree(root, pages, committed={**pages, 'nginx.md': 'score 99\n'})
+            code, output = run(root)
+            self.assertEqual(code, 1, output)
+            self.assertIn('nginx.md', output)
+            self.assertIn('differ from what the generator emits', output)
+
+    def test_generator_change_without_regenerating_is_caught(self):
+        """IRO-715's actual scenario: template moves, docs/scores/ does not."""
+        with temp_root() as root:
+            build_tree(root, {'nginx.md': 'score 41\n'})
+            # Same shape as editing the generator's template: emitted bytes move
+            # while the committed tree stays where it was.
+            (root / 'examples' / 'isolation-survey' / 'gen_scorecards.py').write_text(
+                STUB_GENERATOR.replace('f.write(body)', 'f.write("NEW TEMPLATE\\n" + body)'),
+                encoding='utf-8',
+            )
+            code, output = run(root)
+            self.assertEqual(code, 1, output)
+            self.assertIn('nginx.md', output)
+
+    def test_stale_committed_page_is_caught(self):
+        with temp_root() as root:
+            pages = {'nginx.md': 'score 41\n'}
+            build_tree(root, pages, committed={**pages, 'dropped.md': 'gone\n'})
+            code, output = run(root)
+            self.assertEqual(code, 1, output)
+            self.assertIn('dropped.md', output)
+            self.assertIn('generator does not', output)
+
+    def test_uncommitted_generated_page_is_caught(self):
+        with temp_root() as root:
+            build_tree(root, {'nginx.md': 'score 41\n', 'redis.md': 'score 20\n'},
+                       committed={'nginx.md': 'score 41\n'})
+            code, output = run(root)
+            self.assertEqual(code, 1, output)
+            self.assertIn('redis.md', output)
+            self.assertIn('not committed', output)
+
+    def test_hand_maintained_nav_is_not_drift(self):
+        """`.nav.yml` is hand-maintained; a plain `diff -r` fails a clean tree on it."""
+        with temp_root() as root:
+            build_tree(root, {'nginx.md': 'score 41\n'})
+            scores = root / 'docs' / 'scores'
+            (scores / '.nav.yml').write_text('nav:\n  - index.md\n', encoding='utf-8')
+            (scores / 'collections' / '.nav.yml').write_text('nav:\n', encoding='utf-8')
+            code, output = run(root)
+            self.assertEqual(code, 0, output)
+
+    def test_generator_stderr_is_not_failure(self):
+        """The real generator warns on stderr on every clean run."""
+        with temp_root() as root:
+            build_tree(
+                root,
+                {'nginx.md': 'score 41\n'},
+                generator=STUB_GENERATOR
+                + 'sys.stderr.write("warning: no family mapping for slug \'x\'\\n")\n',
+            )
+            code, output = run(root)
+            self.assertEqual(code, 0, output)
+
+    def test_broken_generator_is_not_green(self):
+        with temp_root() as root:
+            build_tree(root, {'nginx.md': 'x\n'}, generator='import sys; sys.exit(3)\n')
+            code, output = run(root)
+            self.assertEqual(code, 2, output)
+            self.assertIn('cannot be re-derived', output)
+
+    def test_generator_emitting_nothing_is_not_green(self):
+        """An empty emission compares equal to nothing; that must not read as pass."""
+        with temp_root() as root:
+            build_tree(root, {}, committed={})
+            code, output = run(root)
+            self.assertEqual(code, 2, output)
+            self.assertIn('nothing was compared', output)
+
+    def test_missing_generator_is_not_green(self):
+        with temp_root() as root:
+            build_tree(root, {'nginx.md': 'x\n'})
+            (root / 'examples' / 'isolation-survey' / 'gen_scorecards.py').unlink()
+            code, output = run(root)
+            self.assertEqual(code, 2, output)
+            self.assertIn('generator not found', output)
+
+    def test_missing_scores_dir_is_not_green(self):
+        with temp_root() as root:
+            build_tree(root, {'nginx.md': 'x\n'})
+            (root / 'docs' / 'scores' / 'nginx.md').unlink()
+            (root / 'docs' / 'scores' / 'collections').rmdir()
+            (root / 'docs' / 'scores').rmdir()
+            code, output = run(root)
+            self.assertEqual(code, 2, output)
+            self.assertIn('no committed scores tree', output)
+
+    def test_real_repo_is_clean(self):
+        """Non-vacuity anchor: the real committed tree, real generator, real bytes."""
+        code, output = run(REPO_ROOT)
+        self.assertEqual(code, 0, output)
+        self.assertIn('byte-identical', output)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`.github/workflows/docs.yml` gated on every script the build runs but not `examples/isolation-survey/gen_scorecards.py`, the sole emission site for all 252 pages under `docs/scores/`. A PR touching only the generator ran **no** Docs build and none of the four checks in `build`.

The gap is quiet rather than harmless because the damage is deferred: `scores-refresh.yml` re-runs the generator weekly and force-opens a rolling PR, so a template change that lands ungated gets rewritten across every published scorecard, inside a diff already full of legitimate score movement.

## What changed

- `examples/isolation-survey/**` joins both `paths:` blocks (push and pull_request).
- New `scripts/check-scores-drift.py` regenerates into a scratch dir and compares byte-for-byte against committed `docs/scores/`, wired as a **step in `build`** (the required context on ruleset `17917971`; a new job name would not be enforced). Catches both directions: a generator change not re-emitted, and a hand-edit of a generated page the next refresh would silently revert.

Two carve-outs a naive `diff -r` gets wrong, both pinned by tests: `.nav.yml` (x2) is hand-maintained and never emitted, and the generator writes `warning: no family mapping for slug ...` to stderr on every clean run.

## Verification

- `actionlint` clean on `docs.yml`.
- **Two-arm control on the paths filter itself**, GitHub glob semantics evaluated against the verbatim pre-fix blob from `origin/main`: `gen_scorecards.py` and `results.json` match **zero** patterns PRE and `examples/isolation-survey/**` POST; unrelated `internal/host/scan/scan.go` matches neither, so the filter did not over-broaden.
- Checker green on real `main`: **270** generated files byte-identical, ~1s.
- **12 negative controls** (`scripts/tests/test_check_scores_drift.py`), each asserting the checker refuses to call a drifted or degenerate tree green — hand-edit, generator-moved-but-not-re-emitted, stale file, uncommitted file, broken generator, zero emission — plus a real-repo anchor so the fake-tree cases cannot pass for the wrong reason. Full `scripts/tests` suite: **110 passed**.
- This PR touches `docs.yml`, so the Docs build runs on it and the new step executes here non-vacuously.

## Review note

Touches `.github/workflows/**` (reviewer-bot gated) and adds an enforced check, so it needs a non-author approving review. Nothing else is bundled in. Ratchets protection **up**; no existing check relaxed. Out of scope: the 58 files outside `docs/scores/` carrying the false "No workload is executed" line (IRO-713, with the CEO).