### PR TITLE
docs(blog): 58 guides said no workload runs; the grader starts a container [IRO-716]

### DIFF
--- a/docs/blog/harden-arangodb-container-isolation.md
+++ b/docs/blog/harden-arangodb-container-isolation.md
@@ -11,8 +11,10 @@ default configuration scores **48 of 100, grade D (porous)**. Higher is safer. F
 take the same image to **100 of 100, grade A**. This guide shows the exact gaps and the exact fixes,
 straight from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `arangodb:3.12`, the same data behind
-> its [isolation scorecard](../scores/arangodb.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `arangodb:3.12` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/arangodb.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-cassandra-container-isolation.md
+++ b/docs/blog/harden-cassandra-container-isolation.md
@@ -11,8 +11,10 @@ the default configuration scores **48 of 100, grade D (porous)**. Higher is safe
 flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and the
 exact fixes, straight from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `cassandra:5.0`, the same data behind
-> its [isolation scorecard](../scores/cassandra.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `cassandra:5.0` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/cassandra.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-clickhouse-container-isolation.md
+++ b/docs/blog/harden-clickhouse-container-isolation.md
@@ -11,8 +11,10 @@ the default configuration scores **48 of 100, grade D (porous)**. Higher is safe
 flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and the
 exact fixes, straight from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `clickhouse:24.8`, the same data
-> behind its [isolation scorecard](../scores/clickhouse.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `clickhouse:24.8` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/clickhouse.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-cockroachdb-container-isolation.md
+++ b/docs/blog/harden-cockroachdb-container-isolation.md
@@ -13,8 +13,10 @@ Unlike a broker or a proxy, a single-node SQL database that only its co-located 
 can close every dimension, including the network. A few runtime flags take the same image to a full
 **100 of 100, grade A**. Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `cockroachdb/cockroach:latest`, the
-> same data behind its [isolation scorecard](../scores/cockroach.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from
+> `cockroachdb/cockroach:latest` with plain `docker run` defaults, its entrypoint overridden with
+> `sleep` purely to keep it alive. The scan itself executes nothing inside the container. It is the
+> same data behind its [isolation scorecard](../scores/cockroach.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-consul-container-isolation.md
+++ b/docs/blog/harden-consul-container-isolation.md
@@ -13,8 +13,10 @@ Higher is safer. A few runtime flags take the same image to **89 of 100, grade B
 A, and the one dimension it cannot reach is the one a service-discovery agent needs by definition
 (its clients and peers must connect to it). Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `hashicorp/consul:1.20`, the same data
-> behind its [isolation scorecard](../scores/consul.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `hashicorp/consul:1.20`
+> with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive.
+> The scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/consul.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-couchdb-container-isolation.md
+++ b/docs/blog/harden-couchdb-container-isolation.md
@@ -13,8 +13,10 @@ Unlike a broker or a proxy, a document database that only its co-located applica
 close every dimension, including the network. A few runtime flags take the same image to a full
 **100 of 100, grade A**. Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `couchdb:3.4`, the same data behind its
-> [isolation scorecard](../scores/couchdb.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `couchdb:3.4` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/couchdb.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-dgraph-container-isolation.md
+++ b/docs/blog/harden-dgraph-container-isolation.md
@@ -12,8 +12,10 @@ safer. A short list of runtime flags takes the same image to **100 of 100, grade
 graph database that only its co-located services query can drop its network entirely. Here are the
 exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `dgraph/dgraph:v24.0.5`, the same data
-> behind its [isolation scorecard](../scores/dgraph.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `dgraph/dgraph:v24.0.5`
+> with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive.
+> The scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/dgraph.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-dragonfly-container-isolation.md
+++ b/docs/blog/harden-dragonfly-container-isolation.md
@@ -14,9 +14,12 @@ its co-located application talks to over the loopback can close every dimension,
 network. A few runtime flags take the same image to a full **100 of 100, grade A**. Here are the
 exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of
-> `docker.dragonflydb.io/dragonflydb/dragonfly:latest`, the same data behind its [isolation
-> scorecard](../scores/dragonfly.md). No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from
+> `docker.dragonflydb.io/dragonflydb/dragonfly:latest` with plain `docker run` defaults, its
+> entrypoint overridden with `sleep` purely to keep it alive. The scan itself executes nothing
+> inside the container. It is the same data behind its
+> [isolation scorecard](../scores/dragonfly.md).
+> [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks
 

--- a/docs/blog/harden-elasticsearch-container-isolation.md
+++ b/docs/blog/harden-elasticsearch-container-isolation.md
@@ -12,8 +12,10 @@ Graded on IronClaw's seven-dimension containment scale, the default configuratio
 **100 of 100, grade A**. This guide shows the exact gaps and the exact fixes, straight from the
 scan data.
 
-> Every number here comes from a read-only `docker inspect` of `elasticsearch:8.16.1`, the same
-> data behind its [isolation scorecard](../scores/elasticsearch.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `elasticsearch:8.16.1`
+> with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive.
+> The scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/elasticsearch.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-emqx-container-isolation.md
+++ b/docs/blog/harden-emqx-container-isolation.md
@@ -12,8 +12,10 @@ A few runtime flags take the same image to an honest **89 of 100, grade B** ceil
 can reach without breaking the thing it exists to do: accept connections. This guide shows the exact
 gaps, the exact fixes, and why 89 is the honest number.
 
-> Every number here comes from a read-only `docker inspect` of `emqx:5`, the same data behind its
-> [isolation scorecard](../scores/emqx.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `emqx:5` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/emqx.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-envoy-container-isolation.md
+++ b/docs/blog/harden-envoy-container-isolation.md
@@ -12,8 +12,10 @@ safer. A short list of runtime flags takes the same image to **89 of 100, grade 
 A, and the one dimension it cannot reach is the one a proxy needs by definition (it exists to accept
 and forward traffic). Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `envoyproxy/envoy:v1.32-latest`, the
-> same data behind its [isolation scorecard](../scores/envoy.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from
+> `envoyproxy/envoy:v1.32-latest` with plain `docker run` defaults, its entrypoint overridden with
+> `sleep` purely to keep it alive. The scan itself executes nothing inside the container. It is the
+> same data behind its [isolation scorecard](../scores/envoy.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-gitea-container-isolation.md
+++ b/docs/blog/harden-gitea-container-isolation.md
@@ -13,8 +13,10 @@ reached by browsers and git clients, so it cannot take `--network=none` the way 
 can. That sets an honest ceiling of **89 of 100, grade B**, and the flags below reach it. Here are the
 exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `gitea:1.22`, the same data behind its
-> [isolation scorecard](../scores/gitea.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `gitea:1.22` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/gitea.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-grafana-container-isolation.md
+++ b/docs/blog/harden-grafana-container-isolation.md
@@ -15,8 +15,10 @@ runtime flags take the same image to **89 of 100, grade B**, one point off an A.
 cannot reach is the one a dashboard server needs by definition: browsers have to connect to it. Here
 are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `grafana/grafana:11.2.0`, the same data
-> behind its [isolation scorecard](../scores/grafana.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `grafana/grafana:11.2.0`
+> with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive.
+> The scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/grafana.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-haproxy-container-isolation.md
+++ b/docs/blog/harden-haproxy-container-isolation.md
@@ -13,8 +13,10 @@ Higher is safer. A few runtime flags take the same image to **89 of 100, grade B
 A, and the one dimension it cannot reach is the one a load balancer needs by definition: it exists to
 accept and forward traffic. Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `haproxy:3.1-alpine`, the same data
-> behind its [isolation scorecard](../scores/haproxy.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `haproxy:3.1-alpine` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/haproxy.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-immich-server-container-isolation.md
+++ b/docs/blog/harden-immich-server-container-isolation.md
@@ -14,9 +14,10 @@ IronClaw's seven-dimension containment scale, the default configuration scores
 server needs by definition: your browser and mobile apps must reach its API. Here are the exact gaps
 and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of
-> `ghcr.io/immich-app/immich-server:v1.123.0`, the same data behind its
-> [isolation scorecard](../scores/immich-server.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from
+> `ghcr.io/immich-app/immich-server:v1.123.0` with plain `docker run` defaults, its entrypoint
+> overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the
+> container. It is the same data behind its [isolation scorecard](../scores/immich-server.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-influxdb-container-isolation.md
+++ b/docs/blog/harden-influxdb-container-isolation.md
@@ -13,8 +13,10 @@ Unlike a broker or a proxy, a time-series store that only its co-located writer 
 can close every dimension, including the network. A few runtime flags take the same image to a full
 **100 of 100, grade A**. Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `influxdb:2.7`, the same data behind
-> its [isolation scorecard](../scores/influxdb.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `influxdb:2.7` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/influxdb.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-jenkins-container-isolation.md
+++ b/docs/blog/harden-jenkins-container-isolation.md
@@ -13,8 +13,10 @@ same image to **89 of 100, grade B**, one point off an A, and the one dimension 
 one a CI server needs by definition: agents and browsers must reach it. Here are the exact gaps and
 fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `jenkins/jenkins:lts`, the same data
-> behind its [isolation scorecard](../scores/jenkins.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `jenkins/jenkins:lts` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/jenkins.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-kafka-container-isolation.md
+++ b/docs/blog/harden-kafka-container-isolation.md
@@ -13,8 +13,10 @@ non-root user, but graded on IronClaw's seven-dimension containment scale it sti
 broker needs by definition (clients must connect to it). Here are the exact gaps and fixes from the
 scan data.
 
-> Every number here comes from a read-only `docker inspect` of `apache/kafka:3.9.0`, the same data
-> behind its [isolation scorecard](../scores/kafka.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `apache/kafka:3.9.0` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/kafka.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-keycloak-container-isolation.md
+++ b/docs/blog/harden-keycloak-container-isolation.md
@@ -13,8 +13,10 @@ Higher is safer. A few runtime flags take the same image to **89 of 100, grade B
 A, and the one dimension it cannot reach is the one an identity provider needs by definition: every
 app and browser must reach its endpoints. Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `quay.io/keycloak/keycloak`, the same
-> data behind its [isolation scorecard](../scores/keycloak.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from
+> `quay.io/keycloak/keycloak` with plain `docker run` defaults, its entrypoint overridden with
+> `sleep` purely to keep it alive. The scan itself executes nothing inside the container. It is the
+> same data behind its [isolation scorecard](../scores/keycloak.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-kong-container-isolation.md
+++ b/docs/blog/harden-kong-container-isolation.md
@@ -13,8 +13,10 @@ grade B**, one point off an A, and the one dimension it cannot reach is the one 
 definition (clients and upstreams must connect through it). Here are the exact gaps and fixes from
 the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `kong:3.8`, the same data behind its
-> [isolation scorecard](../scores/kong.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `kong:3.8` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/kong.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-loki-container-isolation.md
+++ b/docs/blog/harden-loki-container-isolation.md
@@ -14,8 +14,10 @@ co-located agent and query reader talk to can close every remaining dimension, i
 A few runtime flags take the same image to a full **100 of 100, grade A**. Here are the exact gaps
 and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `grafana/loki:3.3.2`, the same data
-> behind its [isolation scorecard](../scores/loki.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `grafana/loki:3.3.2` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/loki.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-mariadb-container-isolation.md
+++ b/docs/blog/harden-mariadb-container-isolation.md
@@ -11,8 +11,10 @@ the default configuration scores **48 of 100, grade D (porous)**. Higher is safe
 flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and the
 exact fixes, straight from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `mariadb:11`, the same data behind
-> its [isolation scorecard](../scores/mariadb.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `mariadb:11` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/mariadb.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-meilisearch-container-isolation.md
+++ b/docs/blog/harden-meilisearch-container-isolation.md
@@ -13,8 +13,10 @@ Unlike a broker or a proxy, a search store that only its co-located application 
 every dimension, including the network. A few runtime flags take the same image to a full **100 of
 100, grade A**. Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `getmeili/meilisearch:v1.11`, the same
-> data behind its [isolation scorecard](../scores/meilisearch.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from
+> `getmeili/meilisearch:v1.11` with plain `docker run` defaults, its entrypoint overridden with
+> `sleep` purely to keep it alive. The scan itself executes nothing inside the container. It is the
+> same data behind its [isolation scorecard](../scores/meilisearch.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-memcached-container-isolation.md
+++ b/docs/blog/harden-memcached-container-isolation.md
@@ -14,8 +14,10 @@ grade C (partial)**. Higher is safer. A couple of runtime flags take the same im
 needs by definition (clients must connect to it). Here are the exact gaps and fixes from the
 scan data.
 
-> Every number here comes from a read-only `docker inspect` of `memcached:1.6-alpine`, the same
-> data behind its [isolation scorecard](../scores/memcached.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `memcached:1.6-alpine`
+> with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive.
+> The scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/memcached.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-minio-container-isolation.md
+++ b/docs/blog/harden-minio-container-isolation.md
@@ -12,8 +12,10 @@ Higher is safer. A few runtime flags take the same image to **89 of 100, grade B
 A, and the one dimension it cannot reach is the one an S3 server needs by definition (its clients
 must connect over the network). Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `minio/minio:latest`, the same data
-> behind its [isolation scorecard](../scores/minio.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `minio/minio:latest` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/minio.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-mongodb-container-isolation.md
+++ b/docs/blog/harden-mongodb-container-isolation.md
@@ -11,8 +11,10 @@ the default configuration scores **48 of 100, grade D (porous)**. Higher is safe
 flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and the
 exact fixes, straight from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `mongo:7`, the same data behind
-> its [isolation scorecard](../scores/mongo.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `mongo:7` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/mongo.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-mysql-container-isolation.md
+++ b/docs/blog/harden-mysql-container-isolation.md
@@ -11,8 +11,10 @@ scale, the default configuration scores **48 of 100, grade D (porous)**. Higher 
 Four runtime flags take the same image to **100 of 100, grade A**. This guide shows the exact
 gaps and the exact fixes, straight from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `mysql:8.4`, the same data
-> behind its [isolation scorecard](../scores/mysql.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `mysql:8.4` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/mysql.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-nats-container-isolation.md
+++ b/docs/blog/harden-nats-container-isolation.md
@@ -13,8 +13,10 @@ A broker exists to be connected to, so it cannot take `--network=none` the way a
 can. That sets an honest ceiling of **89 of 100, grade B**, and the flags below reach it. Here are the
 exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `nats:2.10-alpine`, the same data behind
-> its [isolation scorecard](../scores/nats.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `nats:2.10-alpine` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/nats.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-neo4j-container-isolation.md
+++ b/docs/blog/harden-neo4j-container-isolation.md
@@ -13,8 +13,10 @@ proxy, a graph database that only its co-located application talks to can close 
 including the network. A few runtime flags take the same image to a full **100 of 100, grade A**. Here
 are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `neo4j:5`, the same data behind its
-> [isolation scorecard](../scores/neo4j.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `neo4j:5` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/neo4j.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-nginx-container-isolation.md
+++ b/docs/blog/harden-nginx-container-isolation.md
@@ -12,8 +12,10 @@ safer. A few runtime flags take the same image to **89 of 100, grade B**, one po
 and the one dimension it cannot reach is the one a reverse proxy needs by definition (egress).
 Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `nginx:1.27-alpine`, the same
-> data behind its [isolation scorecard](../scores/nginx.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `nginx:1.27-alpine` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/nginx.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-nsq-container-isolation.md
+++ b/docs/blog/harden-nsq-container-isolation.md
@@ -13,8 +13,10 @@ of 100, grade B**, one point off an A, and the one dimension it cannot reach is 
 by definition (publishers and subscribers must connect to it). Here are the exact gaps and fixes from
 the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `nsqio/nsq:v1.3.0`, the same data
-> behind its [isolation scorecard](../scores/nsq.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `nsqio/nsq:v1.3.0` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/nsq.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-opensearch-container-isolation.md
+++ b/docs/blog/harden-opensearch-container-isolation.md
@@ -12,8 +12,10 @@ Graded on IronClaw's seven-dimension containment scale, the default configuratio
 **100 of 100, grade A**. This guide shows the exact gaps and the exact fixes, straight from the
 scan data.
 
-> Every number here comes from a read-only `docker inspect` of `opensearchproject/opensearch:2`,
-> the same data behind its [isolation scorecard](../scores/opensearch.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from
+> `opensearchproject/opensearch:2` with plain `docker run` defaults, its entrypoint overridden with
+> `sleep` purely to keep it alive. The scan itself executes nothing inside the container. It is the
+> same data behind its [isolation scorecard](../scores/opensearch.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-pgadmin4-container-isolation.md
+++ b/docs/blog/harden-pgadmin4-container-isolation.md
@@ -14,8 +14,10 @@ The image already runs non-root, which is why it starts at C not D; a few more r
 console needs by definition: your browser must reach its UI. Here are the exact gaps and fixes from the
 scan data.
 
-> Every number here comes from a read-only `docker inspect` of `dpage/pgadmin4:8`, the same data
-> behind its [isolation scorecard](../scores/pgadmin4.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `dpage/pgadmin4:8` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/pgadmin4.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-postgres-container-isolation.md
+++ b/docs/blog/harden-postgres-container-isolation.md
@@ -11,8 +11,10 @@ containment scale, the default configuration scores **48 of 100, grade D (porous
 is safer. Six runtime flags take the same image to **100 of 100, grade A**. This guide shows
 the exact gaps and the exact fixes, straight from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `postgres:17-alpine`, the same
-> data behind its [isolation scorecard](../scores/postgres.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `postgres:17-alpine` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/postgres.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-prometheus-container-isolation.md
+++ b/docs/blog/harden-prometheus-container-isolation.md
@@ -16,8 +16,10 @@ B**, one point off an A. The one dimension it cannot reach is the one a metrics 
 definition: it has to scrape targets and serve its API. Here are the exact gaps and fixes from the
 scan data.
 
-> Every number here comes from a read-only `docker inspect` of `prom/prometheus:v3.1.0`, the same data
-> behind its [isolation scorecard](../scores/prometheus.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `prom/prometheus:v3.1.0`
+> with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive.
+> The scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/prometheus.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-pulsar-container-isolation.md
+++ b/docs/blog/harden-pulsar-container-isolation.md
@@ -13,8 +13,10 @@ flags take the same image to **89 of 100, grade B**, one point off an A, and the
 cannot reach is the one a broker needs by definition (producers and consumers must connect to it).
 Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `apachepulsar/pulsar:3.3.2`, the same
-> data behind its [isolation scorecard](../scores/pulsar.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from
+> `apachepulsar/pulsar:3.3.2` with plain `docker run` defaults, its entrypoint overridden with
+> `sleep` purely to keep it alive. The scan itself executes nothing inside the container. It is the
+> same data behind its [isolation scorecard](../scores/pulsar.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-qdrant-container-isolation.md
+++ b/docs/blog/harden-qdrant-container-isolation.md
@@ -11,8 +11,10 @@ scale, the default configuration scores **48 of 100, grade D (porous)**. Higher 
 runtime flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and
 the exact fixes, straight from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `qdrant/qdrant:v1.12.4`, the same
-> data behind its [isolation scorecard](../scores/qdrant.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `qdrant/qdrant:v1.12.4`
+> with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive.
+> The scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/qdrant.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-questdb-container-isolation.md
+++ b/docs/blog/harden-questdb-container-isolation.md
@@ -13,8 +13,10 @@ Unlike a broker or a proxy, a time-series database that only its co-located appl
 close every dimension, including the network. A few runtime flags take the same image to a full
 **100 of 100, grade A**. Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `questdb:8.2.1`, the same data behind
-> its [isolation scorecard](../scores/questdb.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `questdb:8.2.1` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/questdb.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-rabbitmq-container-isolation.md
+++ b/docs/blog/harden-rabbitmq-container-isolation.md
@@ -12,8 +12,10 @@ seven-dimension containment scale, the default configuration scores **48 of 100,
 one point off an A, and the one dimension it cannot reach is the one a broker needs by
 definition (clients must connect to it). Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `rabbitmq:4-alpine`, the same
-> data behind its [isolation scorecard](../scores/rabbitmq.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `rabbitmq:4-alpine` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/rabbitmq.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-redis-container-isolation.md
+++ b/docs/blog/harden-redis-container-isolation.md
@@ -12,8 +12,10 @@ default configuration scores **48 of 100, grade D (porous)**. Higher is safer. S
 flags take the same image to **100 of 100, grade A**. Here are the exact gaps and fixes, from
 the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `redis:7-alpine`, the same data
-> behind its [isolation scorecard](../scores/redis.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `redis:7-alpine` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/redis.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-redpanda-container-isolation.md
+++ b/docs/blog/harden-redpanda-container-isolation.md
@@ -13,8 +13,10 @@ to **89 of 100, grade B**, one point off an A, and the one dimension it cannot r
 broker needs by definition (clients must connect to it). Here are the exact gaps and fixes from
 the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `redpandadata/redpanda:v24.2.11`,
-> the same data behind its [isolation scorecard](../scores/redpanda.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from
+> `redpandadata/redpanda:v24.2.11` with plain `docker run` defaults, its entrypoint overridden with
+> `sleep` purely to keep it alive. The scan itself executes nothing inside the container. It is the
+> same data behind its [isolation scorecard](../scores/redpanda.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-rethinkdb-container-isolation.md
+++ b/docs/blog/harden-rethinkdb-container-isolation.md
@@ -12,8 +12,10 @@ not: graded on IronClaw's seven-dimension containment scale it scores **48 of 10
 grade A**, because a single-node RethinkDB that only its co-located app queries can drop its network
 entirely. Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `rethinkdb:2.4`, the same data behind
-> its [isolation scorecard](../scores/rethinkdb.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `rethinkdb:2.4` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/rethinkdb.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-scylla-container-isolation.md
+++ b/docs/blog/harden-scylla-container-isolation.md
@@ -11,8 +11,10 @@ scale, the default configuration scores **48 of 100, grade D (porous)**. Higher 
 runtime flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and
 the exact fixes, straight from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `scylladb/scylla:6.2`, the same
-> data behind its [isolation scorecard](../scores/scylla.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `scylladb/scylla:6.2` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/scylla.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-solr-container-isolation.md
+++ b/docs/blog/harden-solr-container-isolation.md
@@ -11,8 +11,10 @@ containment scale, the default configuration scores **63 of 100, grade C (partia
 safer. Three runtime flags take the same image to **100 of 100, grade A**. This guide shows the exact
 gaps and the exact fixes, straight from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `solr:9`, the same data behind its
-> [isolation scorecard](../scores/solr.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `solr:9` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/solr.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-sonarqube-container-isolation.md
+++ b/docs/blog/harden-sonarqube-container-isolation.md
@@ -13,8 +13,10 @@ same image to **89 of 100, grade B**, one point off an A, and the one dimension 
 one a code-quality server needs by definition: scanners and browsers must reach its API and UI. Here
 are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `sonarqube`, the same data behind its
-> [isolation scorecard](../scores/sonarqube.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `sonarqube` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/sonarqube.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-tempo-container-isolation.md
+++ b/docs/blog/harden-tempo-container-isolation.md
@@ -14,8 +14,10 @@ proxy, a trace store that only its co-located writer and query reader talk to ca
 remaining dimension, including the network. A few runtime flags take the same image to a full **100
 of 100, grade A**. Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `grafana/tempo:2.6.1`, the same data
-> behind its [isolation scorecard](../scores/tempo.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `grafana/tempo:2.6.1` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/tempo.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-tidb-container-isolation.md
+++ b/docs/blog/harden-tidb-container-isolation.md
@@ -12,8 +12,10 @@ pingcap/tidb:v8.5.0` is not: graded on IronClaw's seven-dimension containment sc
 of 100, grade A** on a single-instance deployment whose components share one private network. Here
 are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `pingcap/tidb:v8.5.0`, the same data
-> behind its [isolation scorecard](../scores/tidb.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `pingcap/tidb:v8.5.0` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/tidb.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-timescaledb-container-isolation.md
+++ b/docs/blog/harden-timescaledb-container-isolation.md
@@ -13,8 +13,10 @@ Higher is safer. Unlike a broker or a proxy, a database that only its co-located
 can close every dimension, including the network. A few runtime flags take the same image to a full
 **100 of 100, grade A**. Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `timescale/timescaledb:2.17.2-pg17`,
-> the same data behind its [isolation scorecard](../scores/timescaledb.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from
+> `timescale/timescaledb:2.17.2-pg17` with plain `docker run` defaults, its entrypoint overridden
+> with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. It is
+> the same data behind its [isolation scorecard](../scores/timescaledb.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-traefik-container-isolation.md
+++ b/docs/blog/harden-traefik-container-isolation.md
@@ -14,8 +14,10 @@ take the same image to **89 of 100, grade B**, one point off an A, and the one d
 reach is the one a reverse proxy needs by definition: it exists to accept and forward traffic. Here
 are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `traefik:v3.2`, the same data behind
-> its [isolation scorecard](../scores/traefik.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `traefik:v3.2` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/traefik.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-typesense-container-isolation.md
+++ b/docs/blog/harden-typesense-container-isolation.md
@@ -13,8 +13,10 @@ Higher is safer. A few runtime flags take the same image to **89 of 100, grade B
 A, and the one dimension it cannot reach is the one a search server needs by definition: your app must
 reach its API to run queries. Here are the exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `typesense/typesense:27.1`, the same
-> data behind its [isolation scorecard](../scores/typesense.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `typesense/typesense:27.1`
+> with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive.
+> The scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/typesense.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-valkey-container-isolation.md
+++ b/docs/blog/harden-valkey-container-isolation.md
@@ -14,8 +14,10 @@ application talks to it over loopback, a cache can close every dimension, includ
 runtime flags take the same image to a full **100 of 100, grade A**. Here are the exact gaps and fixes
 from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `valkey/valkey:8`, the same data behind
-> its [isolation scorecard](../scores/valkey.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `valkey/valkey:8` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/valkey.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-vault-container-isolation.md
+++ b/docs/blog/harden-vault-container-isolation.md
@@ -13,8 +13,10 @@ take the same image to **89 of 100, grade B**, one point off an A, and the one d
 reach is the one a secrets server needs by definition (its clients must connect to it). Here are the
 exact gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `hashicorp/vault:1.18`, the same data
-> behind its [isolation scorecard](../scores/vault.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `hashicorp/vault:1.18`
+> with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive.
+> The scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/vault.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-victoria-metrics-container-isolation.md
+++ b/docs/blog/harden-victoria-metrics-container-isolation.md
@@ -11,9 +11,10 @@ containment scale, the default configuration scores **48 of 100, grade D (porous
 Four runtime flags take the same image to **100 of 100, grade A**. This guide shows the exact gaps and
 the exact fixes, straight from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of
-> `victoriametrics/victoria-metrics:v1.107.0`, the same data behind its
-> [isolation scorecard](../scores/victoria-metrics.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from
+> `victoriametrics/victoria-metrics:v1.107.0` with plain `docker run` defaults, its entrypoint
+> overridden with `sleep` purely to keep it alive. The scan itself executes nothing inside the
+> container. It is the same data behind its [isolation scorecard](../scores/victoria-metrics.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-weaviate-container-isolation.md
+++ b/docs/blog/harden-weaviate-container-isolation.md
@@ -12,9 +12,11 @@ safer. A short list of runtime flags takes the same image to **100 of 100, grade
 vector store that only its co-located app queries can drop its network entirely. Here are the exact
 gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of
-> `semitechnologies/weaviate:1.28.1`, the same data behind its [isolation
-> scorecard](../scores/weaviate.md). No workload is executed. [How scoring works &rarr;](../scan.md)
+> Graded from a read-only inspect of a **running container** started from
+> `semitechnologies/weaviate:1.28.1` with plain `docker run` defaults, its entrypoint overridden
+> with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. It is
+> the same data behind its [isolation scorecard](../scores/weaviate.md).
+> [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks
 

--- a/docs/blog/harden-yugabyte-container-isolation.md
+++ b/docs/blog/harden-yugabyte-container-isolation.md
@@ -13,8 +13,10 @@ on IronClaw's seven-dimension containment scale, the default configuration score
 **89 of 100, grade B** for a multi-node cluster where peers must reach each other. Here are the exact
 gaps and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `yugabytedb/yugabyte:2.23.0.0-b710`,
-> the same data behind its [isolation scorecard](../scores/yugabyte.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from
+> `yugabytedb/yugabyte:2.23.0.0-b710` with plain `docker run` defaults, its entrypoint overridden
+> with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. It is
+> the same data behind its [isolation scorecard](../scores/yugabyte.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/harden-zookeeper-container-isolation.md
+++ b/docs/blog/harden-zookeeper-container-isolation.md
@@ -9,7 +9,11 @@ A distributed coordination service sits at the absolute core of your infrastruct
 
 A handful of runtime flags takes the exact same image to **89 of 100, grade B**, two full letter grades higher. The single dimension it cannot max out is the one a coordination service requires by definition: client and quorum nodes must be able to communicate across the network. Here are the exact gaps, operational requirements, and fixes from the scan data.
 
-> Every number here comes from a read-only `docker inspect` of `zookeeper:latest` (`sha256:4c6f15fbd5491a3e01b0108c046891125553329a4956848ba3014cedff5386ee`), the same data behind its [isolation scorecard](../scores/zookeeper.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `zookeeper:latest` at
+> digest `sha256:4c6f15fbd5491a3e01b0108c046891125553329a4956848ba3014cedff5386ee` with plain
+> `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The scan
+> itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/zookeeper.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Where the default configuration leaks

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -7,9 +7,10 @@ description: "Every IronClaw harden-a-container walkthrough in one place. Real i
 
 Every guide below takes one popular Docker image, grades its **default** `docker run` on IronClaw's
 seven-dimension containment scale, and shows the exact `ironctl scan --fix` flags that close the gap.
-The numbers are not hand-waved: each comes from a read-only `docker inspect` of the real image, the
-same data behind that image's [isolation scorecard](../scores/index.md). No workload is executed to
-produce them.
+The grades are not hand-waved: each default grade comes from a read-only inspect of a **running
+container** started from the real image with plain `docker run` defaults, its entrypoint overridden
+with `sleep` purely to keep it alive. The scan itself executes nothing inside the container. It is
+the same data behind that image's [isolation scorecard](../scores/index.md).
 
 Two patterns show up across the set:
 

--- a/docs/blog/run-untrusted-nodejs-code-safely.md
+++ b/docs/blog/run-untrusted-nodejs-code-safely.md
@@ -12,8 +12,10 @@ IronClaw's seven-dimension containment scale it scores **48 of 100, grade D (por
 is safer. Six runtime flags take it to **100 of 100, grade A**. This guide shows the exact gaps
 and fixes from the scan data, tuned for the untrusted-code case.
 
-> Every number here comes from a read-only `docker inspect` of `node:22-alpine`, the same data
-> behind its [isolation scorecard](../scores/node.md). No workload is executed.
+> Graded from a read-only inspect of a **running container** started from `node:22-alpine` with
+> plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it alive. The
+> scan itself executes nothing inside the container. It is the same data behind its
+> [isolation scorecard](../scores/node.md).
 > [How scoring works &rarr;](../scan.md)
 
 ## Why the default is not a sandbox


### PR DESCRIPTION
Closes IRO-716. Sibling of #664 (IRO-713), which fixes the same false claim on the 252
`docs/scores/` pages. **Land this after #664** — both edit prose quoting the same
methodology, and landing this first leaves the two corpora contradicting each other.

## The defect

All 56 `docs/blog/harden-*-container-isolation.md` guides plus `hardening-guides.md` and
`run-untrusted-nodejs-code-safely.md` carried one blockquote, byte-identical in shape:

> Every number here comes from a read-only `docker inspect` of `haproxy:3.1-alpine`, the same data
> behind its [isolation scorecard](../scores/haproxy.md). No workload is executed.

Both halves are false. `examples/isolation-survey/survey.sh:187`:

```sh
"$DOCKER" run -d --name "$cname" $flags --entrypoint sleep "$runref" 86400
```

It starts a container and inspects the **running container**. So it is not an image
inspect, and a workload (`sleep`) is executed.

These 58 files are not generated — `gen_scorecards.py` only *links* into `docs/blog/**` —
so nothing re-applies the correction and nothing undoes it.

## The replacement

Matches what #664 landed on the scorecards, adapted to the guide's blockquote voice:

> Graded from a read-only inspect of a **running container** started from `haproxy:3.1-alpine`
> with plain `docker run` defaults, its entrypoint overridden with `sleep` purely to keep it
> alive. The scan itself executes nothing inside the container. It is the same data behind its
> [isolation scorecard](../scores/haproxy.md).
> [How scoring works &rarr;](../scan.md)

The distinction it has to preserve, and now does: the **scan** is read-only and executes
nothing inside the container; the **grading procedure** starts one.

## Two wording calls worth a reviewer's attention

1. **"Every number here comes from" became #664's "Graded from".** Only the
   default-configuration grade is measured: `examples/isolation-survey/images.txt` carries
   run-flags on **4 of 295** scenarios, so a guide's hardened number (89/100, 100/100) is a
   `--fix` projection, not a survey row. Keeping "every number" *and* adding "with plain
   `docker run` defaults" would have replaced one false claim with a sharper one. The
   scorecards already read "Graded from", so this is parity, not a new voice.
2. **`hardening-guides.md` reads "each default grade comes from"** for the same reason. Its
   copy of the sentence wraps across two source lines (`No workload is executed to\nproduce
   them.`), which is why this was a parsed rewrite of the whole block rather than a
   line-wise `sed`.

## Verification

| Check | Result |
|---|---|
| `git grep "No workload is executed"` outside `docs/scores/` + the #664-owned generator | **0** |
| `git grep "read-only \`docker inspect\`"`, same scope | **0** |
| All 58 files assert running-container / scan-executes-nothing / sleep-to-keep-alive | **58/58** |
| **Strip-and-compare**: delete the provenance block from both revisions, compare remainder | **byte-identical in 58/58** — no grade, flag, table or `--user` row moved |
| Built site: pages rendering the corrected sentence | **58**, all under `/blog/` |
| Built site: pages still rendering the old claim | **252**, all under `/scores/` (#664's corpus) |
| Markdown-link/code-span split regression vs `origin/main` | **0 introduced** (2 pre-existing removed) |
| em/en-dash in the new public copy (IRO-254) | **0** |

`check-guide-index.py` (56 guides), `check-guide-uid.py` (56 guides, 82 `--user` flags, 5
pasted scan rows), `check-md-fences.py` (471 files), `check_links.py`, `check-docs-meta.py`
(436 built pages) and `mkdocs build --strict` all exit **0**.

Per IRO-699, no `--user` row was touched. Per IRO-696, `SURFACES` was not widened.

## Out of scope, flagged not fixed

The hardened-configuration numbers on these guides (and the "A fully hardened run scores
N/100" line on every scorecard) are `--fix` projections presented in the same voice as
measured grades. That is a separate accuracy question across ~310 published pages and is the
CEO's to prioritise; this PR only stops the pages from misdescribing how the measured grade
was produced.

Docs-only: touches no `.github/workflows/**`, no signing, attestation, required-check or
installer path.