### PR TITLE
scan: close the three review nits from #665 [IRO-723]

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -72,9 +72,9 @@ func cmdScan(args []string) error {
 	openshift := fs.String("openshift", "", "grade OpenShift workloads (DeploymentConfig, Deployment, Pod) in a manifest file (`oc get -o yaml`) or a directory of them")
 	dockerfile := fs.Bool("dockerfile", false, "statically grade the positional Dockerfile(s) authoring-time posture (daemon-free)")
 	runtime := fs.String("runtime", envOrDefault("IRONCTL_SCAN_RUNTIME", "auto"), "container runtime: auto|docker|podman|nerdctl")
-	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker inspect`")
-	podmanBin := fs.String("podman-bin", envOrDefault("PODMAN", "podman"), "podman binary used for `podman inspect`")
-	nerdctlBin := fs.String("nerdctl-bin", envOrDefault("NERDCTL", "nerdctl"), "nerdctl binary used for `nerdctl inspect`")
+	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker container inspect` and `docker image inspect`")
+	podmanBin := fs.String("podman-bin", envOrDefault("PODMAN", "podman"), "podman binary used for `podman container inspect` and `podman image inspect`")
+	nerdctlBin := fs.String("nerdctl-bin", envOrDefault("NERDCTL", "nerdctl"), "nerdctl binary used for `nerdctl container inspect` and `nerdctl image inspect`")
 	minScore := fs.Int("min-score", 0, "exit non-zero if the score is below this threshold (CI gate)")
 	fs.Usage = func() { scanUsage(os.Stdout) }
 	// Go's flag package stops at the first positional, so `scan <target> --json`
@@ -520,7 +520,8 @@ func cmdScan(args []string) error {
 			"--share":      *share,
 			"--sarif":      *sarif != "",
 			"--min-score":  *minScore > 0,
-			"--fix":        *fix || *remediate,
+			"--fix":        *fix,
+			"--remediate":  *remediate,
 		}); err != nil {
 			return err
 		}
@@ -3008,8 +3009,11 @@ type runtimeBins struct{ docker, podman, nerdctl string }
 
 // scoreBearingFlags is the ordered list of flags whose output is a composite
 // score or a gate on one. Ordered so the error names the same flag every run.
+// --remediate is an alias for --fix and is listed after it, so a run that passes
+// both is still named --fix; a run that passes only --remediate is told about the
+// flag it actually typed rather than about an alias it never used.
 var scoreBearingFlags = []string{
-	"--badge", "--badge-json", "--badge-md", "--md", "--share", "--sarif", "--min-score", "--fix",
+	"--badge", "--badge-json", "--badge-md", "--md", "--share", "--sarif", "--min-score", "--fix", "--remediate",
 }
 
 // rejectScoreBearingOutputs fails the run when any score-bearing output was
@@ -3189,9 +3193,9 @@ FLAGS:
   --nomad-bin BIN     nomad binary for `+"`nomad job run -output`"+` (HCL->JSON; default: nomad)
   --kustomize-bin BIN kustomize binary for `+"`kustomize build`"+` (default: kustomize)
   --kubectl-bin BIN   kubectl binary for `+"`kubectl kustomize`"+` fallback (default: kubectl)
-  --docker-bin BIN    docker binary for `+"`docker inspect`"+` (default: docker)
-  --podman-bin BIN    podman binary for `+"`podman inspect`"+` (default: podman)
-  --nerdctl-bin BIN   nerdctl binary for `+"`nerdctl inspect`"+` (default: nerdctl)
+  --docker-bin BIN    docker binary for `+"`container inspect`/`image inspect`"+` (default: docker)
+  --podman-bin BIN    podman binary for `+"`container inspect`/`image inspect`"+` (default: podman)
+  --nerdctl-bin BIN   nerdctl binary for `+"`container inspect`/`image inspect`"+` (default: nerdctl)
 
 Runtime is auto-detected (docker, then podman, then nerdctl on PATH); override
 with --runtime. Rootless podman is credited: a userns remap of container-uid 0

--- a/cmd/ironctl/scan_test.go
+++ b/cmd/ironctl/scan_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"go/ast"
+	"go/parser"
+	gotoken "go/token"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,25 +138,176 @@ func TestRejectScoreBearingOutputs_ImageMode(t *testing.T) {
 	}
 }
 
-// scoreBearingFlags must stay in sync with the flags runScan actually feeds it;
-// a flag that emits a grade but is missing from the list is a silent hole.
-func TestScoreBearingFlagsCoverGradeEmittingOutputs(t *testing.T) {
-	want := map[string]bool{
-		"--badge": true, "--badge-json": true, "--badge-md": true, "--md": true,
-		"--share": true, "--sarif": true, "--min-score": true, "--fix": true,
+// imageSafeScanFlags classifies every scan flag that is NOT routed through
+// rejectScoreBearingOutputs, grouped by the reason it cannot hand an image
+// reference a composite score. The reason is the payload: the point of the list
+// is to make someone state why a new flag is safe, not to have somewhere to put
+// it. Together with scoreBearingFlags it must cover the flags runScan registers.
+var imageSafeScanFlags = map[string][]string{
+	// Re-renders the same report. In image mode that report already omits
+	// score/grade and marks the six unobservable dimensions N/A (IRO-712).
+	"representation of the report, which carries no composite in image mode": {
+		"--json",
+	},
+	// Rejected for an image reference too, but on its own early-return path
+	// before rejectScoreBearingOutputs is reached (scan.go, runCompare).
+	"score-bearing, rejected for image refs on its own path": {
+		"--compare",
+	},
+	// Grades a Dockerfile with a different, authoring-time dimension set and its
+	// own scorer; daemon-free, so it never resolves an OCI reference at all.
+	"static Dockerfile grading, a separate scorer on a separate path": {
+		"--dockerfile",
+	},
+	// Select a non-runtime input adapter (a manifest, chart, plan or template).
+	// The target is a file, never a container or an image reference.
+	"selects a manifest/IaC input adapter, so the target is never an OCI ref": {
+		"--compose", "--service", "--k8s", "--k8s-admission", "--admission-response",
+		"--emit-policy", "--check", "--helm", "--terraform", "--nomad", "--ecs",
+		"--cloudrun", "--cloudformation", "--sam", "--pulumi", "--azure",
+		"--app-runner", "--bicep", "--cdk", "--kustomize", "--openshift",
+	},
+	// Name a helper binary or pick the runtime. Inputs to how we inspect, not
+	// outputs, so none of them can emit or gate on a number.
+	"names a helper binary or the runtime, not an output": {
+		"--runtime", "--docker-bin", "--podman-bin", "--nerdctl-bin", "--helm-bin",
+		"--terraform-bin", "--nomad-bin", "--bicep-bin", "--az-bin", "--cdk-bin",
+		"--kustomize-bin", "--kubectl-bin",
+	},
+}
+
+// registeredScanFlags parses scan.go and returns every flag runScan registers.
+//
+// Reading the source is the whole point. The previous version of this test
+// compared scoreBearingFlags against a hardcoded copy of itself, so it could
+// only fail if someone edited one of the two lists and not the other — a NEW
+// score-bearing flag, which is the failure the test exists to prevent, passed
+// it silently. Deriving the universe from the fs.* calls means a flag that
+// nobody classified is a red test rather than a hole.
+func registeredScanFlags(t *testing.T) []string {
+	t.Helper()
+	fset := gotoken.NewFileSet()
+	f, err := parser.ParseFile(fset, "scan.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse scan.go: %v", err)
 	}
-	got := map[string]bool{}
+	// Registration methods take the flag name first; the *Var forms take a
+	// pointer first and the name second. Everything else on a FlagSet is
+	// bookkeeping. A method in neither set is a registration form this test does
+	// not understand, and staying quiet about it would reopen the hole.
+	nameFirst := map[string]bool{
+		"String": true, "Bool": true, "Int": true, "Int64": true, "Uint": true,
+		"Uint64": true, "Float64": true, "Duration": true, "Func": true, "BoolFunc": true,
+	}
+	nameSecond := map[string]bool{
+		"StringVar": true, "BoolVar": true, "IntVar": true, "Int64Var": true,
+		"UintVar": true, "Uint64Var": true, "Float64Var": true, "DurationVar": true,
+		"TextVar": true, "Var": true,
+	}
+	bookkeeping := map[string]bool{
+		"Parse": true, "Parsed": true, "Args": true, "Arg": true, "NArg": true,
+		"NFlag": true, "Lookup": true, "Set": true, "Visit": true, "VisitAll": true,
+		"PrintDefaults": true, "SetOutput": true, "Output": true, "Init": true,
+		"Name": true, "ErrorHandling": true,
+	}
+	var flags []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if recv, ok := sel.X.(*ast.Ident); !ok || recv.Name != "fs" {
+			return true
+		}
+		method := sel.Sel.Name
+		idx := -1
+		switch {
+		case nameFirst[method]:
+			idx = 0
+		case nameSecond[method]:
+			idx = 1
+		case bookkeeping[method]:
+			return true
+		default:
+			t.Errorf("scan.go calls fs.%s, which this test does not recognise as a flag "+
+				"registration; teach registeredScanFlags about it or the flag it defines "+
+				"goes unclassified", method)
+			return true
+		}
+		if len(call.Args) <= idx {
+			t.Errorf("fs.%s called with %d args; cannot read the flag name", method, len(call.Args))
+			return true
+		}
+		lit, ok := call.Args[idx].(*ast.BasicLit)
+		if !ok || lit.Kind != gotoken.STRING {
+			t.Errorf("fs.%s registers a flag whose name is not a string literal (%v); "+
+				"this test cannot classify it", method, call.Args[idx])
+			return true
+		}
+		flags = append(flags, "--"+strings.Trim(lit.Value, `"`))
+		return true
+	})
+	return flags
+}
+
+// Every flag scan registers must be classified: either it is score-bearing and
+// rejected for an image reference, or it is on imageSafeScanFlags with a stated
+// reason. Adding a flag without classifying it fails here.
+func TestEveryScanFlagIsClassifiedForImageMode(t *testing.T) {
+	registered := registeredScanFlags(t)
+	// Non-vacuity guard: if the parse silently matched nothing, every assertion
+	// below would pass over an empty set.
+	if len(registered) < 40 {
+		t.Fatalf("only found %d scan flags (%v); the source parse is not seeing the "+
+			"registrations, so this test would pass vacuously", len(registered), registered)
+	}
+
+	classified := map[string]string{}
 	for _, f := range scoreBearingFlags {
-		got[f] = true
+		classified[f] = "score-bearing, rejected by rejectScoreBearingOutputs"
 	}
-	for f := range want {
-		if !got[f] {
-			t.Errorf("%s emits or gates on a score but is not in scoreBearingFlags", f)
+	for reason, flags := range imageSafeScanFlags {
+		for _, f := range flags {
+			if prev, dup := classified[f]; dup {
+				t.Errorf("%s is classified twice: %q and %q", f, prev, reason)
+			}
+			classified[f] = reason
 		}
 	}
-	for f := range got {
-		if !want[f] {
-			t.Errorf("scoreBearingFlags has an unexpected entry %q", f)
+
+	seen := map[string]bool{}
+	for _, f := range registered {
+		seen[f] = true
+		if _, ok := classified[f]; !ok {
+			t.Errorf("%s is registered by runScan but classified nowhere. If it emits or "+
+				"gates on a composite score, add it to scoreBearingFlags; if it cannot, add "+
+				"it to imageSafeScanFlags under the reason why", f)
 		}
+	}
+	// The reverse direction catches a rename or a removal leaving a stale entry,
+	// which would otherwise quietly shrink the set this test actually checks.
+	for f, reason := range classified {
+		if !seen[f] {
+			t.Errorf("%s is classified (%q) but no longer registered by runScan; "+
+				"the classification is stale", f, reason)
+		}
+	}
+}
+
+// --compare claims its own image-ref rejection path in imageSafeScanFlags. That
+// claim is only worth making if it is checked: a comment cannot fail.
+func TestCompareRejectsImageRefsOnItsOwnPath(t *testing.T) {
+	src, err := os.ReadFile("scan.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(src), `scan.UnsupportedForImageRef("--compare"`) {
+		t.Error("--compare is classified as rejecting image refs on its own path, but " +
+			"scan.go no longer calls scan.UnsupportedForImageRef(\"--compare\", ...); " +
+			"either restore the rejection or reclassify the flag")
 	}
 }


### PR DESCRIPTION
Follow-up to the review of #665 (image mode). Three nits the reviewer raised as
non-blocking, plus the podman half of the verification gap that PR left open.
Deliberately small: no scoring change, no schema change, no regenerated
scorecards.

## 1. `--remediate` was told about `--fix`

`--remediate` is an alias for `--fix`, and the image-mode rejection folded both
into one map entry keyed `"--fix"`. A user who typed `--remediate` got an error
naming a flag they never used. The alias now has its own key, listed after
`--fix` so a run passing both is still named `--fix` and the error stays
deterministic.

## 2. The `--*-bin` help strings described one subcommand

They still said the binary was used for `docker inspect`. Since the
mode-detection fix the tool runs `container inspect` and then `image inspect`
against it, which is the distinction those flags now control.

## 3. `TestScoreBearingFlagsCoverGradeEmittingOutputs` could not fail

It compared `scoreBearingFlags` against a hardcoded copy of itself, so it could
only fail if someone edited one of the two lists and not the other. The failure
it exists to prevent -- a new flag that emits or gates on a composite score,
added and never routed through `rejectScoreBearingOutputs` -- passed it
silently. The list is complete today; the test was not going to keep it that
way.

One correction to the review note while I was here: the flag universe is **45**,
not 47. That is what `fs.String`/`fs.Bool`/`fs.Int` actually register on the scan
FlagSet, counted by the parser rather than by hand, and it is 45 both before and
after this PR (I added a list entry, not a flag). The conclusion is unchanged --
every one of the 45 is classified -- but the number is now derived instead of
enumerated, which is the whole point of the change.

It now parses `scan.go` for the `fs.*` registrations and requires every
registered flag to be **classified**: score-bearing, or on `imageSafeScanFlags`
under a stated reason why it cannot hand an image reference a number. A new
flag is red until someone classifies it. An `fs.*` method the parser does not
recognise is an error rather than a skip, stale classifications are caught in
the reverse direction, and a floor on the flag count stops a parse that matched
nothing from passing vacuously.

## Evidence

**Two-arm control on the test, same injected flag both times.** Adding an
unclassified `fs.String("badge-png", ...)` to `scan.go`:

| | verdict |
|---|---|
| old test, verbatim `origin/main` blob | **PASS** (this is the defect) |
| new test | **FAIL** -- `--badge-png is registered by runScan but classified nowhere` |

**Live podman run** (`podman info` -> `crun`; the reviewer could not verify this
path because neither podman nor nerdctl was available to him):

- image mode prints the explicit `mode: image reference` line, no score, one
  `PASS` for `USER haproxy` carrying no points, and six `N/A` dimensions.
- `--remediate` -> `--remediate needs a containment score`, exit 1, nothing
  written. `--fix` -> `--fix ...`. Both flags -> `--fix ...`.
- container mode is **byte-identical pre and post** on a plain and a hardened
  haproxy container (63/100 C, 100/100 A), so no published scorecard moves.

nerdctl is still absent here and remains correct-by-reading; that one is for
the next release smoke.

`go test ./cmd/ironctl/` passes. `TestCheckModelProxy` needs a short `TMPDIR` --
a unix socket path over 104 bytes hits the macOS `sun_path` limit -- and it
fails the same way on unmodified `main`.

Refs IRO-723, follow-up to IRO-712.
