### PR TITLE
scan: name the flag the user typed, and make the image-mode gate defensible [IRO-724]

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -72,9 +72,9 @@ func cmdScan(args []string) error {
 	openshift := fs.String("openshift", "", "grade OpenShift workloads (DeploymentConfig, Deployment, Pod) in a manifest file (`oc get -o yaml`) or a directory of them")
 	dockerfile := fs.Bool("dockerfile", false, "statically grade the positional Dockerfile(s) authoring-time posture (daemon-free)")
 	runtime := fs.String("runtime", envOrDefault("IRONCTL_SCAN_RUNTIME", "auto"), "container runtime: auto|docker|podman|nerdctl")
-	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker inspect`")
-	podmanBin := fs.String("podman-bin", envOrDefault("PODMAN", "podman"), "podman binary used for `podman inspect`")
-	nerdctlBin := fs.String("nerdctl-bin", envOrDefault("NERDCTL", "nerdctl"), "nerdctl binary used for `nerdctl inspect`")
+	dockerBin := fs.String("docker-bin", envOrDefault("DOCKER", "docker"), "docker binary used for `docker container inspect` and `docker image inspect`")
+	podmanBin := fs.String("podman-bin", envOrDefault("PODMAN", "podman"), "podman binary used for `podman container inspect` and `podman image inspect`")
+	nerdctlBin := fs.String("nerdctl-bin", envOrDefault("NERDCTL", "nerdctl"), "nerdctl binary used for `nerdctl container inspect` and `nerdctl image inspect`")
 	minScore := fs.Int("min-score", 0, "exit non-zero if the score is below this threshold (CI gate)")
 	fs.Usage = func() { scanUsage(os.Stdout) }
 	// Go's flag package stops at the first positional, so `scan <target> --json`
@@ -512,15 +512,15 @@ func cmdScan(args []string) error {
 	// presupposes one is rejected BEFORE anything is emitted: a non-zero exit and
 	// an explanation, never a grade or a placeholder.
 	if spec.Mode == scan.ModeImage {
-		if err := rejectScoreBearingOutputs(spec.Target, map[string]bool{
-			"--badge":      *badge != "",
-			"--badge-json": *badgeJSON != "",
-			"--badge-md":   *badgeMd != "",
-			"--md":         *md,
-			"--share":      *share,
-			"--sarif":      *sarif != "",
-			"--min-score":  *minScore > 0,
-			"--fix":        *fix || *remediate,
+		if err := rejectScoreBearingOutputs(spec.Target, map[string]string{
+			"--badge":      blameIf(*badge != "", "--badge"),
+			"--badge-json": blameIf(*badgeJSON != "", "--badge-json"),
+			"--badge-md":   blameIf(*badgeMd != "", "--badge-md"),
+			"--md":         blameIf(*md, "--md"),
+			"--share":      blameIf(*share, "--share"),
+			"--sarif":      blameIf(*sarif != "", "--sarif"),
+			"--min-score":  blameIf(*minScore > 0, "--min-score"),
+			"--fix":        fixFlagBlame(*fix, *remediate),
 		}); err != nil {
 			return err
 		}
@@ -3015,13 +3015,41 @@ var scoreBearingFlags = []string{
 // rejectScoreBearingOutputs fails the run when any score-bearing output was
 // requested for an image-mode target. Image mode supports the default table and
 // --json only; everything else here would have to invent a number.
-func rejectScoreBearingOutputs(target string, requested map[string]bool) error {
+//
+// requested is keyed by the canonical flag name (so the ordering above governs
+// which one is reported first) and valued with the name to BLAME: the same flag
+// normally, or the alias when that is what the user typed. An empty value means
+// the output was not requested.
+func rejectScoreBearingOutputs(target string, requested map[string]string) error {
 	for _, f := range scoreBearingFlags {
-		if requested[f] {
-			return scan.UnsupportedForImageRef(f, target)
+		if blame := requested[f]; blame != "" {
+			return scan.UnsupportedForImageRef(blame, target)
 		}
 	}
 	return nil
+}
+
+// blameIf names the flag to report when a condition holds, and "" otherwise.
+func blameIf(requested bool, name string) string {
+	if !requested {
+		return ""
+	}
+	return name
+}
+
+// fixFlagBlame names the remediation flag the user actually typed. --remediate
+// is an alias for --fix and both are score-bearing, but an error that blames
+// --fix when the user never typed it sends them hunting for the wrong flag.
+// Empty when neither was given; --fix wins if somehow both were.
+func fixFlagBlame(fix, remediate bool) string {
+	switch {
+	case fix:
+		return "--fix"
+	case remediate:
+		return "--remediate"
+	default:
+		return ""
+	}
 }
 
 // targetSpec resolves a positional scan target with the selected (or
@@ -3189,9 +3217,9 @@ FLAGS:
   --nomad-bin BIN     nomad binary for `+"`nomad job run -output`"+` (HCL->JSON; default: nomad)
   --kustomize-bin BIN kustomize binary for `+"`kustomize build`"+` (default: kustomize)
   --kubectl-bin BIN   kubectl binary for `+"`kubectl kustomize`"+` fallback (default: kubectl)
-  --docker-bin BIN    docker binary for `+"`docker inspect`"+` (default: docker)
-  --podman-bin BIN    podman binary for `+"`podman inspect`"+` (default: podman)
-  --nerdctl-bin BIN   nerdctl binary for `+"`nerdctl inspect`"+` (default: nerdctl)
+  --docker-bin BIN    docker binary for `+"`docker container inspect`"+` and `+"`docker image inspect`"+` (default: docker)
+  --podman-bin BIN    podman binary for `+"`podman container inspect`"+` and `+"`podman image inspect`"+` (default: podman)
+  --nerdctl-bin BIN   nerdctl binary for `+"`nerdctl container inspect`"+` and `+"`nerdctl image inspect`"+` (default: nerdctl)
 
 Runtime is auto-detected (docker, then podman, then nerdctl on PATH); override
 with --runtime. Rootless podman is credited: a userns remap of container-uid 0

--- a/cmd/ironctl/scan_flags_test.go
+++ b/cmd/ironctl/scan_flags_test.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	gotoken "go/token"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Image mode has no composite score (IRO-712), so `ironctl scan <image>` rejects
+// every output that would have to invent one. The hole that guards against is a
+// flag added LATER that emits a grade and is never added to scoreBearingFlags:
+// it would sail through the gate and print a number nothing measured.
+//
+// A hand-maintained expectation cannot catch that — it only catches someone
+// editing one copy of the same list. So these tests read the flag universe out
+// of scan.go's own registrations and require every flag to be CLASSIFIED: either
+// score-bearing, an alias of one, or explicitly image-safe. A new flag fails
+// until someone decides which it is.
+
+// scanSourceFile is parsed by the tests below. `go test` runs with the package
+// directory as its working directory, so the bare filename resolves.
+const scanSourceFile = "scan.go"
+
+// imageSafeFlags is the explicit allowlist: scan flags that carry no composite
+// score and so stay legal on an image reference. A flag belongs here for one of
+// two reasons:
+//
+//   - it selects a DIFFERENT input (--compose, --k8s, --dockerfile, --helm, ...),
+//     so it never reaches image mode in the first place; or
+//   - it is a representation or a helper-binary override that reports only what
+//     was actually observed (--json, --runtime, --docker-bin, ...).
+//
+// This list is not documentation. TestEveryScanFlagIsClassified fails on any
+// registered flag that appears in neither this list nor scoreBearingFlags.
+var imageSafeFlags = []string{
+	"--admission-response", "--app-runner", "--az-bin", "--azure", "--bicep",
+	"--bicep-bin", "--cdk", "--cdk-bin", "--check", "--cloudformation",
+	"--cloudrun", "--compare", "--compose", "--docker-bin", "--dockerfile",
+	"--ecs", "--emit-policy", "--helm", "--helm-bin", "--json", "--k8s",
+	"--k8s-admission", "--kubectl-bin", "--kustomize", "--kustomize-bin",
+	"--nerdctl-bin", "--nomad", "--nomad-bin", "--openshift", "--podman-bin",
+	"--pulumi", "--runtime", "--sam", "--service", "--terraform",
+	"--terraform-bin",
+}
+
+// scoreBearingAliases maps an alias onto the canonical score-bearing flag it
+// stands for. An alias is rejected in image mode exactly like its canonical
+// flag, but is tracked separately because the rejection names what the user
+// typed (see fixFlagBlame).
+var scoreBearingAliases = map[string]string{"--remediate": "--fix"}
+
+// TestEveryScanFlagIsClassified is the defence: it derives the flag universe
+// from scan.go's fs.String/fs.Bool/fs.Int registrations, so adding a flag
+// without classifying it turns this red.
+func TestEveryScanFlagIsClassified(t *testing.T) {
+	registered := parseScanFlagRegistrations(t)
+	if len(registered) < 40 {
+		t.Fatalf("only %d flags parsed out of scan.go; the parser has gone blind and every "+
+			"assertion below is vacuous", len(registered))
+	}
+
+	classified := map[string]string{}
+	for _, f := range scoreBearingFlags {
+		classified[f] = "score-bearing"
+	}
+	for alias, canonical := range scoreBearingAliases {
+		if classified[canonical] != "score-bearing" {
+			t.Errorf("alias %s points at %s, which is not in scoreBearingFlags", alias, canonical)
+		}
+		if _, dup := classified[alias]; dup {
+			t.Errorf("%s is classified twice", alias)
+		}
+		classified[alias] = "alias of " + canonical
+	}
+	for _, f := range imageSafeFlags {
+		if prior, dup := classified[f]; dup {
+			t.Errorf("%s is on the image-safe allowlist AND %s; it cannot be both", f, prior)
+		}
+		classified[f] = "image-safe"
+	}
+
+	for _, f := range registered {
+		if _, ok := classified[f]; !ok {
+			t.Errorf("scan flag %s is registered but not classified. Decide: does it emit or "+
+				"gate on a composite score? Add it to scoreBearingFlags (and to the "+
+				"rejectScoreBearingOutputs call site) if so, or to imageSafeFlags if not.", f)
+		}
+	}
+
+	inUniverse := map[string]bool{}
+	for _, f := range registered {
+		inUniverse[f] = true
+	}
+	for f := range classified {
+		if !inUniverse[f] {
+			t.Errorf("%s is classified but is not a registered scan flag (renamed or removed?)", f)
+		}
+	}
+}
+
+// TestRejectScoreBearingOutputsCallSiteIsComplete closes the second half of the
+// hole: a flag can be listed in scoreBearingFlags and still never be rejected,
+// because the gate only sees the flags the call site actually passes it. The
+// keys of that map literal must be exactly scoreBearingFlags.
+func TestRejectScoreBearingOutputsCallSiteIsComplete(t *testing.T) {
+	passed := parseRejectCallSiteKeys(t)
+	if len(passed) == 0 {
+		t.Fatal("found no rejectScoreBearingOutputs call site in scan.go; this test is vacuous")
+	}
+
+	want := append([]string(nil), scoreBearingFlags...)
+	sort.Strings(want)
+	sort.Strings(passed)
+
+	wantSet := map[string]bool{}
+	for _, f := range want {
+		wantSet[f] = true
+	}
+	passedSet := map[string]bool{}
+	for _, f := range passed {
+		passedSet[f] = true
+	}
+	for _, f := range want {
+		if !passedSet[f] {
+			t.Errorf("%s is score-bearing but the rejectScoreBearingOutputs call site never "+
+				"reports whether it was requested, so it is silently allowed on an image ref", f)
+		}
+	}
+	for _, f := range passed {
+		if !wantSet[f] {
+			t.Errorf("the call site passes %q, which is not in scoreBearingFlags, so the gate "+
+				"ignores it", f)
+		}
+	}
+}
+
+// fixFlagBlame decides which of the two remediation spellings the error names.
+func TestFixFlagBlame(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		fix, remediate bool
+		want           string
+	}{
+		{"neither", false, false, ""},
+		{"fix", true, false, "--fix"},
+		{"remediate alone is named as itself", false, true, "--remediate"},
+		{"both", true, true, "--fix"},
+	} {
+		if got := fixFlagBlame(tc.fix, tc.remediate); got != tc.want {
+			t.Errorf("%s: fixFlagBlame(%v, %v) = %q, want %q", tc.name, tc.fix, tc.remediate, got, tc.want)
+		}
+	}
+
+	// End to end through the gate: a user who typed --remediate is told
+	// --remediate is unsupported, not --fix.
+	err := rejectScoreBearingOutputs("docker.io/library/haproxy:latest", map[string]string{
+		"--fix": fixFlagBlame(false, true),
+	})
+	if err == nil {
+		t.Fatal("--remediate must be rejected on an image reference")
+	}
+	if msg := err.Error(); !strings.HasPrefix(msg, "--remediate ") {
+		t.Errorf("rejection should open by naming --remediate, got: %v", msg)
+	}
+}
+
+// registrationMethods are the flag.FlagSet methods that define a flag. Any other
+// method called on the scan flag set is rejected below rather than ignored: a
+// flag registered through an unrecognised method would be invisible to this
+// whole file, which is exactly the blindness these tests exist to prevent.
+var registrationMethods = map[string]bool{
+	"String": true, "Bool": true, "Int": true,
+}
+
+// nonRegistrationMethods are the known flag.FlagSet methods that do NOT define a
+// flag. Everything not in either map fails the parse.
+var nonRegistrationMethods = map[string]bool{
+	"Parse": true, "Args": true, "Arg": true, "NArg": true, "NFlag": true,
+	"PrintDefaults": true, "SetOutput": true, "Output": true, "Lookup": true,
+	"Visit": true, "VisitAll": true, "Set": true, "Init": true, "Name": true,
+	"ErrorHandling": true, "Parsed": true,
+}
+
+// parseScanFlagRegistrations returns every flag scan.go registers on its flag
+// set, with the "--" prefix, read from the source rather than restated.
+func parseScanFlagRegistrations(t *testing.T) []string {
+	t.Helper()
+	file := parseScanSource(t)
+
+	var flags []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if recv, ok := sel.X.(*ast.Ident); !ok || recv.Name != "fs" {
+			return true
+		}
+		method := sel.Sel.Name
+		switch {
+		case registrationMethods[method]:
+		case nonRegistrationMethods[method]:
+			return true
+		default:
+			t.Errorf("scan.go calls fs.%s, which this test does not recognise. If it registers "+
+				"a flag, add it to registrationMethods; otherwise add it to "+
+				"nonRegistrationMethods. Leaving it unlisted makes the flag invisible here.", method)
+			return true
+		}
+		if len(call.Args) == 0 {
+			t.Errorf("fs.%s called with no arguments", method)
+			return true
+		}
+		lit, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || lit.Kind != gotoken.STRING {
+			t.Errorf("fs.%s registers a flag whose name is not a string literal; this test "+
+				"cannot see it", method)
+			return true
+		}
+		name, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			t.Errorf("unquote %s: %v", lit.Value, err)
+			return true
+		}
+		flags = append(flags, "--"+name)
+		return true
+	})
+	sort.Strings(flags)
+	return flags
+}
+
+// parseRejectCallSiteKeys returns the map keys scan.go hands to
+// rejectScoreBearingOutputs.
+func parseRejectCallSiteKeys(t *testing.T) []string {
+	t.Helper()
+	file := parseScanSource(t)
+
+	var keys []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		fn, ok := call.Fun.(*ast.Ident)
+		if !ok || fn.Name != "rejectScoreBearingOutputs" || len(call.Args) < 2 {
+			return true
+		}
+		lit, ok := call.Args[1].(*ast.CompositeLit)
+		if !ok {
+			t.Errorf("rejectScoreBearingOutputs is called with a non-literal map; this test " +
+				"cannot check which flags it covers")
+			return true
+		}
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			k, ok := kv.Key.(*ast.BasicLit)
+			if !ok || k.Kind != gotoken.STRING {
+				continue
+			}
+			name, err := strconv.Unquote(k.Value)
+			if err != nil {
+				continue
+			}
+			keys = append(keys, name)
+		}
+		return true
+	})
+	return keys
+}
+
+func parseScanSource(t *testing.T) *ast.File {
+	t.Helper()
+	file, err := parser.ParseFile(gotoken.NewFileSet(), scanSourceFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", scanSourceFile, err)
+	}
+	return file
+}

--- a/cmd/ironctl/scan_test.go
+++ b/cmd/ironctl/scan_test.go
@@ -116,7 +116,7 @@ func TestCmdScan_DockerfileNoPath(t *testing.T) {
 func TestRejectScoreBearingOutputs_ImageMode(t *testing.T) {
 	const ref = "docker.io/library/haproxy:latest"
 	for _, flag := range scoreBearingFlags {
-		err := rejectScoreBearingOutputs(ref, map[string]bool{flag: true})
+		err := rejectScoreBearingOutputs(ref, map[string]string{flag: flag})
 		if err == nil {
 			t.Errorf("%s was allowed on an image reference; it needs a composite score", flag)
 			continue
@@ -135,25 +135,8 @@ func TestRejectScoreBearingOutputs_ImageMode(t *testing.T) {
 	}
 }
 
-// scoreBearingFlags must stay in sync with the flags runScan actually feeds it;
-// a flag that emits a grade but is missing from the list is a silent hole.
-func TestScoreBearingFlagsCoverGradeEmittingOutputs(t *testing.T) {
-	want := map[string]bool{
-		"--badge": true, "--badge-json": true, "--badge-md": true, "--md": true,
-		"--share": true, "--sarif": true, "--min-score": true, "--fix": true,
-	}
-	got := map[string]bool{}
-	for _, f := range scoreBearingFlags {
-		got[f] = true
-	}
-	for f := range want {
-		if !got[f] {
-			t.Errorf("%s emits or gates on a score but is not in scoreBearingFlags", f)
-		}
-	}
-	for f := range got {
-		if !want[f] {
-			t.Errorf("scoreBearingFlags has an unexpected entry %q", f)
-		}
-	}
-}
+// scoreBearingFlags must stay in sync with the flags cmdScan actually feeds the
+// gate, and every registered flag must be classified one way or the other. Both
+// invariants are derived from scan.go's own source in scan_flags_test.go; a
+// hand-copied expectation here could only ever catch someone editing one of two
+// identical lists.


### PR DESCRIPTION
Closes the three non-blocking nits from the review of #665 (IRO-712), and closes the podman half of the verification gap.

### 1. Stale `--*-bin` help strings

They still described `<bin> inspect`. Since IRO-712 mode detection asks two explicit questions (`container inspect`, then `image inspect`), so the help now names both.

### 2. `--remediate` rejection named the wrong flag

`ironctl scan <image> --remediate` said `--fix` is unsupported. Rejecting it is correct (it is an alias for `--fix` and both are score-bearing), but the map key was hardcoded, so the error sent the user hunting for a flag they never typed.

`rejectScoreBearingOutputs` is now keyed by the canonical flag (preserving the deterministic report order) and valued with the name to *blame*; `fixFlagBlame` picks the spelling actually passed.

### 3. The coverage test was tautological

`TestScoreBearingFlagsCoverGradeEmittingOutputs` built a hardcoded copy of `scoreBearingFlags` and compared it to `scoreBearingFlags`. It could only fail if someone edited one of two identical lists, never on the failure it existed to prevent: a **new** score-bearing flag that misses the gate and prints a number nothing measured.

Replaced with two source-derived tests in `cmd/ironctl/scan_flags_test.go`:

- **`TestEveryScanFlagIsClassified`** parses the flag universe out of `scan.go`'s own `fs.String`/`fs.Bool`/`fs.Int` registrations and requires every flag to be classified: score-bearing, an alias of one, or on an explicit image-safe allowlist. Registration goes through a known set of `FlagSet` methods; any other method fails the parse rather than being skipped, so the AST walk cannot go blind silently.
- **`TestRejectScoreBearingOutputsCallSiteIsComplete`** parses the `rejectScoreBearingOutputs` call site and requires its map keys to be exactly `scoreBearingFlags` — a flag cannot be listed as score-bearing and still never be checked.

`scoreBearingFlags` is unchanged; this makes the list defensible, not different.

## Verification

**Non-vacuity — three injected controls, each reverted:**

| injection | result |
|---|---|
| register an unclassified `--grade-csv` | `TestEveryScanFlagIsClassified` **RED** |
| same injection, against the **pre-fix** test | **PASSES green** — the blindness being fixed |
| drop `--sarif` from the gate call site | call-site test **RED** |
| register via `fs.Float64` | parser-blindness guard **RED** |

**Live, against podman 5.5.2 / crun** (nerdctl is still absent here and stays for the next release smoke):

- image mode emits no composite, six dimensions `N/A`, header reads `(podman)`
- `--remediate`, `--fix`, `--md`, `--share`, `--badge`, `--min-score` all rejected with exit 1 and no badge file written; `--remediate` now names itself
- container mode **byte-identical to `origin/main`** across 10 combinations (hardened 100/A and porous 48/D, each x plain/`--json`/`--fix`/`--md`/`--share`). The only behavioural delta in the entire matrix is `--remediate` naming itself.

`go test ./cmd/ironctl/ ./internal/host/scan/` is green (`CGO_ENABLED=1`). Note `TestCheckModelProxy` fails on this machine for an environmental reason — a unix socket path over macOS's 104-byte limit under a long `TMPDIR` — and fails identically on unmodified `origin/main`; it passes with `TMPDIR=/tmp`.

No scoring or schema change. `internal/contract` untouched. `docs/scores/**` not regenerated.