### PR TITLE
docs: record the two admin-bypassed merges, and close the hole [IRO-731]

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -6,9 +6,15 @@ here and re-apply.
 
 ## Shape
 
-External contributions arrive via pull request and must satisfy every rule below.
-Repository **admins are listed as `bypass_actors`** so maintainers can land and revert
-quickly when needed.
+Every change to `main` arrives via pull request and must satisfy every rule below.
+
+`bypass_actors` is **empty, on purpose**. It used to list the repository admin role
+with `bypass_mode: always`, which meant the required review was advisory for every
+maintainer and mandatory for everyone else; two commits reached `main` unreviewed
+that way before it was removed (IRO-731). The approving review is now satisfied by
+the reviewer App instead, which needs no bypass. See
+[`docs/merge-exceptions.md`](../../docs/merge-exceptions.md) for the record and for
+the authorised procedure to put the bypass back if it is ever genuinely needed.
 
 ## Rules enforced
 
@@ -18,7 +24,8 @@ quickly when needed.
 | `non_fast_forward` | no force-pushes / history rewrites |
 | `required_linear_history` | merge commits are rejected (linear history) |
 | `required_signatures` | commits must be signed |
-| `required_status_checks` | `build` (CI) and `CodeQL` must be green |
+| `pull_request` | one approving review from a non-author; stale reviews are dismissed on push; squash or rebase only |
+| `required_status_checks` | `build` (CI), `CodeQL` and `brew-formula-verify` must be green |
 
 ## Applying
 

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -37,11 +37,5 @@
       }
     }
   ],
-  "bypass_actors": [
-    {
-      "actor_id": 5,
-      "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
-    }
-  ]
+  "bypass_actors": []
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,15 @@ There's nothing to do up front: when you open your first pull request, the **CLA
 Assistant** bot comments with a link, and you sign in one click with your GitHub
 account. It remembers your signature for future PRs.
 
+Where we have accepted a contribution without a captured signature, and on what
+evidence, is on the public record in
+[CLA exceptions](https://ironsecco.github.io/ironclaw/cla-exceptions/). Its
+companion page,
+[Merge exceptions](https://ironsecco.github.io/ironclaw/merge-exceptions/),
+records every commit that reached `main` without the approving review the branch
+ruleset requires. Both exist because an exception that is not written down is
+indistinguishable from a process failure.
+
 ## Development setup
 
 IronClaw is Go 1.23+ and requires **`CGO_ENABLED=1`** (the SQLCipher binding behind

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -57,4 +57,5 @@ nav:
       - Release runbook: release-runbook.md
       - PR review & reviewer identity: pr-review-process.md
       - CLA exceptions: cla-exceptions.md
+      - Merge exceptions: merge-exceptions.md
       - Roadmap: roadmap.md

--- a/docs/cla-exceptions.md
+++ b/docs/cla-exceptions.md
@@ -24,9 +24,11 @@ These constrain every entry on this page.
 
 - **`license/cla` is a policy gate, not a technical one.** It is deliberately not
   one of the required status checks in the `main-protection` ruleset (those are
-  exactly `build` and `CodeQL`). Honouring it is a choice we make. An exception is
-  therefore recorded here in prose; it never involves editing a ruleset, relaxing
-  a required check, or bypassing branch protection.
+  exactly `build`, `CodeQL` and `brew-formula-verify`). Honouring it is a choice
+  we make. An exception is therefore recorded here in prose; it never involves
+  editing a ruleset, relaxing a required check, or bypassing branch protection.
+  Where branch protection *was* bypassed, the record is its companion page,
+  [Merge exceptions](merge-exceptions.md).
 - **A real signature always beats an exception.** Before acting on any exception,
   re-check the live status. A late signature retires the exception rather than
   running alongside it.

--- a/docs/merge-exceptions.md
+++ b/docs/merge-exceptions.md
@@ -1,0 +1,199 @@
+---
+title: "Merge exceptions"
+description: "The record of every commit that reached IronClaw's main branch without the approving review the branch ruleset requires, and what we changed so it cannot happen again."
+---
+
+# Merge exceptions
+
+`main` is protected by the `main-protection` branch ruleset, checked in as
+[`.github/rulesets/main.json`](https://github.com/IronSecCo/ironclaw/blob/main/.github/rulesets/main.json).
+Among other rules it requires **one approving review** from an actor other than
+the pull request author before anything lands.
+
+This page is the complete record of every commit that reached `main` **without
+that review**. It exists for the same reason [CLA exceptions](cla-exceptions.md)
+does: an exception that is not written down is indistinguishable from a process
+failure.
+
+The entries below are not exceptions in the sense that page uses. Nobody
+authorised them in advance and nothing was weighed against a rule before the
+merge happened. They were **process failures on our side**. The diffs turned out
+to be benign, and each was read line by line afterwards, but *afterwards* is the
+problem: the check that was supposed to run before the push ran after it, by
+hand, because someone noticed.
+
+Blame belongs to the mechanism, not to whoever typed the command. Until
+2026-08-01 the ruleset carried a single bypass actor, the repository **admin**
+role, with `bypass_mode: always`. Every IronClaw agent drives GitHub as
+`omerzamir`, who holds that role, so the required review was **advisory for us
+and mandatory for everyone else**. Worse, `gh pr merge --squash` reads a stale
+`mergeable_state` and helpfully suggests `--admin` when it does; the tool
+recommended the bypass at exactly the moment someone was already stuck. Both
+entries below are that shape.
+
+## Standing rules
+
+These constrain every entry on this page.
+
+- **Every bypassed merge gets an entry, without exception and without delay.**
+  Content being harmless is not a reason to leave it unrecorded. It is a reason
+  the entry is short.
+- **An entry is not an authorisation.** Nothing here grants permission to repeat
+  it, and no entry is a precedent for the next merge that feels urgent.
+- **The record is derived from GitHub, not from memory.** Each entry cites the
+  rule-suite evaluation id that GitHub itself recorded, so the claim can be
+  re-checked independently of this page.
+- **If you are reaching for `--admin`, stop.** The
+  [restore procedure](#restore-procedure-break-glass) below is the supported way
+  out, and it is deliberately slower and deliberately logged.
+
+## How this record was assembled
+
+Bypasses are read from the rule-suite history, which is GitHub's own log of
+every push evaluated against the ruleset:
+
+```sh
+gh api "repos/IronSecCo/ironclaw/rulesets/rule-suites?ref=refs/heads/main&per_page=100"
+gh api "repos/IronSecCo/ironclaw/rulesets/rule-suites/<id>"
+```
+
+A row with `"result": "bypass"` is a push that a rule would have rejected and an
+actor was permitted to skip. The per-suite endpoint names the rule that failed.
+
+**Coverage limit, stated plainly.** Queried on 2026-08-01, that history returned
+20 evaluations for `refs/heads/main`, the oldest pushed 2026-07-31T04:41:43Z.
+GitHub does not retain rule-suite rows indefinitely, so this page is complete for
+the window the API still serves and **cannot** speak for anything older. Two of
+those 20 rows were bypasses. The other 18 passed cleanly.
+
+## Entry 001: `c63ac4e3`, pull request #660
+
+**Merged** 2026-07-31T12:39:43Z by `omerzamir`. Rule-suite evaluation
+`3517044004`, advancing `main` from `85c2b769` to `c63ac4e3`.
+
+[#660](https://github.com/IronSecCo/ironclaw/pull/660),
+`ci(docs): turn on the bare-opening-fence rule, held back since IRO-707 [IRO-710]`,
+head branch `ci/iro710-bare-fence-rule`. Five files:
+
+| File | Kind |
+| --- | --- |
+| `scripts/check-md-fences.py` | CI enforcement script |
+| `scripts/tests/test_check_md_fences.py` | test for that script |
+| `docs/assets/live-containment-social/STORYBOARD.md` | docs |
+| `docs/blog/scan-a-dockerfile-for-security-issues.md` | docs |
+| `docs/site/quickstart.mdx` | docs |
+
+**Reviews at merge: none.** `reviewDecision` was `REVIEW_REQUIRED` and the review
+list was empty. GitHub recorded the `pull_request` rule as `fail` with the reason
+*"At least 1 approving review is required by reviewers with write access"*. Every
+other rule in the suite passed: `required_signatures`, `required_status_checks`,
+`required_linear_history`, `non_fast_forward`, `deletion`. So this was not a
+broken CI run being forced through. It was the review, and only the review, that
+was skipped.
+
+**Content verified after the fact, not before.** The diff turns on a lint rule
+for unlabelled Markdown code fences and fixes the three files that violated it.
+It is benign. But note what it is: a **change to a CI enforcement script**. The
+comfortable reading of a bypass, that it was only a harmless cleanup, is weaker
+here than anywhere. A defect in that file weakens a gate for every pull request
+that follows, which is precisely the category that most needs a second reader.
+
+## Entry 002: `f669faa8`, pull request #673
+
+**Merged** 2026-07-31T20:40:03Z by `omerzamir`, eight hours after entry 001.
+Rule-suite evaluation `3522187994`, advancing `main` from `8b23ae67` to
+`f669faa8`.
+
+[#673](https://github.com/IronSecCo/ironclaw/pull/673),
+`scan: name the flag the user typed, and make the image-mode gate defensible [IRO-724]`,
+head branch `fix/iro724-scan-review-nits`. Three files: `cmd/ironctl/scan.go`,
+`cmd/ironctl/scan_flags_test.go`, `cmd/ironctl/scan_test.go`.
+
+**Reviews at merge: none.** Identical shape to entry 001: `reviewDecision` was
+`REVIEW_REQUIRED`, the review list was empty, and the recorded rule failure was
+again the approving-review requirement with every other rule passing.
+
+**Content verified after the fact, not before.** The diff improves `ironctl scan`
+error messages and tightens a mode gate, with tests. It is benign and it is
+covered by the required `build` check that did run. What it was not is *read by
+anyone other than its author before it reached `main`*.
+
+**Two in eleven hours is a pattern, not a slip.** This is why the fix below is
+mechanical rather than a reminder to be careful. The first bypass was invisible
+until the second one was investigated, and the second was found only because
+someone went looking at the first.
+
+## What changed on 2026-08-01
+
+The admin bypass actor was **removed** from ruleset `17917971`. `bypass_actors`
+is now `[]`. Every rule is otherwise untouched, including the required review
+count and the required status check list.
+
+No legitimate flow depended on it. The
+[machine reviewer of record](pr-review-process.md) satisfies
+`required_approving_review_count` without any bypass, and that was demonstrated
+on live traffic before the actor was removed: pull request #668 received a real
+`ironclaw-reviewer` **APPROVED** review, its merge state went `CLEAN`, and it
+squash-merged through the plain REST endpoint with no admin flag anywhere.
+
+**The intended consequence.** A required check that is stuck, or missing
+entirely, now blocks every merge to `main` until it clears. That is not a
+side effect to be worked around; it is the point. A gate that any of us can step
+over on a bad night is a gate that records mistakes instead of preventing them.
+
+## Restore procedure (break glass)
+
+If the bypass genuinely has to come back, this is how, and it is written down
+here so that the next person under pressure finds a procedure instead of
+reaching for `--admin`.
+
+This is a **deliberate, logged act**, not a flag on a merge command. It needs CEO
+authorisation, and using it means writing a new entry on this page.
+
+Read the ruleset first and keep the response. `PUT` **replaces** the whole
+object, so a payload carrying only `bypass_actors` silently deletes every rule
+protecting `main`:
+
+```sh
+gh api repos/IronSecCo/ironclaw/rulesets/17917971 > before.json
+```
+
+Build the payload from that file. Keep `name`, `target`, `enforcement`,
+`conditions` and the **entire** `rules` array byte for byte; change only
+`bypass_actors`:
+
+```sh
+python3 - <<'PY' > payload.json
+import json
+d = json.load(open("before.json"))
+json.dump(
+    {
+        "name": d["name"],
+        "target": d["target"],
+        "enforcement": d["enforcement"],
+        "conditions": d["conditions"],
+        "rules": d["rules"],
+        "bypass_actors": [
+            {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"}
+        ],
+    },
+    open("payload.json", "w"),
+)
+PY
+gh api -X PUT repos/IronSecCo/ironclaw/rulesets/17917971 --input payload.json
+```
+
+Then re-read the ruleset and diff it against `before.json`. The only difference
+must be `bypass_actors`:
+
+```sh
+gh api repos/IronSecCo/ironclaw/rulesets/17917971 > after.json
+diff <(jq -S 'del(.updated_at)' before.json) <(jq -S 'del(.updated_at)' after.json)
+```
+
+Finally, update
+[`.github/rulesets/main.json`](https://github.com/IronSecCo/ironclaw/blob/main/.github/rulesets/main.json)
+in the same change. It is the checked-in source of truth and the README beside it
+tells people to re-apply it with `PUT`, so a live ruleset that disagrees with
+that file will be quietly overwritten by the next person who follows those
+instructions.

--- a/docs/merge-exceptions.md
+++ b/docs/merge-exceptions.md
@@ -136,6 +136,18 @@ on live traffic before the actor was removed: pull request #668 received a real
 `ironclaw-reviewer` **APPROVED** review, its merge state went `CLEAN`, and it
 squash-merged through the plain REST endpoint with no admin flag anywhere.
 
+The one flow that looks like a counter-example is the rolling **Homebrew formula
+bump**, which the reviewer App authors and therefore cannot approve, and whose
+head commit is unsigned. It does not need the bypass either: PR #669 merged on
+2026-07-31 with an approving review from `omerzamir`, who is allowed to give one
+because the App, not `omerzamir`, is the author. GitHub logged that push as
+`"result": "pass"`, not `"bypass"`. The recipe is an approving review plus
+`gh api -X PUT repos/IronSecCo/ironclaw/pulls/<N>/merge -f merge_method=squash`;
+the squash is what mints a signed commit on `main`. Note that `gh pr merge`
+computes mergeability against the unsigned head, refuses, and recommends
+`--admin`; that recommendation is wrong and taking it bypasses every rule to work
+around a cache.
+
 **The intended consequence.** A required check that is stuck, or missing
 entirely, now blocks every merge to `main` until it clears. That is not a
 side effect to be worked around; it is the point. A gate that any of us can step

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -13,9 +13,10 @@ description: How IronClaw records pull-request review decisions with a GitHub Ap
 
 `main` is protected by a branch ruleset
 ([`.github/rulesets/main.json`](https://github.com/IronSecCo/ironclaw/blob/main/.github/rulesets/main.json))
-that requires **one approving review** plus the `build` and `CodeQL` status
-checks before any PR can merge. That is the gate that keeps unreviewed code off
-`main`.
+that requires **one approving review** plus the `build`, `CodeQL` and
+`brew-formula-verify` status checks before any PR can merge. That is the gate
+that keeps unreviewed code off `main`, and since 2026-08-01 it has **no bypass
+actors**, so it applies to maintainers exactly as it applies to everyone else.
 
 Today every IronClaw agent (Forge, Relay, QA, …) drives Git/GitHub under the
 **single `omerzamir` GitHub identity**. GitHub will not let an identity approve
@@ -566,15 +567,26 @@ Caveats, because this is the part that is easy to overstate:
 The machine-reviewer path above needs **no edit** to
 [`.github/rulesets/main.json`](https://github.com/IronSecCo/ironclaw/blob/main/.github/rulesets/main.json).
 The App's approving review satisfies the existing
-`pull_request.required_approving_review_count: 1`. The admin `bypass_actors`
-entry stays as the break-glass path of last resort, but with a working machine
-reviewer it should no longer be the *routine* way security PRs merge.
+`pull_request.required_approving_review_count: 1` on its own, with no bypass.
 
-The one ruleset change made since is a **ratchet up**, not a relaxation:
+Both ruleset changes made since are **ratchets up**, not relaxations.
 `brew-formula-verify` was added to `required_status_checks` (IRO-670) so the
-formula gate actually gates. Protection on `main` only ever moves in that
-direction — if a required check is wrong, fix the check on its own ticket rather
-than removing it to unblock a merge.
+formula gate actually gates. Then, on 2026-08-01, `bypass_actors` was emptied
+(IRO-731): it had carried the repo **admin** role with `bypass_mode: always`, and
+since every agent drives GitHub as `omerzamir`, an admin, the required review was
+advisory for us and mandatory for everyone else. Two commits reached `main`
+unreviewed through that hole before it was closed, both recorded in
+[Merge exceptions](merge-exceptions.md). Removing it cost nothing precisely
+because this reviewer path works: PR #668 took a real `ironclaw-reviewer`
+approval and squash-merged through the plain REST endpoint, no `--admin`
+anywhere.
+
+The consequence is intended: **a stuck or missing required check now blocks
+everyone.** Protection on `main` only ever moves in that direction — if a
+required check is wrong, fix the check on its own ticket rather than removing it,
+or bypassing it, to unblock a merge. The authorised way to restore the bypass, if
+it ever truly has to come back, is written down at the bottom of
+[Merge exceptions](merge-exceptions.md).
 
 If we ever adopt Option B instead, the only ruleset change would be flipping
 `require_code_owner_review` to `true` after the reviewer account/team is a

--- a/docs/pr-review-process.md
+++ b/docs/pr-review-process.md
@@ -23,12 +23,14 @@ Today every IronClaw agent (Forge, Relay, QA, …) drives Git/GitHub under the
 its own pull request. So when an agent opens a PR as `omerzamir`, *no agent* can
 post the approving review the ruleset requires — the author and every available
 reviewer are the same actor. Security-critical PRs that have a recorded
-Paperclip review of record still cannot satisfy the GitHub gate, and the only
-escape valve is an admin bypass (the repo-admin `bypass_actors` entry).
+Paperclip review of record still cannot satisfy the GitHub gate, and until this
+document's reviewer existed the only escape valve was an admin bypass (a
+repo-admin `bypass_actors` entry, since removed by IRO-731).
 
-Admin bypass is a band-aid: it lets a green PR merge **without any second-actor
+Admin bypass was a band-aid: it let a green PR merge **without any second-actor
 approval being recorded on GitHub at all**, which is exactly the property the
-gate exists to guarantee. This document is the durable fix: a **distinct,
+gate exists to guarantee. Two commits reached `main` that way before it was
+removed, recorded in [Merge exceptions](merge-exceptions.md). This document is the durable fix: a **distinct,
 trusted reviewer actor** that is not the PR author, so the required-review gate
 is satisfied honestly — no bypass.
 
@@ -173,8 +175,8 @@ deliberately does **not** do:
   this replaces `GITHUB_TOKEN`'s `contents: write` on the same writes rather
   than adding a writer;
 - it does not widen reach into `main`. The App is **not** in the ruleset's
-  `bypass_actors` (only the admin repository role is), so main still requires a
-  reviewed PR, passing required checks and signed commits;
+  `bypass_actors` — since IRO-731 nothing is, that list is empty — so main still
+  requires a reviewed PR, passing required checks and signed commits;
 - it does not change the commit. The `author` pin is what makes the head commit
   unsigned, and that is independent of the token, so `license/cla` still passes and
   the squash still mints main's signature — see *Squash only* below.


### PR DESCRIPTION
Implements the CEO decision on IRO-731. Two commits reached `main` on 2026-07-31 without the approving review the `main-protection` ruleset requires. Neither is reverted; both go on the record, and the mechanism that allowed them is removed.

## What is here

**Decision 1 - the record.** New `docs/merge-exceptions.md`, structured to mirror `docs/cla-exceptions.md`. One entry per bypassed merge (`c63ac4e3` / #660, `f669faa8` / #673) giving the sha, the PR, the diff scope, that no approving review existed, and that the content was verified after the fact rather than before. It says plainly these were process failures on our side and does not assign blame to a report. Linked from `CONTRIBUTING.md` beside the CLA section, from `cla-exceptions.md`, and in the docs nav.

Each entry cites the **rule-suite evaluation id** GitHub itself recorded, so the claim is re-checkable without trusting this page. The page also states the coverage limit: that API returned 20 evaluations for `refs/heads/main`, oldest pushed `2026-07-31T04:41:43Z`, so the record is complete for the window served and cannot speak for anything older.

**Decision 2 - the bypass actor.** `bypass_actors` is emptied. The live ruleset change is applied separately by API (before/after diff posted to IRO-731); this PR carries the checked-in half.

## Two things worth a reviewer's attention

1. **`.github/rulesets/main.json` had to be in this PR.** The README beside it calls it the source of truth and tells the reader to re-apply it with `PUT`. Changing only the live ruleset would leave the admin bypass sitting in the file, waiting to be handed back by the next person who follows those instructions. The `rules` array is untouched - the required check list and `required_approving_review_count` are exactly as they were.

2. **The issue's acceptance criterion says the required checks are `build` and `CodeQL`. There are three.** `brew-formula-verify` was added by IRO-670. I did not touch the check list, per the not-in-scope note, but three docs asserted the two-check version and are corrected here: `.github/rulesets/README.md` (which also never listed the `pull_request` rule at all), `docs/cla-exceptions.md`, `docs/pr-review-process.md`. Flagging it so it can be stripped if unwanted.

`docs/pr-review-process.md` also stated the admin `bypass_actors` entry "stays as the break-glass path of last resort", which this change falsifies. It now points at the restore procedure at the bottom of the new page.

## Verification

- `mkdocs build --strict` passes; the new page builds and carries its own title/description (`check-docs-meta.py`: 437 pages, no fallback meta).
- `scripts/check-guide-index.py` passes (56 guides).
- `scripts/check-md-fences.py` passes (472 files, 1358 blocks).
- `scripts/check_links.py` passes (110 relative links across 10 root Markdown files).
- `.github/rulesets/main.json` parses.

## Merge path

Reviewer App for the approving review, then REST squash. **No `--admin`** - landing this change through a bypass would be self-refuting. The review of record is the CEO decision recorded on IRO-731.