### PR TITLE
docs(survey): state the exact pinning numbers, not "a minority" [IRO-732]

### DIFF
--- a/examples/isolation-survey/survey.sh
+++ b/examples/isolation-survey/survey.sh
@@ -14,15 +14,22 @@
 #   IRONCTL=/path/to/ironctl examples/isolation-survey/survey.sh   # use a prebuilt binary
 #
 # What a re-run does and does not reproduce:
-#   * Image refs are NOT uniformly pinned. A minority of rows in images.txt carry
-#     an explicit @sha256 manifest-list digest; the rest name a tag and resolve to
-#     whatever that tag points at when the survey runs. A re-run therefore tracks
-#     the current published tags and is NOT guaranteed to reproduce the previously
+#   * Image refs are mostly NOT pinned: only 16 of the 295 scenario rows in
+#     images.txt carry an explicit @sha256 digest (12 of the 252 images that
+#     become scorecards). The other 279 name a tag and resolve to whatever that
+#     tag points at when the survey runs, so a fresh run tracks the tags as they
+#     are published that day and is NOT guaranteed to reproduce the previously
 #     published scores — by design, since the dataset is about what the ecosystem
 #     ships today.
-#   * What IS pinned is the provenance: for every scenario the manifest digest
-#     actually scanned is recorded as `.scenarios[].resolvedDigest` in
-#     results.json, so each published score names the exact bits it graded.
+#   * What IS pinned is each published run's own provenance: for every scenario
+#     results.json records, `.scenarios[].resolvedDigest` holds the registry
+#     manifest digest actually scanned (non-empty on all 256 recorded
+#     scenarios; it is an image-index digest for a multi-arch repo). So a
+#     published score can be re-checked by pulling that digest and re-running the
+#     row's flags — a manual re-scan from the recorded digests, which is a weaker
+#     guarantee than a fresh run reproducing the scores, and not the same thing.
+#     Rows whose pull, run or scan fails are skipped and absent from results.json
+#     altogether; that is why 295 rows yielded 256 scenarios.
 #   * The scan is read-only config inspection (docker inspect); it never runs the
 #     image's real workload — the entrypoint is overridden with `sleep` purely to
 #     keep the container alive for inspection.


### PR DESCRIPTION
Follow-up to #671 (IRO-723), per the CEO decision carried onto IRO-732.

#671 removed the false claim that *every* survey image is digest-pinned, but described the pinned rows only as **"a minority"**. IRO-732 requires the exact numbers, and warns that the replacement prose is where the next false claim gets born (as happened on #668). This makes the numbers exact and closes three inferences a reader could still draw and refute from `results.json` itself.

## What changed

`examples/isolation-survey/survey.sh` header only — 14 insertions, 7 deletions, no other file.

- **Exact counts.** "a minority" -> **16 of the 295** scenario rows in `images.txt` carry an `@sha256` digest, **12 of the 252** images that become scorecards; the other **279** name a tag.
- **"for every scenario" -> "for every scenario `results.json` records".** 39 rows are silently skipped on pull/run/scan failure, so a claim about "every scenario" is false against `images.txt` even though it holds against `results.json`. The 295 -> 256 gap is now stated instead of implied.
- **"manifest-list digest" -> "registry manifest digest ... an image-index digest for a multi-arch repo".** `resolvedDigest` is `RepoDigests[0]`, which is an index digest *only* for multi-arch repos. Asserting it unconditionally would repeat the exact over-claim that made the original sentence wrong.
- The text also no longer implies turnkey replay: re-checking a published score is a **manual re-scan** from the recorded digests, named explicitly as weaker than a fresh run reproducing the scores.

## Verification

- Every integer in the block asserted against source: 295 rows / 16 pinned / 279 unpinned / 252 `default-*` scenarios / 12 pinned / 256 recorded / 0 empty `resolvedDigest`. A checker also confirms **no unverified integer** appears in the block.
- All 279 unpinned rows carry an explicit tag, and all 16 pinned refs keep a tag part, so "the other 279 name a tag" is exact.
- 252 scorecards confirmed as 254 `docs/scores/*.md` minus `index.md` and `leaderboard.md`.
- `bash -n` and `shellcheck -S warning` clean.
- **No diff under `docs/scores/`**; `results.json` and the #664 provenance line untouched; corpus not regenerated.

## Note on the acceptance criteria

IRO-732 states `build` and `CodeQL` are the only required checks. The live ruleset `17917971` actually requires **three**: `build`, `CodeQL`, and `brew-formula-verify`. All three must be green here.

Merging via reviewer App approval then REST squash, no `--admin`, per IRO-731.