### PR TITLE
docs(cla): correct the required-check list on the exception 001 record, and cite the rule-suite evaluations [IRO-729]

### DIFF
--- a/docs/cla-exceptions.md
+++ b/docs/cla-exceptions.md
@@ -140,13 +140,32 @@ scope.
 
 **`license/cla` never went green.** It was `pending` on all three head commits when
 they were merged and it is `pending` on them still. The merges relied on the five
-assent comments recorded above, and on nothing else. `build` and `CodeQL`, the two
-checks the ruleset actually requires, were green on all three heads.
+assent comments recorded above, and on nothing else.
 
-No ruleset was edited, no branch protection was bypassed, no administrator override
-was used, and cla-assistant was not touched. The exception was exercised exactly as
-this page describes it: in prose, against a policy gate, on three named pull
-requests.
+**Nothing was bypassed, and that is checkable independently of this page.** The
+ruleset evaluated each of the three pushes and recorded `"result": "pass"` on every
+rule, including `required_status_checks`, `pull_request` (the approving review) and
+`required_signatures`:
+
+| Squash commit | Rule-suite evaluation | Result |
+| --- | --- | --- |
+| `6a70c4d0` | `3523948843` | pass |
+| `a7152232` | `3523949192` | pass |
+| `b17df1fe` | `3523949491` | pass |
+
+Read them back with
+`gh api repos/IronSecCo/ironclaw/rulesets/rule-suites/<id>`. No ruleset was edited,
+no branch protection was skipped, no administrator override was used, and
+cla-assistant was not touched. The exception was exercised exactly as this page
+describes it: in prose, against a policy gate, on three named pull requests.
+
+**One correction to precondition 3 above.** It names the ruleset's required checks
+as `build` and `CodeQL`. At the time of these merges `main-protection` in fact
+required three: `build`, `CodeQL` and `brew-formula-verify`. All three were green on
+all three head commits, which is why `required_status_checks` passed, so the
+precondition was satisfied as intended. The precondition's own list was simply one
+short when it was written. It is left as written because it records what was
+authorised; this note records what was true.
 
 ### What this entry does not do
 


### PR DESCRIPTION
Follow-up to #675, which merged at 01:18Z while I was still verifying it. This is the correction that did not make the merge.

## What is wrong on `main` right now

#675 added a **How it was exercised** section to `docs/cla-exceptions.md` ending with:

> `build` and `CodeQL`, the two checks the ruleset actually requires, were green on all three heads.

**That is false.** Read live off ruleset `17917971`, `main-protection` requires **three** status checks:

```
$ gh api repos/IronSecCo/ironclaw/rulesets/17917971 \
    --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks'
[{"context":"build"},{"context":"CodeQL"},{"context":"brew-formula-verify"}]
```

The IRO-729 brief and precondition 3 on the page both say two, and I repeated the pair without checking it. On a page whose entire purpose is being right about what happened, shipping a fresh false claim in the very section that records the exception being exercised is the defect this ticket exists to prevent.

The outcome is unaffected: **all three checks were green on all three head commits**, so the precondition was satisfied as intended. Only the description of the gate was wrong.

## What this PR changes

1. **Corrects the claim.** The note now names all three required checks, states that all three were green, and explains that **precondition 3 is deliberately left as written**: it records what was *authorised* on 2026-07-30, while the new note records what was *true*. Rewriting the authorisation text after the fact would be a worse defect than the one being fixed.

2. **Replaces the per-check assertion with GitHub's own rule-suite evaluations.** Stronger evidence, and re-derivable by any reader:

   | Squash commit | Rule-suite evaluation | Result |
   | --- | --- | --- |
   | `6a70c4d0` | `3523948843` | pass |
   | `a7152232` | `3523949192` | pass |
   | `b17df1fe` | `3523949491` | pass |

   Every rule passed on every push: `required_signatures`, `pull_request` (the approving review), `required_status_checks`, `required_linear_history`, `non_fast_forward`, `deletion`. This is what makes the page's *"no administrator override was used"* checkable rather than merely asserted, because a bypassed push is recorded as `"result": "bypass"` — as two unrelated merges on 2026-07-31 were, now documented on #676.

   ```sh
   gh api repos/IronSecCo/ironclaw/rulesets/rule-suites/3523948843
   ```

## Relationship to #676 (IRO-731)

#676 corrects the **standing-rule** copy of the same wrong pair, higher up this page, and adds the companion `docs/merge-exceptions.md`. Different hunk, no conflict; between the two PRs every site on the page that names the required checks is correct. Neither PR rewrites precondition 3.

## Verification

Exit codes captured directly, on this branch:

- `mkdocs build --strict` -> **0** (pinned `--require-hashes` venv, mkdocs 1.6.1)
- `scripts/check-docs-meta.py _site` -> **0**, 436 pages, no fallback meta
- Built HTML `_site/cla-exceptions/index.html`: all three rule-suite ids present, `brew-formula-verify` present, `the two checks the ruleset actually requires` **0** occurrences, `not yet exercised` **0** occurrences, and still exactly **five** distinct `issuecomment-` ids. **The five-comment evidence list is untouched.**

Single file, `docs/cla-exceptions.md`.

## Review

Gate is the CEO. Not self-approved, and I will not merge it myself.