### PR TITLE
ci(docs): validate every guide score table against score.go and results.json [IRO-734]

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,11 +22,17 @@ on:
       - "scripts/check-guide-uid.py"
       - "scripts/check-md-fences.py"
       - "scripts/check-scores-drift.py"
+      - "scripts/check-guide-scores.py"
       # check-guide-uid.py reads `hardenedUID` out of this file, so a change to
       # the constant has to trigger this workflow too. Without it, moving the
       # constant would leave 56 guides quoting the old uid and nothing in CI
       # would ever look: the paths filter, not the check, would be the hole.
       - "internal/host/scan/remediate.go"
+      # check-guide-scores.py derives the canonical dimension set, its weights
+      # and each dimension's reachable (score, verdict) pairs from this file.
+      # Same reason as remediate.go above: add a dimension or reweight one and
+      # 56 guides publish the old table, with nothing in CI looking.
+      - "internal/host/scan/score.go"
       # Every page under docs/scores/ is emitted from this directory
       # (gen_scorecards.py + results.json), so a change here changes published
       # docs without touching docs/**. Omitting it meant a generator-only PR ran
@@ -46,11 +52,17 @@ on:
       - "scripts/check-guide-uid.py"
       - "scripts/check-md-fences.py"
       - "scripts/check-scores-drift.py"
+      - "scripts/check-guide-scores.py"
       # check-guide-uid.py reads `hardenedUID` out of this file, so a change to
       # the constant has to trigger this workflow too. Without it, moving the
       # constant would leave 56 guides quoting the old uid and nothing in CI
       # would ever look: the paths filter, not the check, would be the hole.
       - "internal/host/scan/remediate.go"
+      # check-guide-scores.py derives the canonical dimension set, its weights
+      # and each dimension's reachable (score, verdict) pairs from this file.
+      # Same reason as remediate.go above: add a dimension or reweight one and
+      # 56 guides publish the old table, with nothing in CI looking.
+      - "internal/host/scan/score.go"
       # Every page under docs/scores/ is emitted from this directory
       # (gen_scorecards.py + results.json), so a change here changes published
       # docs without touching docs/**. Omitting it meant a generator-only PR ran
@@ -179,6 +191,41 @@ jobs:
         # gets wrong -- hand-maintained .nav.yml files, and the generator's
         # routine stderr warnings. See IRO-715.
         run: python3 scripts/check-scores-drift.py
+
+      - name: Check every hardening guide's score table adds up
+        # check-scores-drift.py above owns docs/scores/, which is generated. The
+        # 56 hand-written guides under docs/blog/ are not generated and nothing
+        # in this pipeline read them at all, so the numbers in them were only
+        # ever checked by a human remembering to.
+        #
+        # PR #661 is what that costs. It rewrote the HAProxy guide so the scores
+        # column summed to 58 while the page claimed 63/100 in four places, and
+        # all 17 checks went green -- build, CodeQL, brew-formula-verify, and the
+        # three checkers above included. The camouflage was that the max column
+        # still totalled 100 (rootfs +5, docker.sock 15 -> an invented
+        # `Privilege escalation` 10), so only the scores were short, by 5. It
+        # also deleted a canonical dimension and gave rootfs a 5/15 WARN the
+        # scorer cannot emit. Four rounds of manual review found it; this is
+        # that review, mechanised.
+        #
+        # Every canonical number is derived from source, never copied here: the
+        # dimension set and weights from the `scorers` slice in score.go, each
+        # dimension's reachable (score, verdict) pairs from its grade* function,
+        # the letter bands from grade(), the measured values from results.json.
+        # A copy would rot silently the moment a dimension is added, which is the
+        # failure mode this exists to close, so score.go is in the paths filter
+        # above for the same reason remediate.go is.
+        #
+        # A step in `build` for the same reason as the checks around it: `build`
+        # is the required check on ruleset 17917971 and a new job name would not
+        # be. Stdlib only, so it runs before the toolchain install and fails
+        # fast. It asserts it parsed at least 56 guides and exits 2 if not: a
+        # guard that is green because it read nothing is the exact shape of the
+        # bug it is here to catch. Negative controls:
+        # scripts/tests/test_check_guide_scores.py (run by ci.yml script-tests),
+        # including a fixture of #661's five defects and an assertion that a
+        # max-column-only check is green on it. See IRO-734.
+        run: python3 scripts/check-guide-scores.py
 
       - name: Install MkDocs toolchain (hash-pinned)
         # --require-hashes makes pip refuse any wheel whose SHA-256 isn't in the

--- a/docs/blog/harden-jenkins-container-isolation.md
+++ b/docs/blog/harden-jenkins-container-isolation.md
@@ -1,6 +1,6 @@
 ---
-title: "How to harden a Jenkins container: jenkins/jenkins scores 48/100 by default"
-description: "jenkins/jenkins:lts defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a CI server to its honest 89/100 grade B."
+title: "How to harden a Jenkins container: jenkins/jenkins scores 63/100 by default"
+description: "jenkins/jenkins:lts defaults score 63/100 (grade C): full caps, writable rootfs. The exact ironctl scan --fix flags that take a CI server to its honest 89/100 grade B."
 ---
 
 # How to harden a Jenkins container (and is jenkins/jenkins:lts safe to run builds?)
@@ -8,7 +8,7 @@ description: "jenkins/jenkins:lts defaults score 48/100 (grade D): root, full ca
 Jenkins is one of the most attacked services in a stack: it holds deploy credentials, cloud keys, and
 source, and it runs arbitrary build steps by design. A stock `docker run jenkins/jenkins:lts` is not
 the boundary that role deserves. Graded on IronClaw's seven-dimension containment scale, the default
-configuration scores **48 of 100, grade D (porous)**. Higher is safer. A few runtime flags take the
+configuration scores **63 of 100, grade C (partial)**. Higher is safer. A few runtime flags take the
 same image to **89 of 100, grade B**, one point off an A, and the one dimension it cannot reach is the
 one a CI server needs by definition: agents and browsers must reach it. Here are the exact gaps and
 fixes from the scan data.
@@ -22,11 +22,11 @@ fixes from the scan data.
 ## Where the default configuration leaks
 
 `ironctl scan` grades seven independent containment boundaries. On a default `docker run
-jenkins/jenkins:lts`, three fail and one warns:
+jenkins/jenkins:lts`, two fail and one warns:
 
 | Dimension | Verdict | Score | What the scan found |
 |-----------|:-------:|------:|---------------------|
-| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as jenkins (uid != 0) |
 | Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
 | Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
 | Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
@@ -34,22 +34,23 @@ jenkins/jenkins:lts`, three fail and one warns:
 | No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
 | No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
 
-The one that should worry you most is **root**, and Jenkins makes it worse than most. A plugin CVE, a
-malicious pipeline, or a poisoned dependency that lands code execution in a root container escapes as
-root on the host, next to the credentials store Jenkins guards. A very common Jenkins pattern is
-mounting `docker.sock` so pipelines can build images; do not, and note that this scan would fail the
-docker.sock dimension if you did. Mounting the host Docker socket hands a build step full control of
-the host. Use a rootless builder or a scoped socket-proxy instead. The full capability set and
-writable rootfs widen and entrench any foothold.
+Jenkins already gets the hardest dimension right by dropping to the `jenkins` uid, which is why it
+starts a full grade above most CI images. The two that remain are the **full capability set** and the
+**writable rootfs**. A plugin CVE, a malicious pipeline, or a poisoned dependency that lands code
+execution keeps CAP_NET_RAW to craft raw packets and a writable rootfs to persist, next to the
+credentials store Jenkins guards. A very common Jenkins pattern is mounting `docker.sock` so pipelines
+can build images; do not, and note that this scan would fail the docker.sock dimension if you did.
+Mounting the host Docker socket hands a build step full control of the host whatever uid it started
+as. Use a rootless builder or a scoped socket-proxy instead.
 
 ## Harden it: the exact `--fix` remediation
 
 `ironctl scan my-jenkins --fix` prints one remediation per failed dimension, then one hardened run.
 For `jenkins/jenkins:lts`:
 
-- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
-  host uid 0. `--fix` emits 65532, the distroless nonroot uid. Point `JENKINS_HOME` at a volume uid
-  65532 owns.
+- **`--user 65532:65532`** (Non-root user, already +15): the image already drops to the `jenkins` uid,
+  so this dimension is closed by default. Keep a non-root uid pinned if you override the entrypoint;
+  `--fix` emits 65532, the distroless nonroot uid. Point `JENKINS_HOME` at a volume that uid owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; the Jenkins
   controller serves its UI and agent port on high ports and needs none of the default set.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
@@ -63,7 +64,7 @@ For `jenkins/jenkins:lts`:
 ## Before and after
 
 ```bash
-# Before: 48/100, grade D
+# Before: 63/100, grade C
 docker run -d --name jenkins jenkins/jenkins:lts
 
 # After: 89/100, grade B (scoped private network for agents and proxy)
@@ -77,11 +78,11 @@ docker run -d --name jenkins-hardened \
   jenkins/jenkins:lts
 ```
 
-Rescan: `ironctl scan jenkins-hardened` reports `89/100 grade B`. A **41-point swing** with no custom
+Rescan: `ironctl scan jenkins-hardened` reports `89/100 grade B`. A **26-point swing** with no custom
 image build, just the right flags. The only dimension still short of full marks is the network (4 of
 15), because a CI server exists to be reached by its agents and users; `network=none` would score the
 last points but leave nothing able to connect. That is the honest ceiling for this role, and it is a
-long way from the default D.
+long way from the default C.
 
 ## Verify it on your own Jenkins
 

--- a/docs/blog/harden-keycloak-container-isolation.md
+++ b/docs/blog/harden-keycloak-container-isolation.md
@@ -1,6 +1,6 @@
 ---
-title: "How to harden a Keycloak container: keycloak scores 48/100 by default"
-description: "keycloak defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take an identity server to its honest 89/100 grade B."
+title: "How to harden a Keycloak container: keycloak scores 63/100 by default"
+description: "keycloak defaults score 63/100 (grade C): full caps, writable rootfs. The exact ironctl scan --fix flags that take an identity server to its honest 89/100 grade B."
 ---
 
 # How to harden a Keycloak container (and is quay.io/keycloak/keycloak safe as your IdP?)
@@ -8,7 +8,7 @@ description: "keycloak defaults score 48/100 (grade D): root, full caps, writabl
 Keycloak is the front door to every app behind it: it mints the tokens, holds the signing keys, and
 stores the user directory that authenticates your whole stack. A stock `docker run
 quay.io/keycloak/keycloak` is not the boundary that role deserves. Graded on IronClaw's
-seven-dimension containment scale, the default configuration scores **48 of 100, grade D (porous)**.
+seven-dimension containment scale, the default configuration scores **63 of 100, grade C (partial)**.
 Higher is safer. A few runtime flags take the same image to **89 of 100, grade B**, one point off an
 A, and the one dimension it cannot reach is the one an identity provider needs by definition: every
 app and browser must reach its endpoints. Here are the exact gaps and fixes from the scan data.
@@ -22,11 +22,11 @@ app and browser must reach its endpoints. Here are the exact gaps and fixes from
 ## Where the default configuration leaks
 
 `ironctl scan` grades seven independent containment boundaries. On a default `docker run
-quay.io/keycloak/keycloak`, three fail and one warns:
+quay.io/keycloak/keycloak`, two fail and one warns:
 
 | Dimension | Verdict | Score | What the scan found |
 |-----------|:-------:|------:|---------------------|
-| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as 1000 (uid != 0) |
 | Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
 | Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
 | Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
@@ -34,20 +34,23 @@ quay.io/keycloak/keycloak`, three fail and one warns:
 | No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
 | No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
 
-The one that should worry you most is **root**, and for an identity provider the stakes are the whole
-trust chain. A protocol-parsing or provider CVE that lands code execution in a root container escapes
-as root on the host, next to the realm signing keys and the user store Keycloak guards. Whoever holds
-those keys can mint a valid token for any user of any app behind Keycloak. The full capability set
-widens that foothold and the writable rootfs makes it durable. This is the same shape as a secrets
-server: the value of what it holds is what makes containing it non-negotiable.
+Keycloak already gets the hardest dimension right by dropping to uid 1000, which is why it starts a
+full grade above most identity images. The two that remain are the **full capability set** and the
+**writable rootfs**, and for an identity provider the stakes are the whole trust chain. A
+protocol-parsing or provider CVE that lands code execution keeps CAP_NET_RAW to craft raw packets and
+a writable rootfs to persist, next to the realm signing keys and the user store Keycloak guards.
+Whoever holds those keys can mint a valid token for any user of any app behind Keycloak. This is the
+same shape as a secrets server: the value of what it holds is what makes containing it
+non-negotiable.
 
 ## Harden it: the exact `--fix` remediation
 
 `ironctl scan my-keycloak --fix` prints one remediation per failed dimension, then one hardened run.
 For `quay.io/keycloak/keycloak`:
 
-- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
-  host uid 0. `--fix` emits 65532, the distroless nonroot uid.
+- **`--user 65532:65532`** (Non-root user, already +15): the image already drops to uid 1000, so this
+  dimension is closed by default. Keep a non-root uid pinned if you override the entrypoint; `--fix`
+  emits 65532, the distroless nonroot uid.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; Keycloak serves its
   HTTP and management endpoints on high ports and needs none of the default set.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only. Build a
@@ -62,7 +65,7 @@ For `quay.io/keycloak/keycloak`:
 ## Before and after
 
 ```bash
-# Before: 48/100, grade D
+# Before: 63/100, grade C
 docker run -d --name keycloak quay.io/keycloak/keycloak:26.0 start
 
 # After: 89/100, grade B (scoped private network for its database and proxy)
@@ -75,11 +78,11 @@ docker run -d --name keycloak-hardened \
   quay.io/keycloak/keycloak:26.0 start
 ```
 
-Rescan: `ironctl scan keycloak-hardened` reports `89/100 grade B`. A **41-point swing** with no custom
+Rescan: `ironctl scan keycloak-hardened` reports `89/100 grade B`. A **26-point swing** with no custom
 image build, just the right flags. The only dimension still short of full marks is the network (4 of
 15), because an identity provider exists to be reached by every app it authenticates; `network=none`
 would score the last points but leave nothing able to connect. That is the honest ceiling for this
-role, and it is a long way from the default D.
+role, and it is a long way from the default C.
 
 ## Verify it on your own Keycloak
 

--- a/docs/blog/harden-sonarqube-container-isolation.md
+++ b/docs/blog/harden-sonarqube-container-isolation.md
@@ -1,6 +1,6 @@
 ---
-title: "How to harden a SonarQube container: sonarqube scores 48/100 by default"
-description: "sonarqube defaults score 48/100 (grade D): root, full caps, writable rootfs. The exact ironctl scan --fix flags that take a code-quality server to its honest 89/100 grade B."
+title: "How to harden a SonarQube container: sonarqube scores 63/100 by default"
+description: "sonarqube defaults score 63/100 (grade C): full caps, writable rootfs. The exact ironctl scan --fix flags that take a code-quality server to its honest 89/100 grade B."
 ---
 
 # How to harden a SonarQube container (and is sonarqube safe in your CI stack?)
@@ -8,7 +8,7 @@ description: "sonarqube defaults score 48/100 (grade D): root, full caps, writab
 SonarQube reads every line of your source on every scan and stores the findings, the tokens CI uses to
 push results, and often a copy of your code smells and secrets. A stock `docker run sonarqube` is not
 the boundary that role deserves. Graded on IronClaw's seven-dimension containment scale, the default
-configuration scores **48 of 100, grade D (porous)**. Higher is safer. A few runtime flags take the
+configuration scores **63 of 100, grade C (partial)**. Higher is safer. A few runtime flags take the
 same image to **89 of 100, grade B**, one point off an A, and the one dimension it cannot reach is the
 one a code-quality server needs by definition: scanners and browsers must reach its API and UI. Here
 are the exact gaps and fixes from the scan data.
@@ -22,11 +22,11 @@ are the exact gaps and fixes from the scan data.
 ## Where the default configuration leaks
 
 `ironctl scan` grades seven independent containment boundaries. On a default `docker run sonarqube`,
-three fail and one warns:
+two fail and one warns:
 
 | Dimension | Verdict | Score | What the scan found |
 |-----------|:-------:|------:|---------------------|
-| Non-root user (uid != 0) | ❌ FAIL | 0/15 | runs as root (uid 0); a container escape starts with host-uid 0 |
+| Non-root user (uid != 0) | ✅ PASS | 15/15 | runs as sonarqube (uid != 0) |
 | Dropped capabilities | ❌ FAIL | 4/20 | default capability set retained (CAP_NET_RAW, CAP_MKNOD, and more) |
 | Seccomp profile | ✅ PASS | 15/15 | seccomp profile active |
 | Network isolation / egress | ⚠️ WARN | 4/15 | network=bridge: outbound egress is possible |
@@ -34,21 +34,23 @@ three fail and one warns:
 | No docker.sock exposure | ✅ PASS | 15/15 | no control socket mounted |
 | No shared host namespaces | ✅ PASS | 10/10 | no host PID/IPC/network sharing |
 
-The one that should worry you most is **root**. SonarQube parses attacker-adjacent input, the source
-under analysis, on every scan; a parser or plugin CVE that lands code execution in a root container
-escapes as root on the host, next to the analysis tokens and the database credentials it holds. The
-full capability set widens that foothold and the writable rootfs makes it durable. SonarQube also
-needs a co-located database (Postgres); harden that too, and it can reach grade A on its own page since
-only SonarQube talks to it.
+SonarQube already gets the hardest dimension right by dropping to the `sonarqube` uid, which is why it
+starts a full grade above most CI images. The two that remain are the **full capability set** and the
+**writable rootfs**. SonarQube parses attacker-adjacent input, the source under analysis, on every
+scan; a parser or plugin CVE that lands code execution keeps CAP_NET_RAW to craft raw packets and a
+writable rootfs to persist, next to the analysis tokens and the database credentials it holds.
+SonarQube also needs a co-located database (Postgres); harden that too, and it can reach grade A on its
+own page since only SonarQube talks to it.
 
 ## Harden it: the exact `--fix` remediation
 
 `ironctl scan my-sonarqube --fix` prints one remediation per failed dimension, then one hardened run.
 For `sonarqube`:
 
-- **`--user 65532:65532`** (Non-root user, +15): pin a non-root uid so an escape does not begin as
-  host uid 0. `--fix` emits 65532, the distroless nonroot uid. Point the data, logs, and extensions
-  directories at volumes uid 65532 owns.
+- **`--user 65532:65532`** (Non-root user, already +15): the image already drops to the `sonarqube`
+  uid, so this dimension is closed by default. Keep a non-root uid pinned if you override the
+  entrypoint; `--fix` emits 65532, the distroless nonroot uid. Point the data, logs, and extensions
+  directories at volumes that uid owns.
 - **`--cap-drop=ALL`** (Dropped capabilities, +16): drop every Linux capability; SonarQube serves its
   UI and API on a high port and needs none of the default set.
 - **`--read-only --tmpfs /tmp`** (Read-only rootfs, +10): make the root filesystem read-only and mount
@@ -62,7 +64,7 @@ For `sonarqube`:
 ## Before and after
 
 ```bash
-# Before: 48/100, grade D
+# Before: 63/100, grade C
 docker run -d --name sonarqube sonarqube:community
 
 # After: 89/100, grade B (scoped private network for CI and its database)
@@ -77,11 +79,11 @@ docker run -d --name sonarqube-hardened \
   sonarqube:community
 ```
 
-Rescan: `ironctl scan sonarqube-hardened` reports `89/100 grade B`. A **41-point swing** with no
+Rescan: `ironctl scan sonarqube-hardened` reports `89/100 grade B`. A **26-point swing** with no
 custom image build, just the right flags. The only dimension still short of full marks is the network
 (4 of 15), because a code-quality server exists to be reached by its scanners and users;
 `network=none` would score the last points but leave nothing able to connect. That is the honest
-ceiling for this role, and it is a long way from the default D.
+ceiling for this role, and it is a long way from the default C.
 
 > SonarQube also needs `vm.max_map_count` raised on the host for its embedded search engine. That is a
 > host sysctl, not a container capability, and it does not affect the containment grade.

--- a/docs/blog/hardening-guides.md
+++ b/docs/blog/hardening-guides.md
@@ -75,14 +75,14 @@ These services must accept client connections, so the network dimension holds at
 | [nginx](harden-nginx-container-isolation.md) | 48/100 D | **89/100 B** | proxy: it exists to forward traffic |
 | [Vault](harden-vault-container-isolation.md) | 48/100 D | **89/100 B** | secrets server: apps must reach the API |
 | [Consul](harden-consul-container-isolation.md) | 48/100 D | **89/100 B** | service mesh: peers and clients must connect |
-| [ZooKeeper](harden-zookeeper-container-isolation.md) | 55/100 C | **89/100 B** | coordination server: peers and clients must connect |
+| [ZooKeeper](harden-zookeeper-container-isolation.md) | 48/100 D | **89/100 B** | coordination server: peers and clients must connect |
 | [MinIO](harden-minio-container-isolation.md) | 48/100 D | **89/100 B** | object store: S3 clients must reach the API |
 | [Grafana](harden-grafana-container-isolation.md) | 63/100 C | **89/100 B** | dashboard: browsers must reach the UI |
 | [Prometheus](harden-prometheus-container-isolation.md) | 63/100 C | **89/100 B** | metrics: it scrapes targets and serves its API |
 | [Traefik](harden-traefik-container-isolation.md) | 48/100 D | **89/100 B** | proxy: it exists to accept and forward traffic |
-| [Jenkins](harden-jenkins-container-isolation.md) | 48/100 D | **89/100 B** | CI server: agents and browsers must reach it |
-| [SonarQube](harden-sonarqube-container-isolation.md) | 48/100 D | **89/100 B** | code-quality server: scanners and browsers must reach it |
-| [Keycloak](harden-keycloak-container-isolation.md) | 48/100 D | **89/100 B** | identity provider: every app must reach its endpoints |
+| [Jenkins](harden-jenkins-container-isolation.md) | 63/100 C | **89/100 B** | CI server: agents and browsers must reach it |
+| [SonarQube](harden-sonarqube-container-isolation.md) | 63/100 C | **89/100 B** | code-quality server: scanners and browsers must reach it |
+| [Keycloak](harden-keycloak-container-isolation.md) | 63/100 C | **89/100 B** | identity provider: every app must reach its endpoints |
 | [NATS](harden-nats-container-isolation.md) | 48/100 D | **89/100 B** | broker: publishers and subscribers must connect |
 | [Gitea](harden-gitea-container-isolation.md) | 48/100 D | **89/100 B** | git server: developers and CI must reach it |
 | [HAProxy](harden-haproxy-container-isolation.md) | 63/100 C | **89/100 B** | load balancer: it exists to accept and forward traffic |

--- a/scripts/check-guide-scores.py
+++ b/scripts/check-guide-scores.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+"""Fail the docs build when a hardening guide's score table does not add up.
+
+Every ``docs/blog/harden-*-container-isolation.md`` opens with a seven-row
+dimension table and then restates its total in four places: the front-matter
+``title:``, the front-matter ``description:``, the body prose, and a
+``# Before: NN/100`` comment in the run block. Nothing in the pipeline reads any
+of it. ``check-scores-drift.py`` is the closest thing, and its ``SCORES_DIR`` is
+``docs/scores``, so ``docs/blog/**`` is outside every existing guard.
+
+What that costs, concretely: PR #661 rewrote the HAProxy guide so its table
+summed to 58 while the page claimed 63/100 in four places, invented a
+``Privilege escalation`` dimension the scorer does not have, deleted the
+canonical ``No docker.sock exposure`` row, and moved ``Read-only root
+filesystem`` from its real ``0/10`` to ``5/15``. All 17 checks went green --
+``build``, ``CodeQL``, ``brew-formula-verify``, ``check-guide-uid.py``,
+``check-guide-index.py``, ``check-md-fences.py``. The camouflage is that the
+*denominators* still totalled 100 (rootfs +5, docker.sock 15 -> privesc 10), so
+only the scores column was short, by exactly 5. It took four rounds of manual
+review to catch. This is that review, mechanised.
+
+Five checks, in order of what they catch:
+
+1. **Arithmetic.** The scores column sums to the number the page states, at
+   every site that states it. A page claiming its score in four places and
+   summing to a fifth number fails.
+2. **Dimension integrity.** Row titles and ``max`` weights must equal the
+   canonical ordered set, so an invented row, a deleted row, a reordered row or
+   a reweighted row all fail.
+3. **Verdict reachability.** A row's ``(score, verdict)`` pair must be one the
+   scorer can actually emit. ``gradeReadonly`` returns only ``10/PASS`` or
+   ``0/FAIL``, so #661's ``5/15 WARN`` rootfs row is unreachable and fails even
+   though 5 is a perfectly plausible-looking number.
+4. **Grade band.** The letter stated next to a total must be the band
+   ``grade()`` puts that total in.
+5. **Agreement with measured data.** Where the guide's image has a ``default-*``
+   scenario in ``examples/isolation-survey/results.json``, every row's score,
+   max and verdict must equal what was actually recorded, and so must the total,
+   the grade and the failed-dimension set.
+
+Everything canonical is derived from source, never copied:
+
+* the dimension set, titles and weights come from the ``scorers`` slice in
+  ``internal/host/scan/score.go``;
+* the reachable ``(score, verdict)`` pairs come from parsing the ``grade*``
+  function bodies in the same file;
+* the letter bands come from its ``grade()`` switch;
+* the measured values come from ``results.json``.
+
+A copy would rot the moment a dimension is added, and rot silently -- which is
+the exact failure mode this guard exists to close. When the parser cannot find
+what it expects in ``score.go`` it exits 2 with the reason rather than passing
+with an empty canonical set; a guard that is green because it parsed nothing is
+worse than no guard.
+
+``gen_scorecards.py`` documents the same seven dimensions in prose for readers.
+That copy is cross-checked against ``score.go`` and a divergence is reported as
+``canonical-mirror``: it would mean the scorer and the published methodology
+disagree, which is a product bug and not something to paper over here.
+
+**Scope: the "Before" table only.** 35 guides plus the flagship comparison page
+publish post-hardening ("After") numbers that were never measured; that is
+IRO-726 and it is a wording call owned there. This guard reads the default-
+configuration table and the sites that restate its total. "After" totals
+(``take the same image to **89 of 100**``, ``# After: 89/100``, ``Rescan: ...
+reports 89/100``) are deliberately not validated.
+
+Usage:
+
+    python3 scripts/check-guide-scores.py [--report] [--min-guides N] [root]
+
+    --report        print the violations and exit 0 (rollout mode)
+    --min-guides N  fail if fewer than N guides were parsed (default 56)
+
+Exits 0 when every guide is consistent, 1 on violations, and 2 on a usage/IO
+error or a ``score.go`` this parser no longer understands. Negative controls:
+scripts/tests/test_check_guide_scores.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+SCORE_GO = Path("internal/host/scan/score.go")
+GEN_SCORECARDS = Path("examples/isolation-survey/gen_scorecards.py")
+RESULTS = Path("examples/isolation-survey/results.json")
+GUIDE_GLOB = "docs/blog/harden-*-container-isolation.md"
+
+# The corpus is 56 guides today. Asserted, not assumed: this whole script is a
+# response to a check that was green for the wrong reason, so it refuses to be
+# green because it found nothing to read.
+DEFAULT_MIN_GUIDES = 56
+
+
+class ParseError(Exception):
+    """Source no longer matches what this parser expects -- exit 2, not 0."""
+
+
+# --------------------------------------------------------------------------- #
+# Canonical values, parsed out of internal/host/scan/score.go.
+# --------------------------------------------------------------------------- #
+
+# {"user.nonroot", "Non-root user (uid != 0)", 15, gradeNonRoot},
+_SCORER_RE = re.compile(
+    r'\{"(?P<key>[^"]+)",\s*"(?P<title>[^"]+)",\s*(?P<max>\d+),\s*(?P<fn>\w+)\}'
+)
+_SCORERS_BLOCK_RE = re.compile(r"var scorers = \[\]scorer\{(.*?)\n\}", re.S)
+_TOTAL_WEIGHT_RE = re.compile(r"const TotalWeight = (\d+)")
+
+
+class Dimension:
+    def __init__(self, key: str, title: str, max_: int, fn: str) -> None:
+        self.key = key
+        self.title = title
+        self.max = max_
+        self.fn = fn
+
+
+def parse_scorers(score_go: str) -> list[Dimension]:
+    """The ordered dimension set. Order is meaningful: the tables mirror it."""
+    block = _SCORERS_BLOCK_RE.search(score_go)
+    if not block:
+        raise ParseError(
+            "could not find `var scorers = []scorer{...}` in %s; the canonical "
+            "dimension set moved and this parser needs updating" % SCORE_GO
+        )
+    dims = [
+        Dimension(m["key"], m["title"], int(m["max"]), m["fn"])
+        for m in _SCORER_RE.finditer(block.group(1))
+    ]
+    if not dims:
+        raise ParseError("parsed zero dimensions from the `scorers` slice in %s" % SCORE_GO)
+
+    total = _TOTAL_WEIGHT_RE.search(score_go)
+    if not total:
+        raise ParseError("could not find `const TotalWeight` in %s" % SCORE_GO)
+    want = int(total.group(1))
+    got = sum(d.max for d in dims)
+    if got != want:
+        raise ParseError(
+            "dimension weights in %s sum to %d but TotalWeight is %d" % (SCORE_GO, got, want)
+        )
+    return dims
+
+
+# case score >= 90: return "A"
+_BAND_RE = re.compile(r"case score >= (\d+):\s*\n\s*return \"([A-F])\"")
+_GRADE_FUNC_RE = re.compile(r"^func grade\(score int\) string \{(.*?)^\}", re.S | re.M)
+_GRADE_DEFAULT_RE = re.compile(r"default:\s*\n\s*return \"([A-F])\"")
+
+
+def parse_bands(score_go: str) -> list[tuple[int, str]]:
+    """[(90, 'A'), (75, 'B'), ...] plus a (0, 'F') floor, from grade()."""
+    body = _GRADE_FUNC_RE.search(score_go)
+    if not body:
+        raise ParseError("could not find `func grade(score int) string` in %s" % SCORE_GO)
+    bands = [(int(lo), letter) for lo, letter in _BAND_RE.findall(body.group(1))]
+    if not bands:
+        raise ParseError("parsed zero letter bands from grade() in %s" % SCORE_GO)
+    fallthrough = _GRADE_DEFAULT_RE.search(body.group(1))
+    if not fallthrough:
+        raise ParseError("grade() in %s has no default branch" % SCORE_GO)
+    bands.sort(key=lambda b: -b[0])
+    bands.append((0, fallthrough.group(1)))
+    return bands
+
+
+def grade_for(score: int, bands: list[tuple[int, str]]) -> str:
+    for low, letter in bands:
+        if score >= low:
+            return letter
+    raise ParseError("no band matched score %d" % score)
+
+
+# return 15, VerdictPass, ...
+_LITERAL_RETURN_RE = re.compile(r"return (\d+), Verdict(\w+)")
+# return pts, VerdictWarn, ...
+_VAR_RETURN_RE = re.compile(r"return ([a-z]\w*), Verdict(\w+)")
+# pts := 20 - 4*len(s.CapAdd)  /  if pts < 6 { pts = 6 }
+_SCALED_RE = re.compile(r"(\w+) := (\d+) - (\d+)\*len\([^)]*\)")
+_FLOOR_RE = re.compile(r"if (\w+) < (\d+) \{\s*\n\s*\1 = \2\s*\n\s*\}")
+
+
+def parse_reachable(score_go: str, dims: list[Dimension]) -> dict[str, set[tuple[int, str]]]:
+    """Map dimension key -> the (score, VERDICT) pairs its scorer can emit.
+
+    Read out of the Go, not restated here. Most branches are literal
+    ``return <int>, Verdict<X>``. ``gradeCaps`` has one computed branch --
+    ``pts := 20 - 4*len(s.CapAdd)`` floored at 6, for capabilities added back
+    after ``--cap-drop=ALL`` -- which is expanded from the arithmetic. Any other
+    non-literal return is a shape this parser does not understand, and it says
+    so (exit 2) rather than quietly accepting every value for that dimension.
+    """
+    reachable: dict[str, set[tuple[int, str]]] = {}
+    for dim in dims:
+        body_re = re.compile(r"^func %s\(s Spec\) \(int, Verdict, string\) \{(.*?)^\}" % dim.fn,
+                             re.S | re.M)
+        match = body_re.search(score_go)
+        if not match:
+            raise ParseError("could not find `func %s` in %s" % (dim.fn, SCORE_GO))
+        body = match.group(1)
+
+        pairs = {(int(n), v.upper()) for n, v in _LITERAL_RETURN_RE.findall(body)}
+
+        for var, verdict in _VAR_RETURN_RE.findall(body):
+            scaled = _SCALED_RE.search(body)
+            floor = _FLOOR_RE.search(body)
+            if not (scaled and floor and scaled.group(1) == var == floor.group(1)):
+                raise ParseError(
+                    "func %s returns non-literal `%s` and this parser cannot derive its "
+                    "range; update parse_reachable() rather than letting the dimension "
+                    "accept any score" % (dim.fn, var)
+                )
+            base, step, lowest = int(scaled.group(2)), int(scaled.group(3)), int(floor.group(2))
+            value = base - step
+            while value > lowest:
+                pairs.add((value, verdict.upper()))
+                value -= step
+            pairs.add((lowest, verdict.upper()))
+
+        if not pairs:
+            raise ParseError("parsed zero reachable outcomes from func %s" % dim.fn)
+        # Fail-closed: a dimension can always be UNKNOWN at 0 in image mode, but
+        # a guide table never renders that, so it is not added here.
+        reachable[dim.key] = pairs
+    return reachable
+
+
+# - **Non-root user** (15 pts) — does it drop host uid 0?
+_MIRROR_RE = re.compile(r'"- \*\*(?P<title>[^*]+)\*\* \((?P<max>\d+) pts\)')
+
+
+def check_mirror(gen_src: str, dims: list[Dimension]) -> list[str]:
+    """The published methodology bullets vs score.go. A divergence is a product bug."""
+    mirrored = [(m["title"].strip(), int(m["max"])) for m in _MIRROR_RE.finditer(gen_src)]
+    if not mirrored:
+        return [
+            "canonical-mirror: parsed zero dimension bullets from %s; the mirror moved "
+            "and can no longer be cross-checked against %s" % (GEN_SCORECARDS, SCORE_GO)
+        ]
+    problems = []
+    if len(mirrored) != len(dims):
+        problems.append(
+            "canonical-mirror: %s documents %d dimensions, %s defines %d"
+            % (GEN_SCORECARDS, len(mirrored), SCORE_GO, len(dims))
+        )
+    for i, (title, max_) in enumerate(mirrored[: len(dims)]):
+        dim = dims[i]
+        # The prose shortens two titles ("Network isolation" for "Network
+        # isolation / egress"), so match on the leading form, not equality.
+        if not dim.title.startswith(title):
+            problems.append(
+                "canonical-mirror: position %d is %r in %s but %r in %s"
+                % (i + 1, title, GEN_SCORECARDS, dim.title, SCORE_GO)
+            )
+        if max_ != dim.max:
+            problems.append(
+                "canonical-mirror: %r weighs %d in %s but %d in %s"
+                % (title, max_, GEN_SCORECARDS, dim.max, SCORE_GO)
+            )
+    return problems
+
+
+# --------------------------------------------------------------------------- #
+# Guide parsing.
+# --------------------------------------------------------------------------- #
+
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.S)
+_TABLE_HEADER = "| Dimension | Verdict | Score | What the scan found |"
+_ROW_RE = re.compile(r"^\|([^|]+)\|([^|]+)\|\s*(\d+)\s*/\s*(\d+)\s*\|(.*)\|\s*$")
+_VERDICT_RE = re.compile(r"\b(PASS|FAIL|WARN|UNKNOWN)\b")
+
+# The three sites that state the *default* score unambiguously, plus the body
+# prose. "After" totals are phrased differently ("take the same image to",
+# "the honest ceiling becomes", "# After:") and are out of scope by design.
+_SITE_PATTERNS = {
+    "frontmatter title": re.compile(r"scores (\d+)/100 by default"),
+    "frontmatter description": re.compile(r"defaults score (\d+)/100(?: \(grade ([A-F])\))?"),
+    "before-run comment": re.compile(r"#\s*Before:\s*(\d+)/100(?:, grade ([A-F]))?"),
+}
+_BODY_SITE_RE = re.compile(r"scores(?: only)? \*\*(\d+) of 100, grade ([A-F])")
+_REQUIRED_SITES = ("frontmatter title", "frontmatter description", "before-run comment")
+
+
+class Guide:
+    def __init__(self, path: Path, text: str) -> None:
+        self.path = path
+        self.text = text
+        self.slug = re.sub(r"^harden-|-container-isolation\.md$", "", path.name)
+        fm = _FRONTMATTER_RE.match(text)
+        self.frontmatter = fm.group(1) if fm else ""
+        self.body = text[fm.end():] if fm else text
+        # Prose wraps mid-sentence, so score claims straddle newlines.
+        self.flat_body = " ".join(self.body.split())
+        self.flat_fm = " ".join(self.frontmatter.split())
+        image = re.search(r'description:\s*"(\S+) defaults score', self.frontmatter)
+        self.image = image.group(1) if image else None
+
+
+def parse_table(guide: Guide) -> list[dict] | None:
+    """The first (and only) dimension table in the guide, or None if absent."""
+    lines = guide.text.splitlines()
+    try:
+        start = next(i for i, ln in enumerate(lines) if ln.strip() == _TABLE_HEADER)
+    except StopIteration:
+        return None
+    rows = []
+    for line in lines[start + 2:]:
+        if not line.startswith("|"):
+            break
+        m = _ROW_RE.match(line)
+        if not m:
+            break
+        verdict = _VERDICT_RE.search(m.group(2))
+        rows.append({
+            "title": m.group(1).strip(),
+            "verdict": verdict.group(1) if verdict else m.group(2).strip(),
+            "score": int(m.group(3)),
+            "max": int(m.group(4)),
+            "detail": m.group(5).strip(),
+        })
+    return rows
+
+
+def stated_scores(guide: Guide) -> tuple[dict[str, tuple[int, str | None]], list[str]]:
+    """Every site that states the default score -> (score, grade letter or None)."""
+    sites: dict[str, tuple[int, str | None]] = {}
+    missing = []
+    haystack = {
+        "frontmatter title": guide.flat_fm,
+        "frontmatter description": guide.flat_fm,
+        "before-run comment": guide.flat_body,
+    }
+    for name, pattern in _SITE_PATTERNS.items():
+        m = pattern.search(haystack[name])
+        if not m:
+            missing.append(name)
+            continue
+        letter = m.group(2) if pattern.groups > 1 else None
+        sites[name] = (int(m.group(1)), letter)
+    body = _BODY_SITE_RE.search(guide.flat_body)
+    if body:
+        sites["body prose"] = (int(body.group(1)), body.group(2))
+    return sites, missing
+
+
+# --------------------------------------------------------------------------- #
+# Measured data.
+# --------------------------------------------------------------------------- #
+
+# | [ZooKeeper](harden-zookeeper-container-isolation.md) | 48/100 D | **89/100 B** | ... |
+_HUB = Path("docs/blog/hardening-guides.md")
+_HUB_ROW_RE = re.compile(
+    r"\|\s*\[[^\]]+\]\(harden-(?P<slug>[a-z0-9-]+)-container-isolation\.md\)\s*\|"
+    r"\s*(?P<score>\d+)/100\s+(?P<grade>[A-F])\s*\|"
+)
+
+
+def check_hub(hub_src: str, totals: dict[str, int], bands) -> list[str]:
+    """The hub's "Before" column restates every guide's total. IRO-696 is the
+    precedent for why it needs a gate of its own: an index is prose that claims
+    to be exhaustive, and nothing that follows links can see a number in it go
+    stale. Checked against the guide's own table, which check_guide() has
+    already reconciled against score.go and results.json.
+    """
+    rows = list(_HUB_ROW_RE.finditer(hub_src))
+    if not rows:
+        return ["hub: parsed zero guide rows from %s; the table shape changed" % _HUB]
+    problems = []
+    for row in rows:
+        slug, stated, letter = row["slug"], int(row["score"]), row["grade"]
+        total = totals.get(slug)
+        if total is None:
+            problems.append("hub: row for %s has no guide table to check against" % slug)
+            continue
+        if stated != total:
+            problems.append("hub: %s row states %d/100, its guide table sums to %d"
+                            % (slug, stated, total))
+        if letter != grade_for(stated, bands):
+            problems.append("hub: %s row states %d/100 grade %s; %d is grade %s"
+                            % (slug, stated, letter, stated, grade_for(stated, bands)))
+    return problems
+
+
+def repo_basename(image: str) -> str:
+    """`dpage/pgadmin4:8` -> `pgadmin4`; `mongo:7@sha256:...` -> `mongo`."""
+    return re.split(r"[:@]", image, maxsplit=1)[0].rsplit("/", 1)[-1]
+
+
+def index_scenarios(results: dict) -> tuple[dict[str, dict], dict[str, list[dict]]]:
+    by_label, by_repo = {}, {}
+    for scenario in results.get("scenarios", []):
+        if not scenario.get("label", "").startswith("default-"):
+            continue
+        by_label[scenario["label"]] = scenario
+        by_repo.setdefault(repo_basename(scenario.get("image", "")), []).append(scenario)
+    return by_label, by_repo
+
+
+def resolve_scenario(guide: Guide, by_label: dict, by_repo: dict) -> dict | None:
+    """The measured default-configuration run for this guide's image, if any.
+
+    Label first (`default-<slug>` covers 52 of 56). Four guides use a slug the
+    survey does not (`cockroachdb` vs `default-cockroach`, `mongodb` vs
+    `default-mongo`, `pgadmin4` vs `default-pgadmin`, `victoria-metrics` vs
+    `default-victoriametrics`), so fall back to the image repo, and only when
+    exactly one scenario claims it.
+    """
+    scenario = by_label.get("default-" + guide.slug)
+    if scenario:
+        return scenario
+    if not guide.image:
+        return None
+    candidates = by_repo.get(repo_basename(guide.image), [])
+    return candidates[0] if len(candidates) == 1 else None
+
+
+# --------------------------------------------------------------------------- #
+# The check itself.
+# --------------------------------------------------------------------------- #
+
+def check_guide(guide: Guide, dims, reachable, bands, scenario) -> list[str]:
+    problems: list[str] = []
+    rows = parse_table(guide)
+    if rows is None:
+        return ["no dimension table found (expected a `%s` header)" % _TABLE_HEADER]
+    if not rows:
+        return ["dimension table header found but zero rows parsed under it"]
+
+    # (2) Dimension integrity: the exact canonical set, in order, at its weights.
+    if len(rows) != len(dims):
+        problems.append("table has %d rows, the scorer defines %d dimensions"
+                        % (len(rows), len(dims)))
+    canonical_titles = [d.title for d in dims]
+    for row in rows:
+        if row["title"] not in canonical_titles:
+            problems.append("row %r is not a dimension the scorer emits (canonical set: %s)"
+                            % (row["title"], ", ".join(canonical_titles)))
+    for title in canonical_titles:
+        if title not in [r["title"] for r in rows]:
+            problems.append("canonical dimension %r is missing from the table" % title)
+    for i, (row, dim) in enumerate(zip(rows, dims)):
+        if row["title"] == dim.title and row["max"] != dim.max:
+            problems.append("row %r is out of %d, the scorer weights it %d"
+                            % (row["title"], row["max"], dim.max))
+        elif row["title"] != dim.title and row["title"] in canonical_titles:
+            problems.append("row %d is %r, the canonical order puts %r there"
+                            % (i + 1, row["title"], dim.title))
+
+    # (3) Verdict reachability: is this (score, verdict) one the scorer can emit?
+    by_title = {d.title: d for d in dims}
+    for row in rows:
+        dim = by_title.get(row["title"])
+        if dim is None:
+            continue
+        pair = (row["score"], row["verdict"].upper())
+        if pair not in reachable[dim.key]:
+            emits = ", ".join("%d/%s" % p for p in sorted(reachable[dim.key]))
+            problems.append("row %r claims %d/%d %s, which %s cannot emit (it emits: %s)"
+                            % (row["title"], row["score"], row["max"], row["verdict"],
+                               dim.fn, emits))
+
+    # (1) Arithmetic + (4) grade band, at every site that states the total.
+    total = sum(r["score"] for r in rows)
+    sites, missing = stated_scores(guide)
+    for name in missing:
+        if name in _REQUIRED_SITES:
+            problems.append("no default score stated in the %s" % name)
+    for name, (stated, letter) in sorted(sites.items()):
+        if stated != total:
+            problems.append("%s states %d/100 but the table sums to %d"
+                            % (name, stated, total))
+        if letter and letter != grade_for(stated, bands):
+            problems.append("%s states %d/100 grade %s; %d is grade %s"
+                            % (name, stated, letter, stated, grade_for(stated, bands)))
+
+    # (5) Agreement with what the survey actually measured.
+    if scenario is None:
+        problems.append("no `default-*` scenario in %s for image %s; the table is "
+                        "unverifiable against measured data" % (RESULTS, guide.image))
+        return problems
+
+    measured = {d["title"]: d for d in scenario["report"]["dimensions"]}
+    for row in rows:
+        m = measured.get(row["title"])
+        if m is None:
+            continue
+        if (row["score"], row["max"]) != (m["score"], m["max"]):
+            problems.append("row %r claims %d/%d, %s recorded %d/%d"
+                            % (row["title"], row["score"], row["max"],
+                               scenario["label"], m["score"], m["max"]))
+        if row["verdict"].upper() != m["verdict"].upper():
+            problems.append("row %r claims %s, %s recorded %s"
+                            % (row["title"], row["verdict"], scenario["label"], m["verdict"]))
+    if total != scenario["score"]:
+        problems.append("table sums to %d, %s scored %d"
+                        % (total, scenario["label"], scenario["score"]))
+    failed = sorted(r["title"] for r in rows if r["verdict"].upper() == "FAIL")
+    if failed != sorted(scenario.get("failedDimensions", [])):
+        problems.append("table fails %s, %s recorded failures %s"
+                        % (failed or "nothing", scenario["label"],
+                           sorted(scenario.get("failedDimensions", []))))
+    return problems
+
+
+def read(root: Path, rel: Path) -> str:
+    path = root / rel
+    if not path.is_file():
+        raise ParseError("missing %s" % path)
+    return path.read_text(encoding="utf-8")
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("root", nargs="?", default=".", type=Path)
+    ap.add_argument("--report", action="store_true",
+                    help="print violations and exit 0 (rollout mode)")
+    ap.add_argument("--min-guides", type=int, default=DEFAULT_MIN_GUIDES,
+                    help="fail if fewer than N guides were parsed (default %d)"
+                         % DEFAULT_MIN_GUIDES)
+    args = ap.parse_args(argv)
+    root: Path = args.root
+
+    try:
+        score_go = read(root, SCORE_GO)
+        dims = parse_scorers(score_go)
+        bands = parse_bands(score_go)
+        reachable = parse_reachable(score_go, dims)
+        gen_src = read(root, GEN_SCORECARDS)
+        results = json.loads(read(root, RESULTS))
+    except (ParseError, json.JSONDecodeError) as exc:
+        print("error: %s" % exc, file=sys.stderr)
+        return 2
+
+    by_label, by_repo = index_scenarios(results)
+    findings: list[tuple[str, str]] = []
+    for problem in check_mirror(gen_src, dims):
+        findings.append((str(GEN_SCORECARDS), problem))
+
+    guides = sorted((root / "docs" / "blog").glob("harden-*-container-isolation.md"))
+    offenders = set()
+    totals: dict[str, int] = {}
+    for path in guides:
+        guide = Guide(path, path.read_text(encoding="utf-8"))
+        scenario = resolve_scenario(guide, by_label, by_repo)
+        rows = parse_table(guide)
+        if rows:
+            totals[guide.slug] = sum(r["score"] for r in rows)
+        for problem in check_guide(guide, dims, reachable, bands, scenario):
+            rel = path.relative_to(root) if path.is_relative_to(root) else path
+            findings.append((str(rel), problem))
+            offenders.add(str(rel))
+
+    hub = root / _HUB
+    if hub.is_file():
+        for problem in check_hub(hub.read_text(encoding="utf-8"), totals, bands):
+            findings.append((str(_HUB), problem))
+            offenders.add(str(_HUB))
+
+    print("canonical dimensions: %d (%d pts) from %s"
+          % (len(dims), sum(d.max for d in dims), SCORE_GO))
+    print("guides parsed: %d" % len(guides))
+    print("guides with violations: %d" % len(offenders))
+    print("violations: %d" % len(findings))
+    for where, problem in findings:
+        print("  %s: %s" % (where, problem))
+
+    if len(guides) < args.min_guides:
+        print("error: parsed %d guides, expected at least %d -- a guard that reads "
+              "nothing passes for the wrong reason" % (len(guides), args.min_guides),
+              file=sys.stderr)
+        return 2
+
+    if not findings:
+        print("OK: every guide's table adds up, matches the scorer and matches the survey.")
+        return 0
+    if args.report:
+        print("(report mode: not failing the build)")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/tests/test_check_guide_scores.py
+++ b/scripts/tests/test_check_guide_scores.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check-guide-scores.py (IRO-734).
+
+The defect this checker exists to catch shipped through 17 green checks, so its
+own green is worth nothing until proven non-vacuous. Every test below is a
+negative control: build a tree carrying a real defect and assert the checker
+names it, or build a degenerate tree and assert it refuses to call it green.
+
+The headline control is `test_pr661_haproxy_rewrite`, which rebuilds the exact
+five defects PR #661 shipped past CI and took four rounds of manual review to
+find:
+
+* the scores column summed to 58 while four sites claimed 63/100;
+* an invented `Privilege escalation` dimension the scorer does not have;
+* the canonical `No docker.sock exposure` row deleted;
+* `Read-only root filesystem` moved from its real 0/10 to 5/15;
+* `Dropped capabilities` reported WARN where the scorer emits FAIL at 4/20.
+
+The camouflage was that the denominators still summed to 100, so a checker that
+only added up the `max` column would have been green on all five.
+
+Equally important is what must NOT fire: `test_real_corpus_is_clean` runs the
+checker against the repository's own 56 guides, and `test_canonical_set_matches`
+asserts the parsed dimension set is the real seven-dimension one rather than an
+empty set that would make every table trivially conformant.
+
+Run:
+    python3 -m unittest discover -s scripts/tests -v
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import pathlib
+import shutil
+import tempfile
+import unittest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / 'check-guide-scores.py'
+REPO_ROOT = SCRIPT.parent.parent
+
+CANONICAL_ROWS = [
+    ('Non-root user (uid != 0)', '✅ PASS', 15, 15, 'runs as haproxy (uid != 0)'),
+    ('Dropped capabilities', '❌ FAIL', 4, 20, 'default capability set retained'),
+    ('Seccomp profile', '✅ PASS', 15, 15, 'seccomp profile active'),
+    ('Network isolation / egress', '⚠️ WARN', 4, 15, 'network=bridge: outbound egress is possible'),
+    ('Read-only root filesystem', '❌ FAIL', 0, 10, 'root filesystem is writable'),
+    ('No docker.sock exposure', '✅ PASS', 15, 15, 'no control socket mounted'),
+    ('No shared host namespaces', '✅ PASS', 10, 10, 'no host PID/IPC/network sharing'),
+]
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location('check_guide_scores', SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run(root: pathlib.Path, *extra: str):
+    """Run the checker against `root`, returning (exit code, stdout+stderr)."""
+    module = load_module()
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        code = module.main(['--min-guides', '1', *extra, str(root)])
+    return code, out.getvalue() + err.getvalue()
+
+
+def guide(rows=None, *, stated=63, grade='C') -> str:
+    """A well-formed haproxy guide. Defaults are the real, correct page."""
+    rows = CANONICAL_ROWS if rows is None else rows
+    table = '\n'.join(
+        f'| {t} | {v} | {s}/{m} | {d} |' for t, v, s, m, d in rows
+    )
+    return f'''---
+title: "How to harden a HAProxy container: haproxy:3.1-alpine scores {stated}/100 by default"
+description: "haproxy:3.1-alpine defaults score {stated}/100 (grade {grade}): full caps, writable rootfs."
+---
+
+# How to harden a HAProxy container
+
+Graded on IronClaw's seven-dimension containment scale, the default configuration scores
+**{stated} of 100, grade {grade} (partial)**. Higher is safer. A few runtime flags take the same
+image to **89 of 100, grade B**.
+
+## Where the default configuration leaks
+
+| Dimension | Verdict | Score | What the scan found |
+|-----------|:-------:|------:|---------------------|
+{table}
+
+## Before and after
+
+```bash
+# Before: {stated}/100, grade {grade}
+docker run -d --name haproxy haproxy:3.1-alpine
+
+# After: 89/100, grade B
+docker run -d --name haproxy-hardened haproxy:3.1-alpine
+```
+'''
+
+
+class Fixture:
+    """A minimal repo: the real score.go, generator and results.json, one guide."""
+
+    def __init__(self, stack: contextlib.ExitStack, text: str | None = None,
+                 hub: str | None = None):
+        self.root = pathlib.Path(stack.enter_context(tempfile.TemporaryDirectory()))
+        for rel in ('internal/host/scan/score.go',
+                    'examples/isolation-survey/gen_scorecards.py',
+                    'examples/isolation-survey/results.json'):
+            dst = self.root / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(REPO_ROOT / rel, dst)
+        blog = self.root / 'docs' / 'blog'
+        blog.mkdir(parents=True)
+        (blog / 'harden-haproxy-container-isolation.md').write_text(
+            guide() if text is None else text, encoding='utf-8')
+        if hub is not None:
+            (blog / 'hardening-guides.md').write_text(hub, encoding='utf-8')
+
+    def score_go(self) -> pathlib.Path:
+        return self.root / 'internal/host/scan/score.go'
+
+
+class CheckGuideScoresTest(unittest.TestCase):
+
+    def setUp(self):
+        self.stack = contextlib.ExitStack()
+        self.addCleanup(self.stack.close)
+
+    # ---- positive control: the checker must be silent on correct input ---- #
+
+    def test_correct_guide_passes(self):
+        code, out = run(Fixture(self.stack).root)
+        self.assertEqual(code, 0, out)
+        self.assertIn('violations: 0', out)
+
+    def test_real_corpus_is_clean(self):
+        """The repository's own 56 guides. A rule that fires here is wrong."""
+        code, out = run(REPO_ROOT, '--min-guides', '56')
+        self.assertEqual(code, 0, out)
+        self.assertIn('guides parsed: 56', out)
+
+    def test_canonical_set_matches(self):
+        """Guard the guard: an empty canonical set makes every table conformant."""
+        module = load_module()
+        dims = module.parse_scorers((REPO_ROOT / module.SCORE_GO).read_text())
+        self.assertEqual(len(dims), 7)
+        self.assertEqual(sum(d.max for d in dims), 100)
+        self.assertEqual([d.title for d in dims],
+                         [r[0] for r in CANONICAL_ROWS])
+
+    # ---- the trigger: PR #661's five defects, in one file ---- #
+
+    def test_pr661_haproxy_rewrite(self):
+        rows = [
+            ('Non-root user (uid != 0)', '✅ PASS', 15, 15, 'runs as haproxy (uid != 0)'),
+            ('Dropped capabilities', '⚠️ WARN', 4, 20, 'default capability set retained'),
+            ('Seccomp profile', '✅ PASS', 15, 15, 'seccomp profile active'),
+            ('Network isolation / egress', '⚠️ WARN', 4, 15, 'standard bridge network mode'),
+            ('Read-only root filesystem', '⚠️ WARN', 5, 15, 'root filesystem is writable'),
+            ('Privilege escalation', '⚠️ WARN', 5, 10, 'no explicitly enforced no-new-privileges'),
+            ('No shared host namespaces', '✅ PASS', 10, 10, 'no host PID/IPC/network sharing'),
+        ]
+        self.assertEqual(sum(r[2] for r in rows), 58)
+        self.assertEqual(sum(r[3] for r in rows), 100,
+                         'the camouflage: the max column still totals 100')
+        code, out = run(Fixture(self.stack, guide(rows)).root)
+        self.assertEqual(code, 1, out)
+        # 1. arithmetic, at every one of the four sites that state 63
+        for site in ('frontmatter title', 'frontmatter description',
+                     'body prose', 'before-run comment'):
+            self.assertIn(f'{site} states 63/100 but the table sums to 58', out)
+        # 2. the invented dimension
+        self.assertIn("row 'Privilege escalation' is not a dimension the scorer emits", out)
+        # 3. the deleted canonical dimension
+        self.assertIn("canonical dimension 'No docker.sock exposure' is missing", out)
+        # 4. the reweighted rootfs row
+        self.assertIn("row 'Read-only root filesystem' is out of 15, the scorer weights it 10", out)
+        # 5. the unreachable verdict/score pairs
+        self.assertIn("row 'Read-only root filesystem' claims 5/15 WARN, "
+                      "which gradeReadonly cannot emit", out)
+        self.assertIn("row 'Dropped capabilities' claims 4/20 WARN, "
+                      "which gradeCaps cannot emit", out)
+
+    def test_max_column_only_check_would_be_green(self):
+        """Proves the #661 fixture is not caught by the naive check it evaded."""
+        module = load_module()
+        dims = module.parse_scorers((REPO_ROOT / module.SCORE_GO).read_text())
+        self.assertEqual(sum(d.max for d in dims), 100)
+
+    # ---- each rule, isolated ---- #
+
+    def test_score_column_off_by_one(self):
+        rows = [list(r) for r in CANONICAL_ROWS]
+        rows[2][2] = 14  # seccomp 15 -> 14, total 62 against four claims of 63
+        code, out = run(Fixture(self.stack, guide([tuple(r) for r in rows])).root)
+        self.assertEqual(code, 1, out)
+        self.assertIn('the table sums to 62', out)
+
+    def test_stated_score_disagrees_with_measured_run(self):
+        """All four sites agree with each other and with the table, and are still wrong."""
+        rows = [list(r) for r in CANONICAL_ROWS]
+        rows[2][2] = 14
+        text = guide([tuple(r) for r in rows], stated=62)
+        code, out = run(Fixture(self.stack, text).root)
+        self.assertEqual(code, 1, out)
+        self.assertIn('table sums to 62, default-haproxy scored 63', out)
+
+    def test_grade_letter_must_match_band(self):
+        code, out = run(Fixture(self.stack, guide(stated=63, grade='B')).root)
+        self.assertEqual(code, 1, out)
+        self.assertIn('states 63/100 grade B; 63 is grade C', out)
+
+    def test_reordered_dimension_is_flagged(self):
+        rows = list(CANONICAL_ROWS)
+        rows[1], rows[2] = rows[2], rows[1]
+        code, out = run(Fixture(self.stack, guide(rows)).root)
+        self.assertEqual(code, 1, out)
+        self.assertIn('the canonical order puts', out)
+
+    def test_verdict_disagreeing_with_measured_run(self):
+        rows = [list(r) for r in CANONICAL_ROWS]
+        rows[4][1] = '⚠️ WARN'   # rootfs FAIL -> WARN, score untouched
+        code, out = run(Fixture(self.stack, guide([tuple(r) for r in rows])).root)
+        self.assertEqual(code, 1, out)
+        self.assertIn("row 'Read-only root filesystem' claims 0/10 WARN, "
+                      "which gradeReadonly cannot emit", out)
+
+    def test_missing_score_site_is_flagged(self):
+        text = guide().replace('# Before: 63/100, grade C', '# Before hardening')
+        code, out = run(Fixture(self.stack, text).root)
+        self.assertEqual(code, 1, out)
+        self.assertIn('no default score stated in the before-run comment', out)
+
+    def test_hub_row_drift_is_flagged(self):
+        """The IRO-696 surface: the hub restates the total and can go stale alone."""
+        hub = ('| Image | Before | After | Ceiling |\n|---|---|---|---|\n'
+               '| [HAProxy](harden-haproxy-container-isolation.md) | 55/100 C '
+               '| **89/100 B** | load balancer |\n')
+        code, out = run(Fixture(self.stack, hub=hub).root)
+        self.assertEqual(code, 1, out)
+        self.assertIn('hub: haproxy row states 55/100, its guide table sums to 63', out)
+
+    # ---- degenerate inputs must not be green ---- #
+
+    def test_zero_guides_is_not_green(self):
+        fixture = Fixture(self.stack)
+        (fixture.root / 'docs/blog/harden-haproxy-container-isolation.md').unlink()
+        code, out = run(fixture.root)
+        self.assertEqual(code, 2, out)
+        self.assertIn('parsed 0 guides', out)
+
+    def test_guide_count_drop_is_not_green(self):
+        code, out = run(REPO_ROOT, '--min-guides', '57')
+        self.assertEqual(code, 2, out)
+        self.assertIn('expected at least 57', out)
+
+    def test_missing_table_is_flagged(self):
+        text = guide().split('| Dimension |')[0] + '\nNo table here.\n'
+        code, out = run(Fixture(self.stack, text).root)
+        self.assertEqual(code, 1, out)
+        self.assertIn('no dimension table found', out)
+
+    def test_unparseable_scorers_slice_exits_two(self):
+        """A canonical set that cannot be read must fail loudly, not pass empty."""
+        fixture = Fixture(self.stack)
+        path = fixture.score_go()
+        path.write_text(path.read_text().replace('var scorers = []scorer{',
+                                                 'var renamedScorers = []scorer{'))
+        code, out = run(fixture.root)
+        self.assertEqual(code, 2, out)
+        self.assertIn('could not find `var scorers', out)
+
+    def test_reweighted_scorer_is_followed_not_hardcoded(self):
+        """Change score.go and the *guide* becomes the violation. No second copy."""
+        fixture = Fixture(self.stack)
+        path = fixture.score_go()
+        path.write_text(path.read_text()
+                        .replace('"Seccomp profile", 15,', '"Seccomp profile", 14,')
+                        .replace('const TotalWeight = 100', 'const TotalWeight = 99'))
+        code, out = run(fixture.root)
+        self.assertEqual(code, 1, out)
+        self.assertIn("row 'Seccomp profile' is out of 15, the scorer weights it 14", out)
+
+    def test_scorer_mirror_divergence_is_reported(self):
+        """score.go vs the published methodology: a divergence is a product bug."""
+        fixture = Fixture(self.stack)
+        gen = fixture.root / 'examples/isolation-survey/gen_scorecards.py'
+        gen.write_text(gen.read_text().replace(
+            '"- **Dropped capabilities** (20 pts)', '"- **Dropped capabilities** (25 pts)'))
+        code, out = run(fixture.root)
+        self.assertEqual(code, 1, out)
+        self.assertIn('canonical-mirror:', out)
+        self.assertIn('weighs 25', out)
+
+    def test_unmeasured_image_is_flagged(self):
+        """A guide with no default-* scenario cannot be checked and must say so."""
+        fixture = Fixture(self.stack)
+        results = fixture.root / 'examples/isolation-survey/results.json'
+        data = json.loads(results.read_text())
+        data['scenarios'] = [s for s in data['scenarios']
+                             if s.get('label') != 'default-haproxy'
+                             and 'haproxy' not in s.get('image', '')]
+        results.write_text(json.dumps(data))
+        code, out = run(fixture.root)
+        self.assertEqual(code, 1, out)
+        self.assertIn('the table is unverifiable against measured data', out)
+
+    # ---- rollout mode ---- #
+
+    def test_report_mode_prints_but_does_not_fail(self):
+        rows = [list(r) for r in CANONICAL_ROWS]
+        rows[2][2] = 14
+        code, out = run(Fixture(self.stack, guide([tuple(r) for r in rows])).root, '--report')
+        self.assertEqual(code, 0, out)
+        self.assertIn('the table sums to 62', out)
+        self.assertIn('report mode: not failing the build', out)
+
+    def test_report_mode_still_fails_on_zero_guides(self):
+        """Report mode softens violations, never the non-vacuity assertion."""
+        fixture = Fixture(self.stack)
+        (fixture.root / 'docs/blog/harden-haproxy-container-isolation.md').unlink()
+        code, out = run(fixture.root, '--report')
+        self.assertEqual(code, 2, out)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes IRO-734.

## What was unguarded

`scripts/check-scores-drift.py:52` sets `SCORES_DIR = docs/scores`, so the 56 hand-written guides under `docs/blog/**` were outside every check in the pipeline. Nothing read their score tables.

PR #661 rewrote `docs/blog/harden-haproxy-container-isolation.md` and shipped five defects past all 17 checks: the scores column summed to **58** while the page claimed **63/100 in four places**; it invented a `Privilege escalation` dimension the scorer does not have; it deleted the canonical `No docker.sock exposure` row; it moved `Read-only root filesystem` from its real `0/10` to `5/15`; and it reported `Dropped capabilities` as WARN where `gradeCaps` emits FAIL at 4/20. The camouflage is that the **denominators still total 100** (rootfs +5, docker.sock 15 to privesc 10), so a checker that only added up the `max` column would have been green on all five.

## The guard

`scripts/check-guide-scores.py`, wired as a step in the required `build` job of `docs.yml`, alongside `check-scores-drift.py`. Five checks:

1. **Arithmetic** — the scores column sums to the total the page states, at *every* site that states it (front-matter `title:`, front-matter `description:`, body prose, `# Before: NN/100` comment).
2. **Dimension integrity** — row titles and `max` weights equal the canonical ordered set. Invented row, missing row, reordered row and reweighted row all fail.
3. **Verdict reachability** — a row's `(score, verdict)` pair must be one the scorer can emit. `gradeReadonly` returns only `10/PASS` or `0/FAIL`, so a `5/15 WARN` rootfs row fails even though 5 looks plausible. Same for `gradeCaps` (`20 - 4n`, floored at 6).
4. **Grade band** — the letter next to a total is the band `grade()` puts it in.
5. **Agreement with measured data** — every row's score, max and verdict, plus the total, the grade and the failed-dimension set, equal the `default-*` scenario in `results.json`.

**Nothing canonical is copied.** The dimension set and weights are parsed from the `scorers` slice in `internal/host/scan/score.go`; the reachable `(score, verdict)` pairs from each `grade*` function body; the bands from `grade()`; the measured values from `results.json`. A hardcoded copy would rot the moment a dimension is added, and rot silently, which is the failure mode this exists to close. `score.go` therefore joins `remediate.go` in the workflow's `paths:` filter. `docs/blog/**` was already covered by the existing `docs/**` entry; what was missing was `score.go` and the script itself, both now added.

`gen_scorecards.py` documents the same seven dimensions in prose for readers. That copy is cross-checked and a divergence reports as `canonical-mirror`. It is clean today.

## Negative control: PR #661's head `d3016f3b`

Run against `d3016f3b6d8e7c4e2441626d82cf62e47a6deaa4:docs/blog/harden-haproxy-container-isolation.md` with this base's `score.go` and `results.json`. **Exit 1, 14 violations**, covering all four required findings plus two more:

```
row 'Privilege escalation' is not a dimension the scorer emits
canonical dimension 'No docker.sock exposure' is missing from the table
row 'Read-only root filesystem' is out of 15, the scorer weights it 10
row 'Dropped capabilities' claims 4/20 WARN, which gradeCaps cannot emit (it emits: 0/FAIL, 0/UNKNOWN, 4/FAIL, 6/WARN, 8/WARN, 12/WARN, 16/WARN, 20/PASS)
row 'Read-only root filesystem' claims 5/15 WARN, which gradeReadonly cannot emit (it emits: 0/FAIL, 0/UNKNOWN, 10/PASS)
before-run comment states 63/100 but the table sums to 58
body prose states 63/100 but the table sums to 58
frontmatter description states 63/100 but the table sums to 58
frontmatter title states 63/100 but the table sums to 58
row 'Dropped capabilities' claims WARN, default-haproxy recorded FAIL
row 'Read-only root filesystem' claims 5/15, default-haproxy recorded 0/10
row 'Read-only root filesystem' claims WARN, default-haproxy recorded FAIL
table sums to 58, default-haproxy scored 63
table fails nothing, default-haproxy recorded failures ['Dropped capabilities', 'Read-only root filesystem']
```

## Violation count on main: 4 rows across 4 files

Under the ~10 escalation threshold, so per the rollout instruction they are fixed here and the step is **enforcing** from the start. `--report` mode exists and is tested, but is not what CI runs.

**Three guides published a score 15 points below the measured one, on a dimension that was simply wrong.** `jenkins`, `keycloak` and `sonarqube` each carried a `Non-root user (uid != 0) | FAIL | 0/15 | runs as root` row and a `48/100 grade D` total. The survey measured all three as non-root:

| label | image | measured user dim | measured total |
|---|---|---|---|
| `default-jenkins` | `jenkins/jenkins:lts` | 15/15 PASS, `runs as jenkins (uid != 0)` | 63/100 C |
| `default-keycloak` | `quay.io/keycloak/keycloak:26.0.7` | 15/15 PASS, `runs as 1000 (uid != 0)` | 63/100 C |
| `default-sonarqube` | `sonarqube:community` | 15/15 PASS, `runs as sonarqube (uid != 0)` | 63/100 C |

`docs/scores/jenkins.md`, `docs/scores/keycloak.md` and `docs/scores/sonarqube.md` already publish `63/100 (grade C)` with the PASS row, because they are generated from `results.json`. **Two pages on the same site have been contradicting each other about the same image.** Corrected to the measured values, along with the prose that was built on the false root finding ("the one that should worry you most is **root**") and the 41-point swing that followed arithmetically from it (now 26).

**One hub row was stale on its own.** `docs/blog/hardening-guides.md` listed ZooKeeper at `55/100 C`; both the survey and the ZooKeeper guide itself say `48/100 D`. This is the IRO-696 surface, so the guard now checks the hub's Before column against each guide's table as a sixth rule.

## Out of scope

- **The hardened / "After" numbers are untouched.** The guard validates the Before table only; the parser skips After blocks by anchoring on the phrasing that states the default score. That corpus is IRO-726.
- `harden-prometheus-container-isolation.md` says grade C `weak` where the corpus standard is `partial`. Cosmetic, unrelated, left alone as instructed; the guard checks the letter, not the adjective.
- `docs/scores/**` is untouched; `check-scores-drift.py` still owns it.

## Verification

- Guard on this branch: `guides parsed: 56`, `violations: 0`, exit 0.
- Guard on `d3016f3b`: exit 1, 14 violations, listed above.
- **Non-vacuity is asserted, not assumed.** The script exits **2** if it parses fewer than 56 guides, and `test_zero_guides_is_not_green` / `test_guide_count_drop_is_not_green` hold that line. Report mode softens violations but never the count assertion.
- 21 negative controls in `scripts/tests/test_check_guide_scores.py`, including a fixture of #661's exact table, `test_max_column_only_check_would_be_green` proving the naive check it evaded, `test_reweighted_scorer_is_followed_not_hardcoded` proving the canonical set follows `score.go` rather than a copy, and `test_unparseable_scorers_slice_exits_two` proving a renamed slice fails loudly instead of passing with an empty set.
- Full script suite: **131 tests green**.
- `check-md-fences.py`, `check_links.py`, `check-guide-index.py`, `check-guide-uid.py`, `check-scores-drift.py` all still pass against the edited guides.

## Review

This touches `.github/workflows/docs.yml`, so it is reviewer-bot gated. **Not self-merging.** Handing to @omerzamir for the review of record.
