### PR TITLE
fix(survey): record every skipped scenario and fail on lost coverage [IRO-727]

### DIFF
--- a/.github/workflows/scores-refresh.yml
+++ b/.github/workflows/scores-refresh.yml
@@ -71,6 +71,24 @@ jobs:
           PRUNE: "1"
         run: bash examples/isolation-survey/survey.sh
 
+      # survey.sh writes results.* BEFORE the coverage guard runs, precisely so a
+      # failing run leaves the artifact naming which rows dropped and why
+      # (IRO-727). But on a red run nothing downstream commits or pushes, so
+      # without this step that artifact dies with the runner and the expiring
+      # Actions log is once again the only record — the exact defect being fixed.
+      # `if: always()` is the whole point: the run this matters on is the one
+      # that failed.
+      - name: Upload the survey artifact (including on a failed run)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: isolation-survey-results
+          path: |
+            examples/isolation-survey/results.json
+            examples/isolation-survey/results.md
+          if-no-files-found: warn
+          retention-days: 90
+
       - name: Regenerate the scorecard directory
         run: |
           python3 examples/isolation-survey/gen_scorecards.py \

--- a/examples/isolation-survey/README.md
+++ b/examples/isolation-survey/README.md
@@ -85,9 +85,16 @@ exited green (IRO-727).
 manifestRowCount` is not just readable from the artifact, it is enforced:
 [`coverage_guard.py`](./coverage_guard.py) fails the run when the three counts
 do not add up, when a count is missing, or when its own parse of `images.txt`
-disagrees with the row count the sweep recorded. `results.md` derives its
-"every row was scanned" line from that same comparison rather than from the skip
-list being empty, so the sentence cannot contradict the numbers next to it.
+disagrees with the row count the sweep recorded. It also compares the two sides
+**by label, not only by total** — the scored and skipped labels against the rows
+it parses out of `images.txt`, as multisets. Counts alone cannot see a row
+spelled one way by the sweep and another way by the guard, and since the
+regression check below matches the baseline by label, such a row would leave the
+expected set permanently and without a word. `results.md` states "every row was
+scanned" only when all three counts say so, and `manifestRowCount` comes from
+the sweep rather than being derived from the rows that happened to come back —
+deriving it made the invariant true by construction, and was how a single scored
+row could report full coverage of a 295-row manifest.
 
 **Losing coverage fails the run.** [`coverage_guard.py`](./coverage_guard.py)
 compares the finished run against the last **committed** `results.json` — read
@@ -106,8 +113,20 @@ same broken sweep fails with the same message. Fix the rows or retire them.
 written as soon as the sweep finishes — before the `scanned > 0` check and
 before the guard — so a run that fails on coverage, *including one where every
 single row failed*, still leaves an artifact naming each dropped row and its
-stage. A run killed mid-sweep (Ctrl-C, the harness itself crashing) writes
-nothing; there the run log is still the only record.
+stage. In CI the weekly refresh uploads both files as a run artifact with
+`if: always()`, because on a failing run nothing downstream commits them and
+they would otherwise die with the runner.
+
+What that does **not** cover, stated plainly because a false durability claim is
+the same class of bug as the one this fixes: anything that aborts the sweep
+*before* the render step still writes nothing and still destroys the skips
+collected so far. The foreseeable internal aborts are gone — a failed skip write
+on a full temp filesystem, a manifest row that blows up the field parse, and a
+temp file that cannot be created are each recorded and stepped over instead of
+fatal, which is what makes this hold under `PRUNE=1` on a nearly-full runner
+disk. What remains is the process being killed (Ctrl-C, OOM, a job timeout), a
+manifest that cannot be read at all, and `render.py` itself failing. There the
+run log is still the only record.
 
 ## Methodology (so the numbers are defensible)
 
@@ -178,7 +197,7 @@ new page — no manual nav edit.
 |------|-----------|
 | [`images.txt`](./images.txt) | the versioned manifest of scenarios |
 | [`survey.sh`](./survey.sh) | the harness: pull -> run -> `ironctl scan --json` -> aggregate |
-| [`render.py`](./render.py) | stdlib aggregation of scan JSON into `results.{json,md}` |
+| [`render.py`](./render.py) | stdlib aggregation of scan JSON into `results.{json,md}`; driven by `survey.sh`, and `--manifest-rows N` is required so the coverage denominator comes from the sweep |
 | [`coverage_guard.py`](./coverage_guard.py) | fails a run that lost a scenario the previous run scored |
 | [`gen_scorecards.py`](./gen_scorecards.py) | renders `results.json` into `docs/scores/` scorecard pages |
 | [`results.json`](./results.json) | the committed machine-readable dataset |

--- a/examples/isolation-survey/README.md
+++ b/examples/isolation-survey/README.md
@@ -81,16 +81,33 @@ because it was previously invisible: the same 39 of 295 rows failed on every
 weekly refresh, the only trace was an Actions log that expires, and the run
 exited green (IRO-727).
 
+**Every row is accounted for.** `scenarioCount + skippedCount ==
+manifestRowCount` is not just readable from the artifact, it is enforced:
+[`coverage_guard.py`](./coverage_guard.py) fails the run when the three counts
+do not add up, when a count is missing, or when its own parse of `images.txt`
+disagrees with the row count the sweep recorded. `results.md` derives its
+"every row was scanned" line from that same comparison rather than from the skip
+list being empty, so the sentence cannot contradict the numbers next to it.
+
 **Losing coverage fails the run.** [`coverage_guard.py`](./coverage_guard.py)
-compares the finished run against the previous `results.json` and exits non-zero
-if a scenario that scored last time — and is still listed in `images.txt` —
+compares the finished run against the last **committed** `results.json` — read
+from `git`, not from the working tree the run is about to overwrite — and exits
+non-zero if a scenario that scored there, and is still listed in `images.txt`,
 produced nothing now. Deliberately a *regression* check rather than "any skip is
 fatal": a transient registry failure is absent from the baseline too, so it
 cannot wedge the weekly refresh, while a row that rots for good is caught the
 first week it stops scoring. If a row can never be scanned again, the fix is to
 delete it from `images.txt` — a label that leaves the manifest is not a
-regression. Results are written *before* the guard runs, so a failed run still
-leaves the artifact that explains itself.
+regression. **Re-running does not clear it.** The baseline comes from `HEAD`,
+and only a run that passed the guard is ever committed, so a second run over the
+same broken sweep fails with the same message. Fix the rows or retire them.
+
+**A failed run still leaves its evidence.** `results.json` and `results.md` are
+written as soon as the sweep finishes — before the `scanned > 0` check and
+before the guard — so a run that fails on coverage, *including one where every
+single row failed*, still leaves an artifact naming each dropped row and its
+stage. A run killed mid-sweep (Ctrl-C, the harness itself crashing) writes
+nothing; there the run log is still the only record.
 
 ## Methodology (so the numbers are defensible)
 

--- a/examples/isolation-survey/README.md
+++ b/examples/isolation-survey/README.md
@@ -71,6 +71,27 @@ set grows past a couple dozen images. Set `MIRROR=0` to pull straight from the
 original registry. A scenario whose image cannot be pulled or run is **skipped**,
 never fatal, so one unavailable image never aborts the survey.
 
+**Coverage is part of the output.** A skip is recorded, not just logged: every
+dropped scenario lands in `.skipped[]` of `results.json` as
+`{label, image, stage, reason}` — `stage` being `pull`, `run` or `scan` — and is
+listed in the "Not scanned" table of [`results.md`](./results.md), alongside
+`manifestRowCount` / `scenarioCount` / `skippedCount`. A skipped row is **not
+measured**; it is not a low score, and it is not in the table. This exists
+because it was previously invisible: the same 39 of 295 rows failed on every
+weekly refresh, the only trace was an Actions log that expires, and the run
+exited green (IRO-727).
+
+**Losing coverage fails the run.** [`coverage_guard.py`](./coverage_guard.py)
+compares the finished run against the previous `results.json` and exits non-zero
+if a scenario that scored last time — and is still listed in `images.txt` —
+produced nothing now. Deliberately a *regression* check rather than "any skip is
+fatal": a transient registry failure is absent from the baseline too, so it
+cannot wedge the weekly refresh, while a row that rots for good is caught the
+first week it stops scoring. If a row can never be scanned again, the fix is to
+delete it from `images.txt` — a label that leaves the manifest is not a
+regression. Results are written *before* the guard runs, so a failed run still
+leaves the artifact that explains itself.
+
 ## Methodology (so the numbers are defensible)
 
 * **Read-only, config-based.** `ironctl scan` inspects a container's declared
@@ -141,6 +162,7 @@ new page — no manual nav edit.
 | [`images.txt`](./images.txt) | the versioned manifest of scenarios |
 | [`survey.sh`](./survey.sh) | the harness: pull -> run -> `ironctl scan --json` -> aggregate |
 | [`render.py`](./render.py) | stdlib aggregation of scan JSON into `results.{json,md}` |
+| [`coverage_guard.py`](./coverage_guard.py) | fails a run that lost a scenario the previous run scored |
 | [`gen_scorecards.py`](./gen_scorecards.py) | renders `results.json` into `docs/scores/` scorecard pages |
 | [`results.json`](./results.json) | the committed machine-readable dataset |
 | [`results.md`](./results.md) | the committed rendered table |

--- a/examples/isolation-survey/coverage_guard.py
+++ b/examples/isolation-survey/coverage_guard.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""coverage_guard.py — fail a survey run that lost coverage it used to have.
+
+`survey.sh` is deliberately tolerant of a scenario it cannot pull, run or scan:
+it is sweeping 295 images from live public registries, and one transient 500
+should never wedge the weekly scorecard refresh. The bug (IRO-727) was that the
+only guard on the whole sweep was `scanned > 0`, so 39 rows failed every single
+week and the run still exited green with a clean-looking artifact.
+
+"Any skip is fatal" is the wrong correction — it trades a silent hole for a
+pipeline that goes red on registry weather, and a guard you learn to re-run on
+red is not a guard. So this checks for **regression**, not absence:
+
+* Every scenario that produced output in the PREVIOUS results.json and is STILL
+  listed in the manifest must produce output again. A genuinely flaky pull is
+  missing from the baseline too, so it cannot trip this; a row that fails
+  deterministically week after week is invisible to it only until the first week
+  it succeeds, after which it is pinned.
+* A row deliberately deleted from images.txt is not a regression — retiring a
+  dead row is the intended fix, so the baseline is intersected with the current
+  manifest.
+* The absolute floor is the backstop, and it comes from the previous run's
+  count, not from 1. With no baseline available (a first run, or a fresh
+  checkout with no committed results.json) it degrades to "> 0" and says so,
+  loudly, instead of pretending it verified something.
+
+Usage:
+
+    coverage_guard.py --manifest images.txt --results results.json \
+                      [--baseline previous-results.json] [--min-scanned N]
+
+Exits 0 when coverage held, 1 on a coverage regression, 2 on a usage/IO error.
+Negative controls: scripts/tests/test_coverage_guard.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def manifest_labels(path):
+    """Scenario labels in images.txt, in file order, deduplicated.
+
+    Mirrors survey.sh's own parse: strip CR, skip blanks and `#` comments, split
+    on `|`, take field 1. If these two ever disagree the guard measures a
+    different manifest than the sweep did.
+    """
+    labels = []
+    seen = set()
+    with open(path) as f:
+        for line in f:
+            line = line.strip().rstrip("\r")
+            if not line or line.startswith("#"):
+                continue
+            label = line.split("|")[0].strip()
+            if not label or label in seen:
+                continue
+            seen.add(label)
+            labels.append(label)
+    return labels
+
+
+def scenario_labels(results_path):
+    """Labels that produced a scorecard in a results.json."""
+    with open(results_path) as f:
+        doc = json.load(f)
+    return {s.get("label", "") for s in doc.get("scenarios", [])}
+
+
+def skip_index(results_path):
+    """label -> {stage, reason} for the scenarios this run recorded as skipped.
+
+    Empty for a schema-1.0 results.json, which had nowhere to record them; the
+    guard still works, it just cannot explain the regression it found.
+    """
+    with open(results_path) as f:
+        doc = json.load(f)
+    return {s.get("label", ""): s for s in doc.get("skipped", [])}
+
+
+def evaluate(manifest, scanned, baseline, min_scanned=None):
+    """Decide whether coverage held.
+
+    manifest -- labels the manifest asked for (list, file order)
+    scanned  -- labels that produced a scorecard this run (set)
+    baseline -- labels that produced one last run, or None when unavailable
+    Returns (ok, floor, regressed, messages).
+    """
+    messages = []
+    regressed = []
+
+    if baseline is None:
+        expected = None
+        floor = 1 if min_scanned is None else min_scanned
+        messages.append(
+            "no baseline results.json: coverage regression is UNCHECKED this "
+            f"run, falling back to a floor of {floor}")
+    else:
+        # Only rows the manifest still asks for. Deleting a dead row is the
+        # intended fix for a permanently failing scenario, not a regression.
+        expected = [lab for lab in manifest if lab in baseline]
+        regressed = [lab for lab in expected if lab not in scanned]
+        floor = len(expected) if min_scanned is None else min_scanned
+
+    ok = not regressed and len(scanned) >= floor
+    return ok, floor, regressed, messages
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest", required=True)
+    ap.add_argument("--results", required=True,
+                    help="results.json this run just wrote")
+    ap.add_argument("--baseline", default="",
+                    help="the previous results.json, captured before the run "
+                         "overwrote it")
+    ap.add_argument("--min-scanned", type=int, default=None,
+                    help="override the absolute floor (default: the baseline's "
+                         "own count)")
+    args = ap.parse_args(argv)
+
+    try:
+        manifest = manifest_labels(args.manifest)
+        scanned = scenario_labels(args.results)
+        skips = skip_index(args.results)
+        baseline = scenario_labels(args.baseline) if args.baseline else None
+    except (OSError, ValueError, KeyError) as exc:
+        print(f"coverage guard: cannot read inputs: {exc}", file=sys.stderr)
+        return 2
+
+    ok, floor, regressed, messages = evaluate(
+        manifest, scanned, baseline, args.min_scanned)
+
+    print(f"coverage: {len(scanned)} scanned / {len(manifest)} manifest rows "
+          f"/ {len(skips)} recorded skips (floor {floor})", file=sys.stderr)
+    for m in messages:
+        print(f"coverage guard: {m}", file=sys.stderr)
+
+    if regressed:
+        print(f"coverage guard: FAIL — {len(regressed)} scenario(s) scored in "
+              "the previous results.json and produced nothing now:",
+              file=sys.stderr)
+        for lab in regressed:
+            s = skips.get(lab)
+            why = (f"failed at {s.get('stage', '?')}: "
+                   f"{(s.get('reason') or '').strip()}") if s else \
+                "never reached the sweep (not attempted, or the run died early)"
+            print(f"  - {lab}: {why}", file=sys.stderr)
+        print("coverage guard: fix the rows, or delete them from the manifest "
+              "if they can never be scanned again.", file=sys.stderr)
+    elif len(scanned) < floor:
+        print(f"coverage guard: FAIL — only {len(scanned)} scenarios scanned, "
+              f"floor is {floor}.", file=sys.stderr)
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/isolation-survey/coverage_guard.py
+++ b/examples/isolation-survey/coverage_guard.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""coverage_guard.py — fail a survey run that lost coverage it used to have.
+r"""coverage_guard.py — fail a survey run that lost coverage it used to have.
 
 `survey.sh` is deliberately tolerant of a scenario it cannot pull, run or scan:
 it is sweeping 295 images from live public registries, and one transient 500
@@ -9,27 +9,42 @@ week and the run still exited green with a clean-looking artifact.
 
 "Any skip is fatal" is the wrong correction — it trades a silent hole for a
 pipeline that goes red on registry weather, and a guard you learn to re-run on
-red is not a guard. So this checks for **regression**, not absence:
+red is not a guard. So this checks two things instead:
 
-* Every scenario that produced output in the PREVIOUS results.json and is STILL
-  listed in the manifest must produce output again. A genuinely flaky pull is
-  missing from the baseline too, so it cannot trip this; a row that fails
-  deterministically week after week is invisible to it only until the first week
-  it succeeds, after which it is pinned.
-* A row deliberately deleted from images.txt is not a regression — retiring a
-  dead row is the intended fix, so the baseline is intersected with the current
-  manifest.
-* The absolute floor is the backstop, and it comes from the previous run's
-  count, not from 1. With no baseline available (a first run, or a fresh
-  checkout with no committed results.json) it degrades to "> 0" and says so,
-  loudly, instead of pretending it verified something.
+1. **No regression.** Every scenario that produced output in the baseline
+   results.json and is STILL listed in the manifest must produce output again. A
+   genuinely flaky pull is missing from the baseline too, so it cannot trip
+   this; a row that fails deterministically week after week is invisible to it
+   only until the first week it succeeds, after which it is pinned. A row
+   deliberately deleted from images.txt is not a regression — retiring a dead
+   row is the intended fix, so the baseline is intersected with the current
+   manifest.
+
+   The baseline must be the last COMMITTED results.json, never the working-tree
+   copy the run is about to overwrite: see the header of `survey.sh`. Taking it
+   from disk lets a plain re-run launder a regression green.
+
+2. **The accounting adds up.** `scenarioCount + skippedCount == manifestRowCount
+   == the rows this guard parses out of images.txt`. That is the invariant the
+   artifact advertises, and it is what makes "256 scenarios" readable as
+   coverage rather than as a number with no denominator. A count the artifact
+   does not record is reported as unverifiable, never defaulted to zero.
+
+There is no implicit floor. With a baseline, `regressed == []` already implies
+`len(scanned) >= len(expected)`, so an implicit `len(scanned) >= len(expected)`
+floor would be unreachable code dressed up as a second opinion. `--min-scanned`
+still applies when you pass it explicitly, and with no baseline available (a
+first run, or a checkout with no committed results.json) it degrades to "> 0"
+and says the regression check was skipped, loudly, instead of pretending it
+verified something.
 
 Usage:
 
     coverage_guard.py --manifest images.txt --results results.json \
                       [--baseline previous-results.json] [--min-scanned N]
 
-Exits 0 when coverage held, 1 on a coverage regression, 2 on a usage/IO error.
+Exits 0 when coverage held, 1 on a coverage regression or a broken invariant,
+2 on a usage/IO error.
 Negative controls: scripts/tests/test_coverage_guard.py.
 """
 
@@ -39,72 +54,174 @@ import argparse
 import json
 import sys
 
+# The coverage block render.py writes at schemaVersion 1.1. Absent in 1.0, which
+# had nowhere to record any of it.
+REQUIRED_COUNTS = ("manifestRowCount", "scenarioCount", "skippedCount")
+
 
 def manifest_labels(path):
-    """Scenario labels in images.txt, in file order, deduplicated.
+    r"""Scenario labels in images.txt, in file order, INCLUDING duplicates.
 
-    Mirrors survey.sh's own parse: strip CR, skip blanks and `#` comments, split
-    on `|`, take field 1. If these two ever disagree the guard measures a
-    different manifest than the sweep did.
+    Mirrors survey.sh's own parse, because the guard's arithmetic only means
+    anything if it measures the row set the sweep actually walked:
+
+    * a trailing CR is stripped, as `line="${line%%$'\r'}"` does;
+    * a line is a comment only when `#` is at column 0, as
+      `case "$line" in ''|'#'*)` does. An INDENTED `#` is a scenario row to the
+      sweep, so it is one here too — this function used to `.strip()` first and
+      silently disagreed with the sweep about it;
+    * the label is field 1 of a `|` split, whitespace-collapsed the way
+      `echo "$label" | xargs` collapses it: leading/trailing dropped, internal
+      runs squeezed to a single space;
+    * a row whose label is empty after that is dropped, as `[ -z "$label" ]`
+      does;
+    * duplicates are KEPT, because the sweep walks and counts them twice. This
+      function used to deduplicate.
+
+    Not mirrored, deliberately: `xargs` also applies shell quote/backslash
+    processing, which nothing in images.txt uses. If a label ever needs it, the
+    accounting check below is what catches the disagreement — it compares this
+    row count against the count survey.sh recorded, so a drift fails the run
+    instead of quietly shifting the denominator.
     """
     labels = []
-    seen = set()
     with open(path) as f:
-        for line in f:
-            line = line.strip().rstrip("\r")
+        for raw in f:
+            line = raw.rstrip("\n")
+            if line.endswith("\r"):
+                line = line[:-1]
             if not line or line.startswith("#"):
                 continue
-            label = line.split("|")[0].strip()
-            if not label or label in seen:
+            label = " ".join(line.split("|")[0].split())
+            if not label:
                 continue
-            seen.add(label)
             labels.append(label)
     return labels
 
 
-def scenario_labels(results_path):
-    """Labels that produced a scorecard in a results.json."""
-    with open(results_path) as f:
-        doc = json.load(f)
+def load_results(path):
+    """Parse a results.json."""
+    with open(path) as f:
+        return json.load(f)
+
+
+def scenario_labels_of(doc):
+    """Labels that produced a scorecard in a parsed results.json."""
     return {s.get("label", "") for s in doc.get("scenarios", [])}
 
 
-def skip_index(results_path):
+def scenario_labels(results_path):
+    """Labels that produced a scorecard in a results.json on disk."""
+    return scenario_labels_of(load_results(results_path))
+
+
+def skip_index_of(doc):
     """label -> {stage, reason} for the scenarios this run recorded as skipped.
 
     Empty for a schema-1.0 results.json, which had nowhere to record them; the
     guard still works, it just cannot explain the regression it found.
     """
-    with open(results_path) as f:
-        doc = json.load(f)
     return {s.get("label", ""): s for s in doc.get("skipped", [])}
+
+
+def check_accounting(doc, manifest):
+    """Verify `scenarioCount + skippedCount == manifestRowCount == len(manifest)`.
+
+    Returns a list of problems; empty means the invariant holds. The PR that
+    introduced the coverage block advertised this invariant as checkable from
+    the artifact and then checked it nowhere, which is how results.md could
+    print "2 of 3 manifest rows — every row was scanned" and exit 0.
+
+    A count the artifact does not record is a problem, not a zero. Reaching for
+    `doc.get("skippedCount", 0)` here would turn "schema 1.0 could not record
+    this" into "the invariant holds", which is the exact fail-quiet shape this
+    guard exists to kill.
+    """
+    problems = []
+
+    missing = [k for k in REQUIRED_COUNTS if not isinstance(doc.get(k), int)]
+    if missing:
+        problems.append(
+            f"results.json does not record {', '.join(missing)} "
+            f"(schemaVersion {doc.get('schemaVersion', 'unset')!r}; 1.1 records "
+            "them): the coverage invariant is NOT verified, and is not assumed "
+            "to hold")
+        return problems
+
+    n_manifest = doc["manifestRowCount"]
+    n_scen = doc["scenarioCount"]
+    n_skip = doc["skippedCount"]
+
+    # Each counter must describe the array it sits next to, or the invariant is
+    # arithmetic over numbers nobody produced.
+    if n_scen != len(doc.get("scenarios", [])):
+        problems.append(
+            f"scenarioCount is {n_scen} but scenarios[] has "
+            f"{len(doc.get('scenarios', []))} entr(ies)")
+    if n_skip != len(doc.get("skipped", [])):
+        problems.append(
+            f"skippedCount is {n_skip} but skipped[] has "
+            f"{len(doc.get('skipped', []))} entr(ies)")
+
+    if n_scen + n_skip != n_manifest:
+        gap = n_manifest - n_scen - n_skip
+        if gap > 0:
+            problems.append(
+                f"{gap} manifest row(s) are unaccounted for: scenarioCount "
+                f"({n_scen}) + skippedCount ({n_skip}) = {n_scen + n_skip}, "
+                f"manifestRowCount is {n_manifest}. A row that is neither "
+                "scored nor recorded as skipped is exactly the hole IRO-727 "
+                "closed")
+        else:
+            problems.append(
+                f"scenarioCount ({n_scen}) + skippedCount ({n_skip}) = "
+                f"{n_scen + n_skip} exceeds manifestRowCount ({n_manifest}): "
+                "the run produced output for rows the manifest never asked for")
+
+    if n_manifest != len(manifest):
+        problems.append(
+            f"manifestRowCount is {n_manifest} but this guard parses "
+            f"{len(manifest)} row(s) out of the manifest: the sweep and the "
+            "guard disagree about what images.txt asks for, so every coverage "
+            "number here is measured against the wrong denominator")
+
+    return problems
 
 
 def evaluate(manifest, scanned, baseline, min_scanned=None):
     """Decide whether coverage held.
 
-    manifest -- labels the manifest asked for (list, file order)
+    manifest -- labels the manifest asked for (list, file order, may repeat)
     scanned  -- labels that produced a scorecard this run (set)
-    baseline -- labels that produced one last run, or None when unavailable
-    Returns (ok, floor, regressed, messages).
+    baseline -- labels that produced one in the committed results.json, or None
+                when unavailable
+    Returns (ok, floor, regressed, messages). `floor` is None when no absolute
+    floor applies, which is the normal case once a baseline exists.
     """
     messages = []
     regressed = []
 
     if baseline is None:
-        expected = None
         floor = 1 if min_scanned is None else min_scanned
         messages.append(
             "no baseline results.json: coverage regression is UNCHECKED this "
             f"run, falling back to a floor of {floor}")
     else:
-        # Only rows the manifest still asks for. Deleting a dead row is the
-        # intended fix for a permanently failing scenario, not a regression.
-        expected = [lab for lab in manifest if lab in baseline]
+        # Only rows the manifest still asks for, once each. Deleting a dead row
+        # is the intended fix for a permanently failing scenario, not a
+        # regression.
+        seen = set()
+        expected = []
+        for lab in manifest:
+            if lab in baseline and lab not in seen:
+                seen.add(lab)
+                expected.append(lab)
         regressed = [lab for lab in expected if lab not in scanned]
-        floor = len(expected) if min_scanned is None else min_scanned
+        # No implicit floor: `regressed == []` already implies
+        # `len(scanned) >= len(expected)`, so one would never fire.
+        floor = min_scanned
 
-    ok = not regressed and len(scanned) >= floor
+    ok = not regressed and (floor is None or len(scanned) >= floor)
     return ok, floor, regressed, messages
 
 
@@ -114,17 +231,19 @@ def main(argv=None):
     ap.add_argument("--results", required=True,
                     help="results.json this run just wrote")
     ap.add_argument("--baseline", default="",
-                    help="the previous results.json, captured before the run "
-                         "overwrote it")
+                    help="the last COMMITTED results.json, read from git rather "
+                         "than from the working tree this run overwrites")
     ap.add_argument("--min-scanned", type=int, default=None,
-                    help="override the absolute floor (default: the baseline's "
-                         "own count)")
+                    help="fail unless at least N scenarios scanned; applies "
+                         "whether or not a baseline is present (default: no "
+                         "absolute floor with a baseline, 1 without one)")
     args = ap.parse_args(argv)
 
     try:
         manifest = manifest_labels(args.manifest)
-        scanned = scenario_labels(args.results)
-        skips = skip_index(args.results)
+        doc = load_results(args.results)
+        scanned = scenario_labels_of(doc)
+        skips = skip_index_of(doc)
         baseline = scenario_labels(args.baseline) if args.baseline else None
     except (OSError, ValueError, KeyError) as exc:
         print(f"coverage guard: cannot read inputs: {exc}", file=sys.stderr)
@@ -132,9 +251,12 @@ def main(argv=None):
 
     ok, floor, regressed, messages = evaluate(
         manifest, scanned, baseline, args.min_scanned)
+    problems = check_accounting(doc, manifest)
 
+    floor_note = "no floor, regression-relative" if floor is None \
+        else f"floor {floor}"
     print(f"coverage: {len(scanned)} scanned / {len(manifest)} manifest rows "
-          f"/ {len(skips)} recorded skips (floor {floor})", file=sys.stderr)
+          f"/ {len(skips)} recorded skips ({floor_note})", file=sys.stderr)
     for m in messages:
         print(f"coverage guard: {m}", file=sys.stderr)
 
@@ -150,11 +272,18 @@ def main(argv=None):
             print(f"  - {lab}: {why}", file=sys.stderr)
         print("coverage guard: fix the rows, or delete them from the manifest "
               "if they can never be scanned again.", file=sys.stderr)
-    elif len(scanned) < floor:
+    elif floor is not None and len(scanned) < floor:
         print(f"coverage guard: FAIL — only {len(scanned)} scenarios scanned, "
               f"floor is {floor}.", file=sys.stderr)
 
-    return 0 if ok else 1
+    if problems:
+        print("coverage guard: FAIL — the artifact does not account for every "
+              "manifest row (scenarioCount + skippedCount == manifestRowCount):",
+              file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+
+    return 0 if (ok and not problems) else 1
 
 
 if __name__ == "__main__":

--- a/examples/isolation-survey/coverage_guard.py
+++ b/examples/isolation-survey/coverage_guard.py
@@ -25,10 +25,19 @@ red is not a guard. So this checks two things instead:
    from disk lets a plain re-run launder a regression green.
 
 2. **The accounting adds up.** `scenarioCount + skippedCount == manifestRowCount
-   == the rows this guard parses out of images.txt`. That is the invariant the
-   artifact advertises, and it is what makes "256 scenarios" readable as
-   coverage rather than as a number with no denominator. A count the artifact
-   does not record is reported as unverifiable, never defaulted to zero.
+   == the rows this guard parses out of images.txt`, AND the labels match as a
+   multiset, not just as totals. That is the invariant the artifact advertises,
+   and it is what makes "256 scenarios" readable as coverage rather than as a
+   number with no denominator. A count the artifact does not record is reported
+   as unverifiable, never defaulted to zero.
+
+   The multiset half is what makes check 1 sound. Counts are blind to label
+   IDENTITY, and every way this file's parse could still disagree with
+   `survey.sh` changes WHICH label a row carries at an unchanged count. Since
+   check 1 matches the baseline by label, one mis-spelled label leaves
+   `expected` permanently and silently — IRO-727 reproduced by the guard written
+   to prevent it. Comparing multisets turns that whole class loud, including the
+   divergences nobody has thought of yet.
 
 There is no implicit floor. With a baseline, `regressed == []` already implies
 `len(scanned) >= len(expected)`, so an implicit `len(scanned) >= len(expected)`
@@ -51,71 +60,100 @@ Negative controls: scripts/tests/test_coverage_guard.py.
 from __future__ import annotations
 
 import argparse
+import collections
 import json
+import re
 import sys
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 # The coverage block render.py writes at schemaVersion 1.1. Absent in 1.0, which
 # had nowhere to record any of it.
 REQUIRED_COUNTS = ("manifestRowCount", "scenarioCount", "skippedCount")
 
+# Runs of the ONLY two blanks bash's default IFS splits on. Not `bytes.split()`
+# with no argument, and not `str.split()`: both also split on \x0b, \x0c and (in
+# text mode) every Unicode space, none of which bash treats as a separator. A
+# label containing U+00A0 parsed one way here and another way in the sweep.
+_BLANKS = re.compile(rb"[ \t]+")
 
-def manifest_labels(path):
+
+def manifest_labels(path: str) -> List[str]:
     r"""Scenario labels in images.txt, in file order, INCLUDING duplicates.
 
     Mirrors survey.sh's own parse, because the guard's arithmetic only means
     anything if it measures the row set the sweep actually walked:
 
+    * the file is split on b"\n" and nothing else, as `IFS= read -r line` does.
+      Text mode is universal-newline mode, where a BARE CR is a line terminator
+      to Python and an ordinary character to `read` — the file was already
+      re-split before any per-line fix-up could help;
     * a trailing CR is stripped, as `line="${line%%$'\r'}"` does;
     * a line is a comment only when `#` is at column 0, as
       `case "$line" in ''|'#'*)` does. An INDENTED `#` is a scenario row to the
       sweep, so it is one here too — this function used to `.strip()` first and
       silently disagreed with the sweep about it;
-    * the label is field 1 of a `|` split, whitespace-collapsed the way
-      `echo "$label" | xargs` collapses it: leading/trailing dropped, internal
-      runs squeezed to a single space;
+    * the label is field 1 of a `|` split, with runs of space/tab collapsed to
+      one space and leading/trailing dropped — exactly what survey.sh's
+      `collapse()` does with `read -r -a` under the default IFS;
     * a row whose label is empty after that is dropped, as `[ -z "$label" ]`
       does;
     * duplicates are KEPT, because the sweep walks and counts them twice. This
       function used to deduplicate.
 
-    Not mirrored, deliberately: `xargs` also applies shell quote/backslash
-    processing, which nothing in images.txt uses. If a label ever needs it, the
-    accounting check below is what catches the disagreement — it compares this
-    row count against the count survey.sh recorded, so a drift fails the run
-    instead of quietly shifting the denominator.
+    survey.sh used to pipe the field through `echo "$label" | xargs`, which is
+    NOT this: xargs applies shell quote and backslash processing, and with no
+    utility argument it defaults to `/bin/echo`, so a label beginning `-n ` was
+    eaten as an option. Both sides now do the same blank-collapse and nothing
+    else, so the classes exist on neither. `check_accounting` compares the two
+    LABEL SETS, not just their sizes, so a residual disagreement fails the run
+    loudly instead of quietly dropping a row out of the baseline comparison.
     """
-    labels = []
-    with open(path) as f:
-        for raw in f:
-            line = raw.rstrip("\n")
-            if line.endswith("\r"):
-                line = line[:-1]
-            if not line or line.startswith("#"):
-                continue
-            label = " ".join(line.split("|")[0].split())
-            if not label:
-                continue
-            labels.append(label)
+    labels: List[str] = []
+    with open(path, "rb") as f:
+        data = f.read()
+    for raw in data.split(b"\n"):
+        line = raw[:-1] if raw.endswith(b"\r") else raw
+        if not line or line.startswith(b"#"):
+            continue
+        field = line.split(b"|")[0]
+        label = b" ".join(p for p in _BLANKS.split(field) if p)
+        if not label:
+            continue
+        # surrogateescape so a non-UTF-8 byte round-trips into a string that
+        # simply will not equal any label the artifact recorded, rather than
+        # raising and taking the guard's exit code to 2.
+        labels.append(label.decode("utf-8", "surrogateescape"))
     return labels
 
 
-def load_results(path):
+def load_results(path: str) -> Dict[str, Any]:
     """Parse a results.json."""
     with open(path) as f:
         return json.load(f)
 
 
-def scenario_labels_of(doc):
+def scenario_labels_of(doc: Dict[str, Any]) -> Set[str]:
     """Labels that produced a scorecard in a parsed results.json."""
     return {s.get("label", "") for s in doc.get("scenarios", [])}
 
 
-def scenario_labels(results_path):
+def scenario_labels(results_path: str) -> Set[str]:
     """Labels that produced a scorecard in a results.json on disk."""
     return scenario_labels_of(load_results(results_path))
 
 
-def skip_index_of(doc):
+def recorded_labels(doc: Dict[str, Any]) -> List[str]:
+    """Every label the run reported, once per row: scored, then skipped.
+
+    A list rather than a set: the manifest may repeat a label, the sweep walks
+    it once per row, and an accounting check that collapsed duplicates could not
+    tell "walked twice" from "walked once and lost one".
+    """
+    return ([s.get("label", "") for s in doc.get("scenarios", [])]
+            + [s.get("label", "") for s in doc.get("skipped", [])])
+
+
+def skip_index_of(doc: Dict[str, Any]) -> Dict[str, Any]:
     """label -> {stage, reason} for the scenarios this run recorded as skipped.
 
     Empty for a schema-1.0 results.json, which had nowhere to record them; the
@@ -124,8 +162,17 @@ def skip_index_of(doc):
     return {s.get("label", ""): s for s in doc.get("skipped", [])}
 
 
-def check_accounting(doc, manifest):
-    """Verify `scenarioCount + skippedCount == manifestRowCount == len(manifest)`.
+def _is_count(value: Any) -> bool:
+    """True for a JSON integer. `bool` is a subclass of `int` in Python, so a
+    bare isinstance check reads `manifestRowCount: true` as a recorded count and
+    then does arithmetic on it as 1."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def check_accounting(doc: Dict[str, Any],
+                     manifest: Sequence[str]) -> List[str]:
+    """Verify `scenarioCount + skippedCount == manifestRowCount == len(manifest)`
+    and that the two sides name the SAME rows.
 
     Returns a list of problems; empty means the invariant holds. The PR that
     introduced the coverage block advertised this invariant as checkable from
@@ -136,10 +183,17 @@ def check_accounting(doc, manifest):
     `doc.get("skippedCount", 0)` here would turn "schema 1.0 could not record
     this" into "the invariant holds", which is the exact fail-quiet shape this
     guard exists to kill.
-    """
-    problems = []
 
-    missing = [k for k in REQUIRED_COUNTS if not isinstance(doc.get(k), int)]
+    Counts alone are not enough, for the same reason. Three ghost labels against
+    a three-row manifest satisfies every sum above while covering none of the
+    rows asked for, and any residual parse disagreement with survey.sh moves
+    label identity at a constant count — invisible to arithmetic, fatal to
+    `evaluate()`, which matches the baseline by label. So the last check is a
+    multiset comparison of the labels themselves.
+    """
+    problems: List[str] = []
+
+    missing = [k for k in REQUIRED_COUNTS if not _is_count(doc.get(k))]
     if missing:
         problems.append(
             f"results.json does not record {', '.join(missing)} "
@@ -185,10 +239,43 @@ def check_accounting(doc, manifest):
             "guard disagree about what images.txt asks for, so every coverage "
             "number here is measured against the wrong denominator")
 
+    # The identity check the sums cannot do. `evaluate()` matches the baseline
+    # by label, so a row the two sides spell differently silently leaves the
+    # expected set forever; the totals stay equal the whole time.
+    asked = collections.Counter(manifest)
+    reported = collections.Counter(recorded_labels(doc))
+    unreported = sorted((asked - reported).elements())
+    unrequested = sorted((reported - asked).elements())
+    if unreported or unrequested:
+        detail = []
+        if unreported:
+            detail.append(
+                f"{len(unreported)} manifest row(s) the artifact never names: "
+                + ", ".join(repr(lab) for lab in unreported[:5])
+                + (", …" if len(unreported) > 5 else ""))
+        if unrequested:
+            detail.append(
+                f"{len(unrequested)} label(s) in the artifact that no manifest "
+                "row asks for: "
+                + ", ".join(repr(lab) for lab in unrequested[:5])
+                + (", …" if len(unrequested) > 5 else ""))
+        problems.append(
+            "the artifact and the manifest do not name the same rows — "
+            + "; ".join(detail)
+            + ". The counts can match while the labels do not, and the "
+            "regression check compares labels, so a row spelled two ways here "
+            "would drop out of the baseline comparison permanently and without "
+            "a word")
+
     return problems
 
 
-def evaluate(manifest, scanned, baseline, min_scanned=None):
+def evaluate(
+    manifest: Sequence[str],
+    scanned: Set[str],
+    baseline: Optional[Set[str]],
+    min_scanned: Optional[int] = None,
+) -> Tuple[bool, Optional[int], List[str], List[str]]:
     """Decide whether coverage held.
 
     manifest -- labels the manifest asked for (list, file order, may repeat)
@@ -198,8 +285,8 @@ def evaluate(manifest, scanned, baseline, min_scanned=None):
     Returns (ok, floor, regressed, messages). `floor` is None when no absolute
     floor applies, which is the normal case once a baseline exists.
     """
-    messages = []
-    regressed = []
+    messages: List[str] = []
+    regressed: List[str] = []
 
     if baseline is None:
         floor = 1 if min_scanned is None else min_scanned
@@ -210,8 +297,8 @@ def evaluate(manifest, scanned, baseline, min_scanned=None):
         # Only rows the manifest still asks for, once each. Deleting a dead row
         # is the intended fix for a permanently failing scenario, not a
         # regression.
-        seen = set()
-        expected = []
+        seen: Set[str] = set()
+        expected: List[str] = []
         for lab in manifest:
             if lab in baseline and lab not in seen:
                 seen.add(lab)
@@ -225,7 +312,7 @@ def evaluate(manifest, scanned, baseline, min_scanned=None):
     return ok, floor, regressed, messages
 
 
-def main(argv=None):
+def main(argv: Optional[List[str]] = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--manifest", required=True)
     ap.add_argument("--results", required=True,

--- a/examples/isolation-survey/render.py
+++ b/examples/isolation-survey/render.py
@@ -10,9 +10,21 @@ Writes results.json to argv[1] and results.md to argv[2]. Deterministic: rows
 are sorted by (score asc, label asc) so a re-run over the same manifest yields a
 byte-identical table (minus the generatedAt/version stamps, which are recorded
 once at the dataset level).
+
+Coverage is part of the output, not a log line (IRO-727). `--skips` takes the
+JSON array survey.sh accumulates for every scenario it dropped, each
+`{"label", "image", "stage", "reason"}`; those land in `.skipped[]` of
+results.json and in a "Not scanned" section of results.md, so a reader can tell
+measured-and-passed from never-measured without opening an Actions log that
+expires. `--manifest-rows` records how many rows the manifest actually had, so
+`scenarioCount + skippedCount == manifestRowCount` is checkable from the
+artifact alone.
 """
+import argparse
 import json
 import sys
+
+SKIP_STAGES = ("pull", "run", "scan")
 
 
 def failed_dims(report):
@@ -24,9 +36,52 @@ def failed_dims(report):
     return [d.get("title", d.get("key", "?")) for d in dims]
 
 
+def load_skips(path):
+    """Normalise survey.sh's skip array. Unknown stages are kept (and sorted
+    last) rather than dropped: a skip we cannot classify is still a scenario
+    that was never measured, and silently discarding it is the bug this whole
+    change exists to fix."""
+    if not path:
+        return []
+    with open(path) as f:
+        raw = json.load(f)
+    skips = []
+    for s in raw:
+        skips.append({
+            "label": s.get("label", ""),
+            "image": s.get("image", ""),
+            "stage": s.get("stage", "unknown"),
+            "reason": (s.get("reason", "") or "").strip(),
+        })
+    skips.sort(key=lambda s: (s["label"], s["stage"]))
+    return skips
+
+
+def skip_counts(skips):
+    """stage -> count, listing the three known stages in pipeline order first."""
+    counts = {}
+    for s in skips:
+        counts[s["stage"]] = counts.get(s["stage"], 0) + 1
+    ordered = {st: counts[st] for st in SKIP_STAGES if st in counts}
+    for st in sorted(counts):
+        ordered.setdefault(st, counts[st])
+    return ordered
+
+
 def main():
-    out_json, out_md = sys.argv[1], sys.argv[2]
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("out_json")
+    ap.add_argument("out_md")
+    ap.add_argument("--skips", default="",
+                    help="JSON array of {label,image,stage,reason} scenarios "
+                         "the survey dropped")
+    ap.add_argument("--manifest-rows", type=int, default=None,
+                    help="number of scenario rows in images.txt")
+    args = ap.parse_args()
+
+    out_json, out_md = args.out_json, args.out_md
     records = json.load(sys.stdin)
+    skips = load_skips(args.skips)
 
     rows = []
     for rec in records:
@@ -46,13 +101,20 @@ def main():
     # A dataset-level stamp: take the tool version + generatedAt from the first
     # report (they are identical across a single run).
     stamp = records[0]["report"] if records else {}
+    manifest_rows = args.manifest_rows
+    if manifest_rows is None:
+        manifest_rows = len(rows) + len(skips)
     dataset = {
         "report": "ironclaw-isolation-survey",
-        "schemaVersion": "1.0",
+        # 1.1 adds the coverage block: manifestRowCount, skippedCount, skipped[].
+        "schemaVersion": "1.1",
         "generatedAt": stamp.get("generatedAt", ""),
         "ironctlVersion": stamp.get("version", ""),
+        "manifestRowCount": manifest_rows,
         "scenarioCount": len(rows),
+        "skippedCount": len(skips),
         "scenarios": rows,
+        "skipped": skips,
     }
     with open(out_json, "w") as f:
         json.dump(dataset, f, indent=2, sort_keys=True)
@@ -65,6 +127,18 @@ def main():
     lines.append(f"Scanned **{len(rows)} scenarios** with "
                  f"`ironctl scan` {dataset['ironctlVersion']} "
                  f"on {dataset['generatedAt']}.")
+    lines.append("")
+    if skips:
+        breakdown = ", ".join(f"{stage} {n}"
+                              for stage, n in skip_counts(skips).items())
+        lines.append(f"**Coverage: {len(rows)} of {manifest_rows} manifest "
+                     f"rows.** {len(skips)} scenario(s) were dropped before "
+                     f"they could be graded ({breakdown}) and are listed under "
+                     "[Not scanned](#not-scanned) below — they are absent from "
+                     "the table, not scored zero.")
+    else:
+        lines.append(f"**Coverage: {len(rows)} of {manifest_rows} manifest "
+                     "rows — every row was scanned.**")
     lines.append("")
     lines.append("Each row is one popular public image run with a specific "
                  "configuration, graded 0-100 across seven containment "
@@ -90,6 +164,27 @@ def main():
     summary = ", ".join(f"{dist[g]}×{g}" for g in sorted(dist))
     lines.append(f"**Grade distribution:** {summary}.")
     lines.append("")
+
+    # Every dropped scenario, by name. A count alone still leaves the reader
+    # guessing which images the dataset does not cover (IRO-727).
+    if skips:
+        lines.append("## Not scanned")
+        lines.append("")
+        lines.append(f"{len(skips)} of the {manifest_rows} rows in "
+                     "[images.txt](./images.txt) produced no scorecard this "
+                     "run. `pull` = the image could not be fetched from the "
+                     "mirror or its original registry, `run` = `docker run "
+                     "--entrypoint sleep` did not start it, `scan` = the "
+                     "container started but `ironctl scan` failed. These rows "
+                     "are **not measured**; they are not a low score.")
+        lines.append("")
+        lines.append("| Scenario | Image | Failed at | Reason |")
+        lines.append("|----------|-------|-----------|--------|")
+        for s in skips:
+            reason = s["reason"].replace("|", "\\|") or "(no detail recorded)"
+            lines.append(f"| `{s['label']}` | `{s['image']}` | {s['stage']} "
+                         f"| {reason} |")
+        lines.append("")
     lines.append("Regenerate this file from a clean checkout with "
                  "`examples/isolation-survey/survey.sh` (Docker required).")
     lines.append("")

--- a/examples/isolation-survey/render.py
+++ b/examples/isolation-survey/render.py
@@ -20,6 +20,17 @@ expires. `--manifest-rows` records how many rows the manifest actually had, so
 `scenarioCount + skippedCount == manifestRowCount` is checkable from the
 artifact alone — and coverage_guard.py, which survey.sh runs immediately after
 this, checks it rather than leaving it to the reader.
+
+`--manifest-rows` is REQUIRED, and that is load-bearing rather than pedantic.
+It used to default to `len(rows) + len(skips)`, i.e. the denominator was
+synthesized from the numerator, so the invariant held by construction and one
+scored row with no skips wrote `manifestRowCount: 1` and printed "Coverage: 1 of
+1 manifest rows, every row was scanned" against a 295-row manifest. A count
+nobody measured is not a count; the number has to come from the sweep.
+
+Usage:
+
+    render.py <out.json> <out.md> --manifest-rows N [--skips skips.json]
 """
 import argparse
 import json
@@ -76,8 +87,11 @@ def main():
     ap.add_argument("--skips", default="",
                     help="JSON array of {label,image,stage,reason} scenarios "
                          "the survey dropped")
-    ap.add_argument("--manifest-rows", type=int, default=None,
-                    help="number of scenario rows in images.txt")
+    ap.add_argument("--manifest-rows", type=int, required=True,
+                    help="number of scenario rows the sweep walked in "
+                         "images.txt. Required: deriving it from the rows that "
+                         "happen to be present makes the coverage invariant "
+                         "hold by construction and hides the whole defect")
     args = ap.parse_args()
 
     out_json, out_md = args.out_json, args.out_md
@@ -103,8 +117,6 @@ def main():
     # report (they are identical across a single run).
     stamp = records[0]["report"] if records else {}
     manifest_rows = args.manifest_rows
-    if manifest_rows is None:
-        manifest_rows = len(rows) + len(skips)
     dataset = {
         "report": "ironclaw-isolation-survey",
         # 1.1 adds the coverage block: manifestRowCount, skippedCount, skipped[].
@@ -134,14 +146,19 @@ def main():
                      "manifest row is accounted for below.")
     lines.append("")
 
-    # "Every row was scanned" is derived from the arithmetic, never from an
-    # empty skip list. Those are not the same claim: a run can drop a row
-    # without recording a skip, and reading the sentence off `if skips:` printed
-    # "Coverage: 2 of 3 manifest rows — every row was scanned" at exit 0
-    # (IRO-727). coverage_guard.py fails a run where they diverge; this file
-    # still has to describe what it actually has.
-    unaccounted = manifest_rows - len(rows) - len(skips)
-    if len(rows) == manifest_rows and not skips:
+    # "Every row was scanned" is one statement about the three counts: the
+    # scored rows are the whole manifest, nothing was dropped, and nothing is
+    # missing. All three are read off the same arithmetic, and `manifest_rows`
+    # now comes from the sweep rather than from `len(rows) + len(skips)`, so the
+    # first term can actually be false. Both of the ways this line used to be
+    # produced — reading it off `if skips:`, and synthesizing the denominator
+    # from the numerator — printed "Coverage: 2 of 3 manifest rows — every row
+    # was scanned" at exit 0 (IRO-727). Anything short of all three goes to the
+    # else branch and reports what the run actually has, including the
+    # over-accounted case where more rows came back than were asked for.
+    scored, dropped = len(rows), len(skips)
+    unaccounted = manifest_rows - scored - dropped
+    if scored == manifest_rows and dropped == 0 and unaccounted == 0:
         lines.append(f"**Coverage: {len(rows)} of {manifest_rows} manifest "
                      "rows — every row was scanned.**")
     else:

--- a/examples/isolation-survey/render.py
+++ b/examples/isolation-survey/render.py
@@ -18,7 +18,8 @@ results.json and in a "Not scanned" section of results.md, so a reader can tell
 measured-and-passed from never-measured without opening an Actions log that
 expires. `--manifest-rows` records how many rows the manifest actually had, so
 `scenarioCount + skippedCount == manifestRowCount` is checkable from the
-artifact alone.
+artifact alone — and coverage_guard.py, which survey.sh runs immediately after
+this, checks it rather than leaving it to the reader.
 """
 import argparse
 import json
@@ -124,21 +125,40 @@ def main():
     lines = []
     lines.append("# State of Container Isolation — survey results")
     lines.append("")
-    lines.append(f"Scanned **{len(rows)} scenarios** with "
-                 f"`ironctl scan` {dataset['ironctlVersion']} "
-                 f"on {dataset['generatedAt']}.")
-    lines.append("")
-    if skips:
-        breakdown = ", ".join(f"{stage} {n}"
-                              for stage, n in skip_counts(skips).items())
-        lines.append(f"**Coverage: {len(rows)} of {manifest_rows} manifest "
-                     f"rows.** {len(skips)} scenario(s) were dropped before "
-                     f"they could be graded ({breakdown}) and are listed under "
-                     "[Not scanned](#not-scanned) below — they are absent from "
-                     "the table, not scored zero.")
+    if rows:
+        lines.append(f"Scanned **{len(rows)} scenarios** with "
+                     f"`ironctl scan` {dataset['ironctlVersion']} "
+                     f"on {dataset['generatedAt']}.")
     else:
+        lines.append("**No scenario produced a scorecard in this run.** Every "
+                     "manifest row is accounted for below.")
+    lines.append("")
+
+    # "Every row was scanned" is derived from the arithmetic, never from an
+    # empty skip list. Those are not the same claim: a run can drop a row
+    # without recording a skip, and reading the sentence off `if skips:` printed
+    # "Coverage: 2 of 3 manifest rows — every row was scanned" at exit 0
+    # (IRO-727). coverage_guard.py fails a run where they diverge; this file
+    # still has to describe what it actually has.
+    unaccounted = manifest_rows - len(rows) - len(skips)
+    if len(rows) == manifest_rows and not skips:
         lines.append(f"**Coverage: {len(rows)} of {manifest_rows} manifest "
                      "rows — every row was scanned.**")
+    else:
+        note = f"**Coverage: {len(rows)} of {manifest_rows} manifest rows.**"
+        if skips:
+            breakdown = ", ".join(f"{stage} {n}"
+                                  for stage, n in skip_counts(skips).items())
+            note += (f" {len(skips)} scenario(s) were dropped before they could "
+                     f"be graded ({breakdown}) and are listed under "
+                     "[Not scanned](#not-scanned) below — they are absent from "
+                     "the table, not scored zero.")
+        if unaccounted:
+            note += (f" {abs(unaccounted)} row(s) are **unaccounted for**: "
+                     f"{len(rows)} scored + {len(skips)} recorded as skipped "
+                     f"does not equal {manifest_rows}. That gap is a bug in the "
+                     "harness, not a property of the images.")
+        lines.append(note)
     lines.append("")
     lines.append("Each row is one popular public image run with a specific "
                  "configuration, graded 0-100 across seven containment "
@@ -158,12 +178,13 @@ def main():
     lines.append("")
 
     # A compact grade-distribution summary.
-    dist = {}
-    for r in rows:
-        dist[r["grade"]] = dist.get(r["grade"], 0) + 1
-    summary = ", ".join(f"{dist[g]}×{g}" for g in sorted(dist))
-    lines.append(f"**Grade distribution:** {summary}.")
-    lines.append("")
+    if rows:
+        dist = {}
+        for r in rows:
+            dist[r["grade"]] = dist.get(r["grade"], 0) + 1
+        summary = ", ".join(f"{dist[g]}×{g}" for g in sorted(dist))
+        lines.append(f"**Grade distribution:** {summary}.")
+        lines.append("")
 
     # Every dropped scenario, by name. A count alone still leaves the reader
     # guessing which images the dataset does not cover (IRO-727).

--- a/examples/isolation-survey/survey.sh
+++ b/examples/isolation-survey/survey.sh
@@ -32,9 +32,12 @@
 #     unavailable image must not wedge a 295-row sweep), but they are no longer
 #     invisible: each is recorded with its stage and reason in `.skipped[]` of
 #     results.json and listed in results.md, and coverage_guard.py fails the run
-#     when a row that scored in the previous results.json stops producing output
-#     (IRO-727). Before that, the same 39 rows failed every weekly refresh and
-#     the run still exited green.
+#     both when a row that scored in the last COMMITTED results.json stops
+#     producing output and when the artifact's own arithmetic does not close
+#     (scenarioCount + skippedCount == manifestRowCount). Baselining off the
+#     committed copy rather than the working tree is what stops a plain re-run
+#     from clearing a real regression (IRO-727). Before all this, the same 39
+#     rows failed every weekly refresh and the run still exited green.
 #   * The scan is read-only config inspection (docker inspect); it never runs the
 #     image's real workload — the entrypoint is overridden with `sleep` purely to
 #     keep the container alive for inspection.
@@ -136,13 +139,28 @@ echo "[]" > "$RECORDS"
 SKIPS="$(mktemp)"
 echo "[]" > "$SKIPS"
 
-# The previous results.json, snapshotted BEFORE this run overwrites it — the
-# baseline coverage_guard.py compares against at the end.
+# The baseline coverage_guard.py compares against: the last COMMITTED
+# results.json, read out of git — NOT the working-tree copy this run is about to
+# overwrite. Snapshotting the working tree lets a plain re-run launder a
+# regression green: run N writes the degraded results.json, run N+1 reads it
+# back as its own baseline and sees no loss. Only a run whose guard passed ever
+# gets committed, so HEAD is by construction a coverage level we actually held,
+# and re-running a broken sweep fails again with the same message.
+#
+# No committed copy (a first run, a checkout without one, an export with no
+# .git) means no baseline at all rather than a fallback to disk — the guard says
+# the regression check was skipped instead of pretending it ran.
 BASELINE=""
-if [ -f "$RESULTS_JSON" ]; then
+if git_prefix="$(git -C "$SCRIPT_DIR" rev-parse --show-prefix 2>/dev/null)"; then
   BASELINE="$(mktemp)"
-  cp "$RESULTS_JSON" "$BASELINE"
+  if git -C "$SCRIPT_DIR" show "HEAD:${git_prefix}results.json" > "$BASELINE" 2>/dev/null; then
+    log "baseline: git HEAD:${git_prefix}results.json"
+  else
+    rm -f "$BASELINE"
+    BASELINE=""
+  fi
 fi
+[ -n "$BASELINE" ] || log "baseline: none committed — the coverage regression check will be skipped"
 
 
 # label image stage reason -> one entry in $SKIPS, plus the same line on stderr
@@ -180,7 +198,11 @@ PY
 
 n=0
 scanned=0
-while IFS= read -r line; do
+# `|| [ -n "$line" ]` so a manifest whose last line has no trailing newline is
+# still swept. Without it the final row is silently dropped, and a silently
+# dropped row is the whole bug (IRO-727) — coverage_guard.py parses the manifest
+# independently and fails the run if its row count ever disagrees with $n.
+while IFS= read -r line || [ -n "$line" ]; do
   # strip comments / blanks
   line="${line%%$'\r'}"
   case "$line" in ''|'#'*) continue;; esac
@@ -257,8 +279,19 @@ while IFS= read -r line; do
     continue
   fi
   rm -f scan.err
-  score="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["score"])' "$scanfile")"
-  grade="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["grade"])' "$scanfile")"
+  # A report we cannot parse is a SKIP, not a `set -e` abort. An abort here kills
+  # the run before render.py writes anything, and cleanup() then deletes $SKIPS,
+  # so every skip recorded up to that point is destroyed — the artifact has to
+  # outlive the run for any of this to be worth anything (IRO-727).
+  if ! summary="$(python3 -c 'import json,sys;d=json.load(open(sys.argv[1]));print(d["score"],d["grade"])' "$scanfile" 2>parse.err)"; then
+    record_skip "$label" "$image" "scan" "unreadable scan report: $(head -1 parse.err)"
+    rm -f parse.err "$scanfile"
+    "$DOCKER" rm -f "$cname" >/dev/null 2>&1 || true
+    continue
+  fi
+  rm -f parse.err
+  score="${summary%% *}"
+  grade="${summary##* }"
   log "[$n] $label — ${score}/100 grade ${grade}"
   append_record "$label" "$image" "$flags" "$digest" "$scanfile"
   rm -f "$scanfile"
@@ -275,19 +308,25 @@ while IFS= read -r line; do
   fi
 done < "$MANIFEST"
 
-[ "${scanned:-0}" -gt 0 ] || die "no scenarios scanned from $MANIFEST"
 log "scanned ${scanned}/${n} scenarios"
 
-# Render BEFORE the coverage guard runs, deliberately. If coverage regressed we
-# still want the artifact that names every dropped scenario and why — the whole
-# point of IRO-727 is that the evidence must outlive the run log. The guard then
-# fails the run, so a degraded sweep can never quietly open a refresh PR.
+# Render FIRST — before the `scanned > 0` check and before the coverage guard,
+# both deliberately. Whatever the sweep found is the evidence, and the whole
+# point of IRO-727 is that it must outlive an Actions log that expires. The
+# worst runs are the ones that most need explaining: a dead daemon, a mirror
+# outage or a full disk under PRUNE=1 fails every row, and the old ordering
+# died right here without writing anything, leaving the previous healthy
+# results.json byte-identical on disk and cleanup() deleting $SKIPS on the way
+# out. Now even an all-rows-failed run leaves a results.json naming all $n rows
+# and why each one dropped.
 log "rendering results.json + results.md (${scanned} scenarios)…"
 python3 "$SCRIPT_DIR/render.py" "$RESULTS_JSON" "$RESULTS_MD" \
   --skips "$SKIPS" --manifest-rows "$n" < "$RECORDS"
 
 log "done: $RESULTS_JSON"
 log "done: $RESULTS_MD"
+
+[ "${scanned:-0}" -gt 0 ] || die "no scenarios scanned from $MANIFEST — results.* were still written and list every dropped row"
 
 # Coverage regression check: a scenario that scored last run and is still in the
 # manifest must score again. Transient registry weather is absent from the

--- a/examples/isolation-survey/survey.sh
+++ b/examples/isolation-survey/survey.sh
@@ -101,6 +101,10 @@ mirror_ref() {
 command -v "$DOCKER" >/dev/null 2>&1 || die "docker not found (set \$DOCKER)"
 "$DOCKER" info >/dev/null 2>&1 || die "docker daemon not reachable (is it running?)"
 command -v python3 >/dev/null 2>&1 || die "python3 not found (needed to render results)"
+# git is a hard dependency, not an optional nicety: the coverage baseline is read
+# out of HEAD (see below), so a missing git used to degrade silently into "no
+# baseline committed" and an exit-0 run with the regression check switched off.
+command -v git >/dev/null 2>&1 || die "git not found (needed to read the coverage baseline out of HEAD)"
 
 # Resolve ironctl: prefer $IRONCTL, else a repo-local build, else build it.
 IRONCTL="${IRONCTL:-}"
@@ -119,17 +123,27 @@ log "ironctl: $IRONCTL ($("$IRONCTL" scan --help >/dev/null 2>&1 && echo ok))"
 # Track containers we create so we can always tear them down.
 CREATED=()
 cleanup() {
-  rm -f "${SKIPS:-}" "${BASELINE:-}" 2>/dev/null || true
+  rm -f "${SKIPS:-}" "${SKIPS:+$SKIPS.tmp}" "${BASELINE:-}" \
+        "${RECORDS:-}" "${RECORDS:+$RECORDS.tmp}" 2>/dev/null || true
+  [ -n "${ERRDIR:-}" ] && rm -rf "$ERRDIR" 2>/dev/null
   [ "$KEEP" -eq 1 ] && { log "--keep: leaving ${#CREATED[@]} container(s) running"; return; }
   for c in "${CREATED[@]:-}"; do
     [ -n "$c" ] && "$DOCKER" rm -f "$c" >/dev/null 2>&1 || true
   done
+  return 0
 }
 trap cleanup EXIT
 
-# Accumulate per-scenario records as a JSON array on a temp file.
+# Per-scenario stderr captures. These used to be written into the invoking CWD
+# as pull.err / run.err / scan.err / parse.err and were only removed on the
+# happy path, so an aborted run left them behind in whatever directory you
+# happened to be standing in.
+ERRDIR="$(mktemp -d)"
+
+# Accumulate per-scenario records as a JSON array on a temp file. Removed by
+# cleanup(); the `trap ... RETURN` that used to do it is a no-op at top level in
+# bash, so every run leaked this file.
 RECORDS="$(mktemp)"
-trap 'rm -f "$RECORDS"' RETURN 2>/dev/null || true
 echo "[]" > "$RECORDS"
 
 # …and every scenario we DROP, the same way: {label, image, stage, reason}. A
@@ -150,40 +164,103 @@ echo "[]" > "$SKIPS"
 # No committed copy (a first run, a checkout without one, an export with no
 # .git) means no baseline at all rather than a fallback to disk — the guard says
 # the regression check was skipped instead of pretending it ran.
+#
+# "Nothing is committed yet" and "git failed" are NOT the same state and must not
+# collapse into the same exit-0 message. Swallowing git's stderr made a broken
+# object store — the ordinary result of running this in a container over a
+# bind-mounted checkout owned by another uid — print "none committed" and run
+# with the only real safety gate silently disabled. So exactly three states are
+# a legitimate no-baseline, each established by a command that reads only refs
+# or the index, never the object store; anything else is fatal.
 BASELINE=""
+BASELINE_PATH=""
 if git_prefix="$(git -C "$SCRIPT_DIR" rev-parse --show-prefix 2>/dev/null)"; then
-  BASELINE="$(mktemp)"
-  if git -C "$SCRIPT_DIR" show "HEAD:${git_prefix}results.json" > "$BASELINE" 2>/dev/null; then
-    log "baseline: git HEAD:${git_prefix}results.json"
+  BASELINE_PATH="${git_prefix}results.json"
+  GIT_ERR="$ERRDIR/git.err"
+  if head_ref="$(git -C "$SCRIPT_DIR" symbolic-ref -q HEAD 2>/dev/null)" \
+     && ! git -C "$SCRIPT_DIR" show-ref --verify --quiet "$head_ref"; then
+    # (1) A branch pointing at no commit: a fresh `git init`. show-ref reads
+    # refs only, so this cannot be confused with an unreadable .git/objects.
+    log "baseline: none committed — $head_ref has no commits yet, the coverage regression check will be skipped"
+  elif ! listing="$(git -C "$SCRIPT_DIR" ls-tree --full-tree --name-only HEAD -- "$BASELINE_PATH" 2>"$GIT_ERR")"; then
+    # (3) Anything else git has to say is a broken read, not an absent file.
+    die "git could not read HEAD in $SCRIPT_DIR: $(head -1 "$GIT_ERR" 2>/dev/null). The coverage baseline is read from HEAD and is the only check standing between a permanently lost scenario and a green run, so a git failure fails the survey rather than downgrading it to an unchecked run"
+  elif [ -z "$listing" ]; then
+    # (2) git read HEAD fine and the file is genuinely not in it.
+    log "baseline: none committed — $BASELINE_PATH is not in HEAD, the coverage regression check will be skipped"
   else
-    rm -f "$BASELINE"
-    BASELINE=""
+    BASELINE="$(mktemp)"
+    git -C "$SCRIPT_DIR" show "HEAD:$BASELINE_PATH" > "$BASELINE" 2>"$GIT_ERR" \
+      || die "git could not read HEAD:$BASELINE_PATH although ls-tree lists it: $(head -1 "$GIT_ERR" 2>/dev/null)"
+    log "baseline: git HEAD:$BASELINE_PATH"
   fi
+else
+  log "baseline: none committed — $SCRIPT_DIR is not a git checkout, the coverage regression check will be skipped"
 fi
-[ -n "$BASELINE" ] || log "baseline: none committed — the coverage regression check will be skipped"
 
+
+# Rows whose record could not be written at all. Not a counter for show: an
+# unwritten row is neither in .scenarios[] nor in .skipped[], so it lands as an
+# unaccounted row and coverage_guard.py fails the run — with the artifact
+# written, which is the point.
+RECORD_FAILURES=0
+
+# Collapse runs of blanks and trim, mirroring coverage_guard.manifest_labels.
+#
+# This used to be `echo "$x" | xargs`, which is a different function and an
+# abort risk. xargs applies shell quote and backslash processing, so an
+# unbalanced quote anywhere in images.txt is `xargs: unterminated quote`, a
+# non-zero exit, and — under `set -e`, mid-sweep, before render — the death of
+# every skip record collected so far. With no utility argument it also runs
+# /bin/echo, which eats a leading `-n` or `-e` as an option rather than as data.
+# `read -r -a` under the default IFS splits on exactly space/tab/newline and
+# does no quote processing at all, so it cannot fail and the guard can mirror it
+# exactly.
+collapse() {
+  local IFS=$' \t\n'
+  local -a words=()
+  read -r -a words <<<"${1-}" || true
+  printf '%s' "${words[*]:-}"
+}
 
 # label image stage reason -> one entry in $SKIPS, plus the same line on stderr
 # the script always logged. `stage` is one of pull|run|scan.
+#
+# This can never fail the run. It is called from four places under `set -euo
+# pipefail` and it writes to a temp filesystem that PRUNE=1 exists precisely
+# because it fills up: an ENOSPC used to return 1, abort the sweep and take
+# cleanup() with it, deleting every skip recorded so far — destroying the record
+# of exactly the failure worth recording. The write goes through a temp + rename
+# so a failure leaves the previous content intact rather than a truncated file
+# render.py cannot parse.
 record_skip() {
   local label="$1" image="$2" stage="$3" reason="$4"
   log "[$n] $label — SKIP: $stage failed ($reason)"
-  python3 - "$SKIPS" "$label" "$image" "$stage" "$reason" <<'PY'
-import json, sys
+  if ! python3 - "$SKIPS" "$label" "$image" "$stage" "$reason" <<'PY'
+import json, os, sys
 skipfile, label, image, stage, reason = sys.argv[1:6]
 with open(skipfile) as f:
     skips = json.load(f)
 skips.append({"label": label, "image": image, "stage": stage,
               "reason": reason.strip()})
-with open(skipfile, "w") as f:
+tmp = skipfile + ".tmp"
+with open(tmp, "w") as f:
     json.dump(skips, f)
+os.replace(tmp, skipfile)
 PY
+  then
+    RECORD_FAILURES=$((RECORD_FAILURES+1))
+    log "[$n] $label — WARNING: the skip itself could not be recorded (temp filesystem full?). The row will be reported as unaccounted for and the coverage guard will fail this run."
+  fi
+  return 0
 }
 
+# Returns non-zero if the record could not be written, so the caller can decline
+# to count the row as scanned. Called from an `if`, so `set -e` does not fire.
 append_record() { # label image runFlags resolvedDigest scanjson-file
   local label="$1" image="$2" flags="$3" digest="$4" scanfile="$5"
   python3 - "$RECORDS" "$label" "$image" "$flags" "$digest" "$scanfile" <<'PY'
-import json, sys
+import json, os, sys
 recfile, label, image, flags, digest, scanfile = sys.argv[1:7]
 with open(recfile) as f:
     recs = json.load(f)
@@ -191,8 +268,10 @@ with open(scanfile) as f:
     report = json.load(f)
 recs.append({"label": label, "image": image, "runFlags": flags,
              "resolvedDigest": digest, "report": report})
-with open(recfile, "w") as f:
+tmp = recfile + ".tmp"
+with open(tmp, "w") as f:
     json.dump(recs, f)
+os.replace(tmp, recfile)
 PY
 }
 
@@ -208,9 +287,9 @@ while IFS= read -r line || [ -n "$line" ]; do
   case "$line" in ''|'#'*) continue;; esac
   # split on '|'
   IFS='|' read -r label image flags <<<"$line"
-  label="$(echo "$label" | xargs)"
-  image="$(echo "$image" | xargs)"
-  flags="$(echo "${flags:-}" | xargs || true)"
+  label="$(collapse "$label")"
+  image="$(collapse "$image")"
+  flags="$(collapse "${flags:-}")"
   [ -z "$label" ] && continue
   n=$((n+1))
   cname="${NAME_PREFIX}${label}"
@@ -234,9 +313,9 @@ while IFS= read -r line || [ -n "$line" ]; do
     pulled=1
     log "[$n] $label — pulling $runref"
     tries=0
-    until "$DOCKER" pull -q "$runref" >/dev/null 2>pull.err; do
+    until "$DOCKER" pull -q "$runref" >/dev/null 2>"$ERRDIR/pull.err"; do
       tries=$((tries+1))
-      if grep -qi "rate limit" pull.err && [ "$tries" -lt 5 ]; then
+      if grep -qi "rate limit" "$ERRDIR/pull.err" && [ "$tries" -lt 5 ]; then
         wait=$((tries*30))
         log "[$n] $label — rate limited, retrying in ${wait}s (try $tries/5)"
         sleep "$wait"
@@ -247,23 +326,20 @@ while IFS= read -r line || [ -n "$line" ]; do
         runref="$image"
         continue
       fi
-      record_skip "$label" "$image" "pull" "$(head -1 pull.err)"
-      rm -f pull.err
+      record_skip "$label" "$image" "pull" "$(head -1 "$ERRDIR/pull.err")"
       runref=""
       break
     done
-    rm -f pull.err
     [ -z "$runref" ] && continue
   fi
 
   "$DOCKER" rm -f "$cname" >/dev/null 2>&1 || true
   log "[$n] $label — docker run $flags --entrypoint sleep <image>"
   # shellcheck disable=SC2086
-  if ! "$DOCKER" run -d --name "$cname" $flags --entrypoint sleep "$runref" 86400 >/dev/null 2>run.err; then
-    record_skip "$label" "$image" "run" "$(head -1 run.err)"; rm -f run.err
+  if ! "$DOCKER" run -d --name "$cname" $flags --entrypoint sleep "$runref" 86400 >/dev/null 2>"$ERRDIR/run.err"; then
+    record_skip "$label" "$image" "run" "$(head -1 "$ERRDIR/run.err")"
     continue
   fi
-  rm -f run.err
   CREATED+=("$cname")
 
   # The exact bits we scanned, by manifest digest — recorded for provenance so a
@@ -272,30 +348,41 @@ while IFS= read -r line || [ -n "$line" ]; do
   digest="$("$DOCKER" image inspect "$runref" --format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{end}}' 2>/dev/null || true)"
   digest="${digest#*@}"
 
-  scanfile="$(mktemp)"
-  if ! "$IRONCTL" scan "$cname" --json > "$scanfile" 2>scan.err; then
-    record_skip "$label" "$image" "scan" "$(head -1 scan.err)"; rm -f scan.err "$scanfile"
+  # A temp file we cannot even create is a SKIP too: `set -e` on the assignment
+  # would abort the sweep here, before render, and take every skip with it.
+  if ! scanfile="$(mktemp 2>"$ERRDIR/mktemp.err")"; then
+    record_skip "$label" "$image" "scan" "could not create a temp file: $(head -1 "$ERRDIR/mktemp.err")"
     "$DOCKER" rm -f "$cname" >/dev/null 2>&1 || true
     continue
   fi
-  rm -f scan.err
+  if ! "$IRONCTL" scan "$cname" --json > "$scanfile" 2>"$ERRDIR/scan.err"; then
+    record_skip "$label" "$image" "scan" "$(head -1 "$ERRDIR/scan.err")"; rm -f "$scanfile"
+    "$DOCKER" rm -f "$cname" >/dev/null 2>&1 || true
+    continue
+  fi
   # A report we cannot parse is a SKIP, not a `set -e` abort. An abort here kills
   # the run before render.py writes anything, and cleanup() then deletes $SKIPS,
   # so every skip recorded up to that point is destroyed — the artifact has to
   # outlive the run for any of this to be worth anything (IRO-727).
-  if ! summary="$(python3 -c 'import json,sys;d=json.load(open(sys.argv[1]));print(d["score"],d["grade"])' "$scanfile" 2>parse.err)"; then
-    record_skip "$label" "$image" "scan" "unreadable scan report: $(head -1 parse.err)"
-    rm -f parse.err "$scanfile"
+  if ! summary="$(python3 -c 'import json,sys;d=json.load(open(sys.argv[1]));print(d["score"],d["grade"])' "$scanfile" 2>"$ERRDIR/parse.err")"; then
+    record_skip "$label" "$image" "scan" "unreadable scan report: $(head -1 "$ERRDIR/parse.err")"
+    rm -f "$scanfile"
     "$DOCKER" rm -f "$cname" >/dev/null 2>&1 || true
     continue
   fi
-  rm -f parse.err
   score="${summary%% *}"
   grade="${summary##* }"
   log "[$n] $label — ${score}/100 grade ${grade}"
-  append_record "$label" "$image" "$flags" "$digest" "$scanfile"
+  # Counted as scanned only if the record actually landed. A write that failed
+  # must not inflate $scanned — the row is then unaccounted for, which is what
+  # the coverage guard is for.
+  if append_record "$label" "$image" "$flags" "$digest" "$scanfile"; then
+    scanned=$((scanned+1))
+  else
+    RECORD_FAILURES=$((RECORD_FAILURES+1))
+    log "[$n] $label — WARNING: scanned ${score}/100 but the result could not be recorded (temp filesystem full?). The row will be reported as unaccounted for and the coverage guard will fail this run."
+  fi
   rm -f "$scanfile"
-  scanned=$((scanned+1))
 
   if [ "$KEEP" -eq 0 ]; then
     "$DOCKER" rm -f "$cname" >/dev/null 2>&1 || true
@@ -309,16 +396,30 @@ while IFS= read -r line || [ -n "$line" ]; do
 done < "$MANIFEST"
 
 log "scanned ${scanned}/${n} scenarios"
+[ "$RECORD_FAILURES" -eq 0 ] || \
+  log "WARNING: $RECORD_FAILURES row(s) could not be recorded at all; they will show up as unaccounted for and fail the coverage guard below"
 
 # Render FIRST — before the `scanned > 0` check and before the coverage guard,
 # both deliberately. Whatever the sweep found is the evidence, and the whole
 # point of IRO-727 is that it must outlive an Actions log that expires. The
-# worst runs are the ones that most need explaining: a dead daemon, a mirror
-# outage or a full disk under PRUNE=1 fails every row, and the old ordering
-# died right here without writing anything, leaving the previous healthy
-# results.json byte-identical on disk and cleanup() deleting $SKIPS on the way
-# out. Now even an all-rows-failed run leaves a results.json naming all $n rows
-# and why each one dropped.
+# worst runs are the ones that most need explaining: a dead daemon or a mirror
+# outage fails every row, and the old ordering died right here without writing
+# anything, leaving the previous healthy results.json byte-identical on disk and
+# cleanup() deleting $SKIPS on the way out. Now a run where every row failed
+# leaves a results.json naming all $n rows and why each one dropped.
+#
+# What this ordering does NOT buy, stated precisely because a false durability
+# claim is the same class of bug as the one being fixed: anything that aborts
+# the sweep BEFORE this line still writes nothing and still loses every skip
+# collected so far. The foreseeable internal ones are gone — a failed skip write
+# on a full temp filesystem, a manifest row that blows up the field parse, and a
+# temp file that cannot be created are all recorded and stepped over rather than
+# fatal (which is why PRUNE=1, whose whole reason to exist is a nearly-full
+# runner disk, is safe here). What remains is the process being killed (Ctrl-C,
+# OOM, a job timeout), a manifest that cannot be read at all, and render.py
+# itself failing. For the CI case, scores-refresh.yml uploads results.json and
+# results.md as a run artifact with `if: always()` so a failing run's evidence
+# outlives the runner rather than dying with it.
 log "rendering results.json + results.md (${scanned} scenarios)…"
 python3 "$SCRIPT_DIR/render.py" "$RESULTS_JSON" "$RESULTS_MD" \
   --skips "$SKIPS" --manifest-rows "$n" < "$RECORDS"

--- a/examples/isolation-survey/survey.sh
+++ b/examples/isolation-survey/survey.sh
@@ -28,8 +28,13 @@
 #     published score can be re-checked by pulling that digest and re-running the
 #     row's flags — a manual re-scan from the recorded digests, which is a weaker
 #     guarantee than a fresh run reproducing the scores, and not the same thing.
-#     Rows whose pull, run or scan fails are skipped and absent from results.json
-#     altogether; that is why 295 rows yielded 256 scenarios.
+#   * Rows whose pull, run or scan fails are still SKIPPED rather than fatal (one
+#     unavailable image must not wedge a 295-row sweep), but they are no longer
+#     invisible: each is recorded with its stage and reason in `.skipped[]` of
+#     results.json and listed in results.md, and coverage_guard.py fails the run
+#     when a row that scored in the previous results.json stops producing output
+#     (IRO-727). Before that, the same 39 rows failed every weekly refresh and
+#     the run still exited green.
 #   * The scan is read-only config inspection (docker inspect); it never runs the
 #     image's real workload — the entrypoint is overridden with `sleep` purely to
 #     keep the container alive for inspection.
@@ -111,6 +116,7 @@ log "ironctl: $IRONCTL ($("$IRONCTL" scan --help >/dev/null 2>&1 && echo ok))"
 # Track containers we create so we can always tear them down.
 CREATED=()
 cleanup() {
+  rm -f "${SKIPS:-}" "${BASELINE:-}" 2>/dev/null || true
   [ "$KEEP" -eq 1 ] && { log "--keep: leaving ${#CREATED[@]} container(s) running"; return; }
   for c in "${CREATED[@]:-}"; do
     [ -n "$c" ] && "$DOCKER" rm -f "$c" >/dev/null 2>&1 || true
@@ -122,6 +128,39 @@ trap cleanup EXIT
 RECORDS="$(mktemp)"
 trap 'rm -f "$RECORDS"' RETURN 2>/dev/null || true
 echo "[]" > "$RECORDS"
+
+# …and every scenario we DROP, the same way: {label, image, stage, reason}. A
+# skip used to be a log line in an Actions run that expires after 90 days, which
+# is why 39 rows could fail every week without leaving a trace in the artifact
+# (IRO-727). render.py folds this into results.json/.md.
+SKIPS="$(mktemp)"
+echo "[]" > "$SKIPS"
+
+# The previous results.json, snapshotted BEFORE this run overwrites it — the
+# baseline coverage_guard.py compares against at the end.
+BASELINE=""
+if [ -f "$RESULTS_JSON" ]; then
+  BASELINE="$(mktemp)"
+  cp "$RESULTS_JSON" "$BASELINE"
+fi
+
+
+# label image stage reason -> one entry in $SKIPS, plus the same line on stderr
+# the script always logged. `stage` is one of pull|run|scan.
+record_skip() {
+  local label="$1" image="$2" stage="$3" reason="$4"
+  log "[$n] $label — SKIP: $stage failed ($reason)"
+  python3 - "$SKIPS" "$label" "$image" "$stage" "$reason" <<'PY'
+import json, sys
+skipfile, label, image, stage, reason = sys.argv[1:6]
+with open(skipfile) as f:
+    skips = json.load(f)
+skips.append({"label": label, "image": image, "stage": stage,
+              "reason": reason.strip()})
+with open(skipfile, "w") as f:
+    json.dump(skips, f)
+PY
+}
 
 append_record() { # label image runFlags resolvedDigest scanjson-file
   local label="$1" image="$2" flags="$3" digest="$4" scanfile="$5"
@@ -186,7 +225,7 @@ while IFS= read -r line; do
         runref="$image"
         continue
       fi
-      log "[$n] $label — SKIP: pull failed ($(head -1 pull.err))"
+      record_skip "$label" "$image" "pull" "$(head -1 pull.err)"
       rm -f pull.err
       runref=""
       break
@@ -199,7 +238,7 @@ while IFS= read -r line; do
   log "[$n] $label — docker run $flags --entrypoint sleep <image>"
   # shellcheck disable=SC2086
   if ! "$DOCKER" run -d --name "$cname" $flags --entrypoint sleep "$runref" 86400 >/dev/null 2>run.err; then
-    log "[$n] $label — SKIP: docker run failed ($(head -1 run.err))"; rm -f run.err
+    record_skip "$label" "$image" "run" "$(head -1 run.err)"; rm -f run.err
     continue
   fi
   rm -f run.err
@@ -213,7 +252,7 @@ while IFS= read -r line; do
 
   scanfile="$(mktemp)"
   if ! "$IRONCTL" scan "$cname" --json > "$scanfile" 2>scan.err; then
-    log "[$n] $label — SKIP: scan failed ($(head -1 scan.err))"; rm -f scan.err "$scanfile"
+    record_skip "$label" "$image" "scan" "$(head -1 scan.err)"; rm -f scan.err "$scanfile"
     "$DOCKER" rm -f "$cname" >/dev/null 2>&1 || true
     continue
   fi
@@ -239,8 +278,21 @@ done < "$MANIFEST"
 [ "${scanned:-0}" -gt 0 ] || die "no scenarios scanned from $MANIFEST"
 log "scanned ${scanned}/${n} scenarios"
 
+# Render BEFORE the coverage guard runs, deliberately. If coverage regressed we
+# still want the artifact that names every dropped scenario and why — the whole
+# point of IRO-727 is that the evidence must outlive the run log. The guard then
+# fails the run, so a degraded sweep can never quietly open a refresh PR.
 log "rendering results.json + results.md (${scanned} scenarios)…"
-python3 "$SCRIPT_DIR/render.py" "$RESULTS_JSON" "$RESULTS_MD" < "$RECORDS"
+python3 "$SCRIPT_DIR/render.py" "$RESULTS_JSON" "$RESULTS_MD" \
+  --skips "$SKIPS" --manifest-rows "$n" < "$RECORDS"
 
 log "done: $RESULTS_JSON"
 log "done: $RESULTS_MD"
+
+# Coverage regression check: a scenario that scored last run and is still in the
+# manifest must score again. Transient registry weather is absent from the
+# baseline too, so it cannot trip this; a row rotting for good does.
+guard_args=(--manifest "$MANIFEST" --results "$RESULTS_JSON")
+[ -n "$BASELINE" ] && guard_args+=(--baseline "$BASELINE")
+python3 "$SCRIPT_DIR/coverage_guard.py" "${guard_args[@]}" \
+  || die "coverage regressed — results.* were still written, see .skipped[]"

--- a/scripts/tests/test_coverage_guard.py
+++ b/scripts/tests/test_coverage_guard.py
@@ -15,6 +15,12 @@ carve-outs that would make the guard unusable if it got them wrong:
   never scored (registry weather on a brand-new row) is not a regression, which
   is what keeps the weekly refresh from going red on a Docker Hub 500.
 
+The one thing NOT tested here is whether `manifest_labels` really agrees with
+survey.sh's parse. That cannot be settled against a literal in this file, so it
+is settled by driving the real survey.sh over a hostile manifest and diffing the
+two row sets: test_survey_coverage_e2e.py::test_manifest_parse_matches_the_sweep.
+What lives here is the corrected semantics that test pins down.
+
 Run:
     python3 -m unittest discover -s scripts/tests -v
 """
@@ -43,17 +49,34 @@ def _load():
 guard = _load()
 
 
-def write_results(path, labels, skipped=()):
+def results_doc(labels, skipped=(), manifest_rows=None, schema='1.1'):
+    """A results.json shaped like render.py writes one.
+
+    `manifest_rows=None` means "self-consistent": scored + skipped, so a test
+    that is about the regression logic does not accidentally also trip the
+    accounting check. Pass a number to build the inconsistent artifact on
+    purpose. `schema='1.0'` drops the coverage block entirely, which is what the
+    committed results.json looks like today.
+    """
     doc = {
         "report": "ironclaw-isolation-survey",
-        "schemaVersion": "1.1",
-        "scenarioCount": len(labels),
+        "schemaVersion": schema,
         "scenarios": [{"label": lab, "score": 50} for lab in labels],
-        "skippedCount": len(skipped),
         "skipped": [{"label": lab, "image": lab, "stage": stage,
                      "reason": reason} for lab, stage, reason in skipped],
     }
-    path.write_text(json.dumps(doc))
+    if schema != '1.0':
+        if manifest_rows is None:
+            manifest_rows = len(labels) + len(skipped)
+        doc["manifestRowCount"] = manifest_rows
+        doc["scenarioCount"] = len(labels)
+        doc["skippedCount"] = len(skipped)
+    return doc
+
+
+def write_results(path, labels, skipped=(), manifest_rows=None, schema='1.1'):
+    path.write_text(json.dumps(
+        results_doc(labels, skipped, manifest_rows, schema)))
 
 
 def write_manifest(path, labels):
@@ -63,29 +86,119 @@ def write_manifest(path, labels):
 
 
 class ManifestParsing(unittest.TestCase):
-    def test_matches_survey_sh_parse(self):
+    """The corrected parse. Every case here is a row survey.sh walks and the
+    guard used to disagree about -- a disagreement means the guard computes
+    `expected` over a different row set than the sweep swept."""
+
+    def labels(self, text):
         with tempfile.TemporaryDirectory() as d:
             p = pathlib.Path(d) / 'images.txt'
-            p.write_text(
-                "# a comment\n"
-                "\n"
-                "default-nginx | nginx:1.27 |\n"
-                "hardened-nginx | nginx:1.27 | --user 101 --cap-drop=ALL\n"
-                "   spaced   |  busybox:1  |\n"
-                "default-nginx | nginx:1.27 |\n"  # duplicate label
-            )
-            self.assertEqual(guard.manifest_labels(p),
-                             ['default-nginx', 'hardened-nginx', 'spaced'])
+            p.write_text(text)
+            return guard.manifest_labels(p)
+
+    def test_column_zero_comments_and_blanks_are_skipped(self):
+        self.assertEqual(
+            self.labels("# a comment\n\ndefault-nginx | nginx:1.27 |\n"),
+            ['default-nginx'])
+
+    def test_an_indented_comment_is_a_row_not_a_comment(self):
+        """survey.sh matches `#` at column 0 only (`case "$line" in '#'*`), so
+        an indented `#` is a scenario row to the sweep. The guard used to
+        `.strip()` first and drop it, quietly shrinking its denominator."""
+        self.assertEqual(self.labels("  # indented | busybox:1 |\n"),
+                         ['# indented'])
+
+    def test_duplicate_labels_are_kept(self):
+        """The sweep walks a repeated row twice and counts it twice; the guard
+        used to deduplicate, so the two disagreed on manifestRowCount."""
+        self.assertEqual(
+            self.labels("a | x:1 |\nb | y:1 |\na | x:1 |\n"), ['a', 'b', 'a'])
+
+    def test_whitespace_is_collapsed_like_xargs(self):
+        self.assertEqual(self.labels("   two   words   |  busybox:1  |\n"),
+                         ['two words'])
+
+    def test_trailing_cr_is_stripped(self):
+        self.assertEqual(self.labels("crlf-row | busybox:1 |\r\n"),
+                         ['crlf-row'])
+
+    def test_a_row_with_no_label_is_dropped(self):
+        self.assertEqual(self.labels("   \n | busybox:1 |\nreal | b:1 |\n"),
+                         ['real'])
+
+    def test_a_last_line_without_a_newline_still_counts(self):
+        self.assertEqual(self.labels("a | x:1 |\nb | y:1 |"), ['a', 'b'])
+
+
+class Accounting(unittest.TestCase):
+    """`scenarioCount + skippedCount == manifestRowCount == rows parsed here`.
+
+    The PR that added the coverage block advertised this invariant and enforced
+    it nowhere, so results.md could print "Coverage: 2 of 3 manifest rows --
+    every row was scanned" and exit 0.
+    """
+
+    def check(self, doc, manifest):
+        return guard.check_accounting(doc, manifest)
+
+    def test_a_consistent_artifact_has_no_problems(self):
+        doc = results_doc(['a', 'b'], skipped=[('c', 'pull', 'nope')])
+        self.assertEqual(self.check(doc, ['a', 'b', 'c']), [])
+
+    def test_an_unaccounted_row_is_a_failure(self):
+        """256 scored + 0 recorded skips against 295 manifest rows: the exact
+        production shape, where 39 rows vanished with no record at all."""
+        doc = results_doc([f'r{i}' for i in range(256)], manifest_rows=295)
+        problems = self.check(doc, [f'r{i}' for i in range(295)])
+        self.assertTrue(any('39 manifest row(s) are unaccounted for' in p
+                            for p in problems), problems)
+
+    def test_a_missing_count_is_not_read_as_zero(self):
+        """A schema-1.0 artifact records none of the three. Defaulting them to
+        0 would make 0 + 0 == 0 'hold' -- the same fail-quiet shape as the bug
+        being fixed -- so it must report the counts as unverified instead."""
+        doc = results_doc(['a'], schema='1.0')
+        problems = self.check(doc, ['a', 'b'])
+        self.assertEqual(len(problems), 1)
+        self.assertIn('does not record', problems[0])
+        for field in ('manifestRowCount', 'scenarioCount', 'skippedCount'):
+            self.assertIn(field, problems[0])
+
+    def test_a_counter_that_lies_about_its_own_array_fails(self):
+        doc = results_doc(['a', 'b'])
+        doc['scenarioCount'] = 5
+        problems = self.check(doc, ['a', 'b'])
+        self.assertTrue(any('scenarioCount is 5' in p for p in problems),
+                        problems)
+
+    def test_the_sweep_and_the_guard_disagreeing_on_the_manifest_fails(self):
+        """The live detector for a parse drift: survey.sh counts the rows it
+        walked into manifestRowCount, this guard parses images.txt itself, and
+        the two numbers have to be the same one."""
+        doc = results_doc(['a', 'b'], manifest_rows=2)
+        problems = self.check(doc, ['a', 'b', '# indented'])
+        self.assertTrue(any('the sweep and the guard disagree' in p
+                            for p in problems), problems)
+
+    def test_more_output_than_the_manifest_asked_for_fails(self):
+        doc = results_doc(['a', 'b', 'c'], manifest_rows=2)
+        problems = self.check(doc, ['a', 'b'])
+        self.assertTrue(any('exceeds manifestRowCount' in p for p in problems),
+                        problems)
 
 
 class RegressionDetection(unittest.TestCase):
     """The core property: a row that scored before and stopped is a failure."""
 
-    def run_guard(self, manifest, scanned, baseline, skipped=(), extra=None):
+    def run_guard(self, manifest, scanned, baseline, skipped=(), extra=None,
+                  manifest_rows=None, schema='1.1'):
         with tempfile.TemporaryDirectory() as d:
             d = pathlib.Path(d)
             write_manifest(d / 'images.txt', manifest)
-            write_results(d / 'results.json', scanned, skipped)
+            if manifest_rows is None and schema != '1.0':
+                manifest_rows = len(manifest)
+            write_results(d / 'results.json', scanned, skipped, manifest_rows,
+                          schema)
             argv = ['--manifest', str(d / 'images.txt'),
                     '--results', str(d / 'results.json')]
             if baseline is not None:
@@ -103,6 +216,8 @@ class RegressionDetection(unittest.TestCase):
             skipped=[('c', 'pull', 'manifest unknown')])
         self.assertEqual(rc, 1)
         self.assertIn('c: failed at pull: manifest unknown', err)
+        # ...and for the regression, not as a side effect of bad arithmetic.
+        self.assertNotIn('unaccounted', err)
 
     def test_failure_names_the_stage_when_recorded(self):
         rc, err = self.run_guard(
@@ -114,27 +229,34 @@ class RegressionDetection(unittest.TestCase):
 
     def test_failure_without_a_skip_record_is_still_reported(self):
         """A schema-1.0 results.json has nowhere to record skips; the guard must
-        still fail, just without an explanation."""
+        still fail on the regression, and must separately say that the coverage
+        invariant could not be checked rather than assume it held."""
         rc, err = self.run_guard(
-            manifest=['a', 'b'], scanned=['a'], baseline=['a', 'b'])
+            manifest=['a', 'b'], scanned=['a'], baseline=['a', 'b'],
+            schema='1.0')
         self.assertEqual(rc, 1)
         self.assertIn('never reached the sweep', err)
+        self.assertIn('does not record', err)
 
     def test_the_real_39_row_shape_fails(self):
         """The exact production shape: 295 rows, 256 scanned, all 39 of the
-        missing ones scored in the baseline. This is the run that used to be
-        green."""
+        missing ones scored in the baseline, schema 1.0 so nothing recorded the
+        loss. This is the run that used to be green."""
         manifest = [f'row-{i}' for i in range(295)]
         scanned = manifest[:256]
         rc, err = self.run_guard(manifest=manifest, scanned=scanned,
-                                 baseline=manifest)
+                                 baseline=manifest, schema='1.0')
         self.assertEqual(rc, 1)
         self.assertIn('39 scenario(s)', err)
 
     def test_clean_run_passes(self):
-        rc, _ = self.run_guard(manifest=['a', 'b'], scanned=['a', 'b'],
-                               baseline=['a', 'b'])
+        rc, err = self.run_guard(manifest=['a', 'b'], scanned=['a', 'b'],
+                                 baseline=['a', 'b'])
         self.assertEqual(rc, 0)
+        # No implicit floor once a baseline exists: `regressed == []` already
+        # implies `len(scanned) >= len(expected)`, so reporting one would be
+        # theatre (and the branch enforcing it was unreachable).
+        self.assertIn('no floor, regression-relative', err)
 
     def test_new_row_scoring_for_the_first_time_passes(self):
         rc, _ = self.run_guard(manifest=['a', 'b', 'c'], scanned=['a', 'b', 'c'],
@@ -156,17 +278,42 @@ class RegressionDetection(unittest.TestCase):
                                baseline=['a', 'b', 'retired'])
         self.assertEqual(rc, 0)
 
+    def test_a_duplicated_row_is_reported_once(self):
+        """The manifest may repeat a label; the regression list should name it
+        once rather than once per row."""
+        rc, err = self.run_guard(
+            manifest=['a', 'dup', 'dup'], scanned=['a'], baseline=['a', 'dup'],
+            skipped=[('dup', 'pull', 'gone'), ('dup', 'pull', 'gone')])
+        self.assertEqual(rc, 1)
+        self.assertIn('1 scenario(s)', err)
+
     def test_no_baseline_says_so_instead_of_pretending(self):
         rc, err = self.run_guard(manifest=['a', 'b'], scanned=['a'],
-                                 baseline=None)
+                                 baseline=None,
+                                 skipped=[('b', 'pull', 'nope')])
         self.assertEqual(rc, 0)
         self.assertIn('UNCHECKED', err)
 
     def test_no_baseline_still_enforces_a_floor(self):
         rc, err = self.run_guard(manifest=['a', 'b'], scanned=['a'],
-                                 baseline=None, extra=['--min-scanned', '2'])
+                                 baseline=None,
+                                 skipped=[('b', 'pull', 'nope')],
+                                 extra=['--min-scanned', '2'])
         self.assertEqual(rc, 1)
         self.assertIn('floor is 2', err)
+
+    def test_min_scanned_still_bites_with_a_baseline(self):
+        """`--min-scanned` is the only floor left, and it has to mean something
+        independent of the regression check or it is decoration. Here nothing
+        regressed -- `b` never scored before -- and the explicit floor is what
+        fails the run."""
+        rc, err = self.run_guard(manifest=['a', 'b'], scanned=['a'],
+                                 baseline=['a'],
+                                 skipped=[('b', 'pull', 'nope')],
+                                 extra=['--min-scanned', '2'])
+        self.assertEqual(rc, 1)
+        self.assertIn('floor is 2', err)
+        self.assertNotIn('scored in the previous results.json', err)
 
     def test_unreadable_input_is_exit_2_not_a_pass(self):
         with tempfile.TemporaryDirectory() as d:
@@ -204,8 +351,13 @@ class RealRepo(unittest.TestCase):
         ok, floor, regressed, _ = guard.evaluate(manifest, scanned,
                                                  baseline=set(manifest))
         self.assertFalse(ok)
-        self.assertEqual(len(regressed), len(manifest) - len(scanned))
-        self.assertTrue(all(lab.startswith('default-') for lab in regressed))
+        # Exactly the rows the manifest asks for and the artifact never scored.
+        # Deliberately NOT asserting anything about what those labels are named:
+        # the weekly refresh regenerates results.json, so pinning the shape of
+        # the currently-missing rows would turn an unrelated registry outage
+        # into a red unit test.
+        self.assertEqual(sorted(regressed), sorted(set(manifest) - scanned))
+        self.assertEqual(len(regressed), len(set(manifest)) - len(scanned))
 
 
 if __name__ == '__main__':

--- a/scripts/tests/test_coverage_guard.py
+++ b/scripts/tests/test_coverage_guard.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Tests for examples/isolation-survey/coverage_guard.py (IRO-727).
+
+The defect this guard replaces was fail-quiet: 39 of 295 manifest rows produced
+no output every single week and `scanned > 0` still called the run green. A test
+that only asserts "clean input passes" would have passed against the broken code
+too, so every case below is a negative control -- each builds a run that DID
+lose coverage and asserts the guard refuses to call it green -- plus the two
+carve-outs that would make the guard unusable if it got them wrong:
+
+* test_row_deleted_from_manifest_is_not_a_regression -- retiring a permanently
+  dead row is the intended fix, so a label that leaves images.txt must not fail
+  forever after.
+* test_transient_failure_absent_from_baseline_does_not_fail -- a row that has
+  never scored (registry weather on a brand-new row) is not a regression, which
+  is what keeps the weekly refresh from going red on a Docker Hub 500.
+
+Run:
+    python3 -m unittest discover -s scripts/tests -v
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import pathlib
+import tempfile
+import unittest
+
+SCRIPT = (pathlib.Path(__file__).resolve().parent.parent.parent
+          / 'examples' / 'isolation-survey' / 'coverage_guard.py')
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location('coverage_guard', SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+guard = _load()
+
+
+def write_results(path, labels, skipped=()):
+    doc = {
+        "report": "ironclaw-isolation-survey",
+        "schemaVersion": "1.1",
+        "scenarioCount": len(labels),
+        "scenarios": [{"label": lab, "score": 50} for lab in labels],
+        "skippedCount": len(skipped),
+        "skipped": [{"label": lab, "image": lab, "stage": stage,
+                     "reason": reason} for lab, stage, reason in skipped],
+    }
+    path.write_text(json.dumps(doc))
+
+
+def write_manifest(path, labels):
+    lines = ["# scenario | image | run flags", ""]
+    lines += [f"{lab} | example/{lab}:1 |" for lab in labels]
+    path.write_text("\n".join(lines) + "\n")
+
+
+class ManifestParsing(unittest.TestCase):
+    def test_matches_survey_sh_parse(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = pathlib.Path(d) / 'images.txt'
+            p.write_text(
+                "# a comment\n"
+                "\n"
+                "default-nginx | nginx:1.27 |\n"
+                "hardened-nginx | nginx:1.27 | --user 101 --cap-drop=ALL\n"
+                "   spaced   |  busybox:1  |\n"
+                "default-nginx | nginx:1.27 |\n"  # duplicate label
+            )
+            self.assertEqual(guard.manifest_labels(p),
+                             ['default-nginx', 'hardened-nginx', 'spaced'])
+
+
+class RegressionDetection(unittest.TestCase):
+    """The core property: a row that scored before and stopped is a failure."""
+
+    def run_guard(self, manifest, scanned, baseline, skipped=(), extra=None):
+        with tempfile.TemporaryDirectory() as d:
+            d = pathlib.Path(d)
+            write_manifest(d / 'images.txt', manifest)
+            write_results(d / 'results.json', scanned, skipped)
+            argv = ['--manifest', str(d / 'images.txt'),
+                    '--results', str(d / 'results.json')]
+            if baseline is not None:
+                write_results(d / 'baseline.json', baseline)
+                argv += ['--baseline', str(d / 'baseline.json')]
+            argv += extra or []
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                rc = guard.main(argv)
+            return rc, err.getvalue()
+
+    def test_dropped_row_fails(self):
+        rc, err = self.run_guard(
+            manifest=['a', 'b', 'c'], scanned=['a', 'b'], baseline=['a', 'b', 'c'],
+            skipped=[('c', 'pull', 'manifest unknown')])
+        self.assertEqual(rc, 1)
+        self.assertIn('c: failed at pull: manifest unknown', err)
+
+    def test_failure_names_the_stage_when_recorded(self):
+        rc, err = self.run_guard(
+            manifest=['a', 'b'], scanned=['a'], baseline=['a', 'b'],
+            skipped=[('b', 'run', 'exec: "sleep": not found')])
+        self.assertEqual(rc, 1)
+        self.assertIn('failed at run', err)
+        self.assertIn('sleep', err)
+
+    def test_failure_without_a_skip_record_is_still_reported(self):
+        """A schema-1.0 results.json has nowhere to record skips; the guard must
+        still fail, just without an explanation."""
+        rc, err = self.run_guard(
+            manifest=['a', 'b'], scanned=['a'], baseline=['a', 'b'])
+        self.assertEqual(rc, 1)
+        self.assertIn('never reached the sweep', err)
+
+    def test_the_real_39_row_shape_fails(self):
+        """The exact production shape: 295 rows, 256 scanned, all 39 of the
+        missing ones scored in the baseline. This is the run that used to be
+        green."""
+        manifest = [f'row-{i}' for i in range(295)]
+        scanned = manifest[:256]
+        rc, err = self.run_guard(manifest=manifest, scanned=scanned,
+                                 baseline=manifest)
+        self.assertEqual(rc, 1)
+        self.assertIn('39 scenario(s)', err)
+
+    def test_clean_run_passes(self):
+        rc, _ = self.run_guard(manifest=['a', 'b'], scanned=['a', 'b'],
+                               baseline=['a', 'b'])
+        self.assertEqual(rc, 0)
+
+    def test_new_row_scoring_for_the_first_time_passes(self):
+        rc, _ = self.run_guard(manifest=['a', 'b', 'c'], scanned=['a', 'b', 'c'],
+                               baseline=['a', 'b'])
+        self.assertEqual(rc, 0)
+
+    def test_transient_failure_absent_from_baseline_does_not_fail(self):
+        """A row that has never produced output is not a regression -- this is
+        what stops one Docker Hub 500 from wedging the weekly refresh."""
+        rc, _ = self.run_guard(manifest=['a', 'b', 'c'], scanned=['a', 'b'],
+                               baseline=['a', 'b'],
+                               skipped=[('c', 'pull', 'toomanyrequests')])
+        self.assertEqual(rc, 0)
+
+    def test_row_deleted_from_manifest_is_not_a_regression(self):
+        """Deleting a dead row is the sanctioned fix, so the baseline must be
+        intersected with the current manifest, not used raw."""
+        rc, _ = self.run_guard(manifest=['a', 'b'], scanned=['a', 'b'],
+                               baseline=['a', 'b', 'retired'])
+        self.assertEqual(rc, 0)
+
+    def test_no_baseline_says_so_instead_of_pretending(self):
+        rc, err = self.run_guard(manifest=['a', 'b'], scanned=['a'],
+                                 baseline=None)
+        self.assertEqual(rc, 0)
+        self.assertIn('UNCHECKED', err)
+
+    def test_no_baseline_still_enforces_a_floor(self):
+        rc, err = self.run_guard(manifest=['a', 'b'], scanned=['a'],
+                                 baseline=None, extra=['--min-scanned', '2'])
+        self.assertEqual(rc, 1)
+        self.assertIn('floor is 2', err)
+
+    def test_unreadable_input_is_exit_2_not_a_pass(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = pathlib.Path(d)
+            write_manifest(d / 'images.txt', ['a'])
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                rc = guard.main(['--manifest', str(d / 'images.txt'),
+                                 '--results', str(d / 'nope.json')])
+            self.assertEqual(rc, 2)
+
+
+class RealRepo(unittest.TestCase):
+    """Non-vacuity anchor against the committed tree, in both directions."""
+
+    ROOT = SCRIPT.parent
+    MANIFEST = ROOT / 'images.txt'
+    RESULTS = ROOT / 'results.json'
+
+    def test_committed_results_is_self_consistent(self):
+        scanned = guard.scenario_labels(self.RESULTS)
+        manifest = guard.manifest_labels(self.MANIFEST)
+        self.assertGreater(len(manifest), 0)
+        # Every scored label maps back to a manifest row: the survey never
+        # invents scenarios, which is what makes the missing-rows arithmetic
+        # (manifest - scanned) trustworthy.
+        self.assertEqual(sorted(scanned - set(manifest)), [])
+
+    def test_committed_results_would_fail_the_guard_against_a_full_baseline(self):
+        """The live proof that the guard bites: pretend a previous run had
+        covered the whole manifest, and the committed results.json -- the exact
+        artifact that shipped green -- must be rejected."""
+        scanned = guard.scenario_labels(self.RESULTS)
+        manifest = guard.manifest_labels(self.MANIFEST)
+        ok, floor, regressed, _ = guard.evaluate(manifest, scanned,
+                                                 baseline=set(manifest))
+        self.assertFalse(ok)
+        self.assertEqual(len(regressed), len(manifest) - len(scanned))
+        self.assertTrue(all(lab.startswith('default-') for lab in regressed))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/tests/test_coverage_guard.py
+++ b/scripts/tests/test_coverage_guard.py
@@ -91,9 +91,12 @@ class ManifestParsing(unittest.TestCase):
     `expected` over a different row set than the sweep swept."""
 
     def labels(self, text):
+        return self.labels_bytes(text.encode())
+
+    def labels_bytes(self, data):
         with tempfile.TemporaryDirectory() as d:
             p = pathlib.Path(d) / 'images.txt'
-            p.write_text(text)
+            p.write_bytes(data)
             return guard.manifest_labels(p)
 
     def test_column_zero_comments_and_blanks_are_skipped(self):
@@ -128,6 +131,54 @@ class ManifestParsing(unittest.TestCase):
 
     def test_a_last_line_without_a_newline_still_counts(self):
         self.assertEqual(self.labels("a | x:1 |\nb | y:1 |"), ['a', 'b'])
+
+    # The cases below are the residual divergences from survey.sh. Each one
+    # changes label IDENTITY at an unchanged row COUNT, which is why counting
+    # rows could never have caught them: the guard matches the baseline by
+    # label, so a label only it spells that way drops out of the expected set
+    # permanently and silently -- IRO-727, reproduced by its own guard.
+
+    def test_a_bare_cr_is_not_a_line_break(self):
+        """`IFS= read -r line` splits on \\n only. Python text mode is
+        universal-newline mode, where a bare CR ends a line, so the guard used
+        to see two rows ('a', 'b') where the sweep sees the single label
+        'a\\rb'. Stripping a trailing CR per line cannot help: the file was
+        already re-split before any per-line fix-up could run."""
+        self.assertEqual(self.labels_bytes(b"a\rb | busybox:1 |\n"), ['a\rb'])
+
+    def test_a_non_ascii_space_is_not_a_separator(self):
+        """bash's default IFS is space/tab/newline. `str.split()` also splits on
+        every Unicode space, so U+00A0 made the guard read 'a b' where the sweep
+        reads 'a\\xa0b'."""
+        nbsp = "\u00a0"  # explicit: an invisible literal here is unreviewable
+        self.assertEqual(self.labels(f"a{nbsp}b | busybox:1 |\n"),
+                         [f"a{nbsp}b"])
+
+    def test_vertical_tab_and_form_feed_are_not_separators(self):
+        """Same class as the NBSP case, and reachable in bytes mode too:
+        `bytes.split()` with no argument splits on \\x0b and \\x0c, which bash
+        does not."""
+        self.assertEqual(self.labels("a\x0bb\x0cc | busybox:1 |\n"),
+                         ['a\x0bb\x0cc'])
+
+    def test_double_quotes_are_data_not_quoting(self):
+        """`echo "$label" | xargs` applied shell quote processing, so the sweep
+        recorded `say "hi"` as `say hi` while the guard kept the quotes. Neither
+        side does quote processing now."""
+        self.assertEqual(self.labels('say "hi" | busybox:1 |\n'), ['say "hi"'])
+
+    def test_a_backslash_is_data_not_an_escape(self):
+        self.assertEqual(self.labels(r'a\b | busybox:1 |' + "\n"), [r'a\b'])
+
+    def test_a_label_starting_with_a_dash_n_is_kept(self):
+        """`echo "$label" | xargs` runs xargs with no utility, which defaults to
+        /bin/echo, so a label beginning `-n ` was eaten as an option and the
+        sweep recorded 'foo'."""
+        self.assertEqual(self.labels("-n foo | busybox:1 |\n"), ['-n foo'])
+
+    def test_a_tab_run_collapses_like_a_space_run(self):
+        self.assertEqual(self.labels("\ttwo\t \twords\t| busybox:1 |\n"),
+                         ['two words'])
 
 
 class Accounting(unittest.TestCase):
@@ -185,6 +236,52 @@ class Accounting(unittest.TestCase):
         problems = self.check(doc, ['a', 'b'])
         self.assertTrue(any('exceeds manifestRowCount' in p for p in problems),
                         problems)
+
+    def test_ghost_labels_at_matching_counts_are_caught(self):
+        """Every sum closes and the artifact covers none of the rows asked for.
+        Counting rows is structurally blind to this; comparing the label
+        multisets is not."""
+        doc = results_doc(['x', 'y'], skipped=[('z', 'pull', 'nope')])
+        problems = self.check(doc, ['a', 'b', 'c'])
+        self.assertTrue(any('do not name the same rows' in p
+                            for p in problems), problems)
+        joined = ' '.join(problems)
+        for lab in ('a', 'b', 'c', 'x', 'y', 'z'):
+            self.assertIn(repr(lab), joined)
+
+    def test_one_label_spelled_two_ways_is_caught(self):
+        """The residual parse-drift shape, and the reason counts are not enough:
+        3 rows in, 3 rows out, one of them a different string. Under the old
+        count-only check this was silent, and `evaluate()` would then never
+        match that row against the baseline again."""
+        doc = results_doc(['a', 'say hi'], skipped=[('c', 'pull', 'nope')])
+        problems = self.check(doc, ['a', 'say "hi"', 'c'])
+        self.assertTrue(any('do not name the same rows' in p
+                            for p in problems), problems)
+
+    def test_a_duplicate_walked_once_is_caught(self):
+        """A multiset, not a set: the manifest asks for `dup` twice and the
+        artifact reports it once. Set comparison would call this equal."""
+        doc = results_doc(['a', 'dup'], manifest_rows=3)
+        problems = self.check(doc, ['a', 'dup', 'dup'])
+        self.assertTrue(any('do not name the same rows' in p
+                            for p in problems), problems)
+
+    def test_matching_labels_produce_no_identity_problem(self):
+        """Two-sided: the check must be quiet when the two sides do agree,
+        including on a repeated label."""
+        doc = results_doc(['a', 'dup', 'dup'], skipped=[('c', 'pull', 'x')])
+        self.assertEqual(self.check(doc, ['a', 'dup', 'dup', 'c']), [])
+
+    def test_a_boolean_is_not_a_recorded_count(self):
+        """`bool` is a subclass of `int`, so `isinstance(v, int)` read
+        `manifestRowCount: true` as a recorded count and then did arithmetic on
+        it as 1."""
+        doc = results_doc(['a'])
+        doc['manifestRowCount'] = True
+        problems = self.check(doc, ['a'])
+        self.assertTrue(any('does not record' in p and 'manifestRowCount' in p
+                            for p in problems), problems)
 
 
 class RegressionDetection(unittest.TestCase):

--- a/scripts/tests/test_survey_coverage_e2e.py
+++ b/scripts/tests/test_survey_coverage_e2e.py
@@ -30,6 +30,7 @@ import os
 import pathlib
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -91,12 +92,58 @@ case "$target" in
   *bad-scan*) echo "scan: container is not running" >&2; exit 1 ;;
   *bad-json*) echo "<html>502 Bad Gateway</html>"; exit 0 ;;
 esac
+# `target` is deliberately a constant rather than "$target". A scenario label is
+# arbitrary text -- the parse tests drive labels containing a double quote and a
+# bare CR through here -- and interpolating one into JSON unescaped emits a
+# malformed report, which the sweep then correctly records as an unreadable-scan
+# SKIP. That would be the stub failing the row, not the code under test.
 cat <<JSON
 {"score": 42, "grade": "D", "generatedAt": "2026-01-01T00:00:00Z",
- "version": "test", "target": "$target",
+ "version": "test", "target": "stub",
  "dimensions": [{"key": "user", "title": "Non-root user", "verdict": "FAIL", "max": 20}]}
 JSON
 '''
+
+
+# A python3 that fails ONLY the record_skip write, the way a full temp
+# filesystem does. record_skip is the one write PRUNE=1 makes likely to hit
+# ENOSPC -- PRUNE exists because the runner's disk is nearly full, and /tmp
+# shares that filesystem -- and it used to return 1 under `set -euo pipefail`,
+# aborting the sweep before render and taking every skip collected so far with
+# it via cleanup(). Everything else (append_record, the summary parse,
+# render.py, coverage_guard.py) is delegated to the real interpreter.
+PY_ENOSPC_SHIM = r'''#!/usr/bin/env bash
+REAL="__REAL_PYTHON__"
+if [ "${1:-}" = "-" ]; then
+  script="$(cat)"
+  case "$script" in
+    *skipfile*)
+      echo 'Traceback (most recent call last):' >&2
+      echo 'OSError: [Errno 28] No space left on device' >&2
+      exit 1 ;;
+  esac
+  printf '%s' "$script" | "$REAL" "$@"
+  exit $?
+fi
+exec "$REAL" "$@"
+'''
+
+# Labels survey.sh and coverage_guard.py used to parse DIFFERENTLY, at an
+# identical row count. Each is (name, label). The mechanism differs per row --
+# xargs quote processing, xargs backslash processing, xargs defaulting to
+# /bin/echo and eating a leading option, Python's Unicode-aware str.split(),
+# Python's universal-newline file iteration -- but the consequence is one
+# shared, silent failure: the sweep records the row under one spelling, the
+# guard looks for the other, so the row never matches the baseline and a real
+# permanent regression on it exits 0 forever.
+DIVERGENT_LABELS = [
+    ('plain', 'plain'),                       # control: must be LOUD either way
+    ('double quotes', 'say "hi"'),
+    ('backslash', 'a\\b'),
+    ('nbsp', 'a\u00a0b'),  # explicit: an invisible literal is unreviewable
+    ('leading dash-n', '-n foo'),
+    ('bare cr', 'a\rb'),
+]
 
 
 def manifest(rows):
@@ -104,7 +151,11 @@ def manifest(rows):
         f"{lab} | example/{lab}:1 |\n" for lab in rows)
 
 
-class SurveyCoverageE2E(unittest.TestCase):
+class SurveyFixture(unittest.TestCase):
+    """A throwaway repo with stub docker/ironctl, and the helpers to drive
+    survey.sh inside it. Holds no tests of its own so the classes below do not
+    each re-run every other class's cases."""
+
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
         self.root = pathlib.Path(self.tmp.name)
@@ -142,15 +193,19 @@ class SurveyCoverageE2E(unittest.TestCase):
         self.git('commit', '-qm', 'results')
 
     def write_manifest(self, text):
-        (self.dir / 'images.txt').write_text(text)
+        # Bytes, not text: a manifest row can legitimately contain a bare CR,
+        # and writing it through text mode would let the platform newline
+        # translation rewrite the very byte under test.
+        (self.dir / 'images.txt').write_bytes(text.encode())
 
-    def run_survey(self, rows=None):
+    def run_survey(self, rows=None, extra_env=None):
         if rows is not None:
             self.write_manifest(manifest(rows))
         env = dict(os.environ,
                    DOCKER=str(self.bin / 'docker'),
                    IRONCTL=str(self.bin / 'ironctl'),
                    MIRROR='0', PRUNE='0')
+        env.update(extra_env or {})
         return subprocess.run(['bash', str(self.dir / 'survey.sh')],
                               cwd=self.dir, env=env,
                               capture_output=True, text=True)
@@ -158,6 +213,8 @@ class SurveyCoverageE2E(unittest.TestCase):
     def results(self):
         return json.loads((self.dir / 'results.json').read_text())
 
+
+class SurveyCoverageE2E(SurveyFixture):
     def test_all_three_skip_stages_land_in_the_artifact(self):
         proc = self.run_survey(['ok-one', 'bad-pull', 'bad-run', 'bad-scan',
                                 'ok-two'])
@@ -357,6 +414,52 @@ class SurveyCoverageE2E(unittest.TestCase):
         self.assertEqual([s['label'] for s in self.results()['skipped']],
                          ['bad-pull'])
 
+    def test_a_parse_divergence_never_produces_a_silent_regression(self):
+        """The control table for the residual parse gaps.
+
+        For each label the two parsers used to spell differently: score it,
+        commit it as the baseline, then break that exact row and demand the
+        guard is LOUD. Under the old code the sweep recorded one spelling and
+        the guard looked for the other, so the row silently left `expected` and
+        a permanent regression on it printed 'coverage: 1 scanned / 2 manifest
+        rows' and exited 0 -- IRO-727 reproduced inside the guard written to
+        prevent it. `plain` is the positive control: it was loud before this
+        change too, so a harness that cannot fail here proves nothing.
+        """
+        for i, (name, label) in enumerate(DIVERGENT_LABELS):
+            if i:
+                # A fresh repo per row; the outer tearDown cleans the last one.
+                self.tearDown()
+                self.setUp()
+            with self.subTest(divergence=name, label=label):
+                self.write_manifest(f"{label} | example/ok-one:1 |\n"
+                                    "keeper | example/ok-two:1 |\n")
+                first = self.run_survey()
+                self.assertEqual(first.returncode, 0, first.stderr)
+                # The sweep recorded the label verbatim...
+                doc = self.results()
+                self.assertIn(label, [s['label'] for s in doc['scenarios']],
+                              "the sweep rewrote the label while recording it")
+                # ...and the guard parses the identical string out of the same
+                # manifest. This is the equality everything else rests on.
+                self.assertEqual(
+                    collections.Counter(
+                        guard.manifest_labels(self.dir / 'images.txt')),
+                    collections.Counter(
+                        [s['label'] for s in doc['scenarios']]
+                        + [s['label'] for s in doc['skipped']]))
+                self.commit_results()
+
+                # Now that row rots for good. This must be loud.
+                self.write_manifest(f"{label} | example/bad-run:1 |\n"
+                                    "keeper | example/ok-two:1 |\n")
+                second = self.run_survey()
+                self.assertNotEqual(
+                    second.returncode, 0,
+                    "a permanent regression on a label the two parsers spell "
+                    "differently exited 0:\n" + second.stderr)
+                self.assertIn('coverage regressed', second.stderr)
+
     def test_no_committed_baseline_says_the_check_was_skipped(self):
         """A first run has nothing to compare against. It must say so rather
         than quietly falling back to whatever results.json is lying on disk --
@@ -365,6 +468,197 @@ class SurveyCoverageE2E(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertIn('baseline: none committed', proc.stderr)
         self.assertIn('UNCHECKED', proc.stderr)
+
+
+class BaselineReadFailures(SurveyFixture):
+    """`git show` is load-bearing: it feeds the only real safety gate.
+
+    "Nothing is committed yet" and "git could not be read" are different states
+    and used to collapse into one exit-0 message, with `2>/dev/null` discarding
+    the reason. A container running the survey over a bind-mounted checkout
+    owned by another uid gets the second one routinely, and it printed
+    'baseline: none committed' and ran with the regression check off.
+    """
+
+    def test_a_broken_object_store_is_fatal_not_an_unchecked_run(self):
+        """Refs and repo layout intact, object CONTENT unreadable -- what git
+        sees when the survey runs in a container over a bind-mounted checkout
+        owned by another uid. Pre-fix this printed 'none committed' and exited 0
+        with a real regression sitting on disk.
+
+        Emptying the object files rather than deleting the directory is
+        deliberate, and the difference matters: git's repository discovery
+        requires `objects/` to EXIST, so removing it makes the tree stop being a
+        git checkout at all -- a different state, already covered by
+        test_a_non_git_checkout_is_a_legitimate_no_baseline. Corrupting content
+        also needs no uid games, so it behaves the same for a root CI container.
+        """
+        self.assertEqual(self.run_survey(['ok-one', 'ok-two']).returncode, 0)
+        self.commit_results()
+        for obj in (self.root / '.git' / 'objects').rglob('*'):
+            if obj.is_file():
+                obj.chmod(0o644)      # git writes loose objects read-only
+                obj.write_bytes(b'')
+        # Precondition: git itself must now fail to read HEAD, or this test
+        # proves nothing about the branch it is aimed at.
+        probe = subprocess.run(
+            ['git', '-C', str(self.root), 'ls-tree', '--full-tree', 'HEAD'],
+            capture_output=True)
+        self.assertNotEqual(probe.returncode, 0,
+                            'fixture did not actually break the object store')
+
+        self.write_manifest("ok-one | example/ok-one:1 |\n"
+                            "ok-two | example/bad-run:1 |\n")
+        proc = self.run_survey()
+        self.assertNotEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn('git could not read', proc.stderr)
+        self.assertNotIn('none committed', proc.stderr)
+        # The reason git gave is reported, not swallowed.
+        self.assertNotIn('the coverage regression check will be skipped',
+                         proc.stderr)
+
+    def test_an_unborn_head_is_a_legitimate_no_baseline(self):
+        """Non-vacuity for the check above: the fatal path must not swallow the
+        genuine first-run case. A fresh `git init` has refs but no commit."""
+        shutil.rmtree(self.root / '.git')
+        self.git('init', '-q')
+        proc = self.run_survey(['ok-one'])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn('none committed', proc.stderr)
+        self.assertIn('has no commits yet', proc.stderr)
+        self.assertIn('UNCHECKED', proc.stderr)
+
+    def test_a_non_git_checkout_is_a_legitimate_no_baseline(self):
+        """Second non-vacuity arm: an export with no .git at all (a release
+        tarball) still runs, and still says the check was skipped."""
+        shutil.rmtree(self.root / '.git')
+        probe = subprocess.run(['git', '-C', str(self.root), 'rev-parse',
+                                '--show-prefix'], capture_output=True)
+        if probe.returncode == 0:
+            self.skipTest('tmpdir sits inside an enclosing git repository')
+        proc = self.run_survey(['ok-one'])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn('none committed', proc.stderr)
+        self.assertIn('is not a git checkout', proc.stderr)
+
+    def test_git_is_preflighted_like_docker_and_python3(self):
+        """git became a hard dependency the moment the baseline came out of
+        HEAD, so a missing git must `die` up front rather than degrade into an
+        exit-0 run with the regression check silently off."""
+        farm = self.root / 'nogit-bin'
+        farm.mkdir()
+        needed = ['bash', 'mktemp', 'head', 'grep', 'rm', 'sleep', 'dirname',
+                  'cat', 'sed', 'env', 'uname']
+        for tool in needed:
+            found = shutil.which(tool)
+            if found:
+                (farm / tool).symlink_to(found)
+        (farm / 'python3').symlink_to(sys.executable)
+        if shutil.which('git', path=str(farm)):
+            self.skipTest('could not build a git-free PATH')
+        # Sanity: the farm is usable at all, or a failure below means nothing.
+        smoke = subprocess.run(['bash', '-c', 'python3 -c "print(1)"'],
+                               env=dict(os.environ, PATH=str(farm)),
+                               capture_output=True, text=True)
+        if smoke.returncode != 0:
+            self.skipTest(f'git-free PATH cannot run python3: {smoke.stderr}')
+
+        proc = self.run_survey(['ok-one'], extra_env={'PATH': str(farm)})
+        self.assertNotEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn('git not found', proc.stderr)
+
+
+class SweepAbortsThatUsedToDestroyTheEvidence(SurveyFixture):
+    """Finding 2's residual: the render-first ordering only helps a run that
+    REACHES render. Every abort between the first row and the render step left
+    the previous healthy results.json byte-identical on disk and had cleanup()
+    delete every skip collected so far -- the precise state the ordering claims
+    to have removed."""
+
+    def test_a_failed_skip_write_does_not_kill_the_run(self):
+        """ENOSPC inside record_skip. The comment naming 'a full disk under
+        PRUNE=1' was false for exactly this: record_skip is called unguarded
+        under `set -euo pipefail`, so the write failure aborted the sweep before
+        render and destroyed the artifact it promised."""
+        shim = self.bin / 'py-shim' / 'python3'
+        shim.parent.mkdir()
+        shim.write_text(PY_ENOSPC_SHIM.replace('__REAL_PYTHON__',
+                                               sys.executable))
+        shim.chmod(0o755)
+        env_path = f"{shim.parent}{os.pathsep}{os.environ.get('PATH', '')}"
+
+        proc = self.run_survey(['ok-one', 'bad-pull', 'ok-two'],
+                               extra_env={'PATH': env_path})
+
+        # The artifact exists: the run stepped over the failed write.
+        doc = self.results()
+        self.assertEqual(doc['scenarioCount'], 2)
+        self.assertEqual(doc['manifestRowCount'], 3)
+        # The row could not be recorded, so it is unaccounted for -- and that
+        # is LOUD, not a silently smaller denominator.
+        self.assertEqual(doc['skippedCount'], 0)
+        self.assertNotEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn('could not be recorded', proc.stderr)
+        self.assertIn('unaccounted for', proc.stderr)
+
+    def test_an_unbalanced_quote_in_a_row_no_longer_aborts_the_sweep(self):
+        """`label="$(echo "$label" | xargs)"` had no `|| true` while the flags
+        line did. One unbalanced quote anywhere in images.txt was `xargs:
+        unterminated quote`, a non-zero exit mid-sweep, and the loss of every
+        skip recorded before it plus every row after it."""
+        self.write_manifest('bad-pull-row | example/bad-pull:1 |\n'
+                            'say "hi | example/ok-one:1 |\n'
+                            'after | example/ok-two:1 |\n')
+        proc = self.run_survey()
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        doc = self.results()
+        self.assertEqual(doc['manifestRowCount'], 3)
+        # The quote is data. The row before it kept its skip record, and the
+        # row after it was still swept.
+        self.assertIn('say "hi', [s['label'] for s in doc['scenarios']])
+        self.assertIn('after', [s['label'] for s in doc['scenarios']])
+        self.assertEqual([s['label'] for s in doc['skipped']],
+                         ['bad-pull-row'])
+
+
+class RefreshWorkflowKeepsFailedEvidence(unittest.TestCase):
+    """The CI arm of the durability claim.
+
+    survey.sh writing results.* before the guard buys nothing in CI unless
+    something collects them: on a red run every downstream step (regenerate,
+    commit, push, open PR) is skipped, so the files die with the runner and the
+    expiring Actions log is again the only record. Asserted here rather than
+    only described, because an invariant stated in a PR body and checked nowhere
+    is decoration.
+    """
+
+    WORKFLOW = REPO_ROOT / '.github' / 'workflows' / 'scores-refresh.yml'
+
+    def setUp(self):
+        self.text = self.WORKFLOW.read_text()
+
+    def test_the_survey_artifact_is_uploaded_even_when_the_run_fails(self):
+        self.assertIn('actions/upload-artifact@', self.text)
+        upload = self.text.index('actions/upload-artifact@')
+        step = self.text.rindex('- name:', 0, upload)
+        block = self.text[step:upload + 600]
+        self.assertIn('if: always()', block,
+                      "the upload must run on the failing run, which is the "
+                      "only run whose artifact is otherwise lost")
+        self.assertIn('examples/isolation-survey/results.json', block)
+        self.assertIn('examples/isolation-survey/results.md', block)
+
+    def test_the_upload_runs_before_anything_that_could_skip_it(self):
+        """It has to sit directly after the survey step. Placed after the
+        regenerate/build steps it would be skipped along with them on a failure
+        of one of those, which is the same hole one step further down."""
+        survey = self.text.index('bash examples/isolation-survey/survey.sh')
+        upload = self.text.index('actions/upload-artifact@')
+        # ...the first mention AFTER the survey step: the file also names
+        # gen_scorecards.py in its header comment.
+        regen = self.text.index('gen_scorecards.py', survey)
+        self.assertLess(survey, upload)
+        self.assertLess(upload, regen)
 
 
 class RenderCoverageSentence(unittest.TestCase):
@@ -379,28 +673,68 @@ class RenderCoverageSentence(unittest.TestCase):
     has rather than what the skip list happens to be.
     """
 
-    def render(self, labels, manifest_rows, skips=()):
+    def run_render(self, labels, manifest_rows, skips=()):
+        """Returns (CompletedProcess, dir). `manifest_rows=None` omits the flag
+        entirely, which is the shape that used to synthesize a denominator."""
         records = [{"label": lab, "image": f"example/{lab}:1",
                     "runFlags": "", "resolvedDigest": "",
                     "report": {"score": 42, "grade": "D",
                                "generatedAt": "2026-01-01T00:00:00Z",
                                "version": "test", "dimensions": []}}
                    for lab in labels]
-        with tempfile.TemporaryDirectory() as d:
-            d = pathlib.Path(d)
-            argv = [str(SURVEY_DIR / 'render.py'),
-                    str(d / 'results.json'), str(d / 'results.md'),
-                    '--manifest-rows', str(manifest_rows)]
-            if skips:
-                (d / 'skips.json').write_text(json.dumps(
-                    [{"label": lab, "image": f"example/{lab}:1",
-                      "stage": stage, "reason": reason}
-                     for lab, stage, reason in skips]))
-                argv += ['--skips', str(d / 'skips.json')]
-            proc = subprocess.run(['python3', *argv], input=json.dumps(records),
-                                  capture_output=True, text=True)
-            self.assertEqual(proc.returncode, 0, proc.stderr)
-            return (d / 'results.md').read_text()
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = pathlib.Path(tmp.name)
+        argv = [str(SURVEY_DIR / 'render.py'),
+                str(d / 'results.json'), str(d / 'results.md')]
+        if manifest_rows is not None:
+            argv += ['--manifest-rows', str(manifest_rows)]
+        if skips:
+            (d / 'skips.json').write_text(json.dumps(
+                [{"label": lab, "image": f"example/{lab}:1",
+                  "stage": stage, "reason": reason}
+                 for lab, stage, reason in skips]))
+            argv += ['--skips', str(d / 'skips.json')]
+        proc = subprocess.run([sys.executable, *argv],
+                              input=json.dumps(records),
+                              capture_output=True, text=True)
+        return proc, d
+
+    def render(self, labels, manifest_rows, skips=()):
+        proc, d = self.run_render(labels, manifest_rows, skips)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        return (d / 'results.md').read_text()
+
+    def test_a_missing_manifest_row_count_is_refused_not_synthesized(self):
+        """The denominator used to default to `len(rows) + len(skips)`, so the
+        coverage invariant held by construction: one scored row and no skips
+        wrote `manifestRowCount: 1` and printed 'Coverage: 1 of 1 manifest rows
+        - every row was scanned' against a 295-row manifest. A count nobody
+        measured is not a count."""
+        proc, d = self.run_render(['a'], manifest_rows=None)
+        self.assertNotEqual(proc.returncode, 0,
+                            "render.py accepted a run with no measured "
+                            "denominator")
+        self.assertIn('manifest-rows', proc.stderr)
+        self.assertFalse((d / 'results.json').exists())
+        self.assertFalse((d / 'results.md').exists())
+
+    def test_full_coverage_is_not_claimed_when_skips_over_account(self):
+        """Every manifest row scored AND a skip was recorded: the counts do not
+        close, so the artifact must report that rather than print the happy
+        sentence and drop the skip table.
+
+        A spec test, NOT a non-vacuity anchor: it passes against the pre-fix
+        file too, because `len(rows) == manifest_rows and not skips` reaches the
+        same branch here. It is kept to pin the behaviour while the condition is
+        rewritten in terms of the three counts. The anchor for that rewrite is
+        test_a_missing_manifest_row_count_is_refused_not_synthesized.
+        """
+        md = self.render(['a', 'b'], manifest_rows=2,
+                         skips=[('c', 'pull', 'manifest unknown')])
+        self.assertNotIn('every row was scanned', md)
+        self.assertIn('unaccounted for', md)
+        self.assertIn('## Not scanned', md)
 
     def test_an_unaccounted_row_is_never_called_full_coverage(self):
         md = self.render(['a', 'b'], manifest_rows=3)

--- a/scripts/tests/test_survey_coverage_e2e.py
+++ b/scripts/tests/test_survey_coverage_e2e.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""End-to-end test of survey.sh's skip recording + coverage guard (IRO-727).
+
+The unit tests in test_coverage_guard.py exercise the guard's logic; this one
+runs the actual `examples/isolation-survey/survey.sh` -- under `set -euo
+pipefail`, through all three of its skip paths -- against stub `docker` and
+`ironctl` binaries. No daemon, no images, no network: the stubs are the only
+way to prove that a pull/run/scan failure ends up in `results.json` rather than
+only in a run log, which is the defect being fixed.
+
+Two runs, in order, because the guard is about the delta between them:
+
+ 1. every row succeeds -> results.json is the baseline, guard passes.
+ 2. a row that scored in (1) now fails -> survey.sh exits NON-ZERO, and
+    results.json still exists and names the row and its stage. Writing the
+    artifact even on failure is deliberate: the evidence has to outlive the run.
+
+Run:
+    python3 -m unittest discover -s scripts/tests -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+SURVEY_DIR = REPO_ROOT / 'examples' / 'isolation-survey'
+
+# A stub `docker` whose failure modes are keyed off the image/container name, so
+# one manifest exercises all three skip paths. `image inspect` without --format
+# is survey.sh's "is it cached?" probe and must miss, so the pull path runs.
+DOCKER_STUB = r'''#!/usr/bin/env bash
+set -uo pipefail
+cmd="$1"; shift
+case "$cmd" in
+  info) exit 0 ;;
+  image)
+    sub="$1"; shift
+    if [ "$sub" = "inspect" ]; then
+      case " $* " in
+        *--format*) echo "${1}@sha256:$(printf %064d 1)"; exit 0 ;;
+        *) exit 1 ;;   # never cached: force the pull path
+      esac
+    fi
+    exit 0 ;;
+  pull)
+    case " $* " in
+      *bad-pull*) echo "Error response from daemon: manifest unknown" >&2; exit 1 ;;
+    esac
+    exit 0 ;;
+  run)
+    case " $* " in
+      *bad-run*) echo 'docker: Error response from daemon: exec: "sleep": executable file not found in $PATH' >&2; exit 1 ;;
+    esac
+    echo "cid$$"; exit 0 ;;
+  rm|rmi) exit 0 ;;
+  *) exit 0 ;;
+esac
+'''
+
+# A stub `ironctl` that emits a minimal but real-shaped scan report.
+IRONCTL_STUB = r'''#!/usr/bin/env bash
+set -uo pipefail
+[ "${1:-}" = "scan" ] || exit 1
+shift
+[ "${1:-}" = "--help" ] && exit 0
+target="$1"
+case "$target" in
+  *bad-scan*) echo "scan: container is not running" >&2; exit 1 ;;
+esac
+cat <<JSON
+{"score": 42, "grade": "D", "generatedAt": "2026-01-01T00:00:00Z",
+ "version": "test", "target": "$target",
+ "dimensions": [{"key": "user", "title": "Non-root user", "verdict": "FAIL", "max": 20}]}
+JSON
+'''
+
+
+def manifest(rows):
+    return "# scenario | image | run flags\n" + "".join(
+        f"{lab} | example/{lab}:1 |\n" for lab in rows)
+
+
+class SurveyCoverageE2E(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = pathlib.Path(self.tmp.name)
+        # survey.sh derives REPO_ROOT as ../.. from its own location.
+        self.dir = root / 'examples' / 'isolation-survey'
+        self.dir.mkdir(parents=True)
+        for name in ('survey.sh', 'render.py', 'coverage_guard.py'):
+            shutil.copy2(SURVEY_DIR / name, self.dir / name)
+        self.bin = root / 'bin'
+        self.bin.mkdir()
+        for name, body in (('docker', DOCKER_STUB), ('ironctl', IRONCTL_STUB)):
+            p = self.bin / name
+            p.write_text(body)
+            p.chmod(0o755)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def run_survey(self, rows):
+        (self.dir / 'images.txt').write_text(manifest(rows))
+        env = dict(os.environ,
+                   DOCKER=str(self.bin / 'docker'),
+                   IRONCTL=str(self.bin / 'ironctl'),
+                   MIRROR='0', PRUNE='0')
+        return subprocess.run(['bash', str(self.dir / 'survey.sh')],
+                              cwd=self.dir, env=env,
+                              capture_output=True, text=True)
+
+    def results(self):
+        return json.loads((self.dir / 'results.json').read_text())
+
+    def test_all_three_skip_stages_land_in_the_artifact(self):
+        proc = self.run_survey(['ok-one', 'bad-pull', 'bad-run', 'bad-scan',
+                                'ok-two'])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        doc = self.results()
+
+        self.assertEqual(doc['schemaVersion'], '1.1')
+        self.assertEqual(doc['manifestRowCount'], 5)
+        self.assertEqual(doc['scenarioCount'], 2)
+        self.assertEqual(doc['skippedCount'], 3)
+        self.assertEqual(
+            {s['label']: s['stage'] for s in doc['skipped']},
+            {'bad-pull': 'pull', 'bad-run': 'run', 'bad-scan': 'scan'})
+        # scanned + skipped accounts for every manifest row -- the arithmetic a
+        # reader could not previously do from the artifact alone.
+        self.assertEqual(doc['scenarioCount'] + doc['skippedCount'],
+                         doc['manifestRowCount'])
+
+        reasons = {s['label']: s['reason'] for s in doc['skipped']}
+        self.assertIn('manifest unknown', reasons['bad-pull'])
+        self.assertIn('sleep', reasons['bad-run'])
+        self.assertIn('not running', reasons['bad-scan'])
+
+        md = (self.dir / 'results.md').read_text()
+        self.assertIn('Coverage: 2 of 5 manifest rows', md)
+        self.assertIn('## Not scanned', md)
+        for lab in ('bad-pull', 'bad-run', 'bad-scan'):
+            self.assertIn(f'`{lab}`', md)
+
+    def test_full_coverage_says_so(self):
+        proc = self.run_survey(['ok-one', 'ok-two'])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        doc = self.results()
+        self.assertEqual(doc['skipped'], [])
+        self.assertIn('every row was scanned',
+                      (self.dir / 'results.md').read_text())
+
+    def test_losing_a_row_that_scored_before_fails_the_run(self):
+        first = self.run_survey(['ok-one', 'ok-two'])
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(self.results()['scenarioCount'], 2)
+
+        # Same manifest, but ok-two now fails to run. Under the old
+        # `scanned > 0` floor this second run was green.
+        (self.dir / 'images.txt').write_text(
+            "ok-one | example/ok-one:1 |\n"
+            "ok-two | example/bad-run:1 |\n")
+        env = dict(os.environ,
+                   DOCKER=str(self.bin / 'docker'),
+                   IRONCTL=str(self.bin / 'ironctl'),
+                   MIRROR='0', PRUNE='0')
+        second = subprocess.run(['bash', str(self.dir / 'survey.sh')],
+                                cwd=self.dir, env=env,
+                                capture_output=True, text=True)
+        self.assertNotEqual(second.returncode, 0)
+        self.assertIn('ok-two', second.stderr)
+        self.assertIn('coverage regressed', second.stderr)
+
+        # The artifact is written anyway, and explains itself.
+        doc = self.results()
+        self.assertEqual(doc['scenarioCount'], 1)
+        self.assertEqual([s['label'] for s in doc['skipped']], ['ok-two'])
+        self.assertEqual(doc['skipped'][0]['stage'], 'run')
+
+    def test_retiring_a_dead_row_from_the_manifest_is_allowed(self):
+        first = self.run_survey(['ok-one', 'ok-two'])
+        self.assertEqual(first.returncode, 0, first.stderr)
+        second = self.run_survey(['ok-one'])
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertEqual(self.results()['scenarioCount'], 1)
+
+    def test_a_never_scored_row_failing_is_tolerated(self):
+        first = self.run_survey(['ok-one'])
+        self.assertEqual(first.returncode, 0, first.stderr)
+        # A new row is added and its image is unavailable: skipped, recorded,
+        # still green. One registry hiccup must not wedge the weekly refresh.
+        second = self.run_survey(['ok-one', 'bad-pull'])
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertEqual([s['label'] for s in self.results()['skipped']],
+                         ['bad-pull'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/tests/test_survey_coverage_e2e.py
+++ b/scripts/tests/test_survey_coverage_e2e.py
@@ -3,17 +3,19 @@
 
 The unit tests in test_coverage_guard.py exercise the guard's logic; this one
 runs the actual `examples/isolation-survey/survey.sh` -- under `set -euo
-pipefail`, through all three of its skip paths -- against stub `docker` and
-`ironctl` binaries. No daemon, no images, no network: the stubs are the only
-way to prove that a pull/run/scan failure ends up in `results.json` rather than
-only in a run log, which is the defect being fixed.
+pipefail`, through all of its skip paths -- against stub `docker` and `ironctl`
+binaries. No daemon, no images, no network: the stubs are the only way to prove
+that a pull/run/scan failure ends up in `results.json` rather than only in a run
+log, which is the defect being fixed.
 
-Two runs, in order, because the guard is about the delta between them:
-
- 1. every row succeeds -> results.json is the baseline, guard passes.
- 2. a row that scored in (1) now fails -> survey.sh exits NON-ZERO, and
-    results.json still exists and names the row and its stage. Writing the
-    artifact even on failure is deliberate: the evidence has to outlive the run.
+The tmpdir is a real git repo, because the baseline the guard compares against
+is the last COMMITTED `results.json`, not the working-tree copy the run is about
+to overwrite. `commit_results()` below is the test's stand-in for the weekly
+refresh workflow committing a green run. That distinction is the whole of
+test_a_rerun_does_not_launder_the_regression: with a working-tree baseline, run
+N writes the degraded artifact and run N+1 reads it back as its own baseline, so
+the second run of an unfixed sweep goes green and the guard is something you
+learn to re-run through.
 
 Run:
     python3 -m unittest discover -s scripts/tests -v
@@ -21,6 +23,8 @@ Run:
 
 from __future__ import annotations
 
+import collections
+import importlib.util
 import json
 import os
 import pathlib
@@ -32,9 +36,20 @@ import unittest
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 SURVEY_DIR = REPO_ROOT / 'examples' / 'isolation-survey'
 
+
+def _load_guard():
+    spec = importlib.util.spec_from_file_location(
+        'coverage_guard', SURVEY_DIR / 'coverage_guard.py')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+guard = _load_guard()
+
 # A stub `docker` whose failure modes are keyed off the image/container name, so
-# one manifest exercises all three skip paths. `image inspect` without --format
-# is survey.sh's "is it cached?" probe and must miss, so the pull path runs.
+# one manifest exercises every skip path. `image inspect` without --format is
+# survey.sh's "is it cached?" probe and must miss, so the pull path runs.
 DOCKER_STUB = r'''#!/usr/bin/env bash
 set -uo pipefail
 cmd="$1"; shift
@@ -64,7 +79,8 @@ case "$cmd" in
 esac
 '''
 
-# A stub `ironctl` that emits a minimal but real-shaped scan report.
+# A stub `ironctl` that emits a minimal but real-shaped scan report -- or, for
+# `bad-json`, exits 0 with a body render.py cannot read.
 IRONCTL_STUB = r'''#!/usr/bin/env bash
 set -uo pipefail
 [ "${1:-}" = "scan" ] || exit 1
@@ -73,6 +89,7 @@ shift
 target="$1"
 case "$target" in
   *bad-scan*) echo "scan: container is not running" >&2; exit 1 ;;
+  *bad-json*) echo "<html>502 Bad Gateway</html>"; exit 0 ;;
 esac
 cat <<JSON
 {"score": 42, "grade": "D", "generatedAt": "2026-01-01T00:00:00Z",
@@ -90,24 +107,46 @@ def manifest(rows):
 class SurveyCoverageE2E(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
-        root = pathlib.Path(self.tmp.name)
+        self.root = pathlib.Path(self.tmp.name)
         # survey.sh derives REPO_ROOT as ../.. from its own location.
-        self.dir = root / 'examples' / 'isolation-survey'
+        self.dir = self.root / 'examples' / 'isolation-survey'
         self.dir.mkdir(parents=True)
         for name in ('survey.sh', 'render.py', 'coverage_guard.py'):
             shutil.copy2(SURVEY_DIR / name, self.dir / name)
-        self.bin = root / 'bin'
+        self.bin = self.root / 'bin'
         self.bin.mkdir()
         for name, body in (('docker', DOCKER_STUB), ('ironctl', IRONCTL_STUB)):
             p = self.bin / name
             p.write_text(body)
             p.chmod(0o755)
+        # The guard reads its baseline out of git, so the fixture has to be one.
+        self.git('init', '-q')
+        self.git('add', '-A')
+        self.git('commit', '-qm', 'fixture')
 
     def tearDown(self):
         self.tmp.cleanup()
 
-    def run_survey(self, rows):
-        (self.dir / 'images.txt').write_text(manifest(rows))
+    def git(self, *args):
+        return subprocess.run(
+            ['git', '-C', str(self.root),
+             '-c', 'user.email=test@example.com', '-c', 'user.name=test',
+             '-c', 'commit.gpgsign=false', *args],
+            check=True, capture_output=True, text=True)
+
+    def commit_results(self):
+        """Stand in for the refresh workflow committing a green run. Only a run
+        that passed the guard is ever committed, which is what makes HEAD a
+        coverage level we actually held."""
+        self.git('add', '-A')
+        self.git('commit', '-qm', 'results')
+
+    def write_manifest(self, text):
+        (self.dir / 'images.txt').write_text(text)
+
+    def run_survey(self, rows=None):
+        if rows is not None:
+            self.write_manifest(manifest(rows))
         env = dict(os.environ,
                    DOCKER=str(self.bin / 'docker'),
                    IRONCTL=str(self.bin / 'ironctl'),
@@ -133,7 +172,8 @@ class SurveyCoverageE2E(unittest.TestCase):
             {s['label']: s['stage'] for s in doc['skipped']},
             {'bad-pull': 'pull', 'bad-run': 'run', 'bad-scan': 'scan'})
         # scanned + skipped accounts for every manifest row -- the arithmetic a
-        # reader could not previously do from the artifact alone.
+        # reader could not previously do from the artifact alone, and which the
+        # guard now checks rather than printing.
         self.assertEqual(doc['scenarioCount'] + doc['skippedCount'],
                          doc['manifestRowCount'])
 
@@ -156,24 +196,29 @@ class SurveyCoverageE2E(unittest.TestCase):
         self.assertIn('every row was scanned',
                       (self.dir / 'results.md').read_text())
 
+    def test_partial_coverage_never_claims_every_row_was_scanned(self):
+        """The sentence has to come from the arithmetic. Reading it off an empty
+        skip list printed "Coverage: 2 of 3 manifest rows -- every row was
+        scanned" at exit 0, which is the fail-quiet this PR exists to remove."""
+        proc = self.run_survey(['ok-one', 'bad-pull', 'ok-two'])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        md = (self.dir / 'results.md').read_text()
+        self.assertIn('Coverage: 2 of 3 manifest rows', md)
+        self.assertNotIn('every row was scanned', md)
+
     def test_losing_a_row_that_scored_before_fails_the_run(self):
         first = self.run_survey(['ok-one', 'ok-two'])
         self.assertEqual(first.returncode, 0, first.stderr)
         self.assertEqual(self.results()['scenarioCount'], 2)
+        self.commit_results()
 
         # Same manifest, but ok-two now fails to run. Under the old
         # `scanned > 0` floor this second run was green.
-        (self.dir / 'images.txt').write_text(
-            "ok-one | example/ok-one:1 |\n"
-            "ok-two | example/bad-run:1 |\n")
-        env = dict(os.environ,
-                   DOCKER=str(self.bin / 'docker'),
-                   IRONCTL=str(self.bin / 'ironctl'),
-                   MIRROR='0', PRUNE='0')
-        second = subprocess.run(['bash', str(self.dir / 'survey.sh')],
-                                cwd=self.dir, env=env,
-                                capture_output=True, text=True)
+        self.write_manifest("ok-one | example/ok-one:1 |\n"
+                            "ok-two | example/bad-run:1 |\n")
+        second = self.run_survey()
         self.assertNotEqual(second.returncode, 0)
+        self.assertIn('baseline: git HEAD:', second.stderr)
         self.assertIn('ok-two', second.stderr)
         self.assertIn('coverage regressed', second.stderr)
 
@@ -183,9 +228,120 @@ class SurveyCoverageE2E(unittest.TestCase):
         self.assertEqual([s['label'] for s in doc['skipped']], ['ok-two'])
         self.assertEqual(doc['skipped'][0]['stage'], 'run')
 
+    def test_a_rerun_does_not_launder_the_regression(self):
+        """Run the identical broken sweep twice: both must fail.
+
+        This is the finding the working-tree baseline had. Run N overwrote
+        results.json with the degraded artifact and run N+1 snapshotted that
+        file as its own baseline, so the second run saw no loss and exited 0
+        with nothing fixed. The baseline now comes from `git show HEAD:`, and
+        only a passing run is ever committed, so re-running cannot move it.
+        """
+        self.assertEqual(self.run_survey(['ok-one', 'ok-two']).returncode, 0)
+        self.commit_results()
+
+        broken = ("ok-one | example/ok-one:1 |\n"
+                  "ok-two | example/bad-run:1 |\n")
+        self.write_manifest(broken)
+
+        for attempt in (1, 2, 3):
+            proc = self.run_survey()
+            self.assertNotEqual(
+                proc.returncode, 0,
+                f"run {attempt} of the identical unfixed sweep exited 0:\n"
+                f"{proc.stderr}")
+            self.assertIn('coverage regressed', proc.stderr)
+            self.assertIn('ok-two', proc.stderr)
+            # And the degraded artifact on disk is not what it compared against.
+            self.assertEqual(self.results()['scenarioCount'], 1)
+
+        # Fixing the row is what clears it -- the guard is not merely sticky.
+        self.write_manifest(manifest(['ok-one', 'ok-two']))
+        self.assertEqual(self.run_survey().returncode, 0)
+
+    def test_a_run_where_every_row_fails_still_writes_the_artifact(self):
+        """The case the README's durability claim is about. `scanned > 0` used
+        to die before render.py ran, so a dead daemon or a mirror outage left
+        the previous healthy results.json byte-identical on disk and cleanup()
+        deleted every skip record on the way out."""
+        self.assertEqual(self.run_survey(['ok-one', 'ok-two']).returncode, 0)
+        self.commit_results()
+        healthy = (self.dir / 'results.json').read_text()
+
+        self.write_manifest("ok-one | example/bad-pull:1 |\n"
+                            "ok-two | example/bad-pull:1 |\n")
+        proc = self.run_survey()
+        self.assertNotEqual(proc.returncode, 0)
+
+        self.assertNotEqual((self.dir / 'results.json').read_text(), healthy,
+                            "the all-rows-failed run left the previous "
+                            "artifact in place instead of writing its own")
+        doc = self.results()
+        self.assertEqual(doc['scenarioCount'], 0)
+        self.assertEqual(doc['skippedCount'], 2)
+        self.assertEqual(doc['manifestRowCount'], 2)
+        self.assertEqual({s['stage'] for s in doc['skipped']}, {'pull'})
+
+        md = (self.dir / 'results.md').read_text()
+        self.assertIn('No scenario produced a scorecard', md)
+        for lab in ('ok-one', 'ok-two'):
+            self.assertIn(f'`{lab}`', md)
+
+    def test_an_unreadable_scan_report_is_a_skip_not_an_abort(self):
+        """An exit-0 scan whose body is not JSON used to abort the whole run
+        under `set -e`, before render.py, destroying every skip recorded so
+        far."""
+        proc = self.run_survey(['bad-pull', 'bad-json', 'ok-one'])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        doc = self.results()
+        self.assertEqual(doc['manifestRowCount'], 3)
+        self.assertEqual(doc['scenarioCount'], 1)
+        stages = {s['label']: s['stage'] for s in doc['skipped']}
+        self.assertEqual(stages, {'bad-pull': 'pull', 'bad-json': 'scan'})
+        # ...and the pull skip recorded BEFORE the unreadable report survived.
+        self.assertIn('unreadable scan report',
+                      [s['reason'] for s in doc['skipped']
+                       if s['label'] == 'bad-json'][0])
+
+    def test_manifest_parse_matches_the_sweep(self):
+        """coverage_guard.manifest_labels claims to mirror survey.sh's parse, so
+        prove it against survey.sh rather than against a literal in the test.
+
+        Every row here is a case the two used to disagree on: an indented `#`
+        (a comment to the guard's old `.strip()`, a row to the sweep), a
+        repeated label (deduplicated by the guard, walked twice by the sweep),
+        collapsed inner whitespace, and a final line with no trailing newline.
+        """
+        self.write_manifest(
+            "# column-zero comment | ignored |\n"
+            "\n"
+            "ok-one | example/ok-one:1 |\n"
+            "  # indented | example/ok-two:1 |\n"
+            "ok-one | example/ok-one:1 |\n"
+            "   spaced   label   |  example/bad-pull:1  |\n"
+            "last-row | example/ok-three:1 |")  # no trailing newline
+
+        proc = self.run_survey()
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        doc = self.results()
+
+        parsed = guard.manifest_labels(self.dir / 'images.txt')
+        # survey.sh's own count of the rows it walked.
+        self.assertEqual(doc['manifestRowCount'], len(parsed), parsed)
+        # ...and the same labels, with the same multiplicity.
+        walked = [s['label'] for s in doc['scenarios']] + \
+                 [s['label'] for s in doc['skipped']]
+        self.assertEqual(collections.Counter(walked),
+                         collections.Counter(parsed))
+        self.assertIn('# indented', parsed)
+        self.assertEqual(parsed.count('ok-one'), 2)
+        self.assertIn('spaced label', parsed)
+        self.assertIn('last-row', parsed)
+
     def test_retiring_a_dead_row_from_the_manifest_is_allowed(self):
         first = self.run_survey(['ok-one', 'ok-two'])
         self.assertEqual(first.returncode, 0, first.stderr)
+        self.commit_results()
         second = self.run_survey(['ok-one'])
         self.assertEqual(second.returncode, 0, second.stderr)
         self.assertEqual(self.results()['scenarioCount'], 1)
@@ -193,12 +349,76 @@ class SurveyCoverageE2E(unittest.TestCase):
     def test_a_never_scored_row_failing_is_tolerated(self):
         first = self.run_survey(['ok-one'])
         self.assertEqual(first.returncode, 0, first.stderr)
+        self.commit_results()
         # A new row is added and its image is unavailable: skipped, recorded,
         # still green. One registry hiccup must not wedge the weekly refresh.
         second = self.run_survey(['ok-one', 'bad-pull'])
         self.assertEqual(second.returncode, 0, second.stderr)
         self.assertEqual([s['label'] for s in self.results()['skipped']],
                          ['bad-pull'])
+
+    def test_no_committed_baseline_says_the_check_was_skipped(self):
+        """A first run has nothing to compare against. It must say so rather
+        than quietly falling back to whatever results.json is lying on disk --
+        that fallback is what made a re-run launder a regression."""
+        proc = self.run_survey(['ok-one'])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn('baseline: none committed', proc.stderr)
+        self.assertIn('UNCHECKED', proc.stderr)
+
+
+class RenderCoverageSentence(unittest.TestCase):
+    """render.py's coverage line, driven directly.
+
+    survey.sh cannot currently produce a row that is neither scored nor
+    recorded as skipped, so the self-contradicting sentence
+    ("Coverage: 2 of 3 manifest rows -- every row was scanned") is only
+    reachable by handing render.py the numbers. That is exactly why the
+    sentence must be derived from the comparison instead of from `if skips:`:
+    the day survey.sh grows a fourth drop path, the artifact should say what it
+    has rather than what the skip list happens to be.
+    """
+
+    def render(self, labels, manifest_rows, skips=()):
+        records = [{"label": lab, "image": f"example/{lab}:1",
+                    "runFlags": "", "resolvedDigest": "",
+                    "report": {"score": 42, "grade": "D",
+                               "generatedAt": "2026-01-01T00:00:00Z",
+                               "version": "test", "dimensions": []}}
+                   for lab in labels]
+        with tempfile.TemporaryDirectory() as d:
+            d = pathlib.Path(d)
+            argv = [str(SURVEY_DIR / 'render.py'),
+                    str(d / 'results.json'), str(d / 'results.md'),
+                    '--manifest-rows', str(manifest_rows)]
+            if skips:
+                (d / 'skips.json').write_text(json.dumps(
+                    [{"label": lab, "image": f"example/{lab}:1",
+                      "stage": stage, "reason": reason}
+                     for lab, stage, reason in skips]))
+                argv += ['--skips', str(d / 'skips.json')]
+            proc = subprocess.run(['python3', *argv], input=json.dumps(records),
+                                  capture_output=True, text=True)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            return (d / 'results.md').read_text()
+
+    def test_an_unaccounted_row_is_never_called_full_coverage(self):
+        md = self.render(['a', 'b'], manifest_rows=3)
+        self.assertIn('Coverage: 2 of 3 manifest rows', md)
+        self.assertNotIn('every row was scanned', md)
+        self.assertIn('unaccounted for', md)
+
+    def test_full_coverage_is_stated_only_when_the_counts_agree(self):
+        md = self.render(['a', 'b'], manifest_rows=2)
+        self.assertIn('every row was scanned', md)
+        self.assertNotIn('unaccounted for', md)
+
+    def test_skips_that_account_for_the_gap_are_not_reported_as_unaccounted(self):
+        md = self.render(['a', 'b'], manifest_rows=3,
+                         skips=[('c', 'pull', 'manifest unknown')])
+        self.assertIn('Coverage: 2 of 3 manifest rows', md)
+        self.assertNotIn('every row was scanned', md)
+        self.assertNotIn('unaccounted for', md)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`examples/isolation-survey/survey.sh` sweeps 295 manifest rows, produces 256 scenarios, and exits green. The only guard on the whole sweep is `scanned > 0`, and its three skip paths (`pull`, `run`, `scan`) each write a log line and `continue`. So the same 39 rows have failed on every weekly refresh across three full regenerations, and nothing in `results.json`, `results.md` or the refresh PR body says so — you have to open an Actions run log that expires to learn coverage is 13% short. Same fail-quiet shape as IRO-685: the failure mode produces a clean-looking artifact.

This is parts 1 and 2 of IRO-727. Part 3 (triaging the current 39 rows) follows separately as IRO-736, as directed on the issue.

## 1. Skips become data, not log lines

`survey.sh` accumulates `{label, image, stage, reason}` for every scenario it drops. `render.py` emits them:

* `results.json` — `.skipped[]`, plus `manifestRowCount` / `scenarioCount` / `skippedCount`, at `schemaVersion` **1.1** (additive; no consumer reads the version, and `gen_scorecards.py` output is unchanged).
* `results.md` — a coverage line under the header and a **Not scanned** table naming every dropped row, its stage and the first line of the real error.

A skipped row is *not measured*. It is not a low score, and now it says so inside the artifact.

## 2. A regression check, baselined on the committed artifact

New `examples/isolation-survey/coverage_guard.py`. It fails the run when a scenario that scored in the last **committed** `results.json`, and is **still listed** in `images.txt`, produces nothing now.

Deliberately not "any skip is fatal": the survey pulls 295 images from live public registries, and a guard that goes red on registry weather is one people learn to re-run through. A transient failure is absent from the baseline too, so it cannot trip this; a row that rots for good is caught the first week it stops scoring. A row deleted from `images.txt` is not a regression — retiring a genuinely dead row stays the sanctioned fix.

The baseline is read with `git show HEAD:…`, never from the working-tree copy the run is about to overwrite. Only a run that passed the guard is ever committed, so `HEAD` is by construction a coverage level we actually held, and **re-running an unfixed sweep fails again with the same message**. With no committed baseline the guard reports the regression check as `UNCHECKED` out loud and falls back to `> 0`, rather than falling back to whatever `results.json` happens to be lying on disk.

There is no implicit floor. Once a baseline exists, `regressed == []` already implies `len(scanned) >= len(expected)`, so an implicit floor would be unreachable code dressed up as a second opinion. `--min-scanned` still applies when passed explicitly. Its own test (`test_min_scanned_still_bites_with_a_baseline`) is a **spec** test, not the non-vacuity anchor: it passes against the pre-fix file too, because `floor = len(expected) if min_scanned is None else min_scanned` is identical behaviour once `--min-scanned` is explicit. The anchor for removing the dead floor is `test_clean_run_passes`, which asserts `no floor, regression-relative` and does fail pre-fix.

## 3. The coverage invariant is enforced, not printed

`scenarioCount + skippedCount == manifestRowCount == the rows the guard parses out of images.txt`. `check_accounting()` fails the run on any of: a count the artifact does not record (reported as unverified, never defaulted to `0`), a counter that disagrees with the array next to it, an unaccounted row, or `manifestRowCount` disagreeing with the guard's own parse — which is also the live detector for a parse drift between the guard and the sweep. It also compares the two sides **by label, not only by total**: the scored and skipped labels against the rows it parses out of `images.txt`, as multisets. Counts are structurally blind to label *identity*, and since the regression check matches the baseline by label, a row the sweep and the guard spell differently would leave the expected set permanently and silently. `bool` is rejected as a recorded count (it is a subclass of `int`, so `manifestRowCount: true` used to read as a recorded `1`).

`manifestRowCount` comes from the sweep: `render.py --manifest-rows` is **required**. It used to default to `len(rows) + len(skips)`, so the denominator was synthesized from the numerator, the invariant held by construction, and one scored row with no skips reported full coverage of a 295-row manifest. `results.md` states "every row was scanned" only when all three counts say so.

## 4. A failed run leaves its evidence

`results.json` and `results.md` are written as soon as the sweep finishes — **before** the `scanned > 0` check and before the guard. An all-rows-fail run (dead daemon, mirror outage, full disk under `PRUNE=1`) previously died before render and `cleanup()` deleted the skip file on the way out, leaving the previous healthy artifact byte-identical on disk. An unreadable scan report is likewise a recorded `scan` skip rather than a `set -e` abort. The foreseeable internal aborts between the first row and the render step are gone as well: `record_skip` writes via temp+rename and can no longer fail the run (a row it could not record surfaces as **unaccounted** and fails the guard *with the artifact in hand*), the field parse no longer goes through `echo | xargs` so a malformed row cannot abort the sweep, and a temp file that cannot be created is a skip. That is what makes this hold under `PRUNE=1`, whose whole reason to exist is a nearly-full runner disk.

In CI the ordering bought nothing on its own: on a red run every downstream step is skipped, so the artifact died with the runner. `scores-refresh.yml` now uploads `results.json` + `results.md` with `if: always()`, directly after the survey step.

What is still **not** covered, stated because a false durability claim is the same class of bug as the one being fixed: the process being killed (Ctrl-C, OOM, a job timeout), a manifest that cannot be read at all, and `render.py` itself failing. `survey.sh` and the README name exactly those.

## Verification

* `scripts/tests/test_coverage_guard.py` — 28 tests. Every case is a negative control (the passing path is `exit 0`, which is also what a checker that compared nothing produces). Includes the two carve-outs that would make the guard unusable if wrong (deleted row, never-scored row), the exact 295/256/39 production shape, and a live check that the **committed** `results.json` is rejected when evaluated against a full-manifest baseline.
* `scripts/tests/test_survey_coverage_e2e.py` — 14 tests. Runs the real `survey.sh` under `set -euo pipefail` through every skip path against stub `docker` / `ironctl` binaries, in a real git fixture repo. No daemon, no images, no network. Includes the run-it-twice control: the identical unfixed sweep must fail on every attempt.
* **Non-vacuity:** reverting only `survey.sh`, `render.py`, `coverage_guard.py` and `scores-refresh.yml` to the pre-review head while keeping the tests gives **19 failures + 2 errors**, covering every finding of both review rounds. Post-fix the full `scripts/tests` suite is **196/196**.
* **Parser agreement, on live data:** `survey.sh`'s real parse, lifted verbatim and driven over the committed 295-row `images.txt`, matches `coverage_guard.manifest_labels` row for row and in order. Neither side does quote or backslash processing any more; the guard reads the manifest as bytes, splits on `\n` only, and collapses on ASCII blanks only.
* `shellcheck -S warning` and `bash -n` clean on `survey.sh`.
* `scripts/check-scores-drift.py` and `scripts/check-guide-scores.py` both exit 0. **No regeneration of `docs/scores/` rides along here**, and `results.json` / `results.md` are untouched — the coverage block appears on the next survey run.
* Live data: the invariant holds on the production shape (256 scenarios + 39 unscanned == 295 manifest rows; 0 duplicate labels, 0 indented comments). The committed `results.json` is `schemaVersion` 1.0 and records neither `manifestRowCount` nor `skippedCount`, so the guard reports it as unverified rather than assuming it holds. That never gates a run: accounting is checked against the freshly rendered artifact, which `render.py` always writes at 1.1, while the baseline is only ever read for its labels.

## Not in this PR

`.github/workflows/scores-refresh.yml` still needs the skipped count surfaced in the refresh PR body, and carries three stale claims from the same overclaim family (`reproducible`, two `~150-image` figures). Any `.github/workflows` change makes a PR reviewer-bot gated, so that is split out as #684 rather than riding along.

