### PR TITLE
ci(scores): put the weekly refresh's coverage in its PR body [IRO-727]

### DIFF
--- a/.github/workflows/scores-refresh.yml
+++ b/.github/workflows/scores-refresh.yml
@@ -39,8 +39,9 @@ jobs:
     # meaningless off the canonical repo.
     if: github.repository == 'IronSecCo/ironclaw'
     runs-on: ubuntu-latest
-    # The survey pulls + scans ~150 images through mirror.gcr.io; give it room but
-    # cap it so a hung pull can never burn a full 6h of runner time.
+    # The survey pulls + scans the 295 scenario rows in images.txt through
+    # mirror.gcr.io; give it room but cap it so a hung pull can never burn a full
+    # 6h of runner time.
     timeout-minutes: 120
     permissions:
       contents: write # push the rolling refresh branch
@@ -63,8 +64,13 @@ jobs:
         run: CGO_ENABLED=1 go build -o bin/ironctl ./cmd/ironctl
 
       # Run the full survey. PRUNE=1 removes each image right after it is scanned so
-      # the ~150-image sweep never exceeds the runner's free disk. Mirror-first
-      # (the default) dodges Docker Hub's anonymous pull-rate limit.
+      # the sweep never exceeds the runner's free disk. Mirror-first (the default)
+      # dodges Docker Hub's anonymous pull-rate limit.
+      #
+      # survey.sh exits non-zero when a scenario that scored in the committed
+      # results.json stops producing output (IRO-727), which fails this job before
+      # a degraded sweep can open a refresh PR. It still writes results.* first, so
+      # the run's artifacts name what was dropped even when it fails.
       - name: Run the isolation survey
         env:
           IRONCTL: ${{ github.workspace }}/bin/ironctl
@@ -146,8 +152,42 @@ jobs:
           # main, so main's required_signatures rule is still satisfied.
           git push --force origin "$branch"
 
+          # Coverage, in the PR body itself. A refresh that measured fewer images
+          # than the manifest lists used to look identical to one that measured
+          # them all: the only trace was this run's log, which expires (IRO-727).
+          # A results.json written before schemaVersion 1.1 has no coverage block.
+          # That case says "not recorded" rather than defaulting the missing fields
+          # to zero -- defaulting them would print "nothing was skipped" for the
+          # exact artifact shape whose 39 silent drops started this.
+          coverage="$(python3 - <<'PY'
+          import collections, json
+          d = json.load(open("examples/isolation-survey/results.json"))
+          scanned = len(d.get("scenarios", []))
+          skips = d.get("skipped", [])
+          rows = d.get("manifestRowCount")
+          if rows is None or "skipped" not in d:
+              print(f"Coverage this run: {scanned} scenarios scanned. This "
+                    "`results.json` predates schemaVersion 1.1, so how many "
+                    "manifest rows were dropped is **not recorded**.")
+              raise SystemExit(0)
+          line = f"Coverage this run: **{scanned} of {rows}** scenario rows scanned."
+          if skips:
+              stages = collections.Counter(s.get("stage", "?") for s in skips)
+              breakdown = ", ".join(f"{k} {v}" for k, v in sorted(stages.items()))
+              line += (f" **{len(skips)} skipped** ({breakdown}) -- each one is named"
+                       " with its reason in the `skipped` array of `results.json` and"
+                       ' in the "Not scanned" table of `results.md`. A skipped row is'
+                       " not measured; it is not a low score.")
+          else:
+              line += " Nothing was skipped."
+          print(line)
+          PY
+          )" || coverage="Coverage: could not be read from results.json."
+
           title="chore(scores): weekly refresh of the container isolation scores directory"
-          body="Automated by the weekly Scores refresh workflow (IRO-449): re-runs \`examples/isolation-survey/survey.sh\` over the top ~150 public images and regenerates \`docs/scores/\` + \`results.json\` so the [Container Isolation Scores](https://github.com/${REPO}/tree/main/docs/scores) directory tracks current base-image posture. This is the single **rolling** refresh PR, force-reset onto the current main tip each run, so it never conflicts and supersedes any prior refresh. Opened by the reviewer App (PR creation only; a human still approves + merges)."
+          body="Automated by the weekly Scores refresh workflow (IRO-449): re-runs \`examples/isolation-survey/survey.sh\` over the scenario rows in \`examples/isolation-survey/images.txt\` and regenerates \`docs/scores/\` + \`results.json\` so the [Container Isolation Scores](https://github.com/${REPO}/tree/main/docs/scores) directory tracks current base-image posture. This is the single **rolling** refresh PR, force-reset onto the current main tip each run, so it never conflicts and supersedes any prior refresh. Opened by the reviewer App (PR creation only; a human still approves + merges).
+
+          ${coverage}"
 
           emit_manual_fallback() {
             echo "::error title=Scores refresh PR not opened::${1}"


### PR DESCRIPTION
The split half of IRO-727. **Gated by change-kind** (`.github/workflows/*`), so it is deliberately not riding along with #683 — and it should merge **after** #683, which writes the fields this reads.

## What is wrong today

The weekly rolling refresh PR says nothing about how much of the manifest the survey measured. It has been **256 of 295 rows** for months, and that PR is byte-indistinguishable from a full sweep. If tomorrow it drops 80 rows instead of 39, the PR still looks identical. The only trace is an Actions log that expires.

## Changes

* **Coverage in the PR body**, computed from the freshly written `results.json`: scanned / manifest rows, the skipped count broken down by stage, and a pointer to the `skipped` array that names each dropped row and why.
* A `results.json` that predates `schemaVersion` 1.1 reports **"not recorded"** rather than defaulting the missing fields to zero. My first draft defaulted them, and the four-arm test caught it printing *"256 of 256 — nothing was skipped"* against the current committed artifact, the exact shape whose 39 silent drops started this issue. Ironic and worth naming.
* Two stale **`~150 image`** comments corrected to the manifest's real size, and the PR body no longer claims "the top ~150 public images". (295 rows in `images.txt`, 256 currently scanned.)
* A note that `survey.sh` now fails the job on a coverage regression, so a degraded sweep cannot open a refresh PR at all.

## Not changed, deliberately

IRO-727 also flagged line 5's "generated from the **reproducible** isolation-survey" as part of the claim family IRO-723 retracted. **That premise does not hold** — re-derived against `main`: #671 touched `examples/isolation-survey/README.md` and left "reproducible" standing (README.md line 1 and line 9), and the word is still live in `docs/scores/index.md`, `docs/scores/leaderboard.md` and every `docs/scores/collections/*.md` footer. What #671 retracted was the *digest-pin* claim, not reproducibility. Retracting the word here alone would put this workflow out of step with a large CEO-ratified generated corpus, so it stays. If reproducibility should be retracted, that is a corpus-wide decision, not a one-file edit.

## Verification

The step's `run:` body was extracted with a parser and the coverage segment executed **unmodified** under `bash -euo pipefail` against four fixtures:

| fixture | output |
|---|---|
| committed schema-1.0 `results.json` | `256 scenarios scanned … dropped is **not recorded**` |
| 1.1 artifact with skips | `**256 of 295** … **2 skipped** (pull 1, run 1) …` |
| 1.1, full coverage | `**256 of 256** … Nothing was skipped.` |
| `results.json` missing | falls back to the error string, does not abort the step |

The whole extracted body passes `bash -n`; the file parses as YAML.