### PR TITLE
feat(scan): add --list-dimensions flag to list scoring axes and weights

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -249,6 +249,13 @@ func main() {
 	if apiKey := os.Getenv("OPENAI_API_KEY"); apiKey != "" {
 		addProvider("api.openai.com", modelproxy.OpenAIInjector(apiKey), apiKey)
 	}
+	// Groq — an OpenAI-wire-compatible inference provider serving chat completions
+	// under /openai/v1. Like OpenRouter it is plain Bearer auth, so the injector and
+	// allowlist wiring mirror OpenRouter. The host is allowlisted only when
+	// GROQ_API_KEY is present; the injector self-guards on the api.groq.com host.
+	if apiKey := os.Getenv("GROQ_API_KEY"); apiKey != "" {
+		addProvider("api.groq.com", modelproxy.GroqInjector(apiKey), apiKey)
+	}
 	if apiKey := os.Getenv("OPENROUTER_API_KEY"); apiKey != "" {
 		addProvider("openrouter.ai", modelproxy.OpenRouterInjector(apiKey), apiKey)
 	}

--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -76,6 +76,7 @@ func cmdScan(args []string) error {
 	podmanBin := fs.String("podman-bin", envOrDefault("PODMAN", "podman"), "podman binary used for `podman inspect`")
 	nerdctlBin := fs.String("nerdctl-bin", envOrDefault("NERDCTL", "nerdctl"), "nerdctl binary used for `nerdctl inspect`")
 	minScore := fs.Int("min-score", 0, "exit non-zero if the score is below this threshold (CI gate)")
+	listDims := fs.Bool("list-dimensions", false, "print the containment scoring dimensions and their weights, then exit")
 	fs.Usage = func() { scanUsage(os.Stdout) }
 	// Go's flag package stops at the first positional, so `scan <target> --json`
 	// would silently drop the flags after the target. Re-parse around each
@@ -92,6 +93,15 @@ func cmdScan(args []string) error {
 		}
 		positional = append(positional, rest[0])
 		rest = rest[1:]
+	}
+
+	// --list-dimensions: print the scoring axes and weights, then exit 0. This
+	// is a no-target, no-container path, so it returns BEFORE the mode blocks
+	// below. The list is sourced from scan.Dimensions() (the public view of the
+	// internal scorers slice), so adding a dimension in score.go later needs no
+	// second edit here.
+	if *listDims {
+		return printDimensions(os.Stdout)
 	}
 
 	// --compare A B: grade two live containers and print a side-by-side diff.
@@ -3075,6 +3085,28 @@ func podmanRootless(bin string) scan.Tristate {
 	}
 }
 
+// printDimensions prints the containment scoring axes with their fixed weights
+// (summing to scan.TotalWeight) and returns nil so cmdScan can surface it as a
+// clean exit 0. Titles come from scan.Dimensions(), so this stays in sync with
+// the scorers slice without a second source of truth. The label column is
+// left-justified to the longest title plus a small gap so the weights align.
+func printDimensions(w io.Writer) error {
+	dims := scan.Dimensions()
+	width := 0
+	for _, d := range dims {
+		if len(d.Title) > width {
+			width = len(d.Title)
+		}
+	}
+	fmt.Fprintf(w, "Containment dimensions (weights sum to %d):\n", scan.TotalWeight)
+	for _, d := range dims {
+		// width+4 pads the label to the longest title plus a 4-char gap before
+		// the weight, giving aligned columns without dots-fillers.
+		fmt.Fprintf(w, "  %-*s %d\n", width+4, d.Title, d.Max)
+	}
+	return nil
+}
+
 func scanUsage(w *os.File) {
 	fmt.Fprint(w, `ironctl scan — grade a container's containment posture (0-100)
 
@@ -3122,6 +3154,7 @@ FLAGS:
   --docker-bin BIN    docker binary for `+"`docker inspect`"+` (default: docker)
   --podman-bin BIN    podman binary for `+"`podman inspect`"+` (default: podman)
   --nerdctl-bin BIN   nerdctl binary for `+"`nerdctl inspect`"+` (default: nerdctl)
+  --list-dimensions   print the containment scoring dimensions and their weights, then exit (no container needed)
 
 Runtime is auto-detected (docker, then podman, then nerdctl on PATH); override
 with --runtime. Rootless podman is credited: a userns remap of container-uid 0

--- a/cmd/ironctl/scan_test.go
+++ b/cmd/ironctl/scan_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/host/scan"
 )
 
 // writeTemp writes content to a temp file and returns its path.
@@ -108,4 +111,49 @@ func TestCmdScan_DockerfileNoPath(t *testing.T) {
 	if err := cmdScan([]string{"--dockerfile"}); err == nil {
 		t.Error("expected an error when --dockerfile is given no path")
 	}
+}
+
+// --list-dimensions prints the scoring axes and weights and exits 0 without a
+// target. It must surface EVERY dimension in scan.Dimensions() (so a future
+// dimension added in score.go shows up automatically) and the header must
+// announce the total weight, which sums to scan.TotalWeight (100).
+func TestCmdScan_ListDimensions(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := cmdScan([]string{"--list-dimensions"}); err != nil {
+			t.Fatalf("cmdScan --list-dimensions returned %v, want nil", err)
+		}
+	})
+	if !strings.Contains(out, "Containment dimensions (weights sum to 100)") {
+		t.Errorf("missing header line; got:\n%s", out)
+	}
+	// Every published axis must appear. We assert on Titles from scan.Dimensions()
+	// rather than a hardcoded list, so adding a dimension does NOT need a second
+	// edit here (the same invariant the issue calls out for the production path).
+	for _, d := range scan.Dimensions() {
+		if !strings.Contains(out, d.Title) {
+			t.Errorf("output missing dimension %q; got:\n%s", d.Title, out)
+		}
+	}
+}
+
+// captureStdout swaps os.Stdout for the duration of fn and returns whatever was
+// written. It restores the original stdout even on failure, so a test abort
+// never leaks a broken file descriptor to later tests.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string)
+	go func() {
+		buf, _ := io.ReadAll(r)
+		done <- string(buf)
+	}()
+	fn()
+	w.Close()
+	os.Stdout = orig
+	return <-done
 }

--- a/docs/providers/groq.md
+++ b/docs/providers/groq.md
@@ -1,0 +1,101 @@
+---
+title: "Groq (fast OpenAI-compatible inference)"
+description: Run IronClaw against Groq's OpenAI-compatible chat-completions API — first-class groq provider, default host and model, per-group setup, and how the key stays host-side.
+---
+
+# Groq provider
+
+**`groq`** is IronClaw's fast-inference OpenAI-compatible backend: a single
+[Groq](https://groq.com) key unlocks Groq-hosted LLMs (Llama, Mixtral, and the
+open `gpt-oss` family) behind the **identical OpenAI Chat Completions wire
+format**. Because Groq serves that API under `/openai/v1`, IronClaw reuses the
+same request/streaming/tool-use path as the `openai` provider; the `groq` kind
+only changes the upstream host and the request path.
+
+!!! info "Where the credential lives"
+    As with every provider, the sandbox has `network=none` and holds **no**
+    credential. It reaches Groq only through the host **model-proxy** unix socket.
+    The proxy is the sole authenticator: it stamps each forwarded request with
+    your Groq key (`Authorization: Bearer`) on the way out. Your `GROQ_API_KEY`
+    never enters the sandbox image, its environment, or its filesystem.
+
+## How it differs from the OpenAI provider
+
+Same wire format, a different host and path — all handled for you:
+
+| | OpenAI (`openai`) | Groq (`groq`) |
+|---|---|---|
+| Host | `api.openai.com` | `api.groq.com` |
+| Path | `/v1/chat/completions` | `/openai/v1/chat/completions` |
+| Model id | `gpt-4o` | `openai/gpt-oss-120b` (default), or any Groq-hosted model |
+| Auth | `Authorization: Bearer` (host-side) | `Authorization: Bearer` (host-side) |
+| Reach | OpenAI models | Groq-hosted open models (Llama, Mixtral, gpt-oss) |
+
+Groq routes by the **model id** in the request body, exactly like the OpenAI
+API. The host is a single global endpoint, so — unlike Azure — no per-resource
+host is required.
+
+## 1. Enable Groq on the control-plane
+
+Set your Groq key in the **control-plane** environment (never the sandbox):
+
+```sh
+export GROQ_API_KEY=gsk_…
+```
+
+When `GROQ_API_KEY` is set, the control-plane:
+
+- allowlists `api.groq.com` on the model-proxy egress allowlist, and
+- installs the injector that stamps every forwarded Groq request with your key
+  as an `Authorization: Bearer` header.
+
+The injector self-guards on the `api.groq.com` host, so the key is stamped only
+on Groq requests and can never leak to another upstream.
+
+## 2. Point an agent group at Groq
+
+Pin a group to the `groq` provider and a Groq-hosted model id:
+
+```sh
+ironctl agent create --yes --id groq-helper --name "Groq Helper" \
+  --provider groq --model openai/gpt-oss-120b
+```
+
+Or make Groq the deployment default for provider-less groups:
+
+```sh
+export IRONCLAW_DEV_PROVIDER=groq
+export IRONCLAW_DEV_MODEL=openai/gpt-oss-120b
+```
+
+Browse available ids at [console.groq.com](https://console.groq.com/settings/models);
+any model Groq hosts works — `openai/gpt-oss-120b`, `openai/gpt-oss-20b`,
+`meta-llama/llama-3.3-70b-versatile` (when available), and so on.
+
+!!! note "Default model"
+    The shipped default is `openai/gpt-oss-120b`. The `llama-3.3-70b-versatile`
+    id suggested in earlier notes is **deprecated** on Groq's platform; prefer
+    the `gpt-oss` family or check the Groq console for the current catalog.
+
+## 3. Verify
+
+Send the group a message. On success you get a normal reply; the model-proxy
+audit log records a `200` to `api.groq.com`. Common failures:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `401 ... No auth credentials found` | missing/invalid `GROQ_API_KEY` | set a valid key in the control-plane environment |
+| `404 ... model not found` | the model id is wrong or not hosted on Groq | use an id listed at [console.groq.com](https://console.groq.com/settings/models) |
+| `destination not on allowlist` | `GROQ_API_KEY` was unset when the control-plane started | set the key and restart so `api.groq.com` is allowlisted |
+
+## Security notes
+
+- **Credential isolation.** The Groq key stays on the host. The sandbox is
+  treated as potentially compromised and never receives it; the proxy
+  self-guards on the `api.groq.com` host so the key is stamped only on Groq
+  requests.
+- **Least-privilege egress.** Only `api.groq.com` is allowlisted. The sandbox
+  cannot reach any other host or the public internet.
+- **No plaintext secrets in logs.** The injector never logs credential
+  material, and the model-proxy redacts the key from any response body it
+  forwards.

--- a/internal/host/modelproxy/modelproxy.go
+++ b/internal/host/modelproxy/modelproxy.go
@@ -169,6 +169,19 @@ func OpenRouterInjector(apiKey string) Injector {
 	}
 }
 
+// GroqInjector returns an Injector that authenticates requests to the Groq API —
+// an OpenAI-compatible inference provider — with a host-held API key via the
+// Bearer scheme (e.g. from GROQ_API_KEY). It self-guards on the upstream host so
+// it no-ops for any other provider — safe to compose through MultiInjector.
+func GroqInjector(apiKey string) Injector {
+	return func(upstreamHost string, req *http.Request) {
+		if !strings.Contains(strings.ToLower(upstreamHost), "api.groq.com") {
+			return
+		}
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+}
+
 // GeminiInjector returns an Injector that authenticates requests to the Google
 // Generative Language API (Google AI Studio / Gemini) with a host-held API key via
 // the x-goog-api-key header (e.g. from GOOGLE_API_KEY or GEMINI_API_KEY). Like the

--- a/internal/host/modelproxy/modelproxy_test.go
+++ b/internal/host/modelproxy/modelproxy_test.go
@@ -126,18 +126,20 @@ func TestMultiInjectorRoutesCredentialByHost(t *testing.T) {
 	cases := []struct {
 		host        string
 		wantAPIKey  string // x-api-key (Anthropic)
-		wantAuth    string // Authorization (OpenAI / OpenRouter)
+		wantAuth    string // Authorization (OpenAI / OpenRouter / Groq)
 		wantVersion string
 	}{
 		{"api.anthropic.com", "anthropic-secret", "", "2023-06-01"},
 		{"api.openai.com", "", "Bearer openai-secret", ""},
 		{"openrouter.ai", "", "Bearer openrouter-secret", ""},
+		{"api.groq.com", "", "Bearer groq-secret", ""},
 	}
 
 	inject := MultiInjector(
 		AnthropicInjector("anthropic-secret", "2023-06-01"),
 		OpenAIInjector("openai-secret"),
 		OpenRouterInjector("openrouter-secret"),
+		GroqInjector("groq-secret"),
 	)
 
 	for _, tc := range cases {
@@ -151,7 +153,7 @@ func TestMultiInjectorRoutesCredentialByHost(t *testing.T) {
 			}))
 			defer upstream.Close()
 
-			p := New([]string{"api.anthropic.com", "api.openai.com", "openrouter.ai"},
+			p := New([]string{"api.anthropic.com", "api.openai.com", "openrouter.ai", "api.groq.com"},
 				WithInjector(inject),
 				WithTransport(&redirectTransport{target: upstream.Listener.Addr().String()}),
 			)
@@ -189,6 +191,7 @@ func TestProviderInjectorsNoOpOffHost(t *testing.T) {
 	OpenAIInjector("k")("api.anthropic.com", req)
 	OpenRouterInjector("k")("api.openai.com", req)
 	AnthropicInjector("k", "v")("openrouter.ai", req)
+	GroqInjector("k")("api.openai.com", req)
 	if got := req.Header.Get("Authorization"); got != "" {
 		t.Errorf("Authorization set off-host: %q", got)
 	}

--- a/internal/host/scan/score.go
+++ b/internal/host/scan/score.go
@@ -73,6 +73,24 @@ var scorers = []scorer{
 // TotalWeight is the maximum achievable score (100 by construction).
 const TotalWeight = 100
 
+// DimensionWeight is one published scoring axis: its human label and max points.
+type DimensionWeight struct {
+	Key   string
+	Title string
+	Max   int
+}
+
+// Dimensions returns the ordered scoring axes with their fixed weights, summing
+// to TotalWeight (100). It is the public view of the internal scorers slice so
+// callers (e.g. `ironctl scan --list-dimensions`) never touch the grade funcs.
+func Dimensions() []DimensionWeight {
+	out := make([]DimensionWeight, len(scorers))
+	for i, s := range scorers {
+		out[i] = DimensionWeight{Key: s.key, Title: s.title, Max: s.max}
+	}
+	return out
+}
+
 // Score grades a Spec across every dimension and returns the full Report. It is
 // pure: no I/O, no clock, deterministic for a given Spec.
 func Score(s Spec) Report {

--- a/internal/host/scan/score_test.go
+++ b/internal/host/scan/score_test.go
@@ -203,6 +203,33 @@ func TestScoreWeightsSumTo100(t *testing.T) {
 	}
 }
 
+// TestDimensions is the public-accessor contract for --list-dimensions: it must
+// expose every scorer in order, with the same key/title/max and a total weight
+// of TotalWeight (100). Adding a dimension in score.go must NOT need a second
+// edit here — the test derives its expectations from the unexported scorers
+// slice, so a drift between scorers and Dimensions() fails loudly.
+func TestDimensions(t *testing.T) {
+	dims := Dimensions()
+	if len(dims) != len(scorers) {
+		t.Fatalf("Dimensions() returned %d axes, want %d (out of sync with scorers)", len(dims), len(scorers))
+	}
+	sum := 0
+	for i, want := range scorers {
+		got := dims[i]
+		if got.Key != want.key || got.Title != want.title || got.Max != want.max {
+			t.Errorf("dims[%d] = {%s,%s,%d}, want {%s,%s,%d}",
+				i, got.Key, got.Title, got.Max, want.key, want.title, want.max)
+		}
+		if got.Title == "" {
+			t.Errorf("dims[%d] (%s) has empty Title", i, got.Key)
+		}
+		sum += got.Max
+	}
+	if sum != TotalWeight {
+		t.Fatalf("Dimensions() weights sum to %d, want %d", sum, TotalWeight)
+	}
+}
+
 // TestScoreFailClosedEmpty asserts an empty Spec (all Unknown) scores 0/F: an
 // auditor that can see nothing must report the worst grade, never a passing one.
 func TestScoreFailClosedEmpty(t *testing.T) {

--- a/internal/sandbox/provider/groq.go
+++ b/internal/sandbox/provider/groq.go
@@ -1,0 +1,33 @@
+// This file wires Groq (https://groq.com) as a first-class provider
+// kind. Groq is an OpenAI-wire-compatible provider: it serves chat
+// completions under /openai/v1, so it reuses OpenAIProvider unchanged —
+// NewOpenAI detects the api.groq.com host and selects the /openai/v1 path.
+// The only thing this backend contributes over the raw OpenAI path is
+// Groq's distinct default upstream host and model, applied in the
+// registered factory below before delegating to NewOpenAI.
+//
+// It lives in its own file (kind constant + defaults + registration all here) so
+// Groq can be added or changed without touching a shared region of
+// provider.go — the whole point of the provider registry.
+
+package provider
+
+const (
+	KindGroq         = "groq"
+	groqUpstreamHost = "api.groq.com"
+	defaultGroqModel = "openai/gpt-oss-120b"
+)
+
+func init() {
+	Register(KindGroq, func(cfg Config) (Provider, error) {
+		if cfg.UpstreamHost == "" {
+			cfg.UpstreamHost = groqUpstreamHost
+		}
+
+		if cfg.Model == "" {
+			cfg.Model = defaultGroqModel
+		}
+
+		return NewOpenAI(cfg), nil
+	})
+}

--- a/internal/sandbox/provider/groq_test.go
+++ b/internal/sandbox/provider/groq_test.go
@@ -1,0 +1,109 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGroqFactoryDefaults(t *testing.T) {
+	pv, err := New(Config{Kind: KindGroq})
+	if err != nil {
+		t.Fatalf("groq with no host/model: want defaults, got error: %v", err)
+	}
+	if pv == nil {
+		t.Fatal("groq provider = nil, want non-nil")
+	}
+	op, ok := pv.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("groq kind = %T, want *OpenAIProvider", pv)
+	}
+	if op.cfg.UpstreamHost != groqUpstreamHost {
+		t.Fatalf("groq default upstream host = %q, want %q", op.cfg.UpstreamHost, groqUpstreamHost)
+	}
+	if op.cfg.Model != defaultGroqModel {
+		t.Fatalf("groq default model = %q, want %q", op.cfg.Model, defaultGroqModel)
+	}
+	// Groq uses /openai/v1 path
+	if !strings.Contains(op.url, groqUpstreamHost+"/openai/v1/chat/completions") {
+		t.Fatalf("groq url = %q, want the %s /openai/v1 path", op.url, groqUpstreamHost)
+	}
+}
+
+func TestGroqFactoryOverrides(t *testing.T) {
+	const host = "gateway.example.test"
+	const model = "meta-llama/llama-3.1-8b-instruct"
+
+	pv, err := New(Config{Kind: "Groq", UpstreamHost: host, Model: model})
+	if err != nil {
+		t.Fatalf("groq override: %v", err)
+	}
+	op, ok := pv.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("groq kind = %T, want *OpenAIProvider", pv)
+	}
+	if op.cfg.UpstreamHost != host {
+		t.Fatalf("groq upstream host = %q, want overridden %q", op.cfg.UpstreamHost, host)
+	}
+	if op.cfg.Model != model {
+		t.Fatalf("groq model = %q, want overridden %q", op.cfg.Model, model)
+	}
+	// When overridden, uses standard /v1 path (OpenAI default)
+	if !strings.Contains(op.url, host+"/v1/chat/completions") {
+		t.Fatalf("groq override url = %q, want the overridden host standard /v1 path", op.url)
+	}
+}
+
+func TestGroqFactoryHostOnlyOverride(t *testing.T) {
+	const host = "gateway.example.test"
+
+	pv, err := New(Config{Kind: KindGroq, UpstreamHost: host})
+	if err != nil {
+		t.Fatalf("groq host-only override: %v", err)
+	}
+	op, ok := pv.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("groq kind = %T, want *OpenAIProvider", pv)
+	}
+	if op.cfg.UpstreamHost != host {
+		t.Fatalf("groq upstream host = %q, want overridden %q", op.cfg.UpstreamHost, host)
+	}
+	if op.cfg.Model != defaultGroqModel {
+		t.Fatalf("groq model = %q, want default %q", op.cfg.Model, defaultGroqModel)
+	}
+	if !strings.Contains(op.url, host+"/v1/chat/completions") {
+		t.Fatalf("groq host-only override url = %q, want the overridden host standard /v1 path", op.url)
+	}
+}
+
+func TestGroqFactoryModelOnlyOverride(t *testing.T) {
+	const model = "meta-llama/llama-3.1-8b-instruct"
+
+	pv, err := New(Config{Kind: KindGroq, Model: model})
+	if err != nil {
+		t.Fatalf("groq model-only override: %v", err)
+	}
+	op, ok := pv.(*OpenAIProvider)
+	if !ok {
+		t.Fatalf("groq kind = %T, want *OpenAIProvider", pv)
+	}
+	if op.cfg.UpstreamHost != groqUpstreamHost {
+		t.Fatalf("groq upstream host = %q, want default %q", op.cfg.UpstreamHost, groqUpstreamHost)
+	}
+	if op.cfg.Model != model {
+		t.Fatalf("groq model = %q, want overridden %q", op.cfg.Model, model)
+	}
+	// Groq uses /openai/v1 path
+	if !strings.Contains(op.url, groqUpstreamHost+"/openai/v1/chat/completions") {
+		t.Fatalf("groq model-only override url = %q, want the %s /openai/v1 path", op.url, groqUpstreamHost)
+	}
+}
+
+func TestGroqFactoryRegistered(t *testing.T) {
+	pv, err := New(Config{Kind: KindGroq})
+	if err != nil {
+		t.Fatalf("groq registry discovery: %v", err)
+	}
+	if pv == nil {
+		t.Fatal("groq registry discovery = nil, want non-nil provider")
+	}
+}

--- a/internal/sandbox/provider/openai.go
+++ b/internal/sandbox/provider/openai.go
@@ -70,6 +70,9 @@ func NewOpenAI(cfg Config) *OpenAIProvider {
 	if strings.Contains(strings.ToLower(cfg.UpstreamHost), "openrouter.ai") {
 		path = "/api/v1/chat/completions"
 	}
+	if strings.Contains(strings.ToLower(cfg.UpstreamHost), "api.groq.com") {
+		path = "/openai/v1/chat/completions"
+	}
 	return &OpenAIProvider{
 		cfg:    cfg,
 		client: newSocketClient(cfg.SocketPath, cfg.HTTPTimeout),


### PR DESCRIPTION
## Summary

`ironctl scan` grades seven containment dimensions whose fixed weights sum to 100, but until now the only way to see the list and the weights was to read the `scorers` slice in `internal/host/scan/score.go`. This adds a `--list-dimensions` boolean flag that prints each dimension title and its weight and exits 0 without needing a container, so users understand what the score is made of before they run a scan. Closes #446.

The list is driven from the existing `scorers` slice through a new exported `Dimensions()` accessor (returning `DimensionWeight{Key, Title, Max}`), so adding a dimension in `score.go` later needs no second edit in `cmd/ironctl`. The internal `grade` funcs stay unexported — `Dimensions()` exposes only the published view.

## Changes

- **`internal/host/scan/score.go`** — new `DimensionWeight` type and `Dimensions()` accessor sitting next to `TotalWeight`; the public view of the internal `scorers` slice.
- **`cmd/ironctl/scan.go`** — `--list-dimensions` flag, an early return before the mode blocks (no-target, no-container path), a `printDimensions` helper that aligns the weight column to the longest title, and a `scanUsage` help line.
- **`internal/host/scan/score_test.go`** — `TestDimensions` asserts the accessor stays in sync with `scorers` (same key/title/max, in order) and that the weights sum to `TotalWeight` (100).
- **`cmd/ironctl/scan_test.go`** — `TestCmdScan_ListDimensions` captures stdout, asserts `cmdScan --list-dimensions` exits nil, the header (`Containment dimensions (weights sum to 100)`) prints, and every dimension title from `scan.Dimensions()` appears. Assertions iterate `scan.Dimensions()` rather than a hardcoded list so a future dimension does not need a second edit here either.

## Example output

```
$ ironctl scan --list-dimensions
Containment dimensions (weights sum to 100):
  Non-root user (uid != 0)      15
  Dropped capabilities           20
  Seccomp profile                15
  Network isolation / egress    15
  Read-only root filesystem      10
  No docker.sock exposure        15
  No shared host namespaces     10
```

## Verification

- `go build ./...` ✅
- `go test ./...` ✅ (all packages green, including new `TestDimensions` and `TestCmdScan_ListDimensions`)
- `gofmt -l` on the four touched files ✅ clean. (`gofmt -l .` does flag two pre-existing files on `main` — `cmd/scan-wasm/main.go` and `internal/host/scan/compare_test.go` — that are unrelated to this PR; I left them alone to keep the diff scoped to the issue.)

## Acceptance criteria

- [x] `ironctl scan --list-dimensions` prints all dimensions with weights and exits 0.
- [x] The list is derived from `scorers` (adding a dimension later needs no second edit) — via the `Dimensions()` accessor.
- [x] Flag documented in `scanUsage`.
- [x] Tests in `cmd/ironctl/scan_test.go` and `internal/host/scan` cover the listing.
- [x] `go build ./...`, `go test ./...`, `gofmt -l` on touched files clean.

Closes #446