### PR TITLE
feat(scan): add --list-dimensions flag to list scoring axes and weights

### DIFF
--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -76,6 +76,7 @@ func cmdScan(args []string) error {
 	podmanBin := fs.String("podman-bin", envOrDefault("PODMAN", "podman"), "podman binary used for `podman container inspect` and `podman image inspect`")
 	nerdctlBin := fs.String("nerdctl-bin", envOrDefault("NERDCTL", "nerdctl"), "nerdctl binary used for `nerdctl container inspect` and `nerdctl image inspect`")
 	minScore := fs.Int("min-score", 0, "exit non-zero if the score is below this threshold (CI gate)")
+	listDims := fs.Bool("list-dimensions", false, "print the containment scoring dimensions and their weights, then exit")
 	fs.Usage = func() { scanUsage(os.Stdout) }
 	// Go's flag package stops at the first positional, so `scan <target> --json`
 	// would silently drop the flags after the target. Re-parse around each
@@ -92,6 +93,15 @@ func cmdScan(args []string) error {
 		}
 		positional = append(positional, rest[0])
 		rest = rest[1:]
+	}
+
+	// --list-dimensions: print the scoring axes and weights, then exit 0. This
+	// is a no-target, no-container path, so it returns BEFORE the mode blocks
+	// below. The list is sourced from scan.Dimensions() (the public view of the
+	// internal scorers slice), so adding a dimension in score.go later needs no
+	// second edit here.
+	if *listDims {
+		return printDimensions(os.Stdout)
 	}
 
 	// --compare A B: grade two live containers and print a side-by-side diff.
@@ -3172,6 +3182,28 @@ func podmanRootless(bin string) scan.Tristate {
 	}
 }
 
+// printDimensions prints the containment scoring axes with their fixed weights
+// (summing to scan.TotalWeight) and returns nil so cmdScan can surface it as a
+// clean exit 0. Titles come from scan.Dimensions(), so this stays in sync with
+// the scorers slice without a second source of truth. The label column is
+// left-justified to the longest title plus a small gap so the weights align.
+func printDimensions(w io.Writer) error {
+	dims := scan.Dimensions()
+	width := 0
+	for _, d := range dims {
+		if len(d.Title) > width {
+			width = len(d.Title)
+		}
+	}
+	fmt.Fprintf(w, "Containment dimensions (weights sum to %d):\n", scan.TotalWeight)
+	for _, d := range dims {
+		// width+4 pads the label to the longest title plus a 4-char gap before
+		// the weight, giving aligned columns without dots-fillers.
+		fmt.Fprintf(w, "  %-*s %d\n", width+4, d.Title, d.Max)
+	}
+	return nil
+}
+
 func scanUsage(w *os.File) {
 	fmt.Fprint(w, `ironctl scan — grade a container's containment posture (0-100)
 
@@ -3220,6 +3252,7 @@ FLAGS:
   --docker-bin BIN    docker binary for `+"`docker container inspect`"+` and `+"`docker image inspect`"+` (default: docker)
   --podman-bin BIN    podman binary for `+"`podman container inspect`"+` and `+"`podman image inspect`"+` (default: podman)
   --nerdctl-bin BIN   nerdctl binary for `+"`nerdctl container inspect`"+` and `+"`nerdctl image inspect`"+` (default: nerdctl)
+  --list-dimensions   print the containment scoring dimensions and their weights, then exit (no container needed)
 
 Runtime is auto-detected (docker, then podman, then nerdctl on PATH); override
 with --runtime. Rootless podman is credited: a userns remap of container-uid 0

--- a/cmd/ironctl/scan.go
+++ b/cmd/ironctl/scan.go
@@ -3186,7 +3186,8 @@ func podmanRootless(bin string) scan.Tristate {
 // (summing to scan.TotalWeight) and returns nil so cmdScan can surface it as a
 // clean exit 0. Titles come from scan.Dimensions(), so this stays in sync with
 // the scorers slice without a second source of truth. The label column is
-// left-justified to the longest title plus a small gap so the weights align.
+// padded with dots to the longest title plus a 2-dot gap so the weights align
+// in a fixed column, matching the format shown in the issue.
 func printDimensions(w io.Writer) error {
 	dims := scan.Dimensions()
 	width := 0
@@ -3197,9 +3198,16 @@ func printDimensions(w io.Writer) error {
 	}
 	fmt.Fprintf(w, "Containment dimensions (weights sum to %d):\n", scan.TotalWeight)
 	for _, d := range dims {
-		// width+4 pads the label to the longest title plus a 4-char gap before
-		// the weight, giving aligned columns without dots-fillers.
-		fmt.Fprintf(w, "  %-*s %d\n", width+4, d.Title, d.Max)
+		// Pad the title with dots to the longest title plus a 2-dot gap so the
+		// weight column lines up regardless of label length (e.g.
+		// "Non-root user (uid != 0)........  15"). Use lowercase titles to
+		// match the example shape in the issue.
+		label := strings.ToLower(d.Title)
+		pad := width + 2 - len(label)
+		if pad < 1 {
+			pad = 1
+		}
+		fmt.Fprintf(w, "  %s%s %d\n", label, strings.Repeat(".", pad), d.Max)
 	}
 	return nil
 }

--- a/cmd/ironctl/scan_flags_test.go
+++ b/cmd/ironctl/scan_flags_test.go
@@ -42,8 +42,8 @@ var imageSafeFlags = []string{
 	"--cloudrun", "--compare", "--compose", "--docker-bin", "--dockerfile",
 	"--ecs", "--emit-policy", "--helm", "--helm-bin", "--json", "--k8s",
 	"--k8s-admission", "--kubectl-bin", "--kustomize", "--kustomize-bin",
-	"--nerdctl-bin", "--nomad", "--nomad-bin", "--openshift", "--podman-bin",
-	"--pulumi", "--runtime", "--sam", "--service", "--terraform",
+	"--list-dimensions", "--nerdctl-bin", "--nomad", "--nomad-bin", "--openshift",
+	"--podman-bin", "--pulumi", "--runtime", "--sam", "--service", "--terraform",
 	"--terraform-bin",
 }
 

--- a/cmd/ironctl/scan_test.go
+++ b/cmd/ironctl/scan_test.go
@@ -147,7 +147,9 @@ func TestRejectScoreBearingOutputs_ImageMode(t *testing.T) {
 // --list-dimensions prints the scoring axes and weights and exits 0 without a
 // target. It must surface EVERY dimension in scan.Dimensions() (so a future
 // dimension added in score.go shows up automatically) and the header must
-// announce the total weight, which sums to scan.TotalWeight (100).
+// announce the total weight, which sums to scan.TotalWeight (100). Titles are
+// lowercased in the output (matching the issue example), so the assertion
+// compares case-insensitively.
 func TestCmdScan_ListDimensions(t *testing.T) {
 	out := captureStdout(t, func() {
 		if err := cmdScan([]string{"--list-dimensions"}); err != nil {
@@ -157,11 +159,12 @@ func TestCmdScan_ListDimensions(t *testing.T) {
 	if !strings.Contains(out, "Containment dimensions (weights sum to 100)") {
 		t.Errorf("missing header line; got:\n%s", out)
 	}
-	// Every published axis must appear. We assert on Titles from scan.Dimensions()
-	// rather than a hardcoded list, so adding a dimension does NOT need a second
-	// edit here (the same invariant the issue calls out for the production path).
+	// Every published axis must appear. We assert on Titles from
+	// scan.Dimensions() rather than a hardcoded list, so adding a dimension
+	// does NOT need a second edit here. The output lowercases titles, so the
+	// comparison is case-insensitive.
 	for _, d := range scan.Dimensions() {
-		if !strings.Contains(out, d.Title) {
+		if !strings.Contains(strings.ToLower(out), strings.ToLower(d.Title)) {
 			t.Errorf("output missing dimension %q; got:\n%s", d.Title, out)
 		}
 	}

--- a/cmd/ironctl/scan_test.go
+++ b/cmd/ironctl/scan_test.go
@@ -181,13 +181,17 @@ func captureStdout(t *testing.T, fn func()) string {
 		t.Fatalf("pipe: %v", err)
 	}
 	os.Stdout = w
+	defer func() {
+		os.Stdout = orig
+	}()
+	defer w.Close()
 	done := make(chan string)
 	go func() {
 		buf, _ := io.ReadAll(r)
 		done <- string(buf)
 	}()
+
 	fn()
 	w.Close()
-	os.Stdout = orig
 	return <-done
 }

--- a/cmd/ironctl/scan_test.go
+++ b/cmd/ironctl/scan_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/IronSecCo/ironclaw/internal/host/scan"
 )
 
 // writeTemp writes content to a temp file and returns its path.
@@ -140,3 +143,48 @@ func TestRejectScoreBearingOutputs_ImageMode(t *testing.T) {
 // invariants are derived from scan.go's own source in scan_flags_test.go; a
 // hand-copied expectation here could only ever catch someone editing one of two
 // identical lists.
+
+// --list-dimensions prints the scoring axes and weights and exits 0 without a
+// target. It must surface EVERY dimension in scan.Dimensions() (so a future
+// dimension added in score.go shows up automatically) and the header must
+// announce the total weight, which sums to scan.TotalWeight (100).
+func TestCmdScan_ListDimensions(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := cmdScan([]string{"--list-dimensions"}); err != nil {
+			t.Fatalf("cmdScan --list-dimensions returned %v, want nil", err)
+		}
+	})
+	if !strings.Contains(out, "Containment dimensions (weights sum to 100)") {
+		t.Errorf("missing header line; got:\n%s", out)
+	}
+	// Every published axis must appear. We assert on Titles from scan.Dimensions()
+	// rather than a hardcoded list, so adding a dimension does NOT need a second
+	// edit here (the same invariant the issue calls out for the production path).
+	for _, d := range scan.Dimensions() {
+		if !strings.Contains(out, d.Title) {
+			t.Errorf("output missing dimension %q; got:\n%s", d.Title, out)
+		}
+	}
+}
+
+// captureStdout swaps os.Stdout for the duration of fn and returns whatever was
+// written. It restores the original stdout even on failure, so a test abort
+// never leaks a broken file descriptor to later tests.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string)
+	go func() {
+		buf, _ := io.ReadAll(r)
+		done <- string(buf)
+	}()
+	fn()
+	w.Close()
+	os.Stdout = orig
+	return <-done
+}

--- a/internal/host/scan/score.go
+++ b/internal/host/scan/score.go
@@ -89,6 +89,24 @@ var scorers = []scorer{
 // TotalWeight is the maximum achievable score (100 by construction).
 const TotalWeight = 100
 
+// DimensionWeight is one published scoring axis: its human label and max points.
+type DimensionWeight struct {
+	Key   string
+	Title string
+	Max   int
+}
+
+// Dimensions returns the ordered scoring axes with their fixed weights, summing
+// to TotalWeight (100). It is the public view of the internal scorers slice so
+// callers (e.g. `ironctl scan --list-dimensions`) never touch the grade funcs.
+func Dimensions() []DimensionWeight {
+	out := make([]DimensionWeight, len(scorers))
+	for i, s := range scorers {
+		out[i] = DimensionWeight{Key: s.key, Title: s.title, Max: s.max}
+	}
+	return out
+}
+
 // Scored reports whether the report carries a meaningful composite score and
 // grade. It is false in ModeImage, where six of the seven dimensions are not
 // observable and no composite is emitted. Check this before reading Score/Grade

--- a/internal/host/scan/score_test.go
+++ b/internal/host/scan/score_test.go
@@ -203,6 +203,33 @@ func TestScoreWeightsSumTo100(t *testing.T) {
 	}
 }
 
+// TestDimensions is the public-accessor contract for --list-dimensions: it must
+// expose every scorer in order, with the same key/title/max and a total weight
+// of TotalWeight (100). Adding a dimension in score.go must NOT need a second
+// edit here — the test derives its expectations from the unexported scorers
+// slice, so a drift between scorers and Dimensions() fails loudly.
+func TestDimensions(t *testing.T) {
+	dims := Dimensions()
+	if len(dims) != len(scorers) {
+		t.Fatalf("Dimensions() returned %d axes, want %d (out of sync with scorers)", len(dims), len(scorers))
+	}
+	sum := 0
+	for i, want := range scorers {
+		got := dims[i]
+		if got.Key != want.key || got.Title != want.title || got.Max != want.max {
+			t.Errorf("dims[%d] = {%s,%s,%d}, want {%s,%s,%d}",
+				i, got.Key, got.Title, got.Max, want.key, want.title, want.max)
+		}
+		if got.Title == "" {
+			t.Errorf("dims[%d] (%s) has empty Title", i, got.Key)
+		}
+		sum += got.Max
+	}
+	if sum != TotalWeight {
+		t.Fatalf("Dimensions() weights sum to %d, want %d", sum, TotalWeight)
+	}
+}
+
 // TestScoreFailClosedEmpty asserts an empty Spec (all Unknown) scores 0/F: an
 // auditor that can see nothing must report the worst grade, never a passing one.
 func TestScoreFailClosedEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary

`ironctl scan` grades seven containment dimensions whose fixed weights sum to 100, but until now the only way to see the list and the weights was to read the `scorers` slice in `internal/host/scan/score.go`. This adds a `--list-dimensions` boolean flag that prints each dimension title and its weight and exits 0 without needing a container, so users understand what the score is made of before they run a scan.

The list is driven from the existing `scorers` slice through a new exported `Dimensions()` accessor (returning `DimensionWeight{Key, Title, Max}`), so adding a dimension in `score.go` later needs no second edit in `cmd/ironctl`. The internal `grade` funcs stay unexported — `Dimensions()` exposes only the published view.

## Changes

- **`internal/host/scan/score.go`** — new `DimensionWeight` type and `Dimensions()` accessor sitting next to `TotalWeight`; the public view of the internal `scorers` slice.
- **`cmd/ironctl/scan.go`** — `--list-dimensions` flag, an early return before the mode blocks (no-target, no-container path), a `printDimensions` helper that dot-pads labels to align the weight column, and a `scanUsage` help line.
- **`cmd/ironctl/scan_flags_test.go`** — `--list-dimensions` classified as image-safe (it carries no composite score) so `TestEveryScanFlagIsClassified` stays green.
- **`internal/host/scan/score_test.go`** — `TestDimensions` asserts the accessor stays in sync with `scorers` (same key/title/max, in order) and that the weights sum to `TotalWeight` (100).
- **`cmd/ironctl/scan_test.go`** — `TestCmdScan_ListDimensions` captures stdout, asserts `cmdScan --list-dimensions` exits nil, the header (`Containment dimensions (weights sum to 100)`) prints, and every dimension title from `scan.Dimensions()` appears (case-insensitive — output lowercases titles).

## Example output

```
$ ironctl scan --list-dimensions
Containment dimensions (weights sum to 100):
  non-root user (uid != 0).... 15
  dropped capabilities........ 20
  seccomp profile............. 15
  network isolation / egress.. 15
  read-only root filesystem... 10
  no docker.sock exposure..... 15
  no shared host namespaces... 10
```

## Verification

- `go build ./...` ✅
- `go test ./...` ✅ (all packages green, including new `TestDimensions`, `TestCmdScan_ListDimensions`, and `TestEveryScanFlagIsClassified`)
- `gofmt -l` on the touched files ✅ clean. (`gofmt -l .` does flag two pre-existing files on `main` — `cmd/scan-wasm/main.go` and `internal/host/scan/compare_test.go` — that are unrelated to this PR; I left them alone to keep the diff scoped.)

## Acceptance criteria

- [x] `ironctl scan --list-dimensions` prints all dimensions with weights and exits 0.
- [x] The list is derived from `scorers` (adding a dimension later needs no second edit) — via the `Dimensions()` accessor.
- [x] Flag documented in `scanUsage`.
- [x] Tests in `cmd/ironctl/scan_test.go` and `internal/host/scan` cover the listing.
- [x] `go build ./...`, `go test ./...`, `gofmt -l` on touched files clean.

Closes #446