### PR TITLE
test: pin frozen contract enum values

### DIFF
--- a/internal/contract/enums_test.go
+++ b/internal/contract/enums_test.go
@@ -1,0 +1,67 @@
+package contract
+
+import "testing"
+
+func TestStringEnumValues(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "KindChat", got: string(KindChat), want: "chat"},
+		{name: "KindTask", got: string(KindTask), want: "task"},
+		{name: "KindWebhook", got: string(KindWebhook), want: "webhook"},
+		{name: "KindSystem", got: string(KindSystem), want: "system"},
+		{name: "EngagePattern", got: string(EngagePattern), want: "pattern"},
+		{name: "EngageMention", got: string(EngageMention), want: "mention"},
+		{name: "EngageMentionSticky", got: string(EngageMentionSticky), want: "mention-sticky"},
+		{name: "SenderAll", got: string(SenderAll), want: "all"},
+		{name: "SenderKnown", got: string(SenderKnown), want: "known"},
+		{name: "IgnoreDrop", got: string(IgnoreDrop), want: "drop"},
+		{name: "IgnoreAccumulate", got: string(IgnoreAccumulate), want: "accumulate"},
+		{name: "UnknownStrict", got: string(UnknownStrict), want: "strict"},
+		{name: "UnknownRequestApproval", got: string(UnknownRequestApproval), want: "request_approval"},
+		{name: "UnknownPublic", got: string(UnknownPublic), want: "public"},
+		{name: "SessionShared", got: string(SessionShared), want: "shared"},
+		{name: "SessionPerThread", got: string(SessionPerThread), want: "per-thread"},
+		{name: "SessionAgentShared", got: string(SessionAgentShared), want: "agent-shared"},
+		{name: "ChangePersona", got: string(ChangePersona), want: "persona"},
+		{name: "ChangeEnabledTools", got: string(ChangeEnabledTools), want: "enabled_tools"},
+		{name: "ChangePackages", got: string(ChangePackages), want: "packages"},
+		{name: "ChangeWiring", got: string(ChangeWiring), want: "wiring"},
+		{name: "ChangePermissions", got: string(ChangePermissions), want: "permissions"},
+		{name: "ChangeMounts", got: string(ChangeMounts), want: "mounts"},
+		{name: "ChangeCreateAgent", got: string(ChangeCreateAgent), want: "create_agent"},
+		{name: "ChangeMCPAccess", got: string(ChangeMCPAccess), want: "mcp_access"},
+		{name: "ChangeSkillInstall", got: string(ChangeSkillInstall), want: "skill_install"},
+		{name: "ChangeMCPRegister", got: string(ChangeMCPRegister), want: "mcp_register"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("value = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerdictValues(t *testing.T) {
+	tests := []struct {
+		name string
+		got  Verdict
+		want int
+	}{
+		{name: "VerdictPass", got: VerdictPass, want: 0},
+		{name: "VerdictReject", got: VerdictReject, want: 1},
+		{name: "VerdictRequireHuman", got: VerdictRequireHuman, want: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if int(tt.got) != tt.want {
+				t.Fatalf("value = %d, want %d", tt.got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/contract/enums_test.go
+++ b/internal/contract/enums_test.go
@@ -1,3 +1,5 @@
+// FROZEN CONTRACT — do not edit without a joint RFC (see docs/contract.md).
+
 package contract
 
 import "testing"


### PR DESCRIPTION
## What & why

I added table-driven tests that pin every exported enum constant in the host/sandbox frozen contract. A silent string or integer drift now fails the contract package tests instead of becoming a routing or decryption mismatch at runtime.

Closes #282

## Changes

- assert the exact wire values for all 27 exported string enum constants
- assert the exact 0, 1, and 2 values for the three Verdict constants
- keep the change test-only; no frozen production values or behavior changed
- include the required frozen-contract banner on the new test file

## Frozen-contract process note

Issue #282 explicitly requests this test-only coverage, and this PR changes no wire value. The repository policy still describes RFC and code-owner approval for all internal/contract changes, so I am leaving whether the issue plus code-owner review is sufficient to the maintainers; I can add an RFC log entry if requested.

## Checklist

- [x] **Tests pass:** CGO_ENABLED=1 go test ./... is green (CGO is required — SQLCipher binding).
- [x] **Formatted & vetted:** gofmt -l . is empty and go vet ./... passes.
- [ ] **Frozen contract:** the required banner is present and no production contract value changed; maintainer/code-owner process confirmation remains requested above.
- [x] **Threat model:** no change to the sandbox seal / network=none / approval-gateway posture.
- [x] **Docs updated:** not applicable; this is test-only and has no user-facing or behavioral change.
- [x] **No secrets:** no tokens, keys, credentials, or fixtures added.
- [x] **CLA signed:** the existing Yurii201811 CLA record applies.

## Validation

- go test ./internal/contract/...
- CGO_ENABLED=1 go test ./...
- CGO_ENABLED=1 go vet ./...
- CGO_ENABLED=1 go build ./...
- gofmt -l internal/contract/enums_test.go
- git diff --check

All commands passed; gofmt -l produced no output.